### PR TITLE
Add Safari versions for SVGZoomAndPan API

### DIFF
--- a/api/SVGZoomAndPan.json
+++ b/api/SVGZoomAndPan.json
@@ -31,10 +31,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": true

--- a/api/SVGZoomAndPan.json
+++ b/api/SVGZoomAndPan.json
@@ -31,10 +31,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": false
+            "version_added": "3"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `SVGZoomAndPan` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGZoomAndPan
