### PR TITLE
Added opera android support for :where()

### DIFF
--- a/css/selectors/where.json
+++ b/css/selectors/where.json
@@ -68,7 +68,7 @@
               "version_added": "74"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "safari": {
               "version_added": "14"
@@ -116,7 +116,7 @@
                 "version_added": "74"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "63"
               },
               "safari": {
                 "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Added opera android support for :where()

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Opera android 63 is blink 89, and opera android didn't have a blink 88 equivalent.

