### PR TITLE
Add Safari versions for RTCIdentityProviderRegistrar API

### DIFF
--- a/api/RTCIdentityProviderRegistrar.json
+++ b/api/RTCIdentityProviderRegistrar.json
@@ -29,10 +29,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": false
@@ -76,10 +76,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `RTCIdentityProviderRegistrar` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCIdentityProviderRegistrar
