### PR TITLE
Add Safari versions for api.EventSource.EventSource.cors_support

### DIFF
--- a/api/EventSource.json
+++ b/api/EventSource.json
@@ -126,10 +126,10 @@
                 "version_added": "12"
               },
               "safari": {
-                "version_added": null
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": "2.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `EventSource.cors_support` member of the `EventSource` API, based upon commit history and date.

Commit: https://trac.webkit.org/changeset/138083/webkit
