### PR TITLE
Update Safari versions for BarProp

### DIFF
--- a/api/BarProp.json
+++ b/api/BarProp.json
@@ -28,10 +28,10 @@
             "version_added": "16"
           },
           "safari": {
-            "version_added": "6.1"
+            "version_added": "3"
           },
           "safari_ios": {
-            "version_added": "7"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "2.0"
@@ -74,10 +74,10 @@
               "version_added": "30"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "8"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
This matches window.toolbar and other window.*bar properties updated in
https://github.com/mdn/browser-compat-data/pull/6825 based on
mdn-bcd-collector results and manual testing.

Additionally, http://mdn-bcd-collector.appspot.com/tests/api/BarProp/visible
was tested in Safari 4 and iOS 3 (the oldest available on BrowserStack)
to confirm support there. Support going back to 3 / 1 is assumed based
on the other data.