### PR TITLE
Update support for <menu>, <menuitem> and related APIs/events

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -8048,12 +8048,38 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": true
-            },
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "8",
+                "version_removed": "85"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "8",
+                "version_removed": "85"
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -8078,7 +8104,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -4305,12 +4305,38 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": true
-            },
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "8",
+                "version_removed": "85"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "8",
+                "version_removed": "85"
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -4335,7 +4361,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -736,12 +736,38 @@
               "version_added": "≤18",
               "version_removed": "79"
             },
-            "firefox": {
-              "version_added": "8"
-            },
-            "firefox_android": {
-              "version_added": "8"
-            },
+            "firefox": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "8",
+                "version_removed": "85"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "8",
+                "version_removed": "85"
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/HTMLMenuElement.json
+++ b/api/HTMLMenuElement.json
@@ -43,7 +43,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -51,6 +51,7 @@
       "compact": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMenuElement/compact",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#dom-menu-compact",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -109,13 +110,40 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "8"
-            },
-            "firefox_android": {
-              "version_added": "8",
-              "notes": "Nested menus are not supported."
-            },
+            "firefox": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "8",
+                "version_removed": "85"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "85",
+                "notes": "Nested menus are not supported.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "8",
+                "version_removed": "85",
+                "notes": "Nested menus are not supported."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -140,7 +168,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -159,12 +187,38 @@
               "version_added": "12",
               "version_removed": "79"
             },
-            "firefox": {
-              "version_added": "8"
-            },
-            "firefox_android": {
-              "version_added": "8"
-            },
+            "firefox": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "8",
+                "version_removed": "85"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "8",
+                "version_removed": "85"
+              }
+            ],
             "ie": {
               "version_added": "6"
             },
@@ -189,7 +243,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/HTMLMenuItemElement.json
+++ b/api/HTMLMenuItemElement.json
@@ -13,12 +13,38 @@
           "edge": {
             "version_added": false
           },
-          "firefox": {
-            "version_added": "8"
-          },
-          "firefox_android": {
-            "version_added": "8"
-          },
+          "firefox": [
+            {
+              "version_added": "85",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.menuitem.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            {
+              "version_added": "8",
+              "version_removed": "85"
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "85",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.menuitem.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            {
+              "version_added": "8",
+              "version_removed": "85"
+            }
+          ],
           "ie": {
             "version_added": false
           },
@@ -43,7 +69,7 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
+          "standard_track": false,
           "deprecated": true
         }
       },
@@ -60,12 +86,38 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "8"
-            },
-            "firefox_android": {
-              "version_added": "8"
-            },
+            "firefox": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "8",
+                "version_removed": "85"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "8",
+                "version_removed": "85"
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -90,7 +142,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -108,14 +160,42 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": true,
-              "alternative_name": "defaultChecked"
-            },
-            "firefox_android": {
-              "version_added": true,
-              "alternative_name": "defaultChecked"
-            },
+            "firefox": [
+              {
+                "alternative_name": "defaultChecked",
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "alternative_name": "defaultChecked",
+                "version_added": "8",
+                "version_removed": "85"
+              }
+            ],
+            "firefox_android": [
+              {
+                "alternative_name": "defaultChecked",
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "alternative_name": "defaultChecked",
+                "version_added": "8",
+                "version_removed": "85"
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -140,7 +220,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -158,12 +238,38 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "8"
-            },
-            "firefox_android": {
-              "version_added": "8"
-            },
+            "firefox": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "8",
+                "version_removed": "85"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "8",
+                "version_removed": "85"
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -188,7 +294,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -206,12 +312,38 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "8"
-            },
-            "firefox_android": {
-              "version_added": "8"
-            },
+            "firefox": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "8",
+                "version_removed": "85"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "8",
+                "version_removed": "85"
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -236,7 +368,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -254,12 +386,38 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "8"
-            },
-            "firefox_android": {
-              "version_added": "8"
-            },
+            "firefox": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "8",
+                "version_removed": "85"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "8",
+                "version_removed": "85"
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -284,7 +442,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -302,12 +460,38 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "8"
-            },
-            "firefox_android": {
-              "version_added": "8"
-            },
+            "firefox": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "8",
+                "version_removed": "85"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "8",
+                "version_removed": "85"
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -332,7 +516,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -350,12 +534,38 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "8"
-            },
-            "firefox_android": {
-              "version_added": "8"
-            },
+            "firefox": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "8",
+                "version_removed": "85"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "8",
+                "version_removed": "85"
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -380,7 +590,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/html/elements/menu.json
+++ b/html/elements/menu.json
@@ -7,42 +7,40 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/grouping-content.html#the-menu-element",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18",
-              "version_removed": "79"
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": "8"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "8",
-              "notes": "Nested menus are not supported."
+              "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "6"
             },
             "opera": {
-              "version_added": false
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": false
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "1"
             }
           },
           "status": {
@@ -93,9 +91,9 @@
               }
             },
             "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
           }
         },
@@ -112,12 +110,38 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": {
-                "version_added": "51"
-              },
+              "firefox": [
+                {
+                  "version_added": "85",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.menuitem.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "51",
+                  "version_removed": "85"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "85",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.menuitem.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "51",
+                  "version_removed": "85"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -141,9 +165,9 @@
               }
             },
             "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
           }
         },
@@ -159,13 +183,40 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "8"
-              },
-              "firefox_android": {
-                "version_added": "8",
-                "notes": "Nested menus are not supported."
-              },
+              "firefox": [
+                {
+                  "version_added": "85",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.menuitem.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "8",
+                  "version_removed": "85"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "85",
+                  "notes": "Nested menus are not supported.",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.menuitem.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "8",
+                  "version_removed": "85",
+                  "notes": "Nested menus are not supported."
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -189,8 +240,8 @@
               }
             },
             "status": {
-              "experimental": true,
-              "standard_track": true,
+              "experimental": false,
+              "standard_track": false,
               "deprecated": true
             }
           }
@@ -210,13 +261,40 @@
                   "version_added": "≤18",
                   "version_removed": "79"
                 },
-                "firefox": {
-                  "version_added": "8"
-                },
-                "firefox_android": {
-                  "version_added": "8",
-                  "notes": "Nested menus are not supported."
-                },
+                "firefox": [
+                  {
+                    "version_added": "85",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "dom.menuitem.enabled",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  },
+                  {
+                    "version_added": "8",
+                    "version_removed": "85"
+                  }
+                ],
+                "firefox_android": [
+                  {
+                    "version_added": "85",
+                    "notes": "Nested menus are not supported.",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "dom.menuitem.enabled",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  },
+                  {
+                    "version_added": "8",
+                    "version_removed": "85",
+                    "notes": "Nested menus are not supported."
+                  }
+                ],
                 "ie": {
                   "version_added": false
                 },
@@ -240,8 +318,8 @@
                 }
               },
               "status": {
-                "experimental": true,
-                "standard_track": true,
+                "experimental": false,
+                "standard_track": false,
                 "deprecated": true
               }
             }
@@ -288,8 +366,8 @@
                 }
               },
               "status": {
-                "experimental": true,
-                "standard_track": true,
+                "experimental": false,
+                "standard_track": false,
                 "deprecated": true
               }
             }

--- a/html/elements/menuitem.json
+++ b/html/elements/menuitem.json
@@ -30,8 +30,8 @@
                 ]
               },
               {
-                "version_removed": "85",
                 "version_added": "8",
+                "version_removed": "85",
                 "notes": [
                   "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
                   "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
@@ -54,8 +54,8 @@
                 ]
               },
               {
-                "version_removed": "85",
                 "version_added": "8",
+                "version_removed": "85",
                 "notes": [
                   "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
                   "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
@@ -102,12 +102,38 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "8"
-              },
-              "firefox_android": {
-                "version_added": "8"
-              },
+              "firefox": [
+                {
+                  "version_added": "85",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.menuitem.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "8",
+                  "version_removed": "85"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "85",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.menuitem.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "8",
+                  "version_removed": "85"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -149,12 +175,38 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "8"
-              },
-              "firefox_android": {
-                "version_added": "8"
-              },
+              "firefox": [
+                {
+                  "version_added": "85",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.menuitem.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "8",
+                  "version_removed": "85"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "85",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.menuitem.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "8",
+                  "version_removed": "85"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -196,12 +248,38 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "8"
-              },
-              "firefox_android": {
-                "version_added": "8"
-              },
+              "firefox": [
+                {
+                  "version_added": "85",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.menuitem.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "8",
+                  "version_removed": "85"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "85",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.menuitem.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "8",
+                  "version_removed": "85"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -243,12 +321,38 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "8"
-              },
-              "firefox_android": {
-                "version_added": "8"
-              },
+              "firefox": [
+                {
+                  "version_added": "85",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.menuitem.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "8",
+                  "version_removed": "85"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "85",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.menuitem.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "8",
+                  "version_removed": "85"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -290,12 +394,38 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "8"
-              },
-              "firefox_android": {
-                "version_added": "8"
-              },
+              "firefox": [
+                {
+                  "version_added": "85",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.menuitem.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "8",
+                  "version_removed": "85"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "85",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.menuitem.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "8",
+                  "version_removed": "85"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -337,12 +467,38 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "8"
-              },
-              "firefox_android": {
-                "version_added": "8"
-              },
+              "firefox": [
+                {
+                  "version_added": "85",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.menuitem.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "8",
+                  "version_removed": "85"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "85",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.menuitem.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "8",
+                  "version_removed": "85"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -384,12 +540,38 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "8"
-              },
-              "firefox_android": {
-                "version_added": "8"
-              },
+              "firefox": [
+                {
+                  "version_added": "85",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.menuitem.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "8",
+                  "version_removed": "85"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "85",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.menuitem.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "8",
+                  "version_removed": "85"
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -565,9 +565,22 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "9"
-            },
+            "firefox": [
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.menuitem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "9",
+                "version_removed": "85"
+              }
+            ],
             "firefox_android": {
               "version_added": "32",
               "version_removed": "56",


### PR DESCRIPTION
Most of this was only ever implemented in Gecko, and is now behind the
"dom.menuitem.enabled" flag.

A few slices of it remain in HTML and should be supported, namely &lt;menu>
itself, the HTMLMenuElement interface, and the compact attribute. The
latter however is obsolete, so marked as deprecated.

Existing data and notes were preserved as far as possible, even where
this leaves things in an inconsistent and likely incorrect state. This
is because all of this will probably eventually be removed and it would
be a lot of work to determine when exactly each facet of this was
supported in Firefox on different platforms. Assume by default that it
was from 8-85 without a flag, and behind a flag from 85.

Fixes https://github.com/mdn/browser-compat-data/issues/8947.