### PR TITLE
Remove irrelevant Navigator.registerContentHandler

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1980,58 +1980,6 @@
           }
         }
       },
-      "registerContentHandler": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/registerContentHandler",
-          "support": {
-            "chrome": {
-              "version_added": "4",
-              "version_removed": "6"
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": "2",
-              "version_removed": "62"
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "≤12.1",
-              "version_removed": "15"
-            },
-            "opera_android": {
-              "version_added": "≤12.1",
-              "version_removed": "14"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "registerProtocolHandler": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/registerProtocolHandler",


### PR DESCRIPTION
Not implemented anywhere in the last 2 years
Will remove the MDN content, too.