### PR TITLE
Add DataView BigInt handling for Safari

### DIFF
--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -519,10 +519,10 @@
                 "version_added": "48"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15"
               },
               "samsunginternet_android": {
                 "version_added": "9.0"
@@ -571,10 +571,10 @@
                 "version_added": "48"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15"
               },
               "samsunginternet_android": {
                 "version_added": "9.0"
@@ -1039,10 +1039,10 @@
                 "version_added": "48"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15"
               },
               "samsunginternet_android": {
                 "version_added": "9.0"
@@ -1091,10 +1091,10 @@
                 "version_added": "48"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15"
               },
               "samsunginternet_android": {
                 "version_added": "9.0"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Add Safari support for DataView's `getBigInt64`, `setBigInt64`, `getBigUint64`, and `setBigUint64`.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
See https://trac.webkit.org/changeset/272170/webkit and https://developer.apple.com/documentation/safari-release-notes/safari-15-beta-release-notes