### PR TITLE
Add Firefox versions for RTCIdentityProviderRegistrar API

### DIFF
--- a/api/RTCIdentityProviderRegistrar.json
+++ b/api/RTCIdentityProviderRegistrar.json
@@ -14,10 +14,10 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": "38"
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": "38"
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -61,10 +61,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "38"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "38"
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/RTCIdentityProviderRegistrar.json
+++ b/api/RTCIdentityProviderRegistrar.json
@@ -14,10 +14,10 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": null
+            "version_added": "38"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "38"
           },
           "ie": {
             "version_added": false
@@ -61,10 +61,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": "38"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "38"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `RTCIdentityProviderRegistrar` API, based upon information in a tracking bug.

Tracking Bug: https://bugzil.la/975144
