### PR TITLE
Adding dom.events.asyncClipboard.read preference for Clipboard.read() 

### DIFF
--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -92,7 +92,18 @@
             },
             "firefox": [
               {
+                "version_added": "90",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.events.asyncClipboard.read",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "87",
+                "version_removed": "90",
                 "flags": [
                   {
                     "type": "preference",
@@ -121,7 +132,18 @@
             ],
             "firefox_android": [
               {
+                "version_added": "90",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.events.asyncClipboard.read",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "87",
+                "version_removed": "90",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -99,7 +99,8 @@
                     "name": "dom.events.asyncClipboard.read",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "notes": "Firefox only supports reading the clipboard in browser extensions, using the <code>\"clipboardRead\"</code> extension permission."
               },
               {
                 "version_added": "87",
@@ -139,7 +140,8 @@
                     "name": "dom.events.asyncClipboard.read",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "notes": "Firefox only supports reading the clipboard in browser extensions, using the <code>\"clipboardRead\"</code> extension permission."
               },
               {
                 "version_added": "87",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Added data regrading the new pref under which Clipboard.read() is working. 

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
Related to https://github.com/mdn/content/issues/5376

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
