### PR TITLE
Add label usage docs

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,57 @@
+# Issue and pull requests workflow
+
+Or, _How changes are considered, accepted, merged, and published_
+
+## Label usage
+
+Some labels act as special-use flags. Use the following labels according to these guidelines.
+
+### not ready ⛔
+
+| Pulls | Issues | Blocker |
+| ----- | ------ | ------- |
+| Yes   | Yes    | Yes     |
+
+For issues, this label indicates that the issue cannot be completed right now. For pull requests, the label indicates that the pull request cannot be merged.
+
+Set this label on any issue or PR that cannot proceed without some additional action. If you set this label, then leave a comment that says why it's not ready and what needs to happen for it to be ready.
+
+For example, if a pull request cannot be merged without another issue being resolved first, then set the label and leave a comment linking to the blocking issue.
+
+### needs content update 📝
+
+| Pulls | Issues | Blocker |
+| ----- | ------ | ------- |
+| Yes   | Yes    | Yes     |
+
+This label indicates that a pull request needs corresponding changes to [mdn/content](https://github.com/mdn/content/).
+
+You must set this label on a pull request when it:
+
+- Removes or renames features that are referenced by page front matter or `{{Compat}}` macro calls
+- Removes data that has corresponding content on MDN (for example, `mdn_url` links to a non-404 page)
+- Changes anything else you suspect negatively impacts content on MDN (for example, creates confusion on a page that references a feature dropped from BCD)
+
+When in doubt, set the label. Better to find that content changes are unnecessary than to discover they're required after the fact.
+
+Remove this label after a pull request, which makes the required content changes, has been opened. A content change in progress is sufficient to merge compat data changes.
+
+### needs-release-note 📰
+
+| Pulls | Issues | Blocker |
+| ----- | ------ | ------- |
+| Yes   | No     | Yes     |
+
+This label indicates that a pull request needs a corresponding entry in [`RELEASE_NOTES.md`](../RELEASE_NOTES.md).
+
+You must set this label on a pull request when it:
+
+- Breaks backward compatibility (see [_Semantic versioning policy_](../README.md#semantic-versioning-policy))
+- Removes or renames data (for example, removing an irrelevant feature)
+- Adds or changes a data guideline or schema document
+- Adds, removes, or changes linting and other non-schematic data restrictions
+- Does anything else that would trigger a SemVer minor release
+
+You may set this label on a pull request when it changes anything else interesting to consumers. Use your best judgment and leave a comment on the PR to explain.
+
+Remove this label upon committing a release note to a release note pull request (see [_Publishing a new version of `@mdn/browser-compat-data`_](./publishing.md#publishing-a-new-version-of-mdnbrowser-compat-data)).


### PR DESCRIPTION
#### Summary

This PR adds some documentation for label usage on mdn/browser-compat-data and captures some changes to how I intend to use the needs-release-note label.

This fell out of a discussion I had with @Elchi3 yesterday. Mostly, I wanted a vehicle to change how I used the needs-release-note label (which is to remove the label, once the note is done). But there's also a new "needs content change" label which isn't exactly obvious, if you're not already in the know. I figure this might also be a good place to capture other workflow stuff, eventually.

#### Related issues

This is somewhat related to but doesn't re&ZeroWidthSpace;solve https://github.com/mdn/browser-compat-data/issues/4178.