### PR TITLE
Remove non-standard api.Event.getPreventDefault

### DIFF
--- a/api/Event.json
+++ b/api/Event.json
@@ -653,61 +653,6 @@
           }
         }
       },
-      "getPreventDefault": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Event/getPreventDefault",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": true,
-              "version_removed": "59",
-              "notes": "See <a href='https://bugzil.la/691151'>bug 691151</a>."
-            },
-            "firefox_android": {
-              "version_added": true,
-              "version_removed": "59",
-              "notes": "See <a href='https://bugzil.la/691151'>bug 691151</a>."
-            },
-            "ie": {
-              "version_added": false
-            },
-            "nodejs": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "initEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Event/initEvent",


### PR DESCRIPTION
This PR removes the non-standard `getPreventDefault` from the Event API.  This appears to be a Firefox-only feature which has been removed over two years ago.
