### PR TITLE
Add Firefox versions for MediaSettingsRange API

### DIFF
--- a/api/MediaSettingsRange.json
+++ b/api/MediaSettingsRange.json
@@ -15,10 +15,10 @@
             "version_added": "≤79"
           },
           "firefox": {
-            "version_added": null
+            "version_added": "81"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "81"
           },
           "ie": {
             "version_added": false
@@ -63,10 +63,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "81"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "81"
             },
             "ie": {
               "version_added": false
@@ -112,10 +112,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "81"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "81"
             },
             "ie": {
               "version_added": false
@@ -161,10 +161,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "81"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "81"
             },
             "ie": {
               "version_added": false

--- a/api/MediaSettingsRange.json
+++ b/api/MediaSettingsRange.json
@@ -15,10 +15,10 @@
             "version_added": "≤79"
           },
           "firefox": {
-            "version_added": "81"
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": "81"
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -63,10 +63,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "81"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "81"
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -112,10 +112,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "81"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "81"
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -161,10 +161,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "81"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "81"
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `MediaSettingsRange` API, based upon information in a tracking bug.

Tracking Bug: https://bugzil.la/1655715
