### PR TITLE
adds spec URLs to StyleSheetList

### DIFF
--- a/api/StyleSheetList.json
+++ b/api/StyleSheetList.json
@@ -51,6 +51,7 @@
       "item": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StyleSheetList/item",
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-stylesheetlist-item",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -99,6 +100,7 @@
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StyleSheetList/length",
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-stylesheetlist-length",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
Adding the spec URLs for the two missing pages I created to fix https://github.com/mdn/content/issues/6076
