### PR TITLE
Add Firefox versions for RTCIdentityProviderGlobalScope API

### DIFF
--- a/api/RTCIdentityProviderGlobalScope.json
+++ b/api/RTCIdentityProviderGlobalScope.json
@@ -14,10 +14,10 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -61,10 +61,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `RTCIdentityProviderGlobalScope` API.  There is nothing in Firefox's IDL for this interface.
