### PR TITLE
Bump NodeJS requirement for contributors to v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=14.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes #11311 by bumping the minimum NodeJS requirement for contributors from v10 to v14.  We're already not performing tests on NodeJS versions earlier than v14 (active LTS), and this requirement will not affect BCD consumers, only contributors.
