### PR TITLE
Add Safari iOS versions for api.OfflineAudioContext.oncomplete/complete_event

### DIFF
--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -292,7 +292,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -390,7 +390,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.5"


### PR DESCRIPTION
This PR adds real values for Safari iOS/iPadOS for the `oncomplete/complete_event` member of the `OfflineAudioContext` API by mirroring the data.
