### PR TITLE
Add Safari versions for SVGViewElement API

### DIFF
--- a/api/SVGViewElement.json
+++ b/api/SVGViewElement.json
@@ -83,10 +83,12 @@
               "version_removed": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": "6",
+              "version_removed": "13.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "6",
+              "version_removed": "13.4"
             },
             "samsunginternet_android": {
               "version_added": true,


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `SVGViewElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGViewElement
