### PR TITLE
Add spec_url for USBConnectionEvent + bcd for ctor

### DIFF
--- a/api/USBConnectionEvent.json
+++ b/api/USBConnectionEvent.json
@@ -3,6 +3,7 @@
     "USBConnectionEvent": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBConnectionEvent",
+        "spec_url": "https://wicg.github.io/webusb/#usbconnectionevent",
         "support": {
           "chrome": {
             "version_added": "61"
@@ -47,9 +48,60 @@
           "deprecated": false
         }
       },
+      "USBConnectionEvent": {
+        "__compat": {
+          "description": "<code>USBConnectionEvent()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBConnectionEvent/USBConnectionEvent",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbconnectionevent-usbconnectionevent",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "device": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBConnectionEvent/device",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbconnectionevent-device",
           "support": {
             "chrome": {
               "version_added": "61"


### PR DESCRIPTION
Add spec_url for USBConnectionEvent and its children.

Add bcd for the ctor (same as USBConnectionEvent. The ctor has been added before the initial release: https://chromium.googlesource.com/chromium/src/+/bce2e76bb44542c850aacd6b5f7637760a53f3b6 )