### PR TITLE
Add Firefox versions for RTCIdentityEvent API

### DIFF
--- a/api/RTCIdentityEvent.json
+++ b/api/RTCIdentityEvent.json
@@ -14,11 +14,10 @@
             "version_added": false
           },
           "firefox": {
-            "alternative_name": "RTCPeerConnectionIdentityEvent",
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -62,10 +61,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `RTCIdentityEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCIdentityEvent
