### PR TITLE
Add spec_url to html attributes

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -558,6 +558,7 @@
         },
         "rel": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-rel",
             "support": {
               "chrome": {
                 "version_added": true

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -631,6 +631,7 @@
         },
         "rel": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-rel",
             "support": {
               "chrome": {
                 "version_added": true

--- a/html/elements/button.json
+++ b/html/elements/button.json
@@ -145,6 +145,7 @@
         },
         "disabled": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-disabled",
             "support": {
               "chrome": {
                 "version_added": true

--- a/html/elements/fieldset.json
+++ b/html/elements/fieldset.json
@@ -58,6 +58,7 @@
         },
         "disabled": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-disabled",
             "support": {
               "chrome": {
                 "version_added": true

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -257,6 +257,7 @@
         },
         "crossorigin": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-crossorigin",
             "support": {
               "chrome": {
                 "version_added": true

--- a/html/elements/label.json
+++ b/html/elements/label.json
@@ -51,6 +51,7 @@
         },
         "for": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#attr-label-for",
             "support": {
               "chrome": {
                 "version_added": true

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -98,6 +98,7 @@
         },
         "crossorigin": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-link-crossorigin",
             "support": {
               "chrome": {
                 "version_added": "25"
@@ -672,8 +673,7 @@
         },
         "rel": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Link_types",
-            "spec_url": "https://html.spec.whatwg.org/multipage/links.html#linkTypes",
+            "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-link-rel",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/html/elements/meter.json
+++ b/html/elements/meter.json
@@ -192,6 +192,7 @@
         },
         "max": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-meter-max",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -239,6 +240,7 @@
         },
         "min": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-meter-min",
             "support": {
               "chrome": {
                 "version_added": "6"

--- a/html/elements/optgroup.json
+++ b/html/elements/optgroup.json
@@ -51,6 +51,7 @@
         },
         "disabled": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-optgroup-disabled",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/html/elements/option.json
+++ b/html/elements/option.json
@@ -51,6 +51,7 @@
         },
         "disabled": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-option-disabled",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/html/elements/output.json
+++ b/html/elements/output.json
@@ -51,6 +51,7 @@
         },
         "for": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-output-for",
             "support": {
               "chrome": {
                 "version_added": "10"

--- a/html/elements/progress.json
+++ b/html/elements/progress.json
@@ -60,6 +60,7 @@
         },
         "max": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-progress-max",
             "support": {
               "chrome": {
                 "version_added": "6"

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -99,6 +99,7 @@
         },
         "crossorigin": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#attr-script-crossorigin",
             "support": {
               "chrome": {
                 "version_added": "30"

--- a/html/elements/select.json
+++ b/html/elements/select.json
@@ -109,6 +109,7 @@
         },
         "disabled": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-disabled",
             "support": {
               "chrome": {
                 "version_added": true
@@ -156,6 +157,7 @@
         },
         "form": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fae-form",
             "support": {
               "chrome": {
                 "version_added": true
@@ -203,6 +205,7 @@
         },
         "multiple": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-select-multiple",
             "support": {
               "chrome": {
                 "version_added": true
@@ -250,6 +253,7 @@
         },
         "name": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-name",
             "support": {
               "chrome": {
                 "version_added": true
@@ -297,6 +301,7 @@
         },
         "required": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-select-required",
             "support": {
               "chrome": {
                 "version_added": true
@@ -344,6 +349,7 @@
         },
         "size": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-select-size",
             "support": {
               "chrome": {
                 "version_added": true

--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -299,6 +299,7 @@
         },
         "disabled": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-disabled",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -393,6 +394,7 @@
         },
         "maxlength": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-textarea-maxlength",
             "support": {
               "chrome": {
                 "version_added": "4"
@@ -440,6 +442,7 @@
         },
         "minlength": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-textarea-minlength",
             "support": {
               "chrome": {
                 "version_added": "40"
@@ -631,6 +634,7 @@
         },
         "readonly": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-textarea-required",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -678,6 +682,7 @@
         },
         "required": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-textarea-required",
             "support": {
               "chrome": {
                 "version_added": "4"

--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -207,6 +207,7 @@
         },
         "crossorigin": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/media.html#attr-media-crossorigin",
             "support": {
               "chrome": {
                 "version_added": null


### PR DESCRIPTION
Most html attributes haven't yet the spec_url.

This fix some of them (those that I need ;-) ) – there is a lot of work left.