### PR TITLE
Add Firefox versions for RTCConfiguration API

### DIFF
--- a/api/RTCConfiguration.json
+++ b/api/RTCConfiguration.json
@@ -15,10 +15,10 @@
             "version_added": "≤79"
           },
           "firefox": {
-            "version_added": null
+            "version_added": "21"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "21"
           },
           "ie": {
             "version_added": false
@@ -63,10 +63,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "42"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "ie": {
               "version_added": false
@@ -112,10 +112,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "42"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "ie": {
               "version_added": false
@@ -160,10 +160,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -209,10 +209,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "21"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "21"
             },
             "ie": {
               "version_added": false
@@ -258,10 +258,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "42"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "ie": {
               "version_added": false
@@ -306,10 +306,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "32"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "32"
             },
             "ie": {
               "version_added": false
@@ -356,10 +356,10 @@
               "notes": "Default for <code>rtcpMuxPolicy</code> is <code>require</code>"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `RTCConfiguration` API, based upon information in a tracking bug.

Tracking Bug: https://bugzil.la/835712, https://bugzil.la/1112692, https://bugzil.la/1172785, https://bugzil.la/1187775, https://bugzil.la/942367
