### PR TITLE
Add Safari versions for RTCTrackEventInit API

### DIFF
--- a/api/RTCTrackEventInit.json
+++ b/api/RTCTrackEventInit.json
@@ -30,10 +30,10 @@
             "version_added": "43"
           },
           "safari": {
-            "version_added": null
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -78,10 +78,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -127,10 +127,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -176,10 +176,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -225,10 +225,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "6.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `RTCTrackEventInit` API, based upon commit history and date.

Commit: https://trac.webkit.org/browser/webkit/tags/Safari-604.2.4/Source/WebCore/Modules/mediastream/RTCTrackEvent.idl
