### PR TITLE
Normalize spec URL for HTMLInputElement»select()

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1865,7 +1865,7 @@
       "select": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLInputElement/select",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea%2Finput-select",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-select",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
This change replaces the percent-encoding for the slash character in the fragment part of the HTMLInputElement»select() spec URL with the actual literal slash character — which is what the spec itself actually has:

https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-select

cc @teoli2003

---

Part of the context for this is that I regularly run a script that checks for BCD spec URLs with broken fragment IDs — and that script checks against the actual literal canonical IDs in the spec itself.

So that breaks if some part of the URL is instead percent-encoded (although in a browser the URL with the percent-encoded character will also still take you to the right place in the spec).