### PR TITLE
Fix RTCPeerConnectionIceErrorEvent

### DIFF
--- a/api/RTCPeerConnectionIceErrorEvent.json
+++ b/api/RTCPeerConnectionIceErrorEvent.json
@@ -91,7 +91,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/RTCPeerConnectionIceErrorEvent.json
+++ b/api/RTCPeerConnectionIceErrorEvent.json
@@ -91,7 +91,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/RTCPeerConnectionIceErrorEvent.json
+++ b/api/RTCPeerConnectionIceErrorEvent.json
@@ -235,7 +235,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": false,
             "deprecated": true
           }

--- a/api/RTCPeerConnectionIceErrorEvent.json
+++ b/api/RTCPeerConnectionIceErrorEvent.json
@@ -273,7 +273,7 @@
               "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "13.0"

--- a/api/RTCPeerConnectionIceErrorEvent.json
+++ b/api/RTCPeerConnectionIceErrorEvent.json
@@ -235,7 +235,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": true
           }

--- a/api/RTCPeerConnectionIceErrorEvent.json
+++ b/api/RTCPeerConnectionIceErrorEvent.json
@@ -252,7 +252,7 @@
               "version_added": "81"
             },
             "edge": {
-              "version_added": null
+              "version_added": "81"
             },
             "firefox": {
               "version_added": false

--- a/api/RTCPeerConnectionIceErrorEvent.json
+++ b/api/RTCPeerConnectionIceErrorEvent.json
@@ -60,7 +60,7 @@
               "version_added": "81"
             },
             "edge": {
-              "version_added": null
+              "version_added": "81"
             },
             "firefox": {
               "version_added": false

--- a/api/RTCPeerConnectionIceErrorEvent.json
+++ b/api/RTCPeerConnectionIceErrorEvent.json
@@ -51,12 +51,13 @@
       "address": {
         "__compat": {
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnectioniceerrorevent-address",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionIceErrorEvent/address",
           "support": {
             "chrome": {
               "version_added": "81"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "81"
             },
             "edge": {
               "version_added": null
@@ -71,22 +72,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "68"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "13.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "81"
             }
           },
           "status": {
@@ -248,7 +249,7 @@
               "version_added": "81"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "81"
             },
             "edge": {
               "version_added": null
@@ -263,22 +264,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "68"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "13.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "81"
             }
           },
           "status": {

--- a/api/RTCPeerConnectionIceErrorEvent.json
+++ b/api/RTCPeerConnectionIceErrorEvent.json
@@ -81,7 +81,7 @@
               "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "13.0"

--- a/api/RTCPeerConnectionIceErrorEvent.json
+++ b/api/RTCPeerConnectionIceErrorEvent.json
@@ -48,6 +48,54 @@
           "deprecated": false
         }
       },
+      "address": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnectioniceerrorevent-address",
+          "support": {
+            "chrome": {
+              "version_added": "81"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "errorCode": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionIceErrorEvent/errorCode",
@@ -183,6 +231,54 @@
             },
             "webview_android": {
               "version_added": "77"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
+      "port": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnectioniceerrorevent-port",
+          "support": {
+            "chrome": {
+              "version_added": "81"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
             }
           },
           "status": {

--- a/api/RTCPeerConnectionIceErrorEvent.json
+++ b/api/RTCPeerConnectionIceErrorEvent.json
@@ -78,7 +78,7 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": null
+              "version_added": "14.1"
             },
             "safari_ios": {
               "version_added": null

--- a/api/RTCPeerConnectionIceErrorEvent.json
+++ b/api/RTCPeerConnectionIceErrorEvent.json
@@ -270,7 +270,7 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": null
+              "version_added": "14.1"
             },
             "safari_ios": {
               "version_added": null


### PR DESCRIPTION
- Marked RTCPeerConnectionIceErrorEvent.hostCandidate as deprecated, no more on standard track.
- Added RTCPeerConnectionIceErrorEvent.{address, port} as supported by Chrome 81.
Source: https://raw.githubusercontent.com/foolip/mdn-bcd-results/main/3.1.4-chrome-81.0.4044.129-windows-10-5267fa8422.json
See also chromium sourcecode: https://chromium.googlesource.com/chromium/src/+/72c1e715fa208acb02a5ec2468f477c4cbd9debf%5E%21/#F11
-Used npm run mirror to complete info. I left safari and edge as null as they are "base" browsers, but it likely is supported there too.