### PR TITLE
Add Safari versions for api.Element.error_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2718,10 +2718,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/Element.json
+++ b/api/Element.json
@@ -2718,7 +2718,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `error_event` member of the `Element` API, based upon manual testing.

Test Code Used: 
```html
<div id="test">
	<div class="controls">
	  <button id="img-error" type="button">Generate image error</button>
	  <img id="bad-img" />
	</div>
</div>

<script>
	var badImg = document.getElementById('bad-img');
	badImg.addEventListener('error', function(event) {
		alert('Error!');
	});

	var imgError = document.getElementById('img-error');
	imgError.addEventListener('click', function() {
	    badImg.setAttribute('src', 'i-dont-exist');
	});
</script>
```