### PR TITLE
Add Safari versions for api.FontFaceSet.worker_support

### DIFF
--- a/api/FontFaceSet.json
+++ b/api/FontFaceSet.json
@@ -828,10 +828,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `worker_support` member of the `FontFaceSet` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FontFaceSet
