### PR TITLE
Add HTTP Sec-CH-UA-* hints

### DIFF
--- a/http/headers/accept-ch.json
+++ b/http/headers/accept-ch.json
@@ -93,6 +93,342 @@
             "status": {
               "experimental": true,
               "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "Sec-CH-UA": {
+          "__compat": {
+            "description": "<code>Sec-CH-UA</code>",
+            "support": {
+              "chrome": {
+                "version_added": "89"
+              },
+              "chrome_android": {
+                "version_added": "89"
+              },
+              "edge": {
+                "version_added": "89"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "75"
+              },
+              "opera_android": {
+                "version_added": "63"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "89"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "Sec-CH-UA-Arch": {
+          "__compat": {
+            "description": "<code>Sec-CH-UA-Arch</code>",
+            "support": {
+              "chrome": {
+                "version_added": "89"
+              },
+              "chrome_android": {
+                "version_added": "89"
+              },
+              "edge": {
+                "version_added": "89"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "75"
+              },
+              "opera_android": {
+                "version_added": "63"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "89"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "Sec-CH-UA-Full-Version": {
+          "__compat": {
+            "description": "<code>Sec-CH-UA-Full-Version</code>",
+            "support": {
+              "chrome": {
+                "version_added": "89"
+              },
+              "chrome_android": {
+                "version_added": "89"
+              },
+              "edge": {
+                "version_added": "89"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "75"
+              },
+              "opera_android": {
+                "version_added": "63"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "89"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "Sec-CH-UA-Mobile": {
+          "__compat": {
+            "description": "<code>Sec-CH-UA-Mobile</code>",
+            "support": {
+              "chrome": {
+                "version_added": "89"
+              },
+              "chrome_android": {
+                "version_added": "89"
+              },
+              "edge": {
+                "version_added": "89"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "75"
+              },
+              "opera_android": {
+                "version_added": "63"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "89"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "Sec-CH-UA-Model": {
+          "__compat": {
+            "description": "<code>Sec-CH-UA-Model</code>",
+            "support": {
+              "chrome": {
+                "version_added": "89"
+              },
+              "chrome_android": {
+                "version_added": "89"
+              },
+              "edge": {
+                "version_added": "89"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "75"
+              },
+              "opera_android": {
+                "version_added": "63"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "89"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "Sec-CH-UA-Platform": {
+          "__compat": {
+            "description": "<code>Sec-CH-UA-Platform</code>",
+            "support": {
+              "chrome": {
+                "version_added": "89"
+              },
+              "chrome_android": {
+                "version_added": "89"
+              },
+              "edge": {
+                "version_added": "89"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "75"
+              },
+              "opera_android": {
+                "version_added": "63"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "89"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "Sec-CH-UA-Platform-Version": {
+          "__compat": {
+            "description": "<code>Sec-CH-UA-Platform-Version</code>",
+            "support": {
+              "chrome": {
+                "version_added": "89"
+              },
+              "chrome_android": {
+                "version_added": "89"
+              },
+              "edge": {
+                "version_added": "89"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "75"
+              },
+              "opera_android": {
+                "version_added": "63"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "89"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
               "deprecated": false
             }
           }
@@ -141,7 +477,7 @@
             "status": {
               "experimental": true,
               "standard_track": false,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },
@@ -189,7 +525,7 @@
             "status": {
               "experimental": true,
               "standard_track": false,
-              "deprecated": false
+              "deprecated": true
             }
           }
         }

--- a/http/headers/accept-ch.json
+++ b/http/headers/accept-ch.json
@@ -3,6 +3,7 @@
     "headers": {
       "Accept-CH": {
         "__compat": {
+          "description": "<code>Accept-CH</code> accepts client hints response header",
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-CH",
           "spec_url": "https://datatracker.ietf.org/doc/html/rfc8942#section-3.1",
           "support": {
@@ -147,7 +148,7 @@
         },
         "Sec-CH-UA-Arch": {
           "__compat": {
-            "description": "<code>Sec-CH-UA-Arch</code>",
+            "description": "<code>Sec-CH-UA-Arch</code> client hint header token",
             "support": {
               "chrome": {
                 "version_added": "89"

--- a/http/headers/accept-ch.json
+++ b/http/headers/accept-ch.json
@@ -3,7 +3,7 @@
     "headers": {
       "Accept-CH": {
         "__compat": {
-          "description": "<code>Accept-CH</code> accepts client hints response header",
+          "description": "<code>Accept-CH</code> client hint accept (response) header",
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-CH",
           "spec_url": "https://datatracker.ietf.org/doc/html/rfc8942#section-3.1",
           "support": {
@@ -52,7 +52,7 @@
         },
         "DPR": {
           "__compat": {
-            "description": "<code>DPR</code>",
+            "description": "<code>DPR</code> token",
             "support": {
               "chrome": {
                 "version_added": "46"
@@ -100,7 +100,7 @@
         },
         "Sec-CH-UA": {
           "__compat": {
-            "description": "<code>Sec-CH-UA</code>",
+            "description": "<code>Sec-CH-UA</code> token",
             "support": {
               "chrome": {
                 "version_added": "89"
@@ -148,7 +148,7 @@
         },
         "Sec-CH-UA-Arch": {
           "__compat": {
-            "description": "<code>Sec-CH-UA-Arch</code> client hint header token",
+            "description": "<code>Sec-CH-UA-Arch</code> token",
             "support": {
               "chrome": {
                 "version_added": "89"
@@ -196,7 +196,7 @@
         },
         "Sec-CH-UA-Full-Version": {
           "__compat": {
-            "description": "<code>Sec-CH-UA-Full-Version</code>",
+            "description": "<code>Sec-CH-UA-Full-Version</code> token",
             "support": {
               "chrome": {
                 "version_added": "89"
@@ -244,7 +244,7 @@
         },
         "Sec-CH-UA-Mobile": {
           "__compat": {
-            "description": "<code>Sec-CH-UA-Mobile</code>",
+            "description": "<code>Sec-CH-UA-Mobile</code> token",
             "support": {
               "chrome": {
                 "version_added": "89"
@@ -292,7 +292,7 @@
         },
         "Sec-CH-UA-Model": {
           "__compat": {
-            "description": "<code>Sec-CH-UA-Model</code>",
+            "description": "<code>Sec-CH-UA-Model</code> token",
             "support": {
               "chrome": {
                 "version_added": "89"
@@ -340,7 +340,7 @@
         },
         "Sec-CH-UA-Platform": {
           "__compat": {
-            "description": "<code>Sec-CH-UA-Platform</code>",
+            "description": "<code>Sec-CH-UA-Platform</code> token",
             "support": {
               "chrome": {
                 "version_added": "89"
@@ -388,7 +388,7 @@
         },
         "Sec-CH-UA-Platform-Version": {
           "__compat": {
-            "description": "<code>Sec-CH-UA-Platform-Version</code>",
+            "description": "<code>Sec-CH-UA-Platform-Version</code> token",
             "support": {
               "chrome": {
                 "version_added": "89"
@@ -436,7 +436,7 @@
         },
         "Viewport-Width": {
           "__compat": {
-            "description": "<code>Viewport-Width</code>",
+            "description": "<code>Viewport-Width</code> token",
             "support": {
               "chrome": {
                 "version_added": "46"
@@ -484,7 +484,7 @@
         },
         "Width": {
           "__compat": {
-            "description": "<code>Width</code>",
+            "description": "<code>Width</code> token",
             "support": {
               "chrome": {
                 "version_added": "46"

--- a/http/headers/accept-ch.json
+++ b/http/headers/accept-ch.json
@@ -50,6 +50,102 @@
             "deprecated": false
           }
         },
+        "Content-DPR": {
+          "__compat": {
+            "description": "<code>Content-DPR</code> token",
+            "support": {
+              "chrome": {
+                "version_added": "46"
+              },
+              "chrome_android": {
+                "version_added": "46"
+              },
+              "edge": {
+                "version_added": "≤79"
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "33"
+              },
+              "opera_android": {
+                "version_added": "33"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "46"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "Device-Memory": {
+          "__compat": {
+            "description": "<code>Device-Memory</code> token",
+            "support": {
+              "chrome": {
+                "version_added": "61"
+              },
+              "chrome_android": {
+                "version_added": "61"
+              },
+              "edge": {
+                "version_added": "≤79"
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": "48"
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "8.0"
+              },
+              "webview_android": {
+                "version_added": "61"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "DPR": {
           "__compat": {
             "description": "<code>DPR</code> token",

--- a/http/headers/content-dpr.json
+++ b/http/headers/content-dpr.json
@@ -3,6 +3,7 @@
     "headers": {
       "Content-DPR": {
         "__compat": {
+          "description": "<code>Content-DPR</code> request header",
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-DPR",
           "support": {
             "chrome": {
@@ -44,8 +45,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }

--- a/http/headers/device-memory.json
+++ b/http/headers/device-memory.json
@@ -3,6 +3,7 @@
     "headers": {
       "Device-Memory": {
         "__compat": {
+          "description": "<code>Device-Memory</code> request header",
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Device-Memory",
           "spec_url": "https://w3c.github.io/device-memory/#sec-device-memory-client-hint-header",
           "support": {

--- a/http/headers/dpr.json
+++ b/http/headers/dpr.json
@@ -3,6 +3,7 @@
     "headers": {
       "DPR": {
         "__compat": {
+          "description": "<code>DPR</code> request header",
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/DPR",
           "support": {
             "chrome": {

--- a/http/headers/sec-ch-ua-arch.json
+++ b/http/headers/sec-ch-ua-arch.json
@@ -3,7 +3,7 @@
     "headers": {
       "Sec-CH-UA-Arch": {
         "__compat": {
-          "description": "<code>Sec-CH-UA-Arch</code> user-agent client hint request header",
+          "description": "<code>Sec-CH-UA-Arch</code> request header",
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-CH-UA-Arch",
           "spec_url": "https://wicg.github.io/ua-client-hints/#sec-ch-ua-arch",
           "support": {

--- a/http/headers/sec-ch-ua-arch.json
+++ b/http/headers/sec-ch-ua-arch.json
@@ -1,0 +1,55 @@
+{
+  "http": {
+    "headers": {
+      "Sec-CH-UA-Arch": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-CH-UA-Arch",
+          "spec_url": "https://wicg.github.io/ua-client-hints/#sec-ch-ua-arch",
+          "support": {
+            "chrome": {
+              "version_added": "89"
+            },
+            "chrome_android": {
+              "version_added": "89"
+            },
+            "edge": {
+              "version_added": "89"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "75"
+            },
+            "opera_android": {
+              "version_added": "63"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "89"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/sec-ch-ua-arch.json
+++ b/http/headers/sec-ch-ua-arch.json
@@ -3,6 +3,7 @@
     "headers": {
       "Sec-CH-UA-Arch": {
         "__compat": {
+          "description": "<code>Sec-CH-UA-Arch</code> user-agent client hint request header",
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-CH-UA-Arch",
           "spec_url": "https://wicg.github.io/ua-client-hints/#sec-ch-ua-arch",
           "support": {

--- a/http/headers/sec-ch-ua-full-version.json
+++ b/http/headers/sec-ch-ua-full-version.json
@@ -3,6 +3,7 @@
     "headers": {
       "Sec-CH-UA-Full-Version": {
         "__compat": {
+          "description": "<code>Sec-CH-UA-Full-Version</code> request header",
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-CH-UA-Full-Version",
           "spec_url": "https://wicg.github.io/ua-client-hints/#sec-ch-ua-full-version",
           "support": {

--- a/http/headers/sec-ch-ua-full-version.json
+++ b/http/headers/sec-ch-ua-full-version.json
@@ -1,0 +1,55 @@
+{
+  "http": {
+    "headers": {
+      "Sec-CH-UA-Full-Version": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-CH-UA-Full-Version",
+          "spec_url": "https://wicg.github.io/ua-client-hints/#sec-ch-ua-full-version",
+          "support": {
+            "chrome": {
+              "version_added": "89"
+            },
+            "chrome_android": {
+              "version_added": "89"
+            },
+            "edge": {
+              "version_added": "89"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "75"
+            },
+            "opera_android": {
+              "version_added": "63"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "89"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/sec-ch-ua-mobile.json
+++ b/http/headers/sec-ch-ua-mobile.json
@@ -3,6 +3,7 @@
     "headers": {
       "Sec-CH-UA-Mobile": {
         "__compat": {
+          "description": "<code>Sec-CH-UA-Mobile</code> request header",
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-CH-UA-Mobile",
           "spec_url": "https://wicg.github.io/ua-client-hints/#sec-ch-ua-mobile",
           "support": {

--- a/http/headers/sec-ch-ua-mobile.json
+++ b/http/headers/sec-ch-ua-mobile.json
@@ -1,0 +1,55 @@
+{
+  "http": {
+    "headers": {
+      "Sec-CH-UA-Mobile": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-CH-UA-Mobile",
+          "spec_url": "https://wicg.github.io/ua-client-hints/#sec-ch-ua-mobile",
+          "support": {
+            "chrome": {
+              "version_added": "89"
+            },
+            "chrome_android": {
+              "version_added": "89"
+            },
+            "edge": {
+              "version_added": "89"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "75"
+            },
+            "opera_android": {
+              "version_added": "63"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "89"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/sec-ch-ua-model.json
+++ b/http/headers/sec-ch-ua-model.json
@@ -3,6 +3,7 @@
     "headers": {
       "Sec-CH-UA-Model": {
         "__compat": {
+          "description": "<code>Sec-CH-UA-Model</code> request header",
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-CH-UA-Model",
           "spec_url": "https://wicg.github.io/ua-client-hints/#sec-ch-ua-model",
           "support": {

--- a/http/headers/sec-ch-ua-model.json
+++ b/http/headers/sec-ch-ua-model.json
@@ -1,0 +1,55 @@
+{
+  "http": {
+    "headers": {
+      "Sec-CH-UA-Model": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-CH-UA-Model",
+          "spec_url": "https://wicg.github.io/ua-client-hints/#sec-ch-ua-model",
+          "support": {
+            "chrome": {
+              "version_added": "89"
+            },
+            "chrome_android": {
+              "version_added": "89"
+            },
+            "edge": {
+              "version_added": "89"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "75"
+            },
+            "opera_android": {
+              "version_added": "63"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "89"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/sec-ch-ua-platform-version.json
+++ b/http/headers/sec-ch-ua-platform-version.json
@@ -3,6 +3,7 @@
     "headers": {
       "Sec-CH-UA-Platform-Version": {
         "__compat": {
+          "description": "<code>Sec-CH-UA-Platform-Version</code> request header",
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-CH-UA-Platform-Version",
           "spec_url": "https://wicg.github.io/ua-client-hints/#sec-ch-ua-platform-version",
           "support": {

--- a/http/headers/sec-ch-ua-platform-version.json
+++ b/http/headers/sec-ch-ua-platform-version.json
@@ -1,0 +1,55 @@
+{
+  "http": {
+    "headers": {
+      "Sec-CH-UA-Platform-Version": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-CH-UA-Platform-Version",
+          "spec_url": "https://wicg.github.io/ua-client-hints/#sec-ch-ua-platform-version",
+          "support": {
+            "chrome": {
+              "version_added": "89"
+            },
+            "chrome_android": {
+              "version_added": "89"
+            },
+            "edge": {
+              "version_added": "89"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "75"
+            },
+            "opera_android": {
+              "version_added": "63"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "89"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/sec-ch-ua-platform.json
+++ b/http/headers/sec-ch-ua-platform.json
@@ -3,6 +3,7 @@
     "headers": {
       "Sec-CH-UA-Platform": {
         "__compat": {
+          "description": "<code>Sec-CH-UA-Platform</code> request header",
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-CH-UA-Platform",
           "spec_url": "https://wicg.github.io/ua-client-hints/#sec-ch-ua-platform",
           "support": {

--- a/http/headers/sec-ch-ua-platform.json
+++ b/http/headers/sec-ch-ua-platform.json
@@ -1,0 +1,55 @@
+{
+  "http": {
+    "headers": {
+      "Sec-CH-UA-Platform": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-CH-UA-Platform",
+          "spec_url": "https://wicg.github.io/ua-client-hints/#sec-ch-ua-platform",
+          "support": {
+            "chrome": {
+              "version_added": "89"
+            },
+            "chrome_android": {
+              "version_added": "89"
+            },
+            "edge": {
+              "version_added": "89"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "75"
+            },
+            "opera_android": {
+              "version_added": "63"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "89"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/sec-ch-ua.json
+++ b/http/headers/sec-ch-ua.json
@@ -3,6 +3,7 @@
     "headers": {
       "Sec-CH-UA": {
         "__compat": {
+          "description": "<code>Sec-CH-UA</code> request header",
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-CH-UA",
           "spec_url": "https://wicg.github.io/ua-client-hints/#sec-ch-ua",
           "support": {

--- a/http/headers/sec-ch-ua.json
+++ b/http/headers/sec-ch-ua.json
@@ -1,0 +1,55 @@
+{
+  "http": {
+    "headers": {
+      "Sec-CH-UA": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-CH-UA",
+          "spec_url": "https://wicg.github.io/ua-client-hints/#sec-ch-ua",
+          "support": {
+            "chrome": {
+              "version_added": "89"
+            },
+            "chrome_android": {
+              "version_added": "89"
+            },
+            "edge": {
+              "version_added": "89"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "75"
+            },
+            "opera_android": {
+              "version_added": "63"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "89"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/viewport-width.json
+++ b/http/headers/viewport-width.json
@@ -3,6 +3,7 @@
     "headers": {
       "Viewport-Width": {
         "__compat": {
+          "description": "<code>Viewport-Width</code> request header",
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Viewport-Width",
           "support": {
             "chrome": {

--- a/http/headers/width.json
+++ b/http/headers/width.json
@@ -3,6 +3,7 @@
     "headers": {
       "Width": {
         "__compat": {
+          "description": "<code>Width</code> request header",
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Width",
           "support": {
             "chrome": {


### PR DESCRIPTION
Fixes #11190

Adds header entries for all the User Agent client hints and makes corresponding updates the `Accept-CH` header.
- Spec: https://wicg.github.io/ua-client-hints/
- Added to Chrome in 89 as per https://www.chromestatus.com/feature/5995832180473856
- Demo/testing gitchme: https://user-agent-client-hints.glitch.me/

Appropriate versions added to all chromiums. There is no corresponding version for Samsung Internet yet.

This does not include the header for [Sec-CH-UA-Bitness](https://wicg.github.io/ua-client-hints/#sec-ch-ua-bitness) as that is not tested by the demo and does not appear to be implemented on quick code scan.
