### PR TITLE
Add mdn_url et spec_url to SVGMarkerElement.json

### DIFF
--- a/api/SVGMarkerElement.json
+++ b/api/SVGMarkerElement.json
@@ -2,6 +2,8 @@
   "api": {
     "SVGMarkerElement": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement",
+        "spec_url": "https://www.w3.org/TR/SVG2/painting.html#InterfaceSVGMarkerElement",
         "support": {
           "chrome": {
             "version_added": "1"
@@ -48,6 +50,8 @@
       },
       "markerHeight": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/markerHeight",
+          "spec_url": "https://www.w3.org/TR/SVG2/painting.html#__svg__SVGMarkerElement__markerHeight",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -95,6 +99,8 @@
       },
       "markerUnits": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/markerUnits",
+          "spec_url": "https://www.w3.org/TR/SVG2/painting.html#__svg__SVGMarkerElement__markerUnits",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -142,6 +148,8 @@
       },
       "markerWidth": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/markerWidth",
+          "spec_url": "https://www.w3.org/TR/SVG2/painting.html#__svg__SVGMarkerElement__markerWidth",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -189,6 +197,7 @@
       },
       "orient": {
         "__compat": {
+          "spec_url": "https://www.w3.org/TR/SVG2/painting.html#__svg__SVGMarkerElement__orient",
           "support": {
             "chrome": {
               "version_added": false
@@ -236,6 +245,8 @@
       },
       "orientAngle": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/orientAngle",
+          "spec_url": "https://www.w3.org/TR/SVG2/painting.html#__svg__SVGMarkerElement__orientAngle",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -283,6 +294,8 @@
       },
       "orientType": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/orientType",
+          "spec_url": "https://www.w3.org/TR/SVG2/painting.html#__svg__SVGMarkerElement__orientType",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -330,6 +343,8 @@
       },
       "preserveAspectRatio": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/preserveAspectRatio",
+          "spec_url": "https://www.w3.org/TR/SVG2/types.html#__svg__SVGFitToViewBox__preserveAspectRatio",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -377,6 +392,8 @@
       },
       "refX": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/refX",
+          "spec_url": "https://www.w3.org/TR/SVG2/painting.html#__svg__SVGMarkerElement__refX",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -424,6 +441,8 @@
       },
       "refY": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/refY",
+          "spec_url": "https://www.w3.org/TR/SVG2/painting.html#__svg__SVGMarkerElement__refY",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -471,6 +490,8 @@
       },
       "setOrientToAngle": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/setOrientToAngle",
+          "spec_url": "https://www.w3.org/TR/SVG2/painting.html#__svg__SVGMarkerElement__setOrientToAngle",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -518,6 +539,8 @@
       },
       "setOrientToAuto": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/setOrientToAuto",
+          "spec_url": "https://www.w3.org/TR/SVG2/painting.html#__svg__SVGMarkerElement__setOrientToAuto",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -565,6 +588,8 @@
       },
       "viewBox": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/viewBox",
+          "spec_url": "https://www.w3.org/TR/SVG2/types.html#__svg__SVGFitToViewBox__viewBox",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/SVGMarkerElement.json
+++ b/api/SVGMarkerElement.json
@@ -3,7 +3,7 @@
     "SVGMarkerElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement",
-        "spec_url": "https://www.w3.org/TR/SVG2/painting.html#InterfaceSVGMarkerElement",
+        "spec_url": "https://svgwg.org/svg2-draft/painting.html#InterfaceSVGMarkerElement",
         "support": {
           "chrome": {
             "version_added": "1"
@@ -51,7 +51,7 @@
       "markerHeight": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/markerHeight",
-          "spec_url": "https://www.w3.org/TR/SVG2/painting.html#__svg__SVGMarkerElement__markerHeight",
+          "spec_url": "https://svgwg.org/svg2-draft/painting.html#__svg__SVGMarkerElement__markerHeight",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -100,7 +100,7 @@
       "markerUnits": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/markerUnits",
-          "spec_url": "https://www.w3.org/TR/SVG2/painting.html#__svg__SVGMarkerElement__markerUnits",
+          "spec_url": "https://svgwg.org/svg2-draft/painting.html#__svg__SVGMarkerElement__markerUnits",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -149,7 +149,7 @@
       "markerWidth": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/markerWidth",
-          "spec_url": "https://www.w3.org/TR/SVG2/painting.html#__svg__SVGMarkerElement__markerWidth",
+          "spec_url": "https://svgwg.org/svg2-draft/painting.html#__svg__SVGMarkerElement__markerWidth",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -197,7 +197,7 @@
       },
       "orient": {
         "__compat": {
-          "spec_url": "https://www.w3.org/TR/SVG2/painting.html#__svg__SVGMarkerElement__orient",
+          "spec_url": "https://svgwg.org/svg2-draft/painting.html#__svg__SVGMarkerElement__orient",
           "support": {
             "chrome": {
               "version_added": false
@@ -246,7 +246,7 @@
       "orientAngle": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/orientAngle",
-          "spec_url": "https://www.w3.org/TR/SVG2/painting.html#__svg__SVGMarkerElement__orientAngle",
+          "spec_url": "https://svgwg.org/svg2-draft/painting.html#__svg__SVGMarkerElement__orientAngle",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -295,7 +295,7 @@
       "orientType": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/orientType",
-          "spec_url": "https://www.w3.org/TR/SVG2/painting.html#__svg__SVGMarkerElement__orientType",
+          "spec_url": "https://svgwg.org/svg2-draft/painting.html#__svg__SVGMarkerElement__orientType",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -344,7 +344,7 @@
       "preserveAspectRatio": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/preserveAspectRatio",
-          "spec_url": "https://www.w3.org/TR/SVG2/types.html#__svg__SVGFitToViewBox__preserveAspectRatio",
+          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGFitToViewBox__preserveAspectRatio",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -393,7 +393,7 @@
       "refX": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/refX",
-          "spec_url": "https://www.w3.org/TR/SVG2/painting.html#__svg__SVGMarkerElement__refX",
+          "spec_url": "https://svgwg.org/svg2-draft/painting.html#__svg__SVGMarkerElement__refX",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -442,7 +442,7 @@
       "refY": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/refY",
-          "spec_url": "https://www.w3.org/TR/SVG2/painting.html#__svg__SVGMarkerElement__refY",
+          "spec_url": "https://svgwg.org/svg2-draft/painting.html#__svg__SVGMarkerElement__refY",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -491,7 +491,7 @@
       "setOrientToAngle": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/setOrientToAngle",
-          "spec_url": "https://www.w3.org/TR/SVG2/painting.html#__svg__SVGMarkerElement__setOrientToAngle",
+          "spec_url": "https://svgwg.org/svg2-draft/painting.html#__svg__SVGMarkerElement__setOrientToAngle",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -540,7 +540,7 @@
       "setOrientToAuto": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/setOrientToAuto",
-          "spec_url": "https://www.w3.org/TR/SVG2/painting.html#__svg__SVGMarkerElement__setOrientToAuto",
+          "spec_url": "https://svgwg.org/svg2-draft/painting.html#__svg__SVGMarkerElement__setOrientToAuto",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -589,7 +589,7 @@
       "viewBox": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/viewBox",
-          "spec_url": "https://www.w3.org/TR/SVG2/types.html#__svg__SVGFitToViewBox__viewBox",
+          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGFitToViewBox__viewBox",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
Update methods and spec for all SVGMarkerElement children (and the interface itself)

Note that SVGMarkerElement.orient is not documented on MDN.