### PR TITLE
Rename Point -> WebKitPoint

### DIFF
--- a/api/Point.json
+++ b/api/Point.json
@@ -1,23 +1,20 @@
 {
   "api": {
-    "Point": {
+    "WebKitPoint": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Point",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebKitPoint",
         "support": {
           "chrome": {
             "version_added": "2",
-            "version_removed": "39",
-            "prefix": "WebKit"
+            "version_removed": "39"
           },
           "chrome_android": {
             "version_added": "18",
-            "version_removed": "39",
-            "prefix": "WebKit"
+            "version_removed": "39"
           },
           "edge": {
             "version_added": "12",
-            "version_removed": "79",
-            "prefix": "WebKit"
+            "version_removed": "79"
           },
           "firefox": {
             "version_added": false
@@ -30,31 +27,25 @@
           },
           "opera": {
             "version_added": "15",
-            "version_removed": "26",
-            "prefix": "WebKit"
+            "version_removed": "26"
           },
           "opera_android": {
             "version_added": "14",
-            "version_removed": "26",
-            "prefix": "WebKit"
+            "version_removed": "26"
           },
           "safari": {
-            "version_added": "4",
-            "prefix": "WebKit"
+            "version_added": "4"
           },
           "safari_ios": {
-            "version_added": "3.2",
-            "prefix": "WebKit"
+            "version_added": "3.2"
           },
           "samsunginternet_android": {
             "version_added": "1.0",
-            "version_removed": "4.0",
-            "prefix": "WebKit"
+            "version_removed": "4.0"
           },
           "webview_android": {
             "version_added": "2",
-            "version_removed": "39",
-            "prefix": "WebKit"
+            "version_removed": "39"
           }
         },
         "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -1371,130 +1371,6 @@
           }
         }
       },
-      "convertPointFromNodeToPage": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/convertPointFromNodeToPage",
-          "support": {
-            "chrome": {
-              "version_added": true,
-              "version_removed": "39",
-              "prefix": "webkit"
-            },
-            "chrome_android": {
-              "version_added": true,
-              "version_removed": "39",
-              "prefix": "webkit"
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": true,
-              "version_removed": "26",
-              "prefix": "webkit"
-            },
-            "opera_android": {
-              "version_added": true,
-              "version_removed": "26",
-              "prefix": "webkit"
-            },
-            "safari": {
-              "version_added": true,
-              "prefix": "webkit"
-            },
-            "safari_ios": {
-              "version_added": true,
-              "prefix": "webkit"
-            },
-            "samsunginternet_android": {
-              "version_added": true,
-              "version_removed": "4.0",
-              "prefix": "webkit"
-            },
-            "webview_android": {
-              "version_added": true,
-              "version_removed": "39",
-              "prefix": "webkit"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": false
-          }
-        }
-      },
-      "convertPointFromPageToNode": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/convertPointFromPageToNode",
-          "support": {
-            "chrome": {
-              "version_added": true,
-              "version_removed": "39",
-              "prefix": "webkit"
-            },
-            "chrome_android": {
-              "version_added": true,
-              "version_removed": "39",
-              "prefix": "webkit"
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": true,
-              "version_removed": "26",
-              "prefix": "webkit"
-            },
-            "opera_android": {
-              "version_added": true,
-              "version_removed": "26",
-              "prefix": "webkit"
-            },
-            "safari": {
-              "version_added": true,
-              "prefix": "webkit"
-            },
-            "safari_ios": {
-              "version_added": true,
-              "prefix": "webkit"
-            },
-            "samsunginternet_android": {
-              "version_added": true,
-              "version_removed": "4.0",
-              "prefix": "webkit"
-            },
-            "webview_android": {
-              "version_added": true,
-              "version_removed": "39",
-              "prefix": "webkit"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": false
-          }
-        }
-      },
       "cookieStore": {
         "__compat": {
           "support": {
@@ -10817,6 +10693,114 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": true
+          }
+        }
+      },
+      "webkitConvertPointFromNodeToPage": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/webkitConvertPointFromNodeToPage",
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "version_removed": "39"
+            },
+            "chrome_android": {
+              "version_added": true,
+              "version_removed": "39"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true,
+              "version_removed": "26"
+            },
+            "opera_android": {
+              "version_added": true,
+              "version_removed": "26"
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": true,
+              "version_removed": "39"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitConvertPointFromPageToNode": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/webkitConvertPointFromPageToNode",
+          "support": {
+            "chrome": {
+              "version_added": true,
+              "version_removed": "39"
+            },
+            "chrome_android": {
+              "version_added": true,
+              "version_removed": "39"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": true,
+              "version_removed": "26"
+            },
+            "opera_android": {
+              "version_added": true,
+              "version_removed": "26"
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true,
+              "version_removed": "4.0"
+            },
+            "webview_android": {
+              "version_added": true,
+              "version_removed": "39"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
           }
         }
       },


### PR DESCRIPTION
As inspired by the comments in https://github.com/mdn/browser-compat-data/pull/11310#issuecomment-872100482, this PR renames the `Point` API to `WebKitPoint`, along with the related conversion methods in the `Window` API, since all of these methods have a prefix.
