### PR TITLE
Add Safari versions for api.WebSocket.worker_support

### DIFF
--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -1047,10 +1047,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5.1"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `worker_support` member of the `WebSocket` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WebSocket
