### PR TITLE
Add Safari iOS versions for api.RTCPeerConnection.getStats.with_callbacks

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1694,7 +1694,7 @@
                 "version_added": "11"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "11"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari iOS/iPadOS for the `getStats.with_callbacks` member of the `RTCPeerConnection` API by mirroring the data.
