### PR TITLE
Fix the date and WebKit version of Safari 3

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -34,10 +34,10 @@
           "engine_version": "412"
         },
         "3": {
-          "release_date": "2007-11-14",
+          "release_date": "2007-10-26",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "522.11"
+          "engine_version": "523.10"
         },
         "3.1": {
           "release_date": "2008-03-18",


### PR DESCRIPTION
Old data: 2007-11-14 / 522.11
New data: 2007-10-26 / 523.10

Source: https://en.wikipedia.org/wiki/Safari_version_history#Safari_3

The old release date is that of Mac OS X 10.4.11:
https://en.wikipedia.org/wiki/Mac_OS_X_Tiger#Release_history

However, that came after it was released with Mac OS X 10.5:
https://en.wikipedia.org/wiki/Mac_OS_X_Leopard#Release_history

The old WebKit version seems to be from the initial public beta:
https://en.wikipedia.org/wiki/Safari_version_history#Safari_3

However, Wikipedia says 523.10 for the stable release and this matches
Apple's own sources:
https://opensource.apple.com/release/mac-os-x-105.html
https://opensource.apple.com/source/WebCore/WebCore-5523.10.3/