### PR TITLE
Add Safari versions for api.Document.createElementNS.options

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -2282,10 +2282,10 @@
                 "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "6.0",


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `createElementNS.options` member of the `Document` API, based upon commit history and date.

Commit: https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/dom/Document.idl#L65
