### PR TITLE
Remove redundant viewTarget member of SVGViewElement API

### DIFF
--- a/api/SVGViewElement.json
+++ b/api/SVGViewElement.json
@@ -47,62 +47,6 @@
           "standard_track": true,
           "deprecated": false
         }
-      },
-      "viewTarget": {
-        "__compat": {
-          "support": {
-            "chrome": {
-              "version_added": true,
-              "version_removed": "56"
-            },
-            "chrome_android": {
-              "version_added": true,
-              "version_removed": "56"
-            },
-            "edge": {
-              "version_added": "12",
-              "version_removed": "79"
-            },
-            "firefox": {
-              "version_added": true,
-              "version_removed": "61"
-            },
-            "firefox_android": {
-              "version_added": true,
-              "version_removed": "61"
-            },
-            "ie": {
-              "version_added": "9"
-            },
-            "opera": {
-              "version_added": true,
-              "version_removed": "43"
-            },
-            "opera_android": {
-              "version_added": true,
-              "version_removed": "43"
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": true,
-              "version_removed": "6.0"
-            },
-            "webview_android": {
-              "version_added": true,
-              "version_removed": "56"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
This PR removes the `viewTarget` member of the SVGViewElement API.  This member doesn't have any MDN doc page, is non-standard, and has been removed from browsers for over two years.
