### PR TITLE
Invert meaning of URL.createObjectURL(mediaStream) entry

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -224,56 +224,65 @@
             "deprecated": false
           }
         },
-        "no_MediaStream_argument": {
+        "MediaStream_support": {
           "__compat": {
-            "description": "No longer accepts <code>MediaStream</code> object",
+            "description": "Support for <code>MediaStream</code> objects",
             "support": {
               "chrome": {
-                "version_added": "71"
+                "version_added": "19",
+                "version_removed": "71"
               },
               "chrome_android": {
-                "version_added": "71"
+                "version_added": "25",
+                "version_removed": "71"
               },
               "edge": {
-                "version_added": "79"
+                "version_added": "12",
+                "version_removed": "79"
               },
               "firefox": {
-                "version_added": "62"
+                "version_added": "19",
+                "version_removed": "62"
               },
               "firefox_android": {
-                "version_added": "62"
+                "version_added": "19",
+                "version_removed": "62"
               },
               "ie": {
-                "version_added": false
+                "version_added": "10"
               },
               "nodejs": {
                 "version_added": false
               },
               "opera": {
-                "version_added": "60"
+                "version_added": "15",
+                "version_removed": "60"
               },
               "opera_android": {
-                "version_added": "50"
+                "version_added": "14",
+                "version_removed": "50"
               },
               "safari": {
-                "version_added": null,
-                "notes": "See <a href='https://webkit.org/b/167518'>here</a> for progress on deprecation."
+                "version_added": "6",
+                "version_removed": "11"
               },
               "safari_ios": {
-                "version_added": null,
-                "notes": "See <a href='https://webkit.org/b/167518'>here</a> for progress on deprecation."
+                "version_added": "6",
+                "version_removed": "11"
               },
               "samsunginternet_android": {
-                "version_added": "10.0"
+                "version_added": "1.5",
+                "version_removed": "10.0"
               },
               "webview_android": {
-                "version_added": "71"
+                "version_added": "≤37",
+                "version_removed": "71"
               }
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+              "standard_track": false,
+              "deprecated": true
             }
           }
         }


### PR DESCRIPTION
This puts it on track for removal as irrelevant:
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features

The WebKit removal was in trunk version 604.1.16:
https://trac.webkit.org/changeset/214951/webkit
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=214951