### PR TITLE
Add Edge versions for api.Document.paste_event.clipboardData

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -8193,7 +8193,7 @@
                 "version_added": "58"
               },
               "edge": {
-                "version_added": null
+                "version_added": "≤79"
               },
               "firefox": {
                 "version_added": "22"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `paste_event.clipboardData` member of the `Document` API.  This simply sets the feature to the range of ≤79 based upon mirroring from Chrome.
