### PR TITLE
Add Safari versions for api.Notification.worker_support

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -1365,7 +1365,7 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `worker_support` member of the `Notification` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Notification
