### PR TITLE
Change Safari 6.1 to 7 where the iOS version is already 7

### DIFF
--- a/api/AudioBufferSourceNode.json
+++ b/api/AudioBufferSourceNode.json
@@ -428,7 +428,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/api/AudioScheduledSourceNode.json
+++ b/api/AudioScheduledSourceNode.json
@@ -265,7 +265,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -314,7 +314,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/api/AudioTrack.json
+++ b/api/AudioTrack.json
@@ -85,7 +85,7 @@
             ]
           },
           "safari": {
-            "version_added": "6.1"
+            "version_added": "7"
           },
           "safari_ios": {
             "version_added": "7"
@@ -188,7 +188,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -292,7 +292,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -396,7 +396,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -500,7 +500,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -604,7 +604,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -694,7 +694,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/api/AudioTrackList.json
+++ b/api/AudioTrackList.json
@@ -85,7 +85,7 @@
             ]
           },
           "safari": {
-            "version_added": "6.1"
+            "version_added": "7"
           },
           "safari_ios": {
             "version_added": "7"
@@ -189,7 +189,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -294,7 +294,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -398,7 +398,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -502,7 +502,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -606,7 +606,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -710,7 +710,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -814,7 +814,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -919,7 +919,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/api/BeforeUnloadEvent.json
+++ b/api/BeforeUnloadEvent.json
@@ -30,7 +30,7 @@
             "version_added": "18"
           },
           "safari": {
-            "version_added": "6.1"
+            "version_added": "7"
           },
           "safari_ios": {
             "version_added": "7"

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -253,11 +253,11 @@
             },
             "safari": [
               {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               {
                 "version_added": "5.1",
-                "version_removed": "6.1",
+                "version_removed": "7",
                 "prefix": "webkit"
               }
             ],

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1921,7 +1921,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -2376,7 +2376,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -2534,7 +2534,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -3342,7 +3342,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/api/CompositionEvent.json
+++ b/api/CompositionEvent.json
@@ -79,7 +79,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/api/Console.json
+++ b/api/Console.json
@@ -144,7 +144,7 @@
               "version_added": "12"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -1240,7 +1240,7 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -1668,7 +1668,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/api/Document.json
+++ b/api/Document.json
@@ -6304,7 +6304,7 @@
               "version_added": "12.1"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -11429,7 +11429,7 @@
               }
             ],
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -11488,7 +11488,7 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "safari_ios": {
                 "version_added": "7"

--- a/api/Element.json
+++ b/api/Element.json
@@ -1523,11 +1523,11 @@
             },
             "safari": [
               {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               {
                 "version_added": "6",
-                "version_removed": "6.1",
+                "version_removed": "7",
                 "notes": "Not supported for SVG elements.",
                 "partial_implementation": true
               }

--- a/api/File.json
+++ b/api/File.json
@@ -191,7 +191,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "6.1",
+              "version_added": "7",
               "version_removed": "10"
             },
             "safari_ios": {
@@ -242,7 +242,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -291,7 +291,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/api/FileReaderSync.json
+++ b/api/FileReaderSync.json
@@ -31,7 +31,7 @@
           },
           "safari": {
             "version_added": "6",
-            "version_removed": "6.1"
+            "version_removed": "7"
           },
           "safari_ios": {
             "version_added": "6",
@@ -80,7 +80,7 @@
             },
             "safari": {
               "version_added": "6",
-              "version_removed": "6.1"
+              "version_removed": "7"
             },
             "safari_ios": {
               "version_added": "6",
@@ -131,7 +131,7 @@
             },
             "safari": {
               "version_added": "6",
-              "version_removed": "6.1"
+              "version_removed": "7"
             },
             "safari_ios": {
               "version_added": "6",
@@ -182,7 +182,7 @@
             },
             "safari": {
               "version_added": "6",
-              "version_removed": "6.1"
+              "version_removed": "7"
             },
             "safari_ios": {
               "version_added": "6",
@@ -233,7 +233,7 @@
             },
             "safari": {
               "version_added": "6",
-              "version_removed": "6.1"
+              "version_removed": "7"
             },
             "safari_ios": {
               "version_added": "6",
@@ -284,7 +284,7 @@
             },
             "safari": {
               "version_added": "6",
-              "version_removed": "6.1"
+              "version_removed": "7"
             },
             "safari_ios": {
               "version_added": "6",
@@ -341,7 +341,7 @@
             },
             "safari": {
               "version_added": true,
-              "version_removed": "6.1",
+              "version_removed": "7",
               "notes": "Not supported in service workers."
             },
             "safari_ios": {

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -2418,7 +2418,7 @@
               "version_added": "18"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -2467,7 +2467,7 @@
               "version_added": "18"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -3460,7 +3460,7 @@
             ],
             "safari": [
               {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               {
                 "alternative_name": "webkitTransitionEnd",

--- a/api/HTMLFieldSetElement.json
+++ b/api/HTMLFieldSetElement.json
@@ -172,7 +172,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/api/HTMLFormControlsCollection.json
+++ b/api/HTMLFormControlsCollection.json
@@ -30,7 +30,7 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": "6.1"
+            "version_added": "7"
           },
           "safari_ios": {
             "version_added": "7"
@@ -94,7 +94,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2131,7 +2131,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -1115,7 +1115,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -79,7 +79,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/api/MutationRecord.json
+++ b/api/MutationRecord.json
@@ -30,7 +30,7 @@
             "version_added": true
           },
           "safari": {
-            "version_added": "6.1"
+            "version_added": "7"
           },
           "safari_ios": {
             "version_added": "7"
@@ -77,7 +77,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -125,7 +125,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -173,7 +173,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -221,7 +221,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -269,7 +269,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -317,7 +317,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -365,7 +365,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -413,7 +413,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -461,7 +461,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/api/Node.json
+++ b/api/Node.json
@@ -657,7 +657,7 @@
             },
             "safari": {
               "version_added": "1",
-              "version_removed": "6.1"
+              "version_removed": "7"
             },
             "safari_ios": {
               "version_added": "1",

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -76,7 +76,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/api/SVGFEGaussianBlurElement.json
+++ b/api/SVGFEGaussianBlurElement.json
@@ -76,7 +76,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/api/SVGGraphicsElement.json
+++ b/api/SVGGraphicsElement.json
@@ -81,11 +81,11 @@
           ],
           "safari": [
             {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             {
               "version_added": "3",
-              "version_removed": "6.1",
+              "version_removed": "7",
               "partial_implementation": true,
               "notes": "The <code>SVGGraphicsElement</code> interface itself is not present, but some of its members are available on interfaces that inherit from <code>SVGGraphicsElement</code>."
             }

--- a/api/SVGRadialGradientElement.json
+++ b/api/SVGRadialGradientElement.json
@@ -170,7 +170,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -813,7 +813,7 @@
               "version_removed": "43"
             },
             "safari": {
-              "version_added": "6.1",
+              "version_added": "7",
               "notes": "See <a href='https://webkit.org/b/226721'>bug 226721</a>."
             },
             "safari_ios": {

--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -32,7 +32,7 @@
           },
           "safari": {
             "version_added": "5",
-            "version_removed": "6.1"
+            "version_removed": "7"
           },
           "safari_ios": {
             "version_added": "5.1",
@@ -85,7 +85,7 @@
             },
             "safari": {
               "version_added": "5",
-              "version_removed": "6.1"
+              "version_removed": "7"
             },
             "safari_ios": {
               "version_added": "5.1",
@@ -242,7 +242,7 @@
             },
             "safari": {
               "version_added": "5",
-              "version_removed": "6.1"
+              "version_removed": "7"
             },
             "safari_ios": {
               "version_added": "5.1",
@@ -295,7 +295,7 @@
             },
             "safari": {
               "version_added": "5",
-              "version_removed": "6.1"
+              "version_removed": "7"
             },
             "safari_ios": {
               "version_added": "5.1",

--- a/api/TextTrackList.json
+++ b/api/TextTrackList.json
@@ -386,7 +386,7 @@
               }
             ],
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/api/VideoTrack.json
+++ b/api/VideoTrack.json
@@ -85,7 +85,7 @@
             ]
           },
           "safari": {
-            "version_added": "6.1"
+            "version_added": "7"
           },
           "safari_ios": {
             "version_added": "7"
@@ -188,7 +188,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -292,7 +292,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -396,7 +396,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -500,7 +500,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -604,7 +604,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -694,7 +694,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/api/VideoTrackList.json
+++ b/api/VideoTrackList.json
@@ -85,7 +85,7 @@
             ]
           },
           "safari": {
-            "version_added": "6.1"
+            "version_added": "7"
           },
           "safari_ios": {
             "version_added": "7"
@@ -189,7 +189,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -294,7 +294,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -398,7 +398,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -502,7 +502,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -606,7 +606,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -710,7 +710,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -814,7 +814,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -919,7 +919,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"
@@ -1023,7 +1023,7 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1894,7 +1894,7 @@
               }
             ],
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1060,7 +1060,7 @@
                 "version_added": "12.1"
               },
               "safari": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "safari_ios": {
                 "version_added": "7"

--- a/css/properties/-webkit-mask-attachment.json
+++ b/css/properties/-webkit-mask-attachment.json
@@ -33,7 +33,7 @@
             },
             "safari": {
               "version_added": "4",
-              "version_removed": "6.1"
+              "version_removed": "7"
             },
             "safari_ios": {
               "version_added": "3.2",

--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -71,7 +71,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": "7"
                 }
               ],
               "safari_ios": [

--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -65,7 +65,7 @@
               }
             ],
             "safari": {
-              "version_added": "6.1",
+              "version_added": "7",
               "prefix": "-webkit-",
               "notes": "This property is only supported for inline elements."
             },

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -271,7 +271,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": "7"
                 }
               ],
               "safari_ios": [

--- a/css/properties/flex-flow.json
+++ b/css/properties/flex-flow.json
@@ -72,7 +72,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "6.1"
+                "version_added": "7"
               }
             ],
             "safari_ios": [

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -74,7 +74,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "6.1"
+                "version_added": "7"
               }
             ],
             "safari_ios": [

--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -90,7 +90,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "6.1"
+                "version_added": "7"
               }
             ],
             "safari_ios": [

--- a/css/properties/image-rendering.json
+++ b/css/properties/image-rendering.json
@@ -145,7 +145,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "safari_ios": {
                 "version_added": "7"
@@ -192,7 +192,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "safari_ios": {
                 "version_added": "7"

--- a/css/properties/mask-type.json
+++ b/css/properties/mask-type.json
@@ -31,7 +31,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -109,7 +109,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": "7"
                 },
                 {
                   "alternative_name": "intrinsic",

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -104,7 +104,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": "7"
                 },
                 {
                   "alternative_name": "intrinsic",
@@ -202,7 +202,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": "7"
                 },
                 {
                   "alternative_name": "intrinsic",
@@ -300,7 +300,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": "7"
                 },
                 {
                   "alternative_name": "intrinsic",

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -177,7 +177,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": "7"
                 }
               ],
               "safari_ios": [

--- a/css/properties/overflow-wrap.json
+++ b/css/properties/overflow-wrap.json
@@ -75,7 +75,7 @@
             ],
             "safari": [
               {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               {
                 "alternative_name": "word-wrap",

--- a/css/properties/tab-size.json
+++ b/css/properties/tab-size.json
@@ -58,7 +58,7 @@
               }
             ],
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/css/properties/text-emphasis-color.json
+++ b/css/properties/text-emphasis-color.json
@@ -37,11 +37,11 @@
             },
             "safari": [
               {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "6.1"
+                "version_added": "7"
               }
             ],
             "safari_ios": [

--- a/css/properties/text-emphasis-position.json
+++ b/css/properties/text-emphasis-position.json
@@ -37,11 +37,11 @@
             },
             "safari": [
               {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "6.1"
+                "version_added": "7"
               }
             ],
             "safari_ios": [

--- a/css/properties/text-emphasis-style.json
+++ b/css/properties/text-emphasis-style.json
@@ -37,11 +37,11 @@
             },
             "safari": [
               {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "6.1"
+                "version_added": "7"
               }
             ],
             "safari_ios": [

--- a/css/properties/text-emphasis.json
+++ b/css/properties/text-emphasis.json
@@ -37,11 +37,11 @@
             },
             "safari": [
               {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "6.1"
+                "version_added": "7"
               }
             ],
             "safari_ios": [

--- a/css/properties/unicode-bidi.json
+++ b/css/properties/unicode-bidi.json
@@ -201,7 +201,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": "7"
                 }
               ],
               "safari_ios": [

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -231,7 +231,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": "7"
                 },
                 {
                   "alternative_name": "intrinsic",

--- a/css/selectors/-webkit-meter-inner-element.json
+++ b/css/selectors/-webkit-meter-inner-element.json
@@ -31,7 +31,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/css/selectors/-webkit-progress-bar.json
+++ b/css/selectors/-webkit-progress-bar.json
@@ -31,7 +31,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/css/selectors/-webkit-progress-inner-element.json
+++ b/css/selectors/-webkit-progress-inner-element.json
@@ -31,7 +31,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/css/selectors/-webkit-progress-value.json
+++ b/css/selectors/-webkit-progress-value.json
@@ -31,7 +31,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -282,7 +282,7 @@
               ],
               "safari": [
                 {
-                  "version_added": "6.1"
+                  "version_added": "7"
                 },
                 {
                   "prefix": "-webkit-",
@@ -1630,7 +1630,7 @@
                 ],
                 "safari": [
                   {
-                    "version_added": "6.1"
+                    "version_added": "7"
                   },
                   {
                     "prefix": "-webkit-",
@@ -1836,7 +1836,7 @@
                     "version_added": "27"
                   },
                   "safari": {
-                    "version_added": "6.1"
+                    "version_added": "7"
                   },
                   "safari_ios": {
                     "version_added": "7"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2427,7 +2427,7 @@
                   "version_added": "14"
                 },
                 "safari": {
-                  "version_added": "6.1"
+                  "version_added": "7"
                 },
                 "safari_ios": {
                   "version_added": "7"
@@ -2640,7 +2640,7 @@
                   "version_added": "14"
                 },
                 "safari": {
-                  "version_added": "6.1"
+                  "version_added": "7"
                 },
                 "safari_ios": {
                   "version_added": "7"
@@ -2853,7 +2853,7 @@
                   "version_added": "14"
                 },
                 "safari": {
-                  "version_added": "6.1"
+                  "version_added": "7"
                 },
                 "safari_ios": {
                   "version_added": "7"


### PR DESCRIPTION
This subset of https://github.com/mdn/browser-compat-data/pull/11156
does not need much scrutiny, as this results in the expected matching
of Safari and iOS versions. There may still be errors in this data, but
then it's wrong for both Safaris.

Part of https://github.com/mdn/browser-compat-data/issues/9423.