### PR TITLE
Add Safari versions for api.Document.exitFullscreen.returns_a_promise

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4715,7 +4715,7 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
                 "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `exitFullscreen.returns_a_promise` member of the `Document` API, based upon commit history and date.

Commit: https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/dom/Document%2BFullscreen.idl#L36 (the method returns `undefined`)
