### PR TITLE
Add info for XRRenderState and XRSession

### DIFF
--- a/api/XRRenderState.json
+++ b/api/XRRenderState.json
@@ -2,6 +2,8 @@
   "api": {
     "XRRenderState": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRRenderState",
+        "spec_url": "https://immersive-web.github.io/webxr/#xrrenderstate-interface",
         "support": {
           "chrome": {
             "version_added": "79"
@@ -48,6 +50,8 @@
       },
       "baseLayer": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRRenderState/baseLayer",
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrrenderstate-baselayer",
           "support": {
             "chrome": {
               "version_added": "79"
@@ -95,6 +99,8 @@
       },
       "depthFar": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRRenderState/depthFar",
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrrenderstate-depthfar",
           "support": {
             "chrome": {
               "version_added": "79"
@@ -142,6 +148,8 @@
       },
       "depthNear": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRRenderState/depthNear",
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrrenderstate-depthnear",
           "support": {
             "chrome": {
               "version_added": "79"
@@ -189,6 +197,8 @@
       },
       "inlineVerticalFieldOfView": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRRenderState/inlineVerticalFieldOfView",
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrrenderstate-inlineverticalfieldofview",
           "support": {
             "chrome": {
               "version_added": "79"

--- a/api/XRSession.json
+++ b/api/XRSession.json
@@ -687,6 +687,8 @@
       },
       "onsqueeze": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSession/onsqueeze",
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrsession-onsqueeze",
           "support": {
             "chrome": {
               "version_added": "83"
@@ -734,6 +736,8 @@
       },
       "onsqueezeend": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSession/onsqueezeend",
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrsession-onsqueezeend",
           "support": {
             "chrome": {
               "version_added": "83"
@@ -781,6 +785,8 @@
       },
       "onsqueezestart": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSession/onsqueezestart",
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrsession-onsqueezestart",
           "support": {
             "chrome": {
               "version_added": "83"
@@ -1257,6 +1263,156 @@
             },
             "samsunginternet_android": {
               "version_added": "11.2"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "squeeze_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSession/squeeze_event",
+          "spec_url": "https://immersive-web.github.io/webxr/#eventdef-xrsession-squeeze",
+          "description": "<code>squeeze</code> event",
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "squeezeend_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSession/squeezeend_event",
+          "spec_url": "https://immersive-web.github.io/webxr/#eventdef-xrsession-squeezeend",
+          "description": "<code>squeezeend</code> event",
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "squeezestart_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSession/squeezestart_event",
+          "spec_url": "https://immersive-web.github.io/webxr/#eventdef-xrsession-squeezestart",
+          "description": "<code>squeezestart</code> event",
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "83"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
Added mdn_url and spec_url entries that were missing on XRRenderState.json and XRSession.json.

Added squeeze_event, squeezestart_event and squeezeend_event to the latter (there is a page for them on MDN Web docs, and on* attributes had data)