### PR TITLE
Add Safari versions for api.Element.requestFullscreen.options_parameter

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -6548,10 +6548,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "10.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `requestFullscreen.options_parameter` member of the `Element` API, based upon commit history and date.

Commit: https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/dom/Element%2BFullscreen.idl#L33
