### PR TITLE
Update browser support and experimental status of window.isSecureContext

### DIFF
--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -943,16 +943,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "42"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "42"
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -962,7 +962,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Updated browser support and experimental status of window.isSecureContext.

- Mirrored chrome data to Opera and Opera Android

- Tested Safari versions in browser stack to find it was added in 11.1.

And as it's been supported by all three engines for a few years I unmarked the experimental flag.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Verified the mirror value for Opera by finding https://blogs.opera.com/desktop/2016/10/opera-developer-42-0-2372-0-revealed/#:~:text=We%20also%20include-,Chrome%2055.0.2859.0,-intake.%20Here%20is

Other data in MDN has both opera 42 and opera_android 42 together so I assume that's correct.

Safari I tested on browser stack and found it not present in 10.1, but is present in 11.1.

11.3 of iOS Safari corresponds to 11.1 on desktop afaik.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
