### PR TITLE
api/SourceBuffer/safari

### DIFF
--- a/api/SVGViewElement.json
+++ b/api/SVGViewElement.json
@@ -47,62 +47,6 @@
           "standard_track": true,
           "deprecated": false
         }
-      },
-      "viewTarget": {
-        "__compat": {
-          "support": {
-            "chrome": {
-              "version_added": true,
-              "version_removed": "56"
-            },
-            "chrome_android": {
-              "version_added": true,
-              "version_removed": "56"
-            },
-            "edge": {
-              "version_added": "12",
-              "version_removed": "79"
-            },
-            "firefox": {
-              "version_added": true,
-              "version_removed": "61"
-            },
-            "firefox_android": {
-              "version_added": true,
-              "version_removed": "61"
-            },
-            "ie": {
-              "version_added": "9"
-            },
-            "opera": {
-              "version_added": true,
-              "version_removed": "43"
-            },
-            "opera_android": {
-              "version_added": true,
-              "version_removed": "43"
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": true,
-              "version_removed": "6.0"
-            },
-            "webview_android": {
-              "version_added": true,
-              "version_removed": "56"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
       }
     }
   }

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -272,7 +272,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -563,10 +563,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -566,7 +566,7 @@
               "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": "12.2"
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "10.0"


### PR DESCRIPTION
- Remove redundant viewTarget member of SVGViewElement API
- Add Safari versions for SourceBuffer API
