### PR TITLE
Add Safari versions for api.Notification.secure_context_required

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -1069,7 +1069,7 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `secure_context_required` member of the `Notification` API, based upon manual testing.

Test Code Used: `new Notification('Hi!').show() // on an HTTP:// page`
