### PR TITLE
Add Safari 15 support for instantiateStreaming

### DIFF
--- a/javascript/builtins/webassembly/WebAssembly.json
+++ b/javascript/builtins/webassembly/WebAssembly.json
@@ -247,10 +247,10 @@
                 "version_added": "45"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15"
               },
               "samsunginternet_android": {
                 "version_added": "8.0"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
This change adds Safari 15 and Safari on iOS 15 support for WASM `instantiateStreaming`.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
See the changeset on WebKit Trac: https://trac.webkit.org/changeset/272221/webkit

WASM streaming support was enabled in Safari 15 beta: https://developer.apple.com/documentation/safari-release-notes/safari-15-beta-release-notes
