### PR TITLE
Rename and complete the entries for focus({preventScroll}) parameters

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1030,9 +1030,9 @@
             "deprecated": false
           }
         },
-        "preventScroll_option": {
+        "options_preventScroll_parameter": {
           "__compat": {
-            "description": "<code>preventScroll</code> Boolean option",
+            "description": "<code>options.preventScroll</code> parameter",
             "support": {
               "chrome": {
                 "version_added": "64"
@@ -1050,7 +1050,7 @@
                 "version_added": "68"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "51"

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -242,18 +242,18 @@
             "deprecated": false
           }
         },
-        "preventScroll_option": {
+        "options_preventScroll_parameter": {
           "__compat": {
-            "description": "<code>preventScroll</code> Boolean option",
+            "description": "<code>options.preventScroll</code> parameter",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "78"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "78"
               },
               "edge": {
-                "version_added": false
+                "version_added": "≤79"
               },
               "firefox": {
                 "version_added": "68"
@@ -265,10 +265,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "65"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "56"
               },
               "safari": {
                 "version_added": false,
@@ -279,10 +279,10 @@
                 "notes": "See <a href='https://webkit.org/b/178583'>bug 178583</a>."
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "12.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "78"
               }
             },
             "status": {


### PR DESCRIPTION
The naming now matches the guideline:
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#parameters-and-parameter-object-features

Chromium support for this parameter for SVGElement came when the focus()
methods of HTMLElement and SVGElement were consolidated into
HTMLOrForeignElement. Before that only the HTMLElement variant had the
FocusOptions dictionary as an argument:
https://chromium.googlesource.com/chromium/src/+/5f506297541b9c0a041701401eeb133a16619bf9
https://storage.googleapis.com/chromium-find-releases-static/5f5.html#5f506297541b9c0a041701401eeb133a16619bf9

The other data is mirrored and IE is just assumed to be false.