### PR TITLE
Remove long_to_double from MouseEvent API

### DIFF
--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -101,54 +101,6 @@
             "deprecated": false
           }
         },
-        "long_to_double": {
-          "__compat": {
-            "description": "Redefined <code>mouseEventInit</code> fields from <code>long</code> to <code>double</code>",
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "56"
-              },
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": {
-                "version_added": null
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": "6.0"
-              },
-              "webview_android": {
-                "version_added": "56"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "region_support": {
           "__compat": {
             "description": "Support for <code>mouseEventInit</code> optional <code>region</code> field",
@@ -409,54 +361,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "long_to_double": {
-          "__compat": {
-            "description": "Value type changed from <code>long</code> to <code>double</code>",
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "56"
-              },
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": {
-                "version_added": null
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": "6.0"
-              },
-              "webview_android": {
-                "version_added": "56"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "clientY": {
@@ -505,54 +409,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "long_to_double": {
-          "__compat": {
-            "description": "Value type changed from <code>long</code> to <code>double</code>",
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "56"
-              },
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": {
-                "version_added": null
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": "6.0"
-              },
-              "webview_android": {
-                "version_added": "56"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -1056,54 +912,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "long_to_double": {
-          "__compat": {
-            "description": "Value type changed from <code>long</code> to <code>double</code>",
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "56"
-              },
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": {
-                "version_added": null
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": "6.0"
-              },
-              "webview_android": {
-                "version_added": "56"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "offsetY": {
@@ -1152,54 +960,6 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "long_to_double": {
-          "__compat": {
-            "description": "Value type changed from <code>long</code> to <code>double</code>",
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "56"
-              },
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": {
-                "version_added": null
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": "6.0"
-              },
-              "webview_android": {
-                "version_added": "56"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -1250,54 +1010,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "long_to_double": {
-          "__compat": {
-            "description": "Value type changed from <code>long</code> to <code>double</code>",
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "56"
-              },
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": "6.0"
-              },
-              "webview_android": {
-                "version_added": "56"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "pageY": {
@@ -1346,54 +1058,6 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "long_to_double": {
-          "__compat": {
-            "description": "Value type changed from <code>long</code> to <code>double</code>",
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "56"
-              },
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": "6.0"
-              },
-              "webview_android": {
-                "version_added": "56"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -1569,54 +1233,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "long_to_double": {
-          "__compat": {
-            "description": "Value type changed from <code>long</code> to <code>double</code>",
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "56"
-              },
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": {
-                "version_added": null
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": "6.0"
-              },
-              "webview_android": {
-                "version_added": "56"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "screenY": {
@@ -1665,54 +1281,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "long_to_double": {
-          "__compat": {
-            "description": "Value type changed from <code>long</code> to <code>double</code>",
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "56"
-              },
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": {
-                "version_added": null
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": "6.0"
-              },
-              "webview_android": {
-                "version_added": "56"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },


### PR DESCRIPTION
This PR removes the various `long_to_double` entries from the MouseEvent API.  Overall, the difference between a `long` and a `double` is more floating point accuracy, but I can't imagine a scenario where a web developer will require such high levels of precision, not to mention this is near impossible to test, and only really observable in the WebIDL.