### PR TITLE
Fix redirected mdn_url for <image> functions

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -328,7 +328,7 @@
           "conic-gradient": {
             "__compat": {
               "description": "<code>conic-gradient()</code>",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/conic-gradient()",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient/conic-gradient()",
               "spec_url": "https://drafts.csswg.org/css-images-4/#conic-gradients",
               "support": {
                 "chrome": {
@@ -448,7 +448,7 @@
           "linear-gradient": {
             "__compat": {
               "description": "<code>linear-gradient()</code>",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/linear-gradient()",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradien/linear-gradient()",
               "spec_url": "https://drafts.csswg.org/css-images/#linear-gradients",
               "support": {
                 "chrome": [
@@ -805,7 +805,7 @@
           "radial-gradient": {
             "__compat": {
               "description": "<code>radial-gradient()</code>",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/radial-gradient()",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient/radial-gradient()",
               "spec_url": "https://drafts.csswg.org/css-images/#radial-gradients",
               "support": {
                 "chrome": [
@@ -1116,7 +1116,7 @@
           "repeating-conic-gradient": {
             "__compat": {
               "description": "<code>repeating-conic-gradient()</code>",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/repeating-conic-gradient()",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient/repeating-conic-gradient()",
               "spec_url": "https://drafts.csswg.org/css-images/#repeating-gradients",
               "support": {
                 "chrome": {
@@ -1187,6 +1187,8 @@
           },
           "repeating-linear-gradient": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient/repeating-linear-gradient()",
+              "spec_url": "https://drafts.csswg.org/css-images/#repeating-gradients",
               "description": "<code>repeating-linear-gradient()</code>",
               "support": {
                 "chrome": [
@@ -1331,9 +1333,7 @@
                 "experimental": false,
                 "standard_track": true,
                 "deprecated": false
-              },
-              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/repeating-linear-gradient()",
-              "spec_url": "https://drafts.csswg.org/css-images/#repeating-gradients"
+              }
             },
             "doubleposition": {
               "__compat": {
@@ -1545,7 +1545,7 @@
           "repeating-radial-gradient": {
             "__compat": {
               "description": "<code>repeating-radial-gradient()</code>",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/repeating-radial-gradient()",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient/repeating-radial-gradient()",
               "spec_url": "https://drafts.csswg.org/css-images/#repeating-gradients",
               "support": {
                 "chrome": [
@@ -1861,7 +1861,7 @@
         },
         "image": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image/image()",
             "spec_url": "https://drafts.csswg.org/css-images-4/#image-notation",
             "description": "<code>image()</code>",
             "support": {
@@ -1916,7 +1916,7 @@
         },
         "image-set": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image-set()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image/image-set()",
             "spec_url": "https://drafts.csswg.org/css-images-4/#image-set-notation",
             "description": "<code>image-set()</code>",
             "support": {
@@ -1999,7 +1999,7 @@
         },
         "paint": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/paint()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image/paint()",
             "spec_url": "https://drafts.css-houdini.org/css-paint-api/#paint-notation",
             "description": "<code>paint()</code>",
             "support": {

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -448,7 +448,7 @@
           "linear-gradient": {
             "__compat": {
               "description": "<code>linear-gradient()</code>",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradien/linear-gradient()",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient/linear-gradient()",
               "spec_url": "https://drafts.csswg.org/css-images/#linear-gradients",
               "support": {
                 "chrome": [


### PR DESCRIPTION
In issue mdn/content#2852  (fixed in mdn/content#6113 ), CSS functions have been moved around.

This PR fixes the `mdn_url` to avoid the need for a redirection.

Note that paint() is in the progress of being moved in mdn/content#6445, this slightly anticipates its landing by already using the new url