### PR TITLE
Add spec URLs to GlobalEventHandlers; mark as not experimental

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -3749,6 +3749,7 @@
       "onprogress": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onprogress",
+          "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onprogress",
           "support": {
             "chrome": {
               "version_added": "32"
@@ -3800,7 +3801,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -3809,6 +3810,7 @@
       "onratechange": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onratechange",
+          "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onratechange",
           "support": {
             "chrome": {
               "version_added": "32"
@@ -4026,6 +4028,7 @@
       "onseeked": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onseeked",
+          "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onseeked",
           "support": {
             "chrome": {
               "version_added": "32"
@@ -4086,6 +4089,7 @@
       "onseeking": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onseeking",
+          "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onseeking",
           "support": {
             "chrome": {
               "version_added": "32"
@@ -4235,7 +4239,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -4286,7 +4290,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -4343,6 +4347,7 @@
       "onstalled": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onstalled",
+          "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onstalled",
           "support": {
             "chrome": {
               "version_added": "32"
@@ -4452,6 +4457,7 @@
       "onsuspend": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onsuspend",
+          "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onsuspend",
           "support": {
             "chrome": {
               "version_added": "32"
@@ -4512,6 +4518,7 @@
       "ontimeupdate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/ontimeupdate",
+          "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#handler-ontimeupdate",
           "support": {
             "chrome": {
               "version_added": "32"
@@ -4612,7 +4619,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -4661,7 +4668,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -4710,7 +4717,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -4759,7 +4766,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -4910,6 +4917,7 @@
       "ontransitionrun": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/ontransitionrun",
+          "spec_url": "https://drafts.csswg.org/css-transitions/#ref-for-dom-globaleventhandlers-ontransitionrun",
           "support": {
             "chrome": {
               "version_added": "87"
@@ -4972,6 +4980,7 @@
       "ontransitionstart": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/ontransitionstart",
+          "spec_url": "https://drafts.csswg.org/css-transitions/#ref-for-dom-globaleventhandlers-ontransitionstart",
           "support": {
             "chrome": {
               "version_added": "87"
@@ -5034,6 +5043,7 @@
       "onvolumechange": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onvolumechange",
+          "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onvolumechange",
           "support": {
             "chrome": {
               "version_added": "32"
@@ -5094,6 +5104,7 @@
       "onwaiting": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onwaiting",
+          "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onwaiting",
           "support": {
             "chrome": {
               "version_added": "32"


### PR DESCRIPTION
A few missing spec URLs were added. Additionally, a number of entries
that were marked experimental but are in a spec and have been shipping
in at least Chrome+Safari for a long time were marked not experimental.