### PR TITLE
Add Firefox versions for MediaKeySystemConfiguration API

### DIFF
--- a/api/MediaKeySystemConfiguration.json
+++ b/api/MediaKeySystemConfiguration.json
@@ -15,10 +15,10 @@
             "version_added": "≤79"
           },
           "firefox": {
-            "version_added": "43"
+            "version_added": "38"
           },
           "firefox_android": {
-            "version_added": "43"
+            "version_added": "38"
           },
           "ie": {
             "version_added": false

--- a/api/MediaKeySystemConfiguration.json
+++ b/api/MediaKeySystemConfiguration.json
@@ -63,10 +63,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "50"
+              "version_added": "44"
             },
             "firefox_android": {
-              "version_added": "50"
+              "version_added": "44"
             },
             "ie": {
               "version_added": false
@@ -161,10 +161,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "50"
+              "version_added": "44"
             },
             "firefox_android": {
-              "version_added": "50"
+              "version_added": "44"
             },
             "ie": {
               "version_added": false
@@ -259,10 +259,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "50"
+              "version_added": "44"
             },
             "firefox_android": {
-              "version_added": "50"
+              "version_added": "44"
             },
             "ie": {
               "version_added": false

--- a/api/MediaKeySystemConfiguration.json
+++ b/api/MediaKeySystemConfiguration.json
@@ -63,10 +63,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": "43"
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "43"
             },
             "ie": {
               "version_added": false
@@ -161,10 +161,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": "43"
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "43"
             },
             "ie": {
               "version_added": false
@@ -259,10 +259,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": "43"
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "43"
             },
             "ie": {
               "version_added": false

--- a/api/MediaKeySystemConfiguration.json
+++ b/api/MediaKeySystemConfiguration.json
@@ -15,10 +15,10 @@
             "version_added": "≤79"
           },
           "firefox": {
-            "version_added": null
+            "version_added": "43"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "43"
           },
           "ie": {
             "version_added": false
@@ -63,10 +63,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "50"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "50"
             },
             "ie": {
               "version_added": false
@@ -112,10 +112,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "50"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "50"
             },
             "ie": {
               "version_added": false
@@ -161,10 +161,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "50"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "50"
             },
             "ie": {
               "version_added": false
@@ -210,10 +210,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "50"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "50"
             },
             "ie": {
               "version_added": false
@@ -259,10 +259,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "50"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "50"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `MediaKeySystemConfiguration` API, based upon information in a tracking bug.

Tracking Bug: https://bugzil.la/1189196 + https://bugzil.la/1278198
