### PR TITLE
Add Firefox versions for RTCIceCandidate API

### DIFF
--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -18,7 +18,7 @@
             "version_added": "22"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "22"
           },
           "ie": {
             "version_added": false
@@ -122,10 +122,10 @@
               }
             ],
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -272,7 +272,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `RTCIceCandidate` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCIceCandidate
