### PR TITLE
HTTP DPR header is secure context

### DIFF
--- a/http/headers/dpr.json
+++ b/http/headers/dpr.json
@@ -47,6 +47,54 @@
             "standard_track": false,
             "deprecated": true
           }
+        },
+        "secure_context_required": {
+          "__compat": {
+            "description": "Secure context required",
+            "support": {
+              "chrome": {
+                "version_added": "46"
+              },
+              "chrome_android": {
+                "version_added": "46"
+              },
+              "edge": {
+                "version_added": "≤79"
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "33"
+              },
+              "opera_android": {
+                "version_added": "33"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
As part of [docs work](https://github.com/mdn/content/pull/6097) on [DPR HTTP header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/DPR) I noted that this has secure context header. Did further research and notes seem to indicate all client hints should require secure context.

The problem is I can't find a current spec for DPR to verify this. But it does appear to be well understood - e.g. see 
 comment in https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/client-hints

Anyway, this adds the secure_context_required to DPR. It is by way of "testing the water". If you approve this case I'll add it to the other ones :-)

