### PR TITLE
Update NodeJS releases (add v16)

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -153,7 +153,7 @@
         "10.9.0": {
           "release_date": "2018-08-16",
           "release_notes": "https://nodejs.org/en/blog/release/v10.9.0/",
-          "status": "esr",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "6.8"
         },
@@ -258,9 +258,23 @@
         "15.0.0": {
           "release_date": "2020-10-20",
           "release_notes": "https://nodejs.org/en/blog/release/v15.0.0/",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "8.6"
+        },
+        "16.0.0": {
+          "release_date": "2021-04-20",
+          "release_notes": "https://nodejs.org/en/blog/release/v16.0.0/",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "9.0"
+        },
+        "16.4.0": {
+          "release_date": "2021-06-23",
+          "release_notes": "https://nodejs.org/en/blog/release/v16.4.0/",
+          "status": "current",
+          "engine": "V8",
+          "engine_version": "9.1"
         }
       }
     }


### PR DESCRIPTION
This PR updates the data for the NodeJS releases to mark v10 and v15 as retired, and add data for v16.  All data comes from https://nodejs.org/en/download/releases/ and https://nodejs.org/en/about/releases/.