### PR TITLE
Update the release date of Safari 6.1

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -78,7 +78,7 @@
           "engine_version": "536.25"
         },
         "6.1": {
-          "release_date": "2013-06-11",
+          "release_date": "2013-10-22",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "537.43"


### PR DESCRIPTION
The 2013-06-11 date was originally added here:
https://github.com/mdn/browser-compat-data/pull/595

Source for 2013-10-22:
https://en.wikipedia.org/wiki/Safari_version_history#Safari_6

This also makes more sense in light of the relationship between Safari 6
and 7.1, see https://github.com/mdn/browser-compat-data/issues/9423#issuecomment-796880969.