### PR TITLE
Add safari_version to the safari_ios browser data

### DIFF
--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -36,7 +36,7 @@
           "engine": "WebKit",
           "engine_version": "532.9",
           "release_date": "2010-06-21",
-          "safari_version": "TODO"
+          "safari_version": "4"
         },
         "4.2": {
           "status": "retired",

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -7,146 +7,169 @@
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "522.11",
-          "release_date": "2007-06-29"
+          "release_date": "2007-06-29",
+          "safari_version": "3"
         },
         "2": {
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "525.18",
-          "release_date": "2008-07-11"
+          "release_date": "2008-07-11",
+          "safari_version": "3.1"
         },
         "3": {
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "528.18",
-          "release_date": "2009-06-17"
+          "release_date": "2009-06-17",
+          "safari_version": "TODO"
         },
         "3.2": {
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "531.21",
-          "release_date": "2010-04-03"
+          "release_date": "2010-04-03",
+          "safari_version": "TODO"
         },
         "4": {
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "532.9",
-          "release_date": "2010-06-21"
+          "release_date": "2010-06-21",
+          "safari_version": "TODO"
         },
         "4.2": {
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "533.17",
-          "release_date": "2010-11-22"
+          "release_date": "2010-11-22",
+          "safari_version": "5"
         },
         "5": {
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "534.46",
-          "release_date": "2011-10-12"
+          "release_date": "2011-10-12",
+          "safari_version": "TODO"
         },
         "6": {
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "536.26",
-          "release_date": "2012-09-10"
+          "release_date": "2012-09-10",
+          "safari_version": "6"
         },
         "7": {
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "537.51",
-          "release_date": "2013-09-18"
+          "release_date": "2013-09-18",
+          "safari_version": "7"
         },
         "8": {
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "600.1.4",
-          "release_date": "2014-09-17"
+          "release_date": "2014-09-17",
+          "safari_version": "8"
         },
         "9": {
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "601.1.56",
-          "release_date": "2015-09-16"
+          "release_date": "2015-09-16",
+          "safari_version": "9"
         },
         "9.3": {
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "601.5.17",
-          "release_date": "2016-03-21"
+          "release_date": "2016-03-21",
+          "safari_version": "9.1"
         },
         "10": {
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "602.1.50",
-          "release_date": "2016-09-13"
+          "release_date": "2016-09-13",
+          "safari_version": "10"
         },
         "10.3": {
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "603.2.1",
-          "release_date": "2017-03-27"
+          "release_date": "2017-03-27",
+          "safari_version": "10.1"
         },
         "11": {
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "604.2.4",
-          "release_date": "2017-09-19"
+          "release_date": "2017-09-19",
+          "safari_version": "11"
         },
         "11.3": {
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "605.1.33",
-          "release_date": "2018-03-29"
+          "release_date": "2018-03-29",
+          "safari_version": "11.1"
         },
         "12": {
           "release_date": "2018-09-17",
           "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_release_notes",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "606.1.36"
+          "engine_version": "606.1.36",
+          "safari_version": "12"
         },
         "12.2": {
           "release_date": "2019-03-25",
           "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_1_release_notes",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "607.1.40"
+          "engine_version": "607.1.40",
+          "safari_version": "12.1"
         },
         "13": {
           "release_date": "2019-09-19",
           "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_release_notes",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "608.2.11"
+          "engine_version": "608.2.11",
+          "safari_version": "13"
         },
         "13.4": {
           "release_date": "2020-03-24",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-13_1-release_notes",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "609.1.20"
+          "engine_version": "609.1.20",
+          "safari_version": "13.1"
         },
         "14": {
           "release_date": "2020-09-16",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14-release-notes",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "610.1.28"
+          "engine_version": "610.1.28",
+          "safari_version": "14"
         },
         "14.5": {
           "release_date": "2021-04-26",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14_1-release-notes",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "611.1.21"
+          "engine_version": "611.1.21",
+          "safari_version": "14.1"
         },
         "15": {
           "release_date": "2021-09-20",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "612.1.27"
+          "engine_version": "612.1.27",
+          "safari_version": "15"
         },
         "15.1": {
           "release_date": "2021-10-25",

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -50,7 +50,7 @@
           "engine": "WebKit",
           "engine_version": "534.46",
           "release_date": "2011-10-12",
-          "safari_version": "TODO"
+          "safari_version": "5.1"
         },
         "6": {
           "status": "retired",

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -22,14 +22,14 @@
           "engine": "WebKit",
           "engine_version": "528.18",
           "release_date": "2009-06-17",
-          "safari_version": "TODO"
+          "safari_version": "4"
         },
         "3.2": {
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "531.21",
           "release_date": "2010-04-03",
-          "safari_version": "TODO"
+          "safari_version": "4"
         },
         "4": {
           "status": "retired",

--- a/schemas/browsers-schema.md
+++ b/schemas/browsers-schema.md
@@ -79,6 +79,8 @@ The release objects consist of the following properties:
 
 - An optional `engine_version` property which is the version of the browser's engine. This may or may not differ from the browser version.
 
+- An optional `safari_version` property used only for Safari iOS, which is the version of the corresponding Safari release. This is used to make the non-trivial mapping between the two available to scripts.
+
 ### Exports
 
 This structure is exported for consumers of `@mdn/browser-compat-data`:

--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -78,6 +78,10 @@
           "type": "string",
           "description": "Version of the engine corresponding to the browser version."
         },
+        "safari_version": {
+          "type": "string",
+          "description": "Version of the corresponding Safari on macOS release."
+        },
         "status": {
           "type": "string",
           "enum": ["retired", "current", "exclusive", "beta", "nightly", "esr", "planned"],


### PR DESCRIPTION
The mapping for versions before 6 is complicated and can't be inferred
in a straightforward way from the existing data such as WebKit version.

This is based on research spread across issues and collected here:
https://gist.github.com/foolip/6872cf5350dccf6224fce984fb73fba1