### PR TITLE
Add  spec_url to KeyboardEvent.which

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -1710,6 +1710,7 @@
       "which": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyboardEvent/which",
+          "spec_url": "https://w3c.github.io/uievents/#dom-uievent-which",
           "support": {
             "chrome": {
               "version_added": "4"


### PR DESCRIPTION
KeyboardEvent.which was missing both the mdn_url and spec_url values.