### PR TITLE
Add Safari versions and bugs for preventScroll_option entries

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1059,10 +1059,12 @@
                 "version_added": "47"
               },
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/178583'>bug 178583</a>."
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/178583'>bug 178583</a>."
               },
               "samsunginternet_android": {
                 "version_added": "9.0"

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -271,10 +271,12 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/178583'>bug 178583</a>."
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/178583'>bug 178583</a>."
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `focus.preventScroll_option` member of the `SVGElement` API, based upon information in a tracking bug.

Tracking Bug: https://webkit.org/b/178583
