### PR TITLE
Add Safari versions for api.WindowEventHandlers.onmessageerror

### DIFF
--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -429,10 +429,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -476,10 +476,10 @@
                 "version_added": "44"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "8.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `onmessageerror` member of the `WindowEventHandlers` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WindowEventHandlers/onmessageerror
