### PR TITLE
Add missing Safari 14 support to block top-level data URL navigations

### DIFF
--- a/http/data-url.json
+++ b/http/data-url.json
@@ -234,10 +234,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": null
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Show Safari 14 and Safari on iOS 14 support for blocking top level navigations to data URLs.

#### Test results and supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Addressed with this change https://trac.webkit.org/changeset/255961/webkit