### PR TITLE
Add Safari 15 support for MediaMetadata

### DIFF
--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -44,10 +44,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "15"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "15"
           },
           "samsunginternet_android": {
             "version_added": "7.0"
@@ -93,10 +93,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "15"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -142,10 +142,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "15"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -191,10 +191,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "15"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -240,10 +240,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "15"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -289,10 +289,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "15"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15"
             },
             "samsunginternet_android": {
               "version_added": "7.0"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
This change updates MediaMetadata support for Safari 15 and Safari on iOS 15.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
See: https://trac.webkit.org/changeset/276338/webkit
Also refer to previous conversation about this: https://github.com/mdn/browser-compat-data/pull/10129/files/ce5dff5147ca316a9e048718102c3c191e280a45#diff-4219b4df1eaddd89a1a8f36f4d65074e560f1f1e70a7a1c83cb2988379b9c138

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Follow-up to #10129

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
