### PR TITLE
Add Firefox versions for ServiceWorkerGlobalScope API

### DIFF
--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -414,10 +414,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -704,10 +704,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -997,10 +997,10 @@
               "version_added": "81"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "65"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "65"
             },
             "ie": {
               "version_added": false
@@ -1149,10 +1149,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `ServiceWorkerGlobalScope` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ServiceWorkerGlobalScope
