### PR TITLE
Add Safari version for geolocation secure context

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -873,10 +873,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Add missing Safari data support of secure context requirement for the Geolocation API.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
[STP 5 release notes](https://webkit.org/blog/6415/release-notes-for-safari-technology-preview-5/) and https://trac.webkit.org/changeset/200686/webkit indicate the secure context requirement for geolocation was added in Safari 10 and Safari for iOS 10.