### PR TITLE
Add Safari versions for PerformanceEntry API

### DIFF
--- a/api/PerformanceEntry.json
+++ b/api/PerformanceEntry.json
@@ -380,10 +380,10 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/api/PerformanceEntry.json
+++ b/api/PerformanceEntry.json
@@ -380,10 +380,10 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `PerformanceEntry` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PerformanceEntry
