### PR TITLE
Remove api.PaymentRequest.requestId

### DIFF
--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -561,57 +561,6 @@
           }
         }
       },
-      "requestId": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/requestId",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": "≤18",
-              "version_removed": "79"
-            },
-            "firefox": {
-              "version_added": false,
-              "notes": "Available only in nightly builds."
-            },
-            "firefox_android": {
-              "version_added": false,
-              "notes": "Available only in nightly builds."
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "shippingAddress": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/shippingAddress",


### PR DESCRIPTION
This PR removes the `requestId` member of the `PaymentRequest` API.  It seems that this is simply a copy-paste error, as there is nothing in the spec, and it's not in either Edge nor Firefox, so the existing data is already incorrect.
