### PR TITLE
Remove Safari 3.2 from BCD

### DIFF
--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -625,7 +625,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -304,7 +304,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3"
@@ -356,7 +356,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3"
@@ -657,7 +657,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3"
@@ -818,7 +818,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3"
@@ -867,7 +867,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3"
@@ -1064,7 +1064,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3"
@@ -1213,7 +1213,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3"
@@ -1312,7 +1312,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3"
@@ -1504,7 +1504,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3"
@@ -2230,7 +2230,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3"
@@ -3414,7 +3414,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "2"
@@ -3716,7 +3716,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "2"

--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -45,12 +45,6 @@
           "engine": "WebKit",
           "engine_version": "525.13"
         },
-        "3.2": {
-          "release_date": "2008-11-13",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "525.26"
-        },
         "4": {
           "release_date": "2009-06-08",
           "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_4_0.html",

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -83,7 +83,7 @@
                 "version_removed": "25"
               },
               "safari": {
-                "version_added": "3.2"
+                "version_added": "3.1"
               },
               "safari_ios": {
                 "version_added": "3"
@@ -937,7 +937,7 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "3.2"
+                "version_added": "3.1"
               },
               "safari_ios": {
                 "version_added": "3"

--- a/css/properties/-webkit-mask-box-image.json
+++ b/css/properties/-webkit-mask-box-image.json
@@ -33,7 +33,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/properties/-webkit-mask-box-image.json
+++ b/css/properties/-webkit-mask-box-image.json
@@ -30,7 +30,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3.2"

--- a/css/properties/-webkit-mask-composite.json
+++ b/css/properties/-webkit-mask-composite.json
@@ -33,7 +33,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/properties/-webkit-mask-composite.json
+++ b/css/properties/-webkit-mask-composite.json
@@ -30,7 +30,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3.2"

--- a/css/properties/-webkit-mask-position-x.json
+++ b/css/properties/-webkit-mask-position-x.json
@@ -33,7 +33,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/properties/-webkit-mask-position-x.json
+++ b/css/properties/-webkit-mask-position-x.json
@@ -30,7 +30,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3.2"

--- a/css/properties/-webkit-mask-position-y.json
+++ b/css/properties/-webkit-mask-position-y.json
@@ -33,7 +33,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/properties/-webkit-mask-position-y.json
+++ b/css/properties/-webkit-mask-position-y.json
@@ -30,7 +30,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3.2"

--- a/css/properties/mask-position.json
+++ b/css/properties/mask-position.json
@@ -36,7 +36,7 @@
             },
             "safari": {
               "prefix": "-webkit-",
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "prefix": "-webkit-",
@@ -98,7 +98,7 @@
               },
               "safari": {
                 "prefix": "-webkit-",
-                "version_added": "3.2"
+                "version_added": "3.1"
               },
               "safari_ios": {
                 "prefix": "-webkit-",

--- a/css/properties/mask-position.json
+++ b/css/properties/mask-position.json
@@ -40,7 +40,7 @@
             },
             "safari_ios": {
               "prefix": "-webkit-",
-              "version_added": "3.2"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "prefix": "-webkit-",
@@ -102,7 +102,7 @@
               },
               "safari_ios": {
                 "prefix": "-webkit-",
-                "version_added": "3.2"
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "prefix": "-webkit-",

--- a/css/properties/mask-repeat.json
+++ b/css/properties/mask-repeat.json
@@ -40,7 +40,7 @@
             },
             "safari_ios": {
               "prefix": "-webkit-",
-              "version_added": "3.2"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "prefix": "-webkit-",

--- a/css/properties/mask-repeat.json
+++ b/css/properties/mask-repeat.json
@@ -36,7 +36,7 @@
             },
             "safari": {
               "prefix": "-webkit-",
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "prefix": "-webkit-",

--- a/css/properties/mask.json
+++ b/css/properties/mask.json
@@ -82,13 +82,13 @@
             ],
             "safari_ios": [
               {
-                "version_added": "3.2",
+                "version_added": "2",
                 "partial_implementation": true,
                 "notes": "While the property is recognized, values applied to it don't have any effect."
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "3.2",
+                "version_added": "2",
                 "notes": "The prefixed property can be used with SVG and HTML with a slightly different syntax, which allows setting the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-attachment'><code>-webkit-mask-attachment</code></a> property."
               }
             ],

--- a/css/properties/mask.json
+++ b/css/properties/mask.json
@@ -70,13 +70,13 @@
             ],
             "safari": [
               {
-                "version_added": "3.2",
+                "version_added": "3.1",
                 "partial_implementation": true,
                 "notes": "While the property is recognized, values applied to it don't have any effect."
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "3.2",
+                "version_added": "3.1",
                 "notes": "The prefixed property can be used with SVG and HTML with a slightly different syntax, which allows setting the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-attachment'><code>-webkit-mask-attachment</code></a> property."
               }
             ],

--- a/css/selectors/first-of-type.json
+++ b/css/selectors/first-of-type.json
@@ -34,7 +34,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3.2"

--- a/css/selectors/first-of-type.json
+++ b/css/selectors/first-of-type.json
@@ -37,7 +37,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/last-child.json
+++ b/css/selectors/last-child.json
@@ -32,7 +32,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3.2"

--- a/css/selectors/last-child.json
+++ b/css/selectors/last-child.json
@@ -35,7 +35,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/last-of-type.json
+++ b/css/selectors/last-of-type.json
@@ -34,7 +34,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3.2"

--- a/css/selectors/last-of-type.json
+++ b/css/selectors/last-of-type.json
@@ -37,7 +37,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/not.json
+++ b/css/selectors/not.json
@@ -32,7 +32,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3.2"

--- a/css/selectors/not.json
+++ b/css/selectors/not.json
@@ -35,7 +35,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/nth-last-child.json
+++ b/css/selectors/nth-last-child.json
@@ -32,7 +32,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3.2"

--- a/css/selectors/nth-last-child.json
+++ b/css/selectors/nth-last-child.json
@@ -35,7 +35,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/nth-last-of-type.json
+++ b/css/selectors/nth-last-of-type.json
@@ -34,7 +34,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3.2"

--- a/css/selectors/nth-last-of-type.json
+++ b/css/selectors/nth-last-of-type.json
@@ -37,7 +37,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/only-of-type.json
+++ b/css/selectors/only-of-type.json
@@ -34,7 +34,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3.2"

--- a/css/selectors/only-of-type.json
+++ b/css/selectors/only-of-type.json
@@ -37,7 +37,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/javascript/operators/void.json
+++ b/javascript/operators/void.json
@@ -34,7 +34,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3"

--- a/svg/elements/font.json
+++ b/svg/elements/font.json
@@ -49,7 +49,7 @@
               "version_removed": "25"
             },
             "safari": {
-              "version_added": "3.2"
+              "version_added": "3.1"
             },
             "safari_ios": {
               "version_added": "3.2"

--- a/svg/elements/font.json
+++ b/svg/elements/font.json
@@ -52,7 +52,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0",


### PR DESCRIPTION
This PR removes Safari 3.2 from BCD.  After comparing the results collected from the mdn-bcd-collector project for both 3.1 and 3.2, I had only found one difference between them: the User Agent string.  On top of that, I've spot checked a number of the entries reported as Safari 3.2 that the collector doesn't check, and found pretty much everything to be supported in Safari 3.1, so there is no need to track Safari 3.2 separately.
