### PR TITLE
Add Safari versions for PerformanceObserver API

### DIFF
--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -351,10 +351,10 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -351,10 +351,10 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `PerformanceObserver` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PerformanceObserver
