### PR TITLE
Add Chrome/Safari versions for api.Element.requestPointerLock

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -8786,10 +8786,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": [
               {
@@ -8864,10 +8864,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": [
               {

--- a/api/Element.json
+++ b/api/Element.json
@@ -6627,7 +6627,8 @@
                 "version_added": "37"
               },
               {
-                "version_added": true,
+                "version_added": "22",
+                "version_removed": "38",
                 "prefix": "webkit"
               }
             ],
@@ -6636,19 +6637,14 @@
                 "version_added": "37"
               },
               {
-                "version_added": true,
+                "version_added": "25",
+                "version_removed": "38",
                 "prefix": "webkit"
               }
             ],
-            "edge": [
-              {
-                "version_added": "13"
-              },
-              {
-                "version_added": "79",
-                "prefix": "webkit"
-              }
-            ],
+            "edge": {
+              "version_added": "13"
+            },
             "firefox": [
               {
                 "version_added": "50"
@@ -6669,7 +6665,8 @@
                 "version_added": "24"
               },
               {
-                "version_added": true,
+                "version_added": "15",
+                "version_removed": "25",
                 "prefix": "webkit"
               }
             ],
@@ -6678,19 +6675,14 @@
                 "version_added": "24"
               },
               {
-                "version_added": true,
+                "version_added": "14",
+                "version_removed": "25",
                 "prefix": "webkit"
               }
             ],
-            "safari": [
-              {
-                "version_added": "10.1"
-              },
-              {
-                "version_added": true,
-                "prefix": "webkit"
-              }
-            ],
+            "safari": {
+              "version_added": "10.1"
+            },
             "safari_ios": {
               "version_added": false
             },
@@ -6699,7 +6691,8 @@
                 "version_added": "3.0"
               },
               {
-                "version_added": true,
+                "version_added": "1.5",
+                "version_removed": "3.0",
                 "prefix": "webkit"
               }
             ],
@@ -6708,7 +6701,8 @@
                 "version_added": "37"
               },
               {
-                "version_added": true,
+                "version_added": "≤37",
+                "version_removed": "38",
                 "prefix": "webkit"
               }
             ]


### PR DESCRIPTION
This PR adds real values for Chrome and Safari for the `requestPointerLock` member of the `Element` API.  By running `document.forms[0].webkitRequestPointerLock;` in various versions of Chrome and Safari, I have determined that Safari has never supported pointer locks before Safari 10.1, with or without a prefix.  Additionally, Chrome has removed the prefixed version of `requestPointerLock` in the following version after adding the non-prefixed version, so it is not present in Edge.
