### PR TITLE
missing shadowRoot property and AriaMixin spec URLs

### DIFF
--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -342,6 +342,55 @@
           }
         }
       },
+      "shadowRoot": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/shadowRoot",
+          "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#dom-elementinternals-shadowroot",
+          "support": {
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "77"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "64"
+            },
+            "opera_android": {
+              "version_added": "55"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "12.0"
+            },
+            "webview_android": {
+              "version_added": "77"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "validationMessage": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/validationMessage",

--- a/api/_mixins/ARIAMixin__ElementInternals.json
+++ b/api/_mixins/ARIAMixin__ElementInternals.json
@@ -4,6 +4,7 @@
       "ariaAtomic": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaAtomic",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariaatomic",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -52,6 +53,7 @@
       "ariaAutoComplete": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaAutoComplete",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariaautocomplete",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -100,6 +102,7 @@
       "ariaBusy": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaBusy",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariabusy",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -148,6 +151,7 @@
       "ariaChecked": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaChecked",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariachecked",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -196,6 +200,7 @@
       "ariaColCount": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaColCount",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariacolcount",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -244,6 +249,7 @@
       "ariaColIndex": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaColIndex",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariacolindex",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -292,6 +298,7 @@
       "ariaColSpan": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaColSpan",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariacolspan",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -340,6 +347,7 @@
       "ariaCurrent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaCurrent",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariacurrent",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -388,6 +396,7 @@
       "ariaDescription": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaDescription",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariadescription",
           "support": {
             "chrome": {
               "version_added": "83"
@@ -436,6 +445,7 @@
       "ariaDisabled": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaDisabled",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariadisabled",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -484,6 +494,7 @@
       "ariaExpanded": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaExpanded",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariaexpanded",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -532,6 +543,7 @@
       "ariaHasPopup": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaHasPopup",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariahaspopup",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -580,6 +592,7 @@
       "ariaHidden": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaHidden",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariahidden",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -628,6 +641,7 @@
       "ariaKeyShortcuts": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaKeyShortcuts",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariakeyshortcuts",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -676,6 +690,7 @@
       "ariaLabel": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaLabel",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-arialabel",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -724,6 +739,7 @@
       "ariaLevel": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaLevel",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-arialevel",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -772,6 +788,7 @@
       "ariaLive": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaLive",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-arialive",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -820,6 +837,7 @@
       "ariaModal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaModal",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariamodal",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -868,6 +886,7 @@
       "ariaMultiLine": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaMultiLine",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariamultiline",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -916,6 +935,7 @@
       "ariaMultiSelectable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaMultiSelectable",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariamultiselectable",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -964,6 +984,7 @@
       "ariaOrientation": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaOrientation",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariaorientation",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -1012,6 +1033,7 @@
       "ariaPlaceholder": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaPlaceholder",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariaplaceholder",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -1060,6 +1082,7 @@
       "ariaPosInSet": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaPosInSet",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariaposinset",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -1108,6 +1131,7 @@
       "ariaPressed": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaPressed",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariapressed",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -1156,6 +1180,7 @@
       "ariaReadOnly": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaReadOnly",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariareadonly",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -1204,6 +1229,7 @@
       "ariaRelevant": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaRelevant",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariarelevant",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -1252,6 +1278,7 @@
       "ariaRequired": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaRequired",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariarequired",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -1300,6 +1327,7 @@
       "ariaRoleDescription": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaRoleDescription",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariaroledescription",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -1348,6 +1376,7 @@
       "ariaRowCount": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaRowCount",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariarowcount",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -1396,6 +1425,7 @@
       "ariaRowIndex": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaRowIndex",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariarowindex",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -1444,6 +1474,7 @@
       "ariaRowSpan": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaRowSpan",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariarowspan",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -1492,6 +1523,7 @@
       "ariaSelected": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaSelected",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariaselected",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -1540,6 +1572,7 @@
       "ariaSetSize": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaSetSize",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariasetsize",
           "support": {
             "chrome": {
               "version_added": "84"
@@ -1588,6 +1621,7 @@
       "ariaSort": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaSort",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariasort",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -1636,6 +1670,7 @@
       "ariaValueMax": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaValueMax",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariavaluemax",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -1684,6 +1719,7 @@
       "ariaValueMin": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaValueMin",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariavaluemin",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -1732,6 +1768,7 @@
       "ariaValueNow": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaValueNow",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariavaluenow",
           "support": {
             "chrome": {
               "version_added": "81"
@@ -1780,6 +1817,7 @@
       "ariaValueText": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaValueText",
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariavaluetext",
           "support": {
             "chrome": {
               "version_added": "81"


### PR DESCRIPTION
I've been documenting ElementInternals in https://github.com/mdn/content/pull/6335

This adds a missing property `shadowRoot`, and also all of the spec URLs for `AriaMixin` in ElementInternals.