### PR TITLE
Add missing mdn_url

### DIFF
--- a/api/HTMLHtmlElement.json
+++ b/api/HTMLHtmlElement.json
@@ -50,6 +50,7 @@
       },
       "version": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHtmlElement/version",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/MIDIPort.json
+++ b/api/MIDIPort.json
@@ -289,6 +289,7 @@
       },
       "onstatechange": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/onstatechange",
           "support": {
             "chrome": {
               "version_added": "43"

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1783,6 +1783,7 @@
       },
       "getTransceivers": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/getTransceivers",
           "support": {
             "chrome": {
               "version_added": "69"

--- a/api/SVGPointList.json
+++ b/api/SVGPointList.json
@@ -2,6 +2,7 @@
   "api": {
     "SVGPointList": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList",
         "support": {
           "chrome": {
             "version_added": "5"
@@ -48,6 +49,7 @@
       },
       "appendItem": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/appendItem",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -95,6 +97,7 @@
       },
       "clear": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/clear",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -142,6 +145,7 @@
       },
       "getItem": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/getItem",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -189,6 +193,7 @@
       },
       "initialize": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/initialize",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -236,6 +241,7 @@
       },
       "insertItemBefore": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/insertItemBefore",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -283,6 +289,7 @@
       },
       "length": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/length",
           "support": {
             "chrome": {
               "version_added": true
@@ -330,6 +337,7 @@
       },
       "numberOfItems": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/numberOfItems",
           "support": {
             "chrome": {
               "version_added": true
@@ -377,6 +385,7 @@
       },
       "removeItem": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/removeItem",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -424,6 +433,7 @@
       },
       "replaceItem": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/replaceItem",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/html/elements/html.json
+++ b/html/elements/html.json
@@ -51,6 +51,7 @@
         },
         "manifest": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/html/manifest",
             "support": {
               "chrome": {
                 "version_added": "4"

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -147,6 +147,7 @@
         },
         "SameSite": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
             "description": "<code>SameSite</code>",
             "support": {
               "chrome": {

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -2205,6 +2205,7 @@
         },
         "goBack": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/goBack",
             "support": {
               "chrome": {
                 "version_added": "72"
@@ -2229,6 +2230,7 @@
         },
         "goForward": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/goForward",
             "support": {
               "chrome": {
                 "version_added": "72"


### PR DESCRIPTION
While working on a script to check the coherence between mdn_url here and the content of the browser-compat in MDN's front-runner, I found a few existing MDN pages without the mdn_url clause here.

I'm fixing these.

All these URLs do exist.