### PR TITLE
Add Safari versions for SVGHKernElement API

### DIFF
--- a/api/SVGHKernElement.json
+++ b/api/SVGHKernElement.json
@@ -34,10 +34,10 @@
             "version_removed": "27"
           },
           "safari": {
-            "version_added": null
+            "version_added": "6"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "6"
           },
           "samsunginternet_android": {
             "version_added": "1.5",


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `SVGHKernElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGHKernElement
