### PR TITLE
Add Safari versions for NotificationEvent API

### DIFF
--- a/api/NotificationEvent.json
+++ b/api/NotificationEvent.json
@@ -31,10 +31,10 @@
             "version_added": "37"
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "4.0"
@@ -82,10 +82,10 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -132,10 +132,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -182,10 +182,10 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `NotificationEvent` API, based upon results from WPT.fyi.

Test Used: https://wpt.fyi/results/notifications/idlharness.https.any.serviceworker.html?label=experimental&label=master&aligned
