### PR TITLE
Add Safari versions for api.Element.click_event.on_disabled_form_elements

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1788,10 +1788,10 @@
                 "notes": "Only works for <code>&lt;textarea&gt;</code> elements and some <code>&lt;input&gt;</code> element types."
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": true,


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `click_event.on_disabled_form_elements` member of the `Element` API, based upon manual testing.

Test Code Used:
```html
<textarea id="input" disabled></textarea>

<script>
  document.getElementById('input').addEventListener('click', function() {
    console.log('Hi!');
  });
</script>
````
