### PR TITLE
Add Firefox versions for api.TouchList.identifiedTouch

### DIFF
--- a/api/TouchList.json
+++ b/api/TouchList.json
@@ -68,10 +68,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `identifiedTouch` member of the `TouchList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TouchList/identifiedTouch
