### PR TITLE
@supports selector() supported by Safari 14.1

### DIFF
--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -109,12 +109,10 @@
                 "notes": "See <a href='https://crbug.com/979041'>bug 979041</a>."
               },
               "safari": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/199237'>bug 199237</a>"
+                "version_added": "14.1"
               },
               "safari_ios": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/199237'>bug 199237</a>"
+                "version_added": "14.1"
               },
               "samsunginternet_android": {
                 "version_added": "13.0"


### PR DESCRIPTION
#### Summary
An updated version of the merged and reverted pull request https://github.com/mdn/browser-compat-data/pull/6591

#### Summary from the previous pull request:
The implementation patch for this feature was landed in WebKit.
https://bugs.webkit.org/show_bug.cgi?id=199237