### PR TITLE
Add Safari versions for PaintWorkletGlobalScope API

### DIFF
--- a/api/PaintWorkletGlobalScope.json
+++ b/api/PaintWorkletGlobalScope.json
@@ -30,10 +30,10 @@
             "version_added": null
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "9.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `PaintWorkletGlobalScope` API.  The data for `api.CSS.paintWorklet` indicates Safari doesn't support paint worklets, not to mention none of the subfeatures for this interface are supported.
