### PR TITLE
Add missing urls for Trusted* (and toJSON() entries)

### DIFF
--- a/api/TrustedHTML.json
+++ b/api/TrustedHTML.json
@@ -2,6 +2,8 @@
   "api": {
     "TrustedHTML": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedHTML",
+        "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#trusted-html",
         "support": {
           "chrome": {
             "version_added": "83"
@@ -46,8 +48,59 @@
           "deprecated": false
         }
       },
+      "toJSON": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedHTML/toJSON",
+          "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#dom-trustedhtml-tojson",
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "69"
+            },
+            "opera_android": {
+              "version_added": "59"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "83"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "toString": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedHTML/toString",
+          "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#trustedhtml-stringification-behavior",
           "support": {
             "chrome": {
               "version_added": "83"

--- a/api/TrustedHTML.json
+++ b/api/TrustedHTML.json
@@ -54,13 +54,14 @@
           "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#dom-trustedhtml-tojson",
           "support": {
             "chrome": {
-              "version_added": "83"
+              "version_added": false,
+              "notes": "Currently Chrome Canary only"
             },
             "chrome_android": {
-              "version_added": "83"
+              "version_added": false
             },
             "edge": {
-              "version_added": "83"
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -72,10 +73,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "69"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "59"
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -84,10 +85,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "13.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "83"
+              "version_added": false
             }
           },
           "status": {

--- a/api/TrustedScript.json
+++ b/api/TrustedScript.json
@@ -2,6 +2,8 @@
   "api": {
     "TrustedScript": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedScript",
+        "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#trusted-script",
         "support": {
           "chrome": {
             "version_added": "83"
@@ -46,8 +48,59 @@
           "deprecated": false
         }
       },
+      "toJSON": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedScript/toJSON",
+          "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#dom-trustedscript-tojson",
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "69"
+            },
+            "opera_android": {
+              "version_added": "59"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "83"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "toString": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedScript/toString",
+          "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#trustedscripturl-stringification-behavior",
           "support": {
             "chrome": {
               "version_added": "83"

--- a/api/TrustedScript.json
+++ b/api/TrustedScript.json
@@ -54,13 +54,14 @@
           "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#dom-trustedscript-tojson",
           "support": {
             "chrome": {
-              "version_added": "83"
+              "version_added": false,
+              "notes": "Currently Chrome Canary only"
             },
             "chrome_android": {
-              "version_added": "83"
+              "version_added": false
             },
             "edge": {
-              "version_added": "83"
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -72,10 +73,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "69"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "59"
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -84,10 +85,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "13.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "83"
+              "version_added": false
             }
           },
           "status": {

--- a/api/TrustedScriptURL.json
+++ b/api/TrustedScriptURL.json
@@ -2,6 +2,8 @@
   "api": {
     "TrustedScriptURL": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedScriptURL",
+        "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#trused-script-url",
         "support": {
           "chrome": {
             "version_added": "83"
@@ -46,8 +48,59 @@
           "deprecated": false
         }
       },
+      "toJSON": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedScriptURL/toJSON",
+          "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#dom-trustedscripturl-tojson",
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "69"
+            },
+            "opera_android": {
+              "version_added": "59"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "83"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "toString": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedScriptURL/toString",
+          "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#trustedscripturl-stringification-behavior",
           "support": {
             "chrome": {
               "version_added": "83"

--- a/api/TrustedScriptURL.json
+++ b/api/TrustedScriptURL.json
@@ -54,13 +54,14 @@
           "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#dom-trustedscripturl-tojson",
           "support": {
             "chrome": {
-              "version_added": "83"
+              "version_added": false,
+              "notes": "Currently Chrome Canary only"
             },
             "chrome_android": {
-              "version_added": "83"
+              "version_added": false
             },
             "edge": {
-              "version_added": "83"
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -72,10 +73,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "69"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "59"
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -84,10 +85,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "13.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "83"
+              "version_added": false
             }
           },
           "status": {

--- a/api/TrustedTypePolicy.json
+++ b/api/TrustedTypePolicy.json
@@ -2,6 +2,8 @@
   "api": {
     "TrustedTypePolicy": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicy",
+        "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#trusted-type-policy",
         "support": {
           "chrome": {
             "version_added": "83"
@@ -48,6 +50,8 @@
       },
       "createHTML": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicy/createHTML",
+          "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#dom-trustedtypepolicy-createhtml",
           "support": {
             "chrome": {
               "version_added": "83"
@@ -95,6 +99,8 @@
       },
       "createScript": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicy/createScript",
+          "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#dom-trustedtypepolicy-createscript",
           "support": {
             "chrome": {
               "version_added": "83"
@@ -142,6 +148,8 @@
       },
       "createScriptURL": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicy/createScriptURL",
+          "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#dom-trustedtypepolicy-createscripturl",
           "support": {
             "chrome": {
               "version_added": "83"
@@ -189,6 +197,8 @@
       },
       "name": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicy/name",
+          "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#dom-trustedtypepolicy-name",
           "support": {
             "chrome": {
               "version_added": "83"

--- a/api/TrustedTypePolicyFactory.json
+++ b/api/TrustedTypePolicyFactory.json
@@ -2,6 +2,8 @@
   "api": {
     "TrustedTypePolicyFactory": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicyFactory",
+        "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#trusted-type-policy-factory",
         "support": {
           "chrome": {
             "version_added": "83"
@@ -48,6 +50,8 @@
       },
       "createPolicy": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicyFactory/createPolicy",
+          "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#dom-trustedtypepolicyfactory-createpolicy",
           "support": {
             "chrome": {
               "version_added": "83"
@@ -95,6 +99,8 @@
       },
       "defaultPolicy": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicyFactory/defaultPolicy",
+          "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#dom-trustedtypepolicyfactory-defaultpolicy",
           "support": {
             "chrome": {
               "version_added": "83"
@@ -142,6 +148,8 @@
       },
       "emptyHTML": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicyFactory/emptyHTML",
+          "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#dom-trustedtypepolicyfactory-emptyhtml",
           "support": {
             "chrome": {
               "version_added": "83"
@@ -189,6 +197,8 @@
       },
       "emptyScript": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicyFactory/emptyScript",
+          "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#dom-trustedtypepolicyfactory-emptyscript",
           "support": {
             "chrome": {
               "version_added": "83"
@@ -236,6 +246,8 @@
       },
       "getAttributeType": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicyFactory/getAttributeType",
+          "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#dom-trustedtypepolicyfactory-getattributetype",
           "support": {
             "chrome": {
               "version_added": "83"
@@ -283,6 +295,8 @@
       },
       "getPropertyType": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicyFactory/getPropertyType",
+          "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#dom-trustedtypepolicyfactory-getpropertytype",
           "support": {
             "chrome": {
               "version_added": "83"
@@ -330,6 +344,8 @@
       },
       "isHTML": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicyFactory/isHTML",
+          "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#dom-trustedtypepolicyfactory-ishtml",
           "support": {
             "chrome": {
               "version_added": "83"
@@ -377,6 +393,8 @@
       },
       "isScript": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicyFactory/isScript",
+          "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#dom-trustedtypepolicyfactory-isscript",
           "support": {
             "chrome": {
               "version_added": "83"
@@ -424,6 +442,8 @@
       },
       "isScriptURL": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TrustedTypePolicyFactory/isScriptURL",
+          "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#dom-trustedtypepolicyfactory-isscripturl",
           "support": {
             "chrome": {
               "version_added": "83"


### PR DESCRIPTION
Added the mdn_url and spec_url to `TrustedHTML`, `TrustedScript`, `TrustedScriptURL`, `TrustedTypePolicy`, and `TrustedTypePolicyFactor`(both on the interface and the children).

Added the `TrustedHTML.toJSON()`, `TrustedScript.toJSON()`, and `TrustedScriptURL.toJSON()` compat data. They are only in Canary, so I put a note there. 