### PR TITLE
Simplify engine version for Safari 14.1

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -173,7 +173,7 @@
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14_1-release-notes",
           "status": "current",
           "engine": "WebKit",
-          "engine_version": "611.1.21.161.3"
+          "engine_version": "611.1.21"
         },
         "15": {
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15-beta-release-notes",

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -157,7 +157,7 @@
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14_1-release-notes",
           "status": "current",
           "engine": "WebKit",
-          "engine_version": "611.1.21.161.6"
+          "engine_version": "611.1.21"
         },
         "15": {
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15-beta-release-notes",


### PR DESCRIPTION
This PR simplifies the engine version for Safari 14.1 in our data, stripping out the micro and nano version numbers.  Not only does this level of information not really matter to us, but `compareVersions` doesn't like them, and the micro/nano versions have already changed in 14.1.1.
