### PR TITLE
Add Safari versions for WindowEventHandlers API

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3375,10 +3375,10 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -3870,10 +3870,10 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": null
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -331,10 +331,10 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -380,10 +380,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": null
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `WindowEventHandlers` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.8).

Tests Used:
https://mdn-bcd-collector.appspot.com/tests/api/Window/onlanguagechange
https://mdn-bcd-collector.appspot.com/tests/api/Window/onmessage
