### PR TITLE
Content-DPR, Viewport-Width, Width: set deprecated true

### DIFF
--- a/http/headers/content-dpr.json
+++ b/http/headers/content-dpr.json
@@ -44,7 +44,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/http/headers/content-dpr.json
+++ b/http/headers/content-dpr.json
@@ -45,7 +45,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/http/headers/viewport-width.json
+++ b/http/headers/viewport-width.json
@@ -44,7 +44,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/http/headers/viewport-width.json
+++ b/http/headers/viewport-width.json
@@ -45,7 +45,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/http/headers/width.json
+++ b/http/headers/width.json
@@ -44,7 +44,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/http/headers/width.json
+++ b/http/headers/width.json
@@ -45,7 +45,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
The  "screen" device client hints `Content-DPR`, `Viewport-Width`, `Width`, `DPR` are deprecated. This marks them as such (except for `DPR` which was already done). 

"Proof":
- Last present in [draft6](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-client-hints-06)
- Removed in [draft7](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-client-hints-07) ("_Removed specific features to be defined in other specifications_"). 
- The `Viewport-Width`, `Width`, `DPR` renamed to have prefix `SEC-CH-` and added back in https://wicg.github.io/responsive-image-client-hints/
-  `Content-DPR` permanently dropped - https://github.com/WICG/responsive-image-client-hints/issues/14

At some point will need to add the new headers, but they are not implemented in any browser yet.

Question:
- DPR is marked as "false" for standard track, but the other headers are true. They "were" standard track, but do they count as such now? I.e. should I change to false. 