### PR TITLE
Update Safari versions for Media Extensions APIs

### DIFF
--- a/api/AudioTrack.json
+++ b/api/AudioTrack.json
@@ -697,7 +697,9 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -61,7 +61,9 @@
             "version_added": "8"
           },
           "safari_ios": {
-            "version_added": "8"
+            "version_added": "13",
+            "partial_implementation": true,
+            "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
           },
           "samsunginternet_android": [
             {
@@ -125,7 +127,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -175,7 +179,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -225,7 +231,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -271,7 +279,9 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -321,7 +331,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -371,7 +383,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -421,7 +435,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "8"
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -472,7 +488,9 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -521,7 +539,9 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -570,7 +590,9 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -620,7 +642,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -670,7 +694,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -716,7 +742,9 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -766,7 +794,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "1.5"

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -120,7 +120,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -170,7 +172,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -325,7 +329,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -375,7 +381,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -518,7 +526,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -566,7 +576,9 @@
               "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": "13"
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -616,7 +628,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -665,7 +679,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -714,7 +730,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -763,7 +781,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -812,7 +832,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -861,7 +883,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -911,7 +935,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -1067,7 +1093,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -1165,7 +1193,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "3.0"

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -272,7 +272,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -563,10 +563,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/api/SourceBufferList.json
+++ b/api/SourceBufferList.json
@@ -41,7 +41,9 @@
             "version_added": "8"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "13",
+            "partial_implementation": true,
+            "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
           },
           "samsunginternet_android": {
             "version_added": "3.0"
@@ -90,7 +92,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -139,7 +143,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -188,7 +194,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -663,7 +663,9 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13"
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/VideoTrack.json
+++ b/api/VideoTrack.json
@@ -697,7 +697,9 @@
               "version_added": "6.1"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "13",
+              "partial_implementation": true,
+              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari iOS/iPadOS for the Media Extensions APIs, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).  These APIs were not supported before iOS 13, and a lot was set to `false` when it wasn't supposed to be.

Note: only the `MediaSource` API was actually disabled on iPhones, however to get a SourceBuffer object in the first place, you need the `MediaSource` API.  I've simply marked everything as non-exposed on iPhones since they can't be used.

Tests Used:
https://mdn-bcd-collector.appspot.com/tests/api/MediaSource
https://mdn-bcd-collector.appspot.com/tests/api/SourceBuffer
https://mdn-bcd-collector.appspot.com/tests/api/SourceBufferList
https://mdn-bcd-collector.appspot.com/tests/api/AudioTrack/sourceBuffer
https://mdn-bcd-collector.appspot.com/tests/api/TextTrack/sourceBuffer
https://mdn-bcd-collector.appspot.com/tests/api/VideoTrack/sourceBuffer