### PR TITLE
Add Safari iOS versions for api.XMLHttpRequest.responseType

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1139,7 +1139,7 @@
                 "version_added": "7"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -1193,7 +1193,7 @@
                 "version_added": "7"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari iOS/iPadOS for the `responseType` member of the `XMLHttpRequest` API by mirroring the data.
