### PR TITLE
Fix w3c link of get property

### DIFF
--- a/webdriver/commands/GetElementProperty.json
+++ b/webdriver/commands/GetElementProperty.json
@@ -4,7 +4,7 @@
       "GetElementProperty": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/WebDriver/Commands/GetElementProperty",
-          "spec_url": "https://w3c.github.io/webdriver/#dfn-get-element-attribute",
+          "spec_url": "https://w3c.github.io/webdriver/#dfn-get-element-property",
           "support": {
             "chrome": {
               "version_added": "65",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
The link was pointing to get attribute section, but there is a separate section for the get property:

old: https://w3c.github.io/webdriver/#dfn-get-element-attribute
new: https://w3c.github.io/webdriver/#dfn-get-element-property

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
I opened the link

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
This pull requests is a follow up on https://github.com/mdn/content/pull/6185
