### PR TITLE
Add missing (mdn|spec)_url to XPathResult

### DIFF
--- a/api/XPathResult.json
+++ b/api/XPathResult.json
@@ -50,6 +50,8 @@
       },
       "booleanValue": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XPathResult/booleanValue",
+          "spec_url": "https://dom.spec.whatwg.org/#dom-xpathresult-booleanvalue",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -195,6 +197,8 @@
       },
       "numberValue": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XPathResult/numberValue",
+          "spec_url": "https://dom.spec.whatwg.org/#dom-xpathresult-numbervalue",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -291,6 +295,8 @@
       },
       "singleNodeValue": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XPathResult/singleNodeValue",
+          "spec_url": "https://dom.spec.whatwg.org/#dom-xpathresult-singlenodevalue",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -387,6 +393,8 @@
       },
       "snapshotLength": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XPathResult/snapshotLength",
+          "spec_url": "https://dom.spec.whatwg.org/#dom-xpathresult-snapshotlength",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -434,6 +442,8 @@
       },
       "stringValue": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XPathResult/stringValue",
+          "spec_url": "https://dom.spec.whatwg.org/#dom-xpathresult-stringvalue",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
This interface is formally part of the DOM spec and the links are working even if the info there is a bit "light" (though the WHATWG has an issue to complete it).