### PR TITLE
Remove Safari iOS 4.3

### DIFF
--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -45,12 +45,6 @@
           "engine_version": "533.17",
           "release_date": "2010-11-22"
         },
-        "4.3": {
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "533.17",
-          "release_date": "2011-03-09"
-        },
         "5": {
           "status": "retired",
           "engine": "WebKit",

--- a/css/selectors/placeholder.json
+++ b/css/selectors/placeholder.json
@@ -93,7 +93,7 @@
               },
               {
                 "prefix": "-webkit-input-",
-                "version_added": "4.3"
+                "version_added": "4.2"
               }
             ],
             "samsunginternet_android": [

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -688,7 +688,7 @@
                   "version_added": "5"
                 },
                 "safari_ios": {
-                  "version_added": "4.3"
+                  "version_added": "4.2"
                 },
                 "samsunginternet_android": {
                   "version_added": "1.5"

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -761,7 +761,7 @@
                   "version_added": "5"
                 },
                 "safari_ios": {
-                  "version_added": "4.3"
+                  "version_added": "4.2"
                 },
                 "samsunginternet_android": {
                   "version_added": "1.5"


### PR DESCRIPTION
This PR removes Safari iOS 4.3 from the browser data, and adjusts everything that is set as iOS 4.3 to 4.2 instead. Safari iOS 4.3's WebKit version is the exact same as iOS 4.2's, as confirmed by querying WhatIsMyBrowser.
