### PR TITLE
Add `accepts_flags` to the browsers schema as an optional hint

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -2,6 +2,7 @@
   "browsers": {
     "samsunginternet_android": {
       "name": "Samsung Internet",
+      "accepts_flags": false,
       "releases": {
         "1.0": {
           "release_date": "2013-04-27",

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -2,6 +2,7 @@
   "browsers": {
     "webview_android": {
       "name": "WebView Android",
+      "accepts_flags": false,
       "releases": {
         "1": {
           "release_date": "2008-09-23",

--- a/schemas/browsers-schema.md
+++ b/schemas/browsers-schema.md
@@ -40,6 +40,10 @@ Underneath, there is a `releases` object which will hold the various releases of
 
 The `name` string is a required property which should use the browser brand name and avoid English words if possible, for example `"Firefox"`, `"Firefox Android"`, `"Safari"`, `"iOS Safari"`, etc.
 
+### `accepts_flags`
+
+An optional boolean indicating whether the browser supports flags. This is a hint to data contributors and tools. A `true` value does not mean that there exists any flag data for the browser and a `false` value does not guarantee a lack of flag data for the browser.
+
 ### `pref_url`
 
 An optional string containing the URL of the page where feature flags can be changed (e.g. `"about:config"` for Firefox or `"chrome://flags"` for Chrome).
@@ -61,6 +65,10 @@ The release objects consist of the following properties:
 - An optional `release_date` property with the `YYYY-MM-DD` release date of the browser's release.
 
 - An optional `release_notes` property which points to release notes. It needs to be a valid URL.
+
+- An optional `accepts_flags` boolean property indicating whether the release supports flags.
+
+  This is a hint to data contributors and tools. A `true` value does not mean that there exists any flag data for the release and a `false` value does not guarantee a lack of flag data for the release.
 
 - An optional `engine` property which is the name of the browser's engine.
 

--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -30,6 +30,10 @@
           "type": "string",
           "description": "Browser name, avoid using unnecessary English (e.g. prefer 'Chrome Android' over 'Chrome for Android')."
         },
+        "accepts_flags": {
+          "type": "boolean",
+          "description": "Whether the browser supports flags."
+        },
         "pref_url": {
           "type": "string",
           "description": "URL of the page where feature flags can be changed (e.g. 'about:config' or 'chrome://flags')."
@@ -55,6 +59,10 @@
           "type": "string",
           "format": "uri",
           "description": "A link to the release notes or changelog for a given release."
+        },
+        "accepts_flags": {
+          "type": "boolean",
+          "description": "Whether the release supports flags."
         },
         "engine": {
           "type": "string",


### PR DESCRIPTION
#### Summary

This PR proposes an addition to the schema, `accepts_flags` for both browsers as a whole and individual releases. This is me trying to having it both ways: providing an easy option (per-browser) for easy cases and a harder option (per-release) for harder cases.

I defined this part of the schema as an optional hint, rather than to trying to use it to drive the linter immediately or do anything more restrictive. I'm proposing it in this shallow state now, so that we can roll it into the next breaking release (which we require for schema changes).

#### Related issues

https://github.com/mdn/browser-compat-data/issues/10616
