### PR TITLE
Add versions for RTC dictionaries for Safari

### DIFF
--- a/api/RTCAnswerOptions.json
+++ b/api/RTCAnswerOptions.json
@@ -30,10 +30,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": "5.0"

--- a/api/RTCConfiguration.json
+++ b/api/RTCConfiguration.json
@@ -30,10 +30,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": "7.0"
@@ -78,10 +78,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -127,10 +127,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -175,10 +175,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -224,10 +224,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -273,10 +273,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -321,10 +321,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -372,10 +372,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "7.0"

--- a/api/RTCIceCandidateInit.json
+++ b/api/RTCIceCandidateInit.json
@@ -230,7 +230,7 @@
               "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": "14.1"
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/RTCIceCandidateInit.json
+++ b/api/RTCIceCandidateInit.json
@@ -30,10 +30,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -80,10 +80,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -129,10 +129,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -178,10 +178,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -227,10 +227,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "14.1"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/RTCIceCandidatePairStats.json
+++ b/api/RTCIceCandidatePairStats.json
@@ -30,10 +30,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -78,10 +78,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -127,10 +127,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -176,10 +176,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -225,10 +225,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -274,10 +274,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -323,10 +323,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -372,10 +372,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -439,10 +439,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": [
               {
@@ -500,10 +500,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -549,10 +549,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -598,10 +598,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -647,10 +647,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -696,10 +696,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -745,10 +745,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -794,10 +794,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -843,10 +843,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -892,10 +892,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -953,10 +953,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1001,10 +1001,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1050,10 +1050,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1099,10 +1099,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1148,10 +1148,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1197,10 +1197,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1246,10 +1246,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1295,10 +1295,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1344,10 +1344,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1393,10 +1393,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1460,10 +1460,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": [
               {
@@ -1527,10 +1527,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1578,10 +1578,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true,

--- a/api/RTCIceCandidateStats.json
+++ b/api/RTCIceCandidateStats.json
@@ -30,10 +30,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "12.1"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "12.2"
           },
           "samsunginternet_android": {
             "version_added": false
@@ -90,10 +90,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -139,10 +139,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -189,10 +189,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -238,10 +238,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -286,10 +286,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -337,10 +337,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -386,10 +386,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -447,10 +447,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -508,10 +508,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -559,10 +559,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -608,10 +608,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/RTCIceCredentialType.json
+++ b/api/RTCIceCredentialType.json
@@ -30,10 +30,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": false
@@ -77,10 +77,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -125,10 +125,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -175,10 +175,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/RTCIceServer.json
+++ b/api/RTCIceServer.json
@@ -30,10 +30,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -78,10 +78,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -127,10 +127,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true
@@ -175,10 +175,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true
@@ -224,10 +224,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -273,10 +273,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/RTCOfferAnswerOptions.json
+++ b/api/RTCOfferAnswerOptions.json
@@ -30,10 +30,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": "5.0"
@@ -77,10 +77,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/RTCOfferOptions.json
+++ b/api/RTCOfferOptions.json
@@ -42,10 +42,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": "5.0"
@@ -90,10 +90,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1642,10 +1642,10 @@
                 "version_added": "48"
               },
               "safari": {
-                "version_added": null
+                "version_added": "11"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "11"
               },
               "samsunginternet_android": {
                 "version_added": "9.0"

--- a/api/RTCRtpContributingSource.json
+++ b/api/RTCRtpContributingSource.json
@@ -44,10 +44,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": "12.1"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "12.2"
           },
           "samsunginternet_android": {
             "version_added": "7.0"
@@ -106,10 +106,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -169,10 +169,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -234,10 +234,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "7.0"

--- a/api/RTCRtpEncodingParameters.json
+++ b/api/RTCRtpEncodingParameters.json
@@ -30,10 +30,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": "9.0"
@@ -77,10 +77,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -125,10 +125,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -173,10 +173,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -271,10 +271,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -319,10 +319,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -371,10 +371,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "9.0",
@@ -421,10 +421,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -568,10 +568,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "11.0"

--- a/api/RTCRtpSendParameters.json
+++ b/api/RTCRtpSendParameters.json
@@ -32,10 +32,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "12.1"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "12.2"
           },
           "samsunginternet_android": {
             "version_added": "10.0"
@@ -79,10 +79,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -130,10 +130,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -178,10 +178,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -226,10 +226,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/api/RTCRtpStreamStats.json
+++ b/api/RTCRtpStreamStats.json
@@ -42,10 +42,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": false
@@ -90,10 +90,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -142,10 +142,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -192,10 +192,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -241,10 +241,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -289,10 +289,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -337,10 +337,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -389,10 +389,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -441,10 +441,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -493,10 +493,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -541,10 +541,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -593,10 +593,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -642,10 +642,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -691,10 +691,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/RTCRtpSynchronizationSource.json
+++ b/api/RTCRtpSynchronizationSource.json
@@ -44,10 +44,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": "12.1"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "12.2"
           },
           "samsunginternet_android": {
             "version_added": false
@@ -105,10 +105,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/RTCRtpTransceiverDirection.json
+++ b/api/RTCRtpTransceiverDirection.json
@@ -30,10 +30,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": "10.0"

--- a/api/RTCRtpTransceiverInit.json
+++ b/api/RTCRtpTransceiverInit.json
@@ -127,10 +127,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -175,10 +175,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/api/RTCRtpTransceiverInit.json
+++ b/api/RTCRtpTransceiverInit.json
@@ -30,10 +30,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": "10.0"
@@ -77,10 +77,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -127,10 +127,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -175,10 +175,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "10.0"


### PR DESCRIPTION
This PR adds real versions for Safari for the various RTC dictionaries, based upon the source code at the different Safari releases.  Data is as follows:

<details>
<summary>Safari 11:</summary>

	- api.RTCAnswerOptions

	- api.RTCConfiguration
		- bundlePolicy
		- iceCandidatePoolSize
		- iceServers
		- iceTransportPolicy

	- api.RTCIceCandidateInit
		- candidate
		- sdpMid
		- sdpMLineIndex

	- api.RTCIceCandidatePairStats
		- availableIncomingBitrate
		- availableOutgoingBitrate
		- bytesReceived
		- bytesSent
		- currentRoundTripTime
		- localCandidateId
		- nominated
		- priority
		- readable
		- remoteCandidateId
		- requestsReceived
		- requestsSent
		- responsesReceived
		- responsesSent
		- state
		- totalRoundTripTime
		- transportId
		- writable

	- api.RTCIceServer
		- credential
		- urls
		- username

	- api.RTCOfferAnswerOptions
		- voiceActivityDetection

	- api.RTCOfferOptions
		- iceRestart

	- api.RTCPeerConnection
		- getStats.MediaStreamTrack_argument (https://trac.webkit.org/browser/webkit/tags/Safari-604.2.4/Source/WebCore/Modules/mediastream/RTCPeerConnection.idl#L143)

	- api.RTCRtpEncodingParameters
		- active
		- dtx
		- maxBitrate
		- maxFramerate
		- priority
		- scaleResolutionDownBy

	- api.RTCRtpStreamStats
		- codecId
		- firCount
		- isRemote
		- mediaTrackId
		- mediaType
		- nackCount
		- pliCount
		- qpSum
		- sliCount
		- ssrc
		- transportId

	- api.RTCRtpTransceiverDirection

	- api.RTCRtpTransceiverInit
		- direction
</details>

<details>
<summary>Safari 12.1:</summary>

	- api.RTCConfiguration
		- certificates
		- peerIdentity
		- rtcpMuxPolicy

	- api.RTCIceCandidateStats
		- address
		- candidateType
		- deleted
		- port
		- priority
		- protocol
		- transportId
		- url

	- api.RTCRtpContributingSource
		- audioLevel
		- source
		- timestamp

	- api.RTCRtpSendParameters
		- degradationPreference
		- encodings
		- transactionId

	- api.RTCRtpSynchronizationSource
		- voiceActivityFlag

	- api.RTCRtpTransceiverInit
		- streams

</details>

<details>
<summary>Safari 14:</summary>

	- api.RTCRtpStreamStats
		- kind

</details>

<details>
<summary>Safari 14.1:</summary>

	- api.RTCIceCandidateInit
		- usernameFragment

	- api.RTCRtpTransceiverInit
		- sendEncodings

</details>

<details>
<summary>Unsupported:</summary>

	- api.RTCIceCandidatePairStats
		- circuitBreakerTriggerCount
		- consentExpiredTimestamp
		- consentRequestsSent
		- firstRequestTimeStamp
		- lastPacketReceivedTimestamp
		- lastPacketSentTimestamp
		- lastRequestTimestamp
		- lastResponseTimestamp
		- packetsReceived
		- packetsSent
		- retransmissionsReceived
		- retransmissionsSent

	- api.RTCIceCandidateStats
		- componentId
		- networkType
		- relayProtocol

	- api.RTCIceCredentialType
		- oauth
		- password
		- token

	- api.RTCIceServer
		- credentialType
		- url

	- api.RTCRtpEncodingParameters
		- codecPayloadType
		- ptime

	- api.RTCRtpSendParameters
		- priority

	- api.RTCRtpStreamStats
		- remoteId

</details>

---

Stats Difference:

| browser | real values | `null` values |
| --- | --- | --- |
| total (before) | 89.81% | 1.56% |
| safari (before) | 91.27% | 4.35% |
| safari ios (before) | 89.23% | 4.94% |
| total (after) | 90.18% | 1.19% |
| safari (after) | 92.73% | 2.89% |
| safari ios (after) | 90.69% | 3.48% |
| total (diff) | 0.37% | |
| safari (diff) | 1.46% | |
| safari ios (diff) | 1.46% | |