### PR TITLE
Update Chromium versions for init_delegatesFocus_parameter entry

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1209,10 +1209,10 @@
             "spec_url": "https://dom.spec.whatwg.org/#dom-shadowrootinit-delegatesfocus",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "53"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "53"
               },
               "edge": {
                 "version_added": "79"
@@ -1227,10 +1227,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "40"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "41"
               },
               "safari": {
                 "version_added": "13.1"
@@ -1239,10 +1239,10 @@
                 "version_added": "13.4"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "6.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "53"
               }
             },
             "status": {


### PR DESCRIPTION
This goes back to when Shadow DOM v1 was first enabled in Chromium:
https://storage.googleapis.com/chromium-find-releases-static/972.html#97235496c3dee67efb24f9a7893232df493dcd1e

Thus the versions match the parent feature, attachShadow.