### PR TITLE
Add Safari versions for api.PaymentRequest.requestId

### DIFF
--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -593,10 +593,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `requestId` member of the `PaymentRequest` API.  There is nothing for `requestId` in the IDL for this interface.
