### PR TITLE
Add Safari iOS versions for api.RTCPeerConnection.*_event

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -332,7 +332,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -1093,7 +1093,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -1862,7 +1862,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -1975,7 +1975,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -2348,7 +2348,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -4453,7 +4453,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "6.0"


### PR DESCRIPTION
This PR adds real values for Safari iOS/iPadOS for the event members of the `RTCPeerConnection` API by mirroring the data.
