### PR TITLE
Add missing spec_url and mdn_url to XMLSerializer

### DIFF
--- a/api/XMLSerializer.json
+++ b/api/XMLSerializer.json
@@ -50,6 +50,7 @@
       },
       "XMLSerializer": {
         "__compat": {
+          "spec_url": "https://w3c.github.io/DOM-Parsing/#dom-xmlserializer-constructor",
           "description": "<code>XMLSerializer()</code> constructor",
           "support": {
             "chrome": {
@@ -147,6 +148,8 @@
       },
       "serializeToString": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLSerializer/serializeToString",
+          "spec_url": "https://w3c.github.io/DOM-Parsing/#dom-xmlserializer-serializetostring",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
A few spec_url and one missing mdn_url.