### PR TITLE
Add note about IE7/8/9 support of `+~>` combinators in standards mode

### DIFF
--- a/css/selectors/adjacent_sibling.json
+++ b/css/selectors/adjacent_sibling.json
@@ -25,6 +25,7 @@
             "ie": {
               "version_added": "7",
               "notes": [
+                "Internet Explorer 7/8/9 supports <code>+~&gt;</code> combinators only in standards mode.",
                 "Internet Explorer 7 doesn't update the style correctly when an element is dynamically placed before an element that matched the selector.",
                 "In Internet Explorer 8, if an element is inserted dynamically by clicking on a link the first-child style isn't applied until the link loses focus."
               ]

--- a/css/selectors/adjacent_sibling.json
+++ b/css/selectors/adjacent_sibling.json
@@ -25,7 +25,7 @@
             "ie": {
               "version_added": "7",
               "notes": [
-                "Internet Explorer 7/8/9 supports <code>+~&gt;</code> combinators only in standards mode.",
+                "Before Internet Explorer 10, the combinator only works in standards mode.",
                 "Internet Explorer 7 doesn't update the style correctly when an element is dynamically placed before an element that matched the selector.",
                 "In Internet Explorer 8, if an element is inserted dynamically by clicking on a link the first-child style isn't applied until the link loses focus."
               ]

--- a/css/selectors/child.json
+++ b/css/selectors/child.json
@@ -24,9 +24,7 @@
             },
             "ie": {
               "version_added": "7",
-              "notes": [
-                "Internet Explorer 7/8/9 supports <code>+~&gt;</code> combinators only in standards mode."
-              ]
+              "notes": "Internet Explorer 7/8/9 supports <code>+~&gt;</code> combinators only in standards mode."
             },
             "opera": {
               "version_added": "4"

--- a/css/selectors/child.json
+++ b/css/selectors/child.json
@@ -24,6 +24,9 @@
             },
             "ie": {
               "version_added": "7"
+              "notes": [
+                "Internet Explorer 7/8/9 supports <code>+~&gt;</code> combinators only in standards mode."
+              ]
             },
             "opera": {
               "version_added": "4"

--- a/css/selectors/child.json
+++ b/css/selectors/child.json
@@ -24,7 +24,7 @@
             },
             "ie": {
               "version_added": "7",
-              "notes": "Internet Explorer 7/8/9 supports <code>+~&gt;</code> combinators only in standards mode."
+              "notes": "Before Internet Explorer 10, the combinator only works in standards mode."
             },
             "opera": {
               "version_added": "4"

--- a/css/selectors/child.json
+++ b/css/selectors/child.json
@@ -23,7 +23,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "7"
+              "version_added": "7",
               "notes": [
                 "Internet Explorer 7/8/9 supports <code>+~&gt;</code> combinators only in standards mode."
               ]

--- a/css/selectors/general_sibling.json
+++ b/css/selectors/general_sibling.json
@@ -24,9 +24,7 @@
             },
             "ie": {
               "version_added": "7",
-              "notes": [
-                "Internet Explorer 7/8/9 supports <code>+~&gt;</code> combinators only in standards mode."
-              ]
+              "notes": "Internet Explorer 7/8/9 supports <code>+~&gt;</code> combinators only in standards mode."
             },
             "opera": {
               "version_added": "9"

--- a/css/selectors/general_sibling.json
+++ b/css/selectors/general_sibling.json
@@ -24,6 +24,9 @@
             },
             "ie": {
               "version_added": "7"
+              "notes": [
+                "Internet Explorer 7/8/9 supports <code>+~&gt;</code> combinators only in standards mode."
+              ]
             },
             "opera": {
               "version_added": "9"

--- a/css/selectors/general_sibling.json
+++ b/css/selectors/general_sibling.json
@@ -23,7 +23,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "7"
+              "version_added": "7",
               "notes": [
                 "Internet Explorer 7/8/9 supports <code>+~&gt;</code> combinators only in standards mode."
               ]

--- a/css/selectors/general_sibling.json
+++ b/css/selectors/general_sibling.json
@@ -24,7 +24,7 @@
             },
             "ie": {
               "version_added": "7",
-              "notes": "Internet Explorer 7/8/9 supports <code>+~&gt;</code> combinators only in standards mode."
+              "notes": "Before Internet Explorer 10, the combinator only works in standards mode."
             },
             "opera": {
               "version_added": "9"


### PR DESCRIPTION
Fixes #11198