### PR TITLE
Add Safari real values for Payment Request dictionaries

### DIFF
--- a/api/PayerErrors.json
+++ b/api/PayerErrors.json
@@ -114,10 +114,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "12.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "12.2"
           },
           "samsunginternet_android": {
             "version_added": false
@@ -246,10 +246,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -379,10 +379,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -512,10 +512,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/PaymentCurrencyAmount.json
+++ b/api/PaymentCurrencyAmount.json
@@ -56,10 +56,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -120,10 +120,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -186,10 +186,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -251,10 +251,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/PaymentDetailsBase.json
+++ b/api/PaymentDetailsBase.json
@@ -56,10 +56,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -119,10 +119,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -183,10 +183,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -247,10 +247,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/api/PaymentDetailsInit.json
+++ b/api/PaymentDetailsInit.json
@@ -55,10 +55,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -118,10 +118,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -182,10 +182,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/api/PaymentDetailsUpdate.json
+++ b/api/PaymentDetailsUpdate.json
@@ -56,10 +56,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -119,10 +119,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -247,10 +247,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/api/PaymentItem.json
+++ b/api/PaymentItem.json
@@ -70,10 +70,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": "11.1"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "11.3"
           },
           "samsunginternet_android": {
             "version_added": false
@@ -145,10 +145,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -221,10 +221,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -297,10 +297,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values to Safari for the various Payment Request spec's dictionaries, based upon the source code at various Safari releases.  Additionally, this fixes the bad data from #11053, where I marked it as `false` even though there was actually support (turns out I was looking in the wrong place).  Data is as follows:

    - Support initially enabled by default in Safari 11.1 per CanIUse
    - https://caniuse.com/?search=payment

Safari 11.1:

    api.PaymentCurrencyAmount - https://trac.webkit.org/browser/webkit/tags/Safari-605.1.33.1.4/Source/WebCore/Modules/paymentrequest/PaymentCurrencyAmount.idl
    api.PaymentDetailsBase - https://trac.webkit.org/browser/webkit/tags/Safari-605.1.33.1.4/Source/WebCore/Modules/paymentrequest/PaymentDetailsBase.idl
    api.PaymentDetailsInit - https://trac.webkit.org/browser/webkit/tags/Safari-605.1.33.1.4/Source/WebCore/Modules/paymentrequest/PaymentDetailsInit.idl
    api.PaymentDetailsUpdate - https://trac.webkit.org/browser/webkit/tags/Safari-605.1.33.1.4/Source/WebCore/Modules/paymentrequest/PaymentDetailsUpdate.idl
    api.PaymentItem - https://trac.webkit.org/browser/webkit/tags/Safari-605.1.33.1.4/Source/WebCore/Modules/paymentrequest/PaymentItem.idl

Safari 12.1:

    api.PayerErrors - https://trac.webkit.org/browser/webkit/tags/Safari-607.1.40.3.1/Source/WebCore/Modules/paymentrequest/PayerErrorFields.idl
    api.PaymentDetailsUpdate.shippingAddressErrors - https://trac.webkit.org/browser/webkit/tags/Safari-607.1.40.3.1/Source/WebCore/Modules/paymentrequest/PaymentDetailsUpdate.idl

