### PR TITLE
Add Safari iOS versions for api.TextTrack.cuechange_event

### DIFF
--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -179,6 +179,9 @@
             "safari": {
               "version_added": true
             },
+            "safari_ios": {
+              "version_added": true
+            },
             "samsunginternet_android": {
               "version_added": true
             },


### PR DESCRIPTION
This PR adds real values for Safari iOS/iPadOS for the `cuechange_event` member of the `TextTrack` API by mirroring the data.
