### PR TITLE
Update HTMLOrForeignElement mdn_urls for demixing

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -562,7 +562,7 @@
       },
       "blur": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLOrForeignElement/blur",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/blur",
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-blur-dev",
           "support": {
             "chrome": {
@@ -775,7 +775,7 @@
       },
       "dataset": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLOrForeignElement/dataset",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/dataset",
           "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#dom-dataset-dev",
           "support": {
             "chrome": {
@@ -984,7 +984,7 @@
       },
       "focus": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLOrForeignElement/focus",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/focus",
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-focus-dev",
           "support": {
             "chrome": {
@@ -1921,7 +1921,7 @@
       },
       "nonce": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLOrForeignElement/nonce",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/nonce",
           "spec_url": "https://html.spec.whatwg.org/multipage/urls-and-fetching.html#dom-noncedelement-nonce",
           "support": {
             "chrome": {
@@ -3205,7 +3205,7 @@
       },
       "tabIndex": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLOrForeignElement/tabIndex",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/tabIndex",
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-tabindex",
           "support": {
             "chrome": {

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -97,7 +97,7 @@
       },
       "dataset": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLOrForeignElement/dataset",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGElement/dataset",
           "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#dom-dataset-dev",
           "support": {
             "chrome": {
@@ -196,7 +196,7 @@
       },
       "focus": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLOrForeignElement/focus",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGElement/focus",
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-focus-dev",
           "support": {
             "chrome": {


### PR DESCRIPTION
MDN documents `HTMLOrForeignElement` as a mixin. It isn't in any current spec and if it would be, we should avoid having this documented as a mixin. 

I'm working on the content updates, first MDN PR is https://github.com/mdn/content/pull/6519. Not sure if this BCD PR is really blocked by that work, though. The BCD structures are okay, just the mdn_urls needed updating.