### PR TITLE
Add Safari versions for MediaStreamEvent API

### DIFF
--- a/api/MediaStreamEvent.json
+++ b/api/MediaStreamEvent.json
@@ -29,10 +29,12 @@
             "version_added": true
           },
           "safari": {
-            "version_added": false
+            "version_added": "11",
+            "version_removed": "12"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11",
+            "version_removed": "12"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -77,10 +79,12 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "11",
+              "version_removed": "12"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11",
+              "version_removed": "12"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -125,10 +129,12 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "11",
+              "version_removed": "12"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11",
+              "version_removed": "12"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/MediaStreamEvent.json
+++ b/api/MediaStreamEvent.json
@@ -29,10 +29,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": true
@@ -77,10 +77,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true
@@ -125,10 +125,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `MediaStreamEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.8).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaStreamEvent
