### PR TITLE
Add Firefox versions for RTCDataChannel API

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -1124,10 +1124,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `RTCDataChannel` API.  There's nothing in Firefox's IDL for this property when looking in https://searchfox.org/mozilla-central/source/dom/webidl/RTCDataChannel.webidl.
