### PR TITLE
Add Safari versions for Document API

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -8790,10 +8790,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             },
             "samsunginternet_android": [
               {
@@ -8868,10 +8868,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             },
             "samsunginternet_android": [
               {

--- a/api/Document.json
+++ b/api/Document.json
@@ -5425,10 +5425,12 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": null
+              "version_added": "5.1",
+              "alternative_name": "webkitfullscreenchange"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5.1",
+              "alternative_name": "webkitfullscreenchange"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -5594,10 +5596,12 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": null
+              "version_added": "5.1",
+              "alternative_name": "webkitfullscreenerror"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5.1",
+              "alternative_name": "webkitfullscreenerror"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -8786,10 +8790,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": [
               {
@@ -8864,10 +8868,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": [
               {


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `Document` API.  The data was derived from their handlers (AKA `on*`).
