### PR TITLE
Add Safari versions for media CSS @rule

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -35,7 +35,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "1"
@@ -914,10 +914,10 @@
                 "version_added": "10.1"
               },
               "safari": {
-                "version_added": "1.3"
+                "version_added": "3"
               },
               "safari_ios": {
-                "version_added": "3.1"
+                "version_added": "3"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -917,7 +917,7 @@
                 "version_added": "3"
               },
               "safari_ios": {
-                "version_added": "3"
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `media` CSS @rule.  Since there is nothing in the [source code for Safari 2](https://trac.webkit.org/browser/webkit/tags/old/Safari-421/WebCore/khtml/css) for media queries, it doesn't make sense for this to be set to Safari 1.3.  As I have found in #4369, support for pretty much every part of media queries hadn't been introduced until at least Safari 3.
