### PR TITLE
Add WheelEvent.wheelDelta, wheelDeltaX, wheelDeltaY

### DIFF
--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -349,10 +349,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -367,22 +367,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "30"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": "30"
+              "version_added": true
             },
             "safari": {
-              "version_added": "7"
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": true
             }
           },
           "status": {
@@ -396,10 +396,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -414,22 +414,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "30"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": "30"
+              "version_added": true
             },
             "safari": {
-              "version_added": "7"
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": true
             }
           },
           "status": {
@@ -443,10 +443,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": true
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -461,22 +461,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "30"
+              "version_added": true
             },
             "opera_android": {
-              "version_added": "30"
+              "version_added": true
             },
             "safari": {
-              "version_added": "7"
+              "version_added": true
             },
             "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": true
             }
           },
           "status": {

--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -344,6 +344,151 @@
             "deprecated": false
           }
         }
+      },
+      "wheelDelta": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WheelEvent",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": "90"
+            },
+            "firefox_android": {
+              "version_added": "90"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
+      "wheelDeltaX": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WheelEvent",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "≤79"
+            },
+            "firefox": {
+              "version_added": "90"
+            },
+            "firefox_android": {
+              "version_added": "90"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
+      "wheelDeltaY": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WheelEvent",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "≤79"
+            },
+            "firefox": {
+              "version_added": "90"
+            },
+            "firefox_android": {
+              "version_added": "90"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
       }
     }
   }

--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -347,7 +347,6 @@
       },
       "wheelDelta": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WheelEvent",
           "support": {
             "chrome": {
               "version_added": false
@@ -396,7 +395,6 @@
       },
       "wheelDeltaX": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WheelEvent",
           "support": {
             "chrome": {
               "version_added": true
@@ -444,7 +442,6 @@
       },
       "wheelDeltaY": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WheelEvent",
           "support": {
             "chrome": {
               "version_added": true

--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -349,14 +349,13 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "43"
             },
             "edge": {
-              "version_added": "12",
-              "version_removed": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "90"
@@ -365,25 +364,25 @@
               "version_added": "90"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "30"
             },
             "safari": {
-              "version_added": false
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "43"
             }
           },
           "status": {
@@ -397,13 +396,13 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "90"
@@ -415,22 +414,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "30"
             },
             "safari": {
-              "version_added": false
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -444,13 +443,13 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "90"
@@ -462,22 +461,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "30"
             },
             "safari": {
-              "version_added": false
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1708829 added (deprecated) properties to Wheelevent: wheelDelta, wheelDeltaX, wheelDeltaY

There is some confusion here as I have outlined in https://github.com/mdn/content/pull/5966#issuecomment-861887078

I know that the bug linked above added these properties to [WheelEvent](https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent). However the properties are already shown as present in BCD and MDN under [MouseWheelEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseWheelEvent). @ddbeck indicates these are documented in the wrong place.

What I have done is copied the `MouseWheelEvent` properties across and then added support for FF90. I had to mark Safari as `false` for properties to match the `WheelEvent`. 

@ddbeck 
- Do we remove the BCD for MouseWheelEvent? 
- What about for the MDN docs - just delete all the content except for the warnings not to use and have a note in the properties "This inherits properties from WheelEvent"? 
- As per https://github.com/mdn/content/pull/5966#issuecomment-861887078 I have not noted the compatibility change in the WheelEvent that caused this bug change. There has been a change in behaviour, but it was a change between two allowed  "compatible" outputs. 