### PR TITLE
Add Safari versions for api.XMLHttpRequest.send

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1487,10 +1487,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -1585,10 +1585,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "6"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "6"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -1634,10 +1634,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "6"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "6"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -1683,10 +1683,12 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/227477'>bug 227477</a>."
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/227477'>bug 227477</a>."
               },
               "samsunginternet_android": {
                 "version_added": "7.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `send` member of the `XMLHttpRequest` API, based upon information in a tracking bug.

Tracking Bug: https://webkit.org/b/90536 / https://webkit.org/b/71121 / https://webkit.org/b/227477
