### PR TITLE
Add IE versions for Event API

### DIFF
--- a/api/Event.json
+++ b/api/Event.json
@@ -131,7 +131,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "nodejs": {
               "version_added": "14.5.0",
@@ -184,7 +184,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "nodejs": {
               "version_added": "14.5.0"


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `Event` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.8).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Event
