### PR TITLE
Remove Safari iOS 3.1

### DIFF
--- a/api/ApplicationCache.json
+++ b/api/ApplicationCache.json
@@ -36,7 +36,7 @@
             "version_added": "4"
           },
           "safari_ios": {
-            "version_added": "3.1"
+            "version_added": "3"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -139,7 +139,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -191,7 +191,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -243,7 +243,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -295,7 +295,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -347,7 +347,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -399,7 +399,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -451,7 +451,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -503,7 +503,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -555,7 +555,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -607,7 +607,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -659,7 +659,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/SVGRect.json
+++ b/api/SVGRect.json
@@ -33,7 +33,7 @@
             "version_added": "3.1"
           },
           "safari_ios": {
-            "version_added": "3.1"
+            "version_added": "2"
           },
           "samsunginternet_android": {
             "version_added": "1.0"

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -21,12 +21,6 @@
           "engine_version": "528.18",
           "release_date": "2009-06-17"
         },
-        "3.1": {
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "528.18",
-          "release_date": "2009-09-09"
-        },
         "3.2": {
           "status": "retired",
           "engine": "WebKit",

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -381,7 +381,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": "3.1"
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -843,7 +843,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": "3.1"
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -917,7 +917,7 @@
                 "version_added": "1.3"
               },
               "safari_ios": {
-                "version_added": "1"
+                "version_added": "3.1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -917,7 +917,7 @@
                 "version_added": "1.3"
               },
               "safari_ios": {
-                "version_added": "3.1"
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"

--- a/css/properties/empty-cells.json
+++ b/css/properties/empty-cells.json
@@ -34,7 +34,7 @@
               "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/properties/outline.json
+++ b/css/properties/outline.json
@@ -43,7 +43,7 @@
               "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/properties/unicode-bidi.json
+++ b/css/properties/unicode-bidi.json
@@ -34,7 +34,7 @@
               "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/checked.json
+++ b/css/selectors/checked.json
@@ -47,7 +47,7 @@
               "notes": "Styling <code>&lt;option&gt;</code> elements has no effect."
             },
             "safari_ios": {
-              "version_added": "3.1",
+              "version_added": "2",
               "notes": "Styling <code>&lt;option&gt;</code> elements has no effect."
             },
             "samsunginternet_android": {

--- a/css/selectors/disabled.json
+++ b/css/selectors/disabled.json
@@ -40,7 +40,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/empty.json
+++ b/css/selectors/empty.json
@@ -35,7 +35,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/enabled.json
+++ b/css/selectors/enabled.json
@@ -38,7 +38,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/lang.json
+++ b/css/selectors/lang.json
@@ -35,7 +35,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/nth-child.json
+++ b/css/selectors/nth-child.json
@@ -37,7 +37,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/nth-of-type.json
+++ b/css/selectors/nth-of-type.json
@@ -37,7 +37,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/only-child.json
+++ b/css/selectors/only-child.json
@@ -35,7 +35,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/types/attr.json
+++ b/css/types/attr.json
@@ -35,7 +35,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/html/elements/input/email.json
+++ b/html/elements/input/email.json
@@ -36,7 +36,7 @@
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": "2",
+                "version_added": "3",
                 "notes": [
                   "Doesn't do validation, but instead offers a custom 'email' keyboard, which is designed to make entering email addresses easier.",
                   "The custom 'email' keyboard does not provide a comma key, so users cannot enter multiple email addresses.",

--- a/html/elements/input/email.json
+++ b/html/elements/input/email.json
@@ -36,7 +36,7 @@
                 "version_added": true
               },
               "safari_ios": {
-                "version_added": "3.1",
+                "version_added": "2",
                 "notes": [
                   "Doesn't do validation, but instead offers a custom 'email' keyboard, which is designed to make entering email addresses easier.",
                   "The custom 'email' keyboard does not provide a comma key, so users cannot enter multiple email addresses.",

--- a/svg/elements/a.json
+++ b/svg/elements/a.json
@@ -34,7 +34,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -379,7 +379,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": "3.1"
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -523,7 +523,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": "3.1"
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/svg/elements/circle.json
+++ b/svg/elements/circle.json
@@ -34,7 +34,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/svg/elements/defs.json
+++ b/svg/elements/defs.json
@@ -34,7 +34,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/svg/elements/desc.json
+++ b/svg/elements/desc.json
@@ -34,7 +34,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/svg/elements/g.json
+++ b/svg/elements/g.json
@@ -34,7 +34,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/svg/elements/image.json
+++ b/svg/elements/image.json
@@ -34,7 +34,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/svg/elements/linearGradient.json
+++ b/svg/elements/linearGradient.json
@@ -34,7 +34,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/svg/elements/radialGradient.json
+++ b/svg/elements/radialGradient.json
@@ -34,7 +34,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/svg/elements/rect.json
+++ b/svg/elements/rect.json
@@ -34,7 +34,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -80,7 +80,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": "3.1"
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -127,7 +127,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": "3.1"
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -174,7 +174,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": "3.1"
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -221,7 +221,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": "3.1"
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -268,7 +268,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": "3.1"
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -315,7 +315,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": "3.1"
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/svg/elements/script.json
+++ b/svg/elements/script.json
@@ -34,7 +34,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/svg/elements/style.json
+++ b/svg/elements/style.json
@@ -34,7 +34,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/svg/elements/switch.json
+++ b/svg/elements/switch.json
@@ -34,7 +34,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/svg/elements/symbol.json
+++ b/svg/elements/symbol.json
@@ -34,7 +34,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.1"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR removes Safari iOS 3.1 from the browser data, and changes everything set to Safari iOS 3.1 to mirrored data from Safari Desktop.  Safari iOS 3.1's WebKit version is the exact same as iOS 3.0's, as confirmed by querying WhatIsMyBrowser.

Using the Safari 3 emulator in BrowserStack, I've spot-checked a few entries to ensure this methodology is correct.  I have also found that all of the data for Safari iOS 3.1 came from the initial wiki tables, and most entries are accompanied by Safari Desktop set to 3.1, which further leads me to believe that Safari iOS 3.1 was mistakenly added.

~~Blocked by #11188.~~