### PR TITLE
Add Safari versions for api.HTMLCanvasElement.getContext.failIfMajorPerformanceCaveat

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -284,10 +284,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `getContext.failIfMajorPerformanceCaveat` member of the `HTMLCanvasElement` API, based upon commit history and date.

Commit: https://trac.webkit.org/changeset/204618/webkit / https://trac.webkit.org/browser/webkit/tags/Safari-603.2.1/Source/WebCore/html/canvas/WebGLContextAttributes.idl
