### PR TITLE
Update menclose spec URL

### DIFF
--- a/mathml/elements/menclose.json
+++ b/mathml/elements/menclose.json
@@ -4,7 +4,7 @@
       "menclose": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/menclose",
-          "spec_url": "https://mathml-refresh.github.io/mathml/#presm_menclose",
+          "spec_url": "https://w3c.github.io/mathml/#presm_menclose",
           "support": {
             "chrome": {
               "version_added": false

--- a/test/spec-urls.test.js
+++ b/test/spec-urls.test.js
@@ -51,7 +51,7 @@ describe('spec_url data', () => {
       'https://github.com/tc39/proposal-regexp-legacy-features/',
       'https://webassembly.github.io/threads/js-api/',
       'https://tc39.es/proposal-hashbang/out.html',
-      'https://mathml-refresh.github.io/mathml/',
+      'https://w3c.github.io/mathml/',
       'https://www.w3.org/TR/xpath-31/',
       'https://www.w3.org/TR/xslt-30/',
     ];


### PR DESCRIPTION
https://mathml-refresh.github.io/mathml/#presm_menclose is now 404. The spec has moved to https://w3c.github.io/mathml, so the new URL is https://w3c.github.io/mathml/#presm_menclose.