### PR TITLE
Fix DOMPoint»w|x|y|z spec URLs

### DIFF
--- a/api/DOMPoint.json
+++ b/api/DOMPoint.json
@@ -150,7 +150,7 @@
       "w": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/w",
-          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompoint-w",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompointreadonly-w",
           "support": {
             "chrome": {
               "version_added": "61"
@@ -247,7 +247,7 @@
       "x": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/x",
-          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompoint-x",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompointreadonly-x",
           "support": {
             "chrome": {
               "version_added": "61"
@@ -296,7 +296,7 @@
       "y": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/y",
-          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompoint-y",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompointreadonly-y",
           "support": {
             "chrome": {
               "version_added": "61"
@@ -345,7 +345,7 @@
       "z": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/z",
-          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompoint-z",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompointreadonly-z",
           "support": {
             "chrome": {
               "version_added": "61"


### PR DESCRIPTION
There aren’t actually any #dom-dompoint-w|x|y|z fragment IDs in the https://drafts.fxtf.org/geometry/ spec. Instead the spec has shared text that the `DOMPointReadOnly` and `DOMPoint` IDLs both link to, at, e.g., https://drafts.fxtf.org/geometry/#dom-dompointreadonly-x, which says:

> The x attribute, on getting, must return the x coordinate value. For the DOMPoint interface, setting the x attribute must set the x coordinate to the new value.

That is, the first sentence of that shared text applies to both the `DOMPointReadOnly` and `DOMPoint` interfaces, while the second sentence applies only to the `DOMPoint` interface.

cc @teoli2003