### PR TITLE
Fix multi display mode css

### DIFF
--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -2,60 +2,129 @@
   "css": {
     "properties": {
       "align-content": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-content",
+          "spec_url": [
+            "https://drafts.csswg.org/css-align/#align-justify-content",
+            "https://drafts.csswg.org/css-flexbox/#align-content-property"
+          ],
+          "support": {
+            "chrome": [
+              {
+                "version_added": "29"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "21"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "29"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "25"
+              }
+            ],
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12"
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "28"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "28"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              }
+            ],
+            "ie": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12.1"
+            },
+            "opera_android": {
+              "version_added": "12.1"
+            },
+            "safari": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7"
+              }
+            ],
+            "samsunginternet_android": [
+              {
+                "version_added": "2.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.5"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "4.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "≤37"
+              }
+            ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "flex_context": {
           "__compat": {
-            "description": "Supported in Flex Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-content",
-            "spec_url": [
-              "https://drafts.csswg.org/css-align/#align-justify-content",
-              "https://drafts.csswg.org/css-flexbox/#align-content-property"
-            ],
+            "description": "In Flex Layout",
             "support": {
-              "chrome": [
-                {
-                  "version_added": "29"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "21"
-                }
-              ],
-              "chrome_android": [
-                {
-                  "version_added": "29"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "25"
-                }
-              ],
-              "edge": [
-                {
-                  "version_added": "12"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "12"
-                }
-              ],
-              "firefox": [
-                {
-                  "version_added": "28"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "49"
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "28"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "49"
-                }
-              ],
+              "chrome": {
+                "version_added": "21"
+              },
+              "chrome_android": {
+                "version_added": "25"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "28"
+              },
+              "firefox_android": {
+                "version_added": "28"
+              },
               "ie": {
                 "version_added": "11"
               },
@@ -65,42 +134,18 @@
               "opera_android": {
                 "version_added": "12.1"
               },
-              "safari": [
-                {
-                  "version_added": "9"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
-              "safari_ios": [
-                {
-                  "version_added": "9"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
-              "samsunginternet_android": [
-                {
-                  "version_added": "2.0"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "1.5"
-                }
-              ],
-              "webview_android": [
-                {
-                  "version_added": "4.4"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "≤37"
-                }
-              ]
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "9"
+              },
+              "samsunginternet_android": {
+                "version_added": "2.0"
+              },
+              "webview_android": {
+                "version_added": "4.4"
+              }
             },
             "status": {
               "experimental": false,
@@ -474,12 +519,7 @@
         },
         "grid_context": {
           "__compat": {
-            "description": "Supported in Grid Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-content",
-            "spec_url": [
-              "https://drafts.csswg.org/css-align/#align-justify-content",
-              "https://drafts.csswg.org/css-flexbox/#align-content-property"
-            ],
+            "description": "In Grid Layout",
             "support": {
               "chrome": {
                 "version_added": "57"

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -2,14 +2,113 @@
   "css": {
     "properties": {
       "align-items": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-items",
+          "spec_url": [
+            "https://drafts.csswg.org/css-align/#align-items-property",
+            "https://drafts.csswg.org/css-flexbox/#align-items-property"
+          ],
+          "support": {
+            "chrome": [
+              {
+                "version_added": "29"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "21"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "29"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "25"
+              }
+            ],
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12"
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "20"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "20"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              }
+            ],
+            "ie": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12.1"
+            },
+            "opera_android": {
+              "version_added": "12.1"
+            },
+            "safari": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7"
+              }
+            ],
+            "samsunginternet_android": [
+              {
+                "version_added": "2.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.5"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "4.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "≤37"
+              }
+            ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "flex_context": {
           "__compat": {
-            "description": "Supported in Flex Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-items",
-            "spec_url": [
-              "https://drafts.csswg.org/css-align/#align-items-property",
-              "https://drafts.csswg.org/css-flexbox/#align-items-property"
-            ],
+            "description": "In Flex Layout",
             "support": {
               "chrome": [
                 {
@@ -19,10 +118,6 @@
                   "version_added": "29",
                   "partial_implementation": true,
                   "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Chrome 52."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "21"
                 }
               ],
               "chrome_android": [
@@ -33,41 +128,19 @@
                   "version_added": "29",
                   "partial_implementation": true,
                   "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Chrome 52."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "25"
                 }
               ],
-              "edge": [
-                {
-                  "version_added": "12"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "12"
-                }
-              ],
-              "firefox": [
-                {
-                  "version_added": "20",
-                  "notes": "Multi-line flexbox has been supported since Firefox 28."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "49"
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "20",
-                  "notes": "Multi-line flexbox has been supported since Firefox 28."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "49"
-                }
-              ],
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "20",
+                "notes": "Multi-line flexbox has been supported since Firefox 28."
+              },
+              "firefox_android": {
+                "version_added": "20",
+                "notes": "Multi-line flexbox has been supported since Firefox 28."
+              },
               "ie": {
                 "version_added": "11",
                 "notes": "In Internet Explorer 10 and 11, if column flex items have <code>align-items: center;</code> set on them and their content is too large, then they will overflow the bounds of their container. See <a href='https://github.com/philipwalton/flexbugs#2-column-flex-items-set-to-align-itemscenter-overflow-their-container'>Flexbug #2</a>."
@@ -78,24 +151,12 @@
               "opera_android": {
                 "version_added": "12.1"
               },
-              "safari": [
-                {
-                  "version_added": "9"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
-              "safari_ios": [
-                {
-                  "version_added": "9"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "9"
+              },
               "samsunginternet_android": [
                 {
                   "version_added": "6.0"
@@ -104,10 +165,6 @@
                   "version_added": "2.0",
                   "partial_implementation": true,
                   "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Samsung Internet 6.0."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "1.5"
                 }
               ],
               "webview_android": [
@@ -118,10 +175,6 @@
                   "version_added": "4.4",
                   "partial_implementation": true,
                   "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Chrome 52."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "≤37"
                 }
               ]
             },
@@ -335,12 +388,7 @@
         },
         "grid_context": {
           "__compat": {
-            "description": "Supported in Grid Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-items",
-            "spec_url": [
-              "https://drafts.csswg.org/css-align/#align-items-property",
-              "https://drafts.csswg.org/css-flexbox/#align-items-property"
-            ],
+            "description": "In Grid Layout",
             "support": {
               "chrome": {
                 "version_added": "57"

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -2,14 +2,115 @@
   "css": {
     "properties": {
       "align-self": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-self",
+          "spec_url": [
+            "https://drafts.csswg.org/css-align/#align-self-property",
+            "https://drafts.csswg.org/css-flexbox/#align-items-property"
+          ],
+          "support": {
+            "chrome": [
+              {
+                "version_added": "29"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "21"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "29"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "25"
+              }
+            ],
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": [
+              {
+                "version_added": "20"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "20"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              }
+            ],
+            "ie": [
+              {
+                "version_added": "11"
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "10",
+                "partial_implementation": true,
+                "notes": "Internet Explorer 10 and 11 have the property <code>-ms-grid-row-align</code>, which acts in a similar way to <code>align-self</code>."
+              }
+            ],
+            "opera": {
+              "version_added": "12.1"
+            },
+            "opera_android": {
+              "version_added": "12.1"
+            },
+            "safari": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "6.1"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "6.1"
+              }
+            ],
+            "samsunginternet_android": [
+              {
+                "version_added": "2.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.5"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "4.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "≤37"
+              }
+            ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "flex_context": {
           "__compat": {
             "description": "Supported in Flex Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-self",
-            "spec_url": [
-              "https://drafts.csswg.org/css-align/#align-self-property",
-              "https://drafts.csswg.org/css-flexbox/#align-items-property"
-            ],
             "support": {
               "chrome": [
                 {
@@ -19,10 +120,6 @@
                   "version_added": "29",
                   "partial_implementation": true,
                   "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Chrome 52."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "21"
                 }
               ],
               "chrome_android": [
@@ -33,35 +130,19 @@
                   "version_added": "29",
                   "partial_implementation": true,
                   "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Chrome 52."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "25"
                 }
               ],
               "edge": {
                 "version_added": "12"
               },
-              "firefox": [
-                {
-                  "version_added": "20",
-                  "notes": "Before Firefox 27, only single-line flexbox is supported."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "49"
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "20",
-                  "notes": "Before Firefox 27, only single-line flexbox is supported."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "49"
-                }
-              ],
+              "firefox": {
+                "version_added": "20",
+                "notes": "Before Firefox 27, only single-line flexbox is supported."
+              },
+              "firefox_android": {
+                "version_added": "20",
+                "notes": "Before Firefox 27, only single-line flexbox is supported."
+              },
               "ie": {
                 "version_added": "11"
               },
@@ -71,24 +152,12 @@
               "opera_android": {
                 "version_added": "12.1"
               },
-              "safari": [
-                {
-                  "version_added": "9"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "6.1"
-                }
-              ],
-              "safari_ios": [
-                {
-                  "version_added": "9"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "6.1"
-                }
-              ],
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "9"
+              },
               "samsunginternet_android": [
                 {
                   "version_added": "3.0"
@@ -97,10 +166,6 @@
                   "version_added": "2.0",
                   "partial_implementation": true,
                   "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Samsung Internet 6.0."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "1.5"
                 }
               ],
               "webview_android": [
@@ -111,10 +176,6 @@
                   "version_added": "4.4",
                   "partial_implementation": true,
                   "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Chrome 52."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "≤37"
                 }
               ]
             },
@@ -425,11 +486,6 @@
         "grid_context": {
           "__compat": {
             "description": "Supported in Grid Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-self",
-            "spec_url": [
-              "https://drafts.csswg.org/css-align/#align-self-property",
-              "https://drafts.csswg.org/css-flexbox/#align-items-property"
-            ],
             "support": {
               "chrome": {
                 "version_added": "57"

--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -2,15 +2,72 @@
   "css": {
     "properties": {
       "break-after": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-after",
+          "spec_url": [
+            "https://drafts.csswg.org/css-break/#break-between",
+            "https://drafts.csswg.org/css-regions/#region-flow-break",
+            "https://drafts.csswg.org/css-multicol/#break-before-break-after-break-inside"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "50"
+            },
+            "chrome_android": {
+              "version_added": "50"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "65"
+            },
+            "firefox_android": {
+              "version_added": "65"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": [
+              {
+                "version_added": "37"
+              },
+              {
+                "version_added": "11.1",
+                "version_removed": "12.1"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "37"
+              },
+              {
+                "version_added": "11.1",
+                "version_removed": "12.1"
+              }
+            ],
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": {
+              "version_added": "10"
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
+            "webview_android": {
+              "version_added": "50"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "multicol_context": {
           "__compat": {
-            "description": "Supported in Multi-column Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-after",
-            "spec_url": [
-              "https://drafts.csswg.org/css-break/#break-between",
-              "https://drafts.csswg.org/css-regions/#region-flow-break",
-              "https://drafts.csswg.org/css-multicol/#break-before-break-after-break-inside"
-            ],
+            "description": "In Multi-column Layout",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -235,13 +292,7 @@
         },
         "paged_context": {
           "__compat": {
-            "description": "Supported in Paged Media",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-after",
-            "spec_url": [
-              "https://drafts.csswg.org/css-break/#break-between",
-              "https://drafts.csswg.org/css-regions/#region-flow-break",
-              "https://drafts.csswg.org/css-multicol/#break-before-break-after-break-inside"
-            ],
+            "description": "In Paged Media",
             "support": {
               "chrome": {
                 "version_added": "50"

--- a/css/properties/break-before.json
+++ b/css/properties/break-before.json
@@ -2,15 +2,72 @@
   "css": {
     "properties": {
       "break-before": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-before",
+          "spec_url": [
+            "https://drafts.csswg.org/css-break/#break-between",
+            "https://drafts.csswg.org/css-regions/#region-flow-break",
+            "https://drafts.csswg.org/css-multicol/#break-before-break-after-break-inside"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "50"
+            },
+            "chrome_android": {
+              "version_added": "50"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "65"
+            },
+            "firefox_android": {
+              "version_added": "65"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": [
+              {
+                "version_added": "37"
+              },
+              {
+                "version_added": "11.1",
+                "version_removed": "12.1"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "37"
+              },
+              {
+                "version_added": "11.1",
+                "version_removed": "12.1"
+              }
+            ],
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": {
+              "version_added": "10"
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
+            "webview_android": {
+              "version_added": "50"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "multicol_context": {
           "__compat": {
-            "description": "Supported in Multi-column Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-before",
-            "spec_url": [
-              "https://drafts.csswg.org/css-break/#break-between",
-              "https://drafts.csswg.org/css-regions/#region-flow-break",
-              "https://drafts.csswg.org/css-multicol/#break-before-break-after-break-inside"
-            ],
+            "description": "In Multi-column Layout",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -223,13 +280,7 @@
         },
         "paged_context": {
           "__compat": {
-            "description": "Supported in Paged Media",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-before",
-            "spec_url": [
-              "https://drafts.csswg.org/css-break/#break-between",
-              "https://drafts.csswg.org/css-regions/#region-flow-break",
-              "https://drafts.csswg.org/css-multicol/#break-before-break-after-break-inside"
-            ],
+            "description": "In Paged Media",
             "support": {
               "chrome": {
                 "version_added": "50"

--- a/css/properties/break-inside.json
+++ b/css/properties/break-inside.json
@@ -2,15 +2,72 @@
   "css": {
     "properties": {
       "break-inside": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-inside",
+          "spec_url": [
+            "https://drafts.csswg.org/css-break/#break-within",
+            "https://drafts.csswg.org/css-regions/#region-flow-break",
+            "https://drafts.csswg.org/css-multicol/#break-before-break-after-break-inside"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "50"
+            },
+            "chrome_android": {
+              "version_added": "50"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "65"
+            },
+            "firefox_android": {
+              "version_added": "65"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": [
+              {
+                "version_added": "37"
+              },
+              {
+                "version_added": "11.1",
+                "version_removed": "12.1"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "37"
+              },
+              {
+                "version_added": "11.1",
+                "version_removed": "12.1"
+              }
+            ],
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": {
+              "version_added": "10"
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
+            "webview_android": {
+              "version_added": "50"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "multicol_context": {
           "__compat": {
-            "description": "Supported in Multi-column Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-inside",
-            "spec_url": [
-              "https://drafts.csswg.org/css-break/#break-within",
-              "https://drafts.csswg.org/css-regions/#region-flow-break",
-              "https://drafts.csswg.org/css-multicol/#break-before-break-after-break-inside"
-            ],
+            "description": "In Multi-column Layout",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -118,13 +175,7 @@
         },
         "paged_context": {
           "__compat": {
-            "description": "Supported in Paged Media",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-inside",
-            "spec_url": [
-              "https://drafts.csswg.org/css-break/#break-within",
-              "https://drafts.csswg.org/css-regions/#region-flow-break",
-              "https://drafts.csswg.org/css-multicol/#break-before-break-after-break-inside"
-            ],
+            "description": "In Paged Media",
             "support": {
               "chrome": {
                 "version_added": "50"

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -2,14 +2,113 @@
   "css": {
     "properties": {
       "justify-content": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-content",
+          "spec_url": [
+            "https://drafts.csswg.org/css-align/#align-justify-content",
+            "https://drafts.csswg.org/css-flexbox/#justify-content-property"
+          ],
+          "support": {
+            "chrome": [
+              {
+                "version_added": "29"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "21"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "29"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "25"
+              }
+            ],
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12"
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "20"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "20"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              }
+            ],
+            "ie": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12.1"
+            },
+            "opera_android": {
+              "version_added": "12.1"
+            },
+            "safari": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "6.1"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "6.1"
+              }
+            ],
+            "samsunginternet_android": [
+              {
+                "version_added": "2.0"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1.5"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "4.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "≤37"
+              }
+            ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "flex_context": {
           "__compat": {
-            "description": "Supported in Flex Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-content",
-            "spec_url": [
-              "https://drafts.csswg.org/css-align/#align-justify-content",
-              "https://drafts.csswg.org/css-flexbox/#justify-content-property"
-            ],
+            "description": "In Flex Layout",
             "support": {
               "chrome": [
                 {
@@ -19,10 +118,6 @@
                   "version_added": "29",
                   "partial_implementation": true,
                   "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Chrome 52."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "21"
                 }
               ],
               "chrome_android": [
@@ -30,44 +125,21 @@
                   "version_added": "52"
                 },
                 {
-                  "version_added": "29",
-                  "partial_implementation": true,
-                  "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Chrome 52."
-                },
-                {
                   "prefix": "-webkit-",
                   "version_added": "25"
                 }
               ],
-              "edge": [
-                {
-                  "version_added": "12"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "12"
-                }
-              ],
-              "firefox": [
-                {
-                  "version_added": "20",
-                  "notes": "Before Firefox 27, Firefox supported only single-line flexbox."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "49"
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "20",
-                  "notes": "Before Firefox 27, Firefox supported only single-line flexbox."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "49"
-                }
-              ],
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "20",
+                "notes": "Before Firefox 27, Firefox supported only single-line flexbox."
+              },
+              "firefox_android": {
+                "version_added": "20",
+                "notes": "Before Firefox 27, Firefox supported only single-line flexbox."
+              },
               "ie": {
                 "version_added": "11"
               },
@@ -77,24 +149,12 @@
               "opera_android": {
                 "version_added": "12.1"
               },
-              "safari": [
-                {
-                  "version_added": "9"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "6.1"
-                }
-              ],
-              "safari_ios": [
-                {
-                  "version_added": "9"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "6.1"
-                }
-              ],
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "9"
+              },
               "samsunginternet_android": [
                 {
                   "version_added": "6.0"
@@ -103,10 +163,6 @@
                   "partial_implementation": true,
                   "version_added": "2.0",
                   "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Chrome 52."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "1.5"
                 }
               ],
               "webview_android": [
@@ -117,10 +173,6 @@
                   "version_added": "4.4",
                   "partial_implementation": true,
                   "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Chrome 52."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "≤37"
                 }
               ]
             },
@@ -501,12 +553,7 @@
         },
         "grid_context": {
           "__compat": {
-            "description": "Supported in Grid Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-content",
-            "spec_url": [
-              "https://drafts.csswg.org/css-align/#align-justify-content",
-              "https://drafts.csswg.org/css-flexbox/#justify-content-property"
-            ],
+            "description": "In Grid Layout",
             "support": {
               "chrome": {
                 "version_added": "57"

--- a/css/properties/justify-items.json
+++ b/css/properties/justify-items.json
@@ -2,11 +2,56 @@
   "css": {
     "properties": {
       "justify-items": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-items",
+          "spec_url": "https://drafts.csswg.org/css-align/#justify-items-property",
+          "support": {
+            "chrome": {
+              "version_added": "52"
+            },
+            "chrome_android": {
+              "version_added": "52"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "20"
+            },
+            "firefox_android": {
+              "version_added": "20"
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "12.1"
+            },
+            "opera_android": {
+              "version_added": "12.1"
+            },
+            "safari": {
+              "version_added": "9"
+            },
+            "safari_ios": {
+              "version_added": "9"
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": "52"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "flex_context": {
           "__compat": {
-            "description": "Supported in Flex Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-items",
-            "spec_url": "https://drafts.csswg.org/css-align/#justify-items-property",
+            "description": "In Flex Layout",
             "support": {
               "chrome": {
                 "version_added": "52"
@@ -54,9 +99,7 @@
         },
         "grid_context": {
           "__compat": {
-            "description": "Supported in Grid Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-items",
-            "spec_url": "https://drafts.csswg.org/css-align/#justify-items-property",
+            "description": "In Grid Layout",
             "support": {
               "chrome": {
                 "version_added": "57"

--- a/css/properties/justify-self.json
+++ b/css/properties/justify-self.json
@@ -2,11 +2,59 @@
   "css": {
     "properties": {
       "justify-self": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-self",
+          "spec_url": "https://drafts.csswg.org/css-align/#justify-self-property",
+          "support": {
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "45"
+            },
+            "ie": {
+              "prefix": "-ms-",
+              "version_added": "10",
+              "partial_implementation": true,
+              "notes": "Internet Explorer 10 and 11 have the property <code>-ms-grid-column-align</code>, which acts in a similar way to <code>justify-self</code>."
+            },
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": "57"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "flex_context": {
           "__compat": {
-            "description": "Supported in Flex Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-self",
-            "spec_url": "https://drafts.csswg.org/css-align/#justify-self-property",
+            "description": "In Flex Layout",
             "support": {
               "chrome": {
                 "version_added": "57"
@@ -54,9 +102,7 @@
         },
         "grid_context": {
           "__compat": {
-            "description": "Supported in Grid Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-self",
-            "spec_url": "https://drafts.csswg.org/css-align/#justify-self-property",
+            "description": "In Grid Layout",
             "support": {
               "chrome": {
                 "version_added": "57"


### PR DESCRIPTION
These properties had no bcd directly on them, but only on their subfeatures. I added it (taking the earliest one). That way mdn_url and spec_url are at the right level.

This is similar to what we did in #11214.

(No mdn content will be broken by this change, it will be improved and we will be able to source spec_url through {{Specifications}})