### PR TITLE
Add Internet Explorer 11 as a range

### DIFF
--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -275,6 +275,7 @@ For certain browsers, ranged versions are allowed as it is sometimes impractical
   - "≤79" (supported in some version Chromium-based Edge and possibly in EdgeHTML-based Edge)
 - Internet Explorer
   - "≤6" (earliest IE version supported in BrowserStack)
+  - "≤11" (supported in some version of IE)
 - Opera
   - "≤12.1" (supported in some version of Presto-based Opera)
   - "≤15" (supported in some version of Chromium-based Opera and possibly in Presto-based Opera)

--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -17,7 +17,7 @@ const validBrowserVersions = {};
 /** @type {Object<string, string[]>} */
 const VERSION_RANGE_BROWSERS = {
   edge: ['≤18', '≤79'],
-  ie: ['≤6'],
+  ie: ['≤6', '≤11'],
   opera: ['≤12.1', '≤15'],
   opera_android: ['≤12.1', '≤14'],
   safari: ['≤4'],


### PR DESCRIPTION
This PR adds `≤11` as a valid range for Internet Explorer.  With IE's market share now [less than 1%](https://gs.statcounter.com/browser-market-share), along with the age of its releases, I don't think most developers will care about how far back something has been supported in IE (or in most cases, IE support altogether).  Additionally, this will aid in speeding up the removal of null and true values.

This PR is inspired by a comment from @foolip in #10381.
