### PR TITLE
Add Safari versions for api.Element.attachShadow.delegatesFocus

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1183,10 +1183,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": "13.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "13.4"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `attachShadow.delegatesFocus` member of the `Element` API, based upon commit history and date.

Commit: https://trac.webkit.org/browser/webkit/tags/Safari-609.1.20.111.8/Source/WebCore/dom/Element.idl#L154
