### PR TITLE
Add Safari versions for GlobalEventHandlers API

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -2202,10 +2202,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -4321,10 +4321,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `GlobalEventHandlers` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.8).

Tests Used:
https://mdn-bcd-collector.appspot.com/tests/api/Document/onloadend
https://mdn-bcd-collector.appspot.com/tests/api/Document/onshow
