### PR TITLE
Add Firefox versions for Permissions API

### DIFF
--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -63,10 +63,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -111,10 +111,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -159,10 +159,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -207,10 +207,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -399,10 +399,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "46"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "46"
             },
             "ie": {
               "version_added": false
@@ -447,10 +447,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -495,10 +495,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -543,10 +543,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -591,10 +591,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -639,10 +639,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "46"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "46"
             },
             "ie": {
               "version_added": false
@@ -687,10 +687,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -783,10 +783,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "46"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "46"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `Permissions` API, based upon manual testing.

Test Code Used: `navigator.permissions.query({name: 'XXX'});`
