### PR TITLE
adds URLs for CSSCounterStyleRule

### DIFF
--- a/api/CSSCounterStyleRule.json
+++ b/api/CSSCounterStyleRule.json
@@ -50,6 +50,8 @@
       },
       "additiveSymbols": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule/additiveSymbols",
+          "spec_url": "https://drafts.csswg.org/css-counter-styles/#dom-csscounterstylerule-additivesymbols",
           "support": {
             "chrome": {
               "version_added": "91"
@@ -97,6 +99,8 @@
       },
       "fallback": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule/fallback",
+          "spec_url": "https://drafts.csswg.org/css-counter-styles/#dom-csscounterstylerule-fallback",
           "support": {
             "chrome": {
               "version_added": "91"
@@ -144,6 +148,8 @@
       },
       "name": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule/name",
+          "spec_url": "https://drafts.csswg.org/css-counter-styles/#dom-csscounterstylerule-name",
           "support": {
             "chrome": {
               "version_added": "91"
@@ -191,6 +197,8 @@
       },
       "negative": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule/negative",
+          "spec_url": "https://drafts.csswg.org/css-counter-styles/#dom-csscounterstylerule-negative",
           "support": {
             "chrome": {
               "version_added": "91"
@@ -238,6 +246,8 @@
       },
       "pad": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule/pad",
+          "spec_url": "https://drafts.csswg.org/css-counter-styles/#dom-csscounterstylerule-pad",
           "support": {
             "chrome": {
               "version_added": "91"
@@ -285,6 +295,8 @@
       },
       "prefix": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule/prefix",
+          "spec_url": "https://drafts.csswg.org/css-counter-styles/#dom-csscounterstylerule-prefix",
           "support": {
             "chrome": {
               "version_added": "91"
@@ -332,6 +344,8 @@
       },
       "range": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule/range",
+          "spec_url": "https://drafts.csswg.org/css-counter-styles/#dom-csscounterstylerule-range",
           "support": {
             "chrome": {
               "version_added": "91"
@@ -379,6 +393,8 @@
       },
       "speakAs": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule/speakAs",
+          "spec_url": "https://drafts.csswg.org/css-counter-styles/#dom-csscounterstylerule-speakas",
           "support": {
             "chrome": {
               "version_added": "91"
@@ -426,6 +442,8 @@
       },
       "suffix": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule/suffix",
+          "spec_url": "https://drafts.csswg.org/css-counter-styles/#dom-csscounterstylerule-suffix",
           "support": {
             "chrome": {
               "version_added": "91"
@@ -473,6 +491,8 @@
       },
       "symbols": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule/symbols",
+          "spec_url": "https://drafts.csswg.org/css-counter-styles/#dom-csscounterstylerule-symbols",
           "support": {
             "chrome": {
               "version_added": "91"
@@ -520,6 +540,8 @@
       },
       "system": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSCounterStyleRule/system",
+          "spec_url": "https://drafts.csswg.org/css-counter-styles/#dom-csscounterstylerule-system",
           "support": {
             "chrome": {
               "version_added": "91"


### PR DESCRIPTION
I created the missing property pages for CSSCounterStyleRule which flagged up that they didn't have their spec and MDN URLs. This PR adds them.
