### PR TITLE
Add spec_url & mdn_url to DataTransferIterm.getAsFileSystemHandle

### DIFF
--- a/api/DataTransferItem.json
+++ b/api/DataTransferItem.json
@@ -99,8 +99,8 @@
       },
       "getAsFileSystemHandle": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/file-system-access/#dom-datatransferitem-getasfilesystemhandle",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DataTransferItem/getAsFileSystemHandle",
+          "spec_url": "https://wicg.github.io/file-system-access/#dom-datatransferitem-getasfilesystemhandle",
           "support": {
             "chrome": {
               "version_added": "86"

--- a/api/DataTransferItem.json
+++ b/api/DataTransferItem.json
@@ -99,6 +99,8 @@
       },
       "getAsFileSystemHandle": {
         "__compat": {
+          "spec_url": "https://wicg.github.io/file-system-access/#dom-datatransferitem-getasfilesystemhandle",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DataTransferItem/getAsFileSystemHandle",
           "support": {
             "chrome": {
               "version_added": "86"


### PR DESCRIPTION
Both the spec_url & mdn_url were missing for this method.