### PR TITLE
Add Safari versions for api.ImageData.worker_support

### DIFF
--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -274,10 +274,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `worker_support` member of the `ImageData` API, based upon information in a tracking bug.

Tracking Bug: https://bugs.webkit.org/show_bug.cgi?id=130668
