### PR TITLE
Add Safari versions for api.KeyboardEvent.getModifierState.parameters

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -563,10 +563,10 @@
                 "version_added": "35"
               },
               "safari": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -659,10 +659,10 @@
                 "version_added": "35"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -707,10 +707,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -755,10 +755,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -851,10 +851,10 @@
                 "version_added": "35"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -901,10 +901,10 @@
                 "version_added": "35"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -951,10 +951,10 @@
                 "version_added": "35"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -1047,10 +1047,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -1095,10 +1095,10 @@
                 "version_added": "35"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -1143,10 +1143,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `getModifierState.parameters` member of the `KeyboardEvent` API, based upon commit history and date.

Commit: https://trac.webkit.org/changeset/206725/webkit / https://trac.webkit.org/changeset/206828/webkit / https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/dom/UIEventWithKeyState.cpp#L62
