### PR TITLE
Add mdn_url and spec_url to SWGS's onperiodicsync and periodicsync_event

### DIFF
--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -1185,6 +1185,8 @@
       },
       "onperiodicsync": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/onperiodicsync",
+          "spec_url": "https://wicg.github.io/periodic-background-sync/#dom-serviceworkerglobalscope-onperiodicsync",
           "support": {
             "chrome": {
               "version_added": "80"
@@ -1384,6 +1386,7 @@
       "periodicsync_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerGlobalScope/periodicsync_event",
+          "spec_url": "https://wicg.github.io/periodic-background-sync/#periodicsync-event",
           "description": "<code>periodicsync</code> event",
           "support": {
             "chrome": {


### PR DESCRIPTION
The bcd was there but not these fields (and the spec_url was wrong on MDN).