### PR TITLE
Add CSS <filter-function> and its 10 functions

### DIFF
--- a/css/types/filter-function.json
+++ b/css/types/filter-function.json
@@ -1,0 +1,555 @@
+{
+  "css": {
+    "types": {
+      "filter-function": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#typedef-filter-function",
+          "support": {
+            "chrome": {
+              "version_added": "18"
+            },
+            "chrome_android": {
+              "version_added": "53"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "35"
+            },
+            "firefox_android": {
+              "version_added": "35"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": "4.4"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "blur": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/blur()",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#funcdef-filter-blur",
+            "description": "<code>blur()</code>",
+            "support": {
+              "chrome": {
+                "version_added": "18"
+              },
+              "chrome_android": {
+                "version_added": "53"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "35"
+              },
+              "firefox_android": {
+                "version_added": "35"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "14"
+              },
+              "safari": {
+                "version_added": "6"
+              },
+              "safari_ios": {
+                "version_added": "6"
+              },
+              "samsunginternet_android": {
+                "version_added": "6.0"
+              },
+              "webview_android": {
+                "version_added": "4.4"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "brightness": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/brightness()",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#funcdef-filter-brightness",
+            "description": "<code>brightness()</code>",
+            "support": {
+              "chrome": {
+                "version_added": "18"
+              },
+              "chrome_android": {
+                "version_added": "53"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "35"
+              },
+              "firefox_android": {
+                "version_added": "35"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "14"
+              },
+              "safari": {
+                "version_added": "6"
+              },
+              "safari_ios": {
+                "version_added": "6"
+              },
+              "samsunginternet_android": {
+                "version_added": "6.0"
+              },
+              "webview_android": {
+                "version_added": "4.4"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "constrast": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/contrast()",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#funcdef-filter-contrast",
+            "description": "<code>contrast()</code>",
+            "support": {
+              "chrome": {
+                "version_added": "18"
+              },
+              "chrome_android": {
+                "version_added": "53"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "35"
+              },
+              "firefox_android": {
+                "version_added": "35"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "14"
+              },
+              "safari": {
+                "version_added": "6"
+              },
+              "safari_ios": {
+                "version_added": "6"
+              },
+              "samsunginternet_android": {
+                "version_added": "6.0"
+              },
+              "webview_android": {
+                "version_added": "4.4"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "drop-shadow": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/drop-shadow()",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#funcdef-filter-drop-shadow",
+            "description": "<code>drop-shadow()</code>",
+            "support": {
+              "chrome": {
+                "version_added": "18"
+              },
+              "chrome_android": {
+                "version_added": "53"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "35"
+              },
+              "firefox_android": {
+                "version_added": "35"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "14"
+              },
+              "safari": {
+                "version_added": "6"
+              },
+              "safari_ios": {
+                "version_added": "6"
+              },
+              "samsunginternet_android": {
+                "version_added": "6.0"
+              },
+              "webview_android": {
+                "version_added": "4.4"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "grayscale": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/grayscale()",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#funcdef-filter-grayscale",
+            "description": "<code>grayscale()</code>",
+            "support": {
+              "chrome": {
+                "version_added": "18"
+              },
+              "chrome_android": {
+                "version_added": "53"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "35"
+              },
+              "firefox_android": {
+                "version_added": "35"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "14"
+              },
+              "safari": {
+                "version_added": "6"
+              },
+              "safari_ios": {
+                "version_added": "6"
+              },
+              "samsunginternet_android": {
+                "version_added": "6.0"
+              },
+              "webview_android": {
+                "version_added": "4.4"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "hue-rotate": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/hue-rotate()",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#funcdef-filter-hue-rotate",
+            "description": "<code>hue-rotate()</code>",
+            "support": {
+              "chrome": {
+                "version_added": "18"
+              },
+              "chrome_android": {
+                "version_added": "53"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "35"
+              },
+              "firefox_android": {
+                "version_added": "35"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "14"
+              },
+              "safari": {
+                "version_added": "6"
+              },
+              "safari_ios": {
+                "version_added": "6"
+              },
+              "samsunginternet_android": {
+                "version_added": "6.0"
+              },
+              "webview_android": {
+                "version_added": "4.4"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "invert": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/invert()",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#funcdef-filter-invert",
+            "description": "<code>invert()</code>",
+            "support": {
+              "chrome": {
+                "version_added": "18"
+              },
+              "chrome_android": {
+                "version_added": "53"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "35"
+              },
+              "firefox_android": {
+                "version_added": "35"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "14"
+              },
+              "safari": {
+                "version_added": "6"
+              },
+              "safari_ios": {
+                "version_added": "6"
+              },
+              "samsunginternet_android": {
+                "version_added": "6.0"
+              },
+              "webview_android": {
+                "version_added": "4.4"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "opacity": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/opacity()",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#funcdef-filter-opacity",
+            "description": "<code>opacity()</code>",
+            "support": {
+              "chrome": {
+                "version_added": "18"
+              },
+              "chrome_android": {
+                "version_added": "53"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "35"
+              },
+              "firefox_android": {
+                "version_added": "35"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "14"
+              },
+              "safari": {
+                "version_added": "6"
+              },
+              "safari_ios": {
+                "version_added": "6"
+              },
+              "samsunginternet_android": {
+                "version_added": "6.0"
+              },
+              "webview_android": {
+                "version_added": "4.4"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "saturate": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/saturate()",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#funcdef-filter-saturate",
+            "description": "<code>saturate()</code>",
+            "support": {
+              "chrome": {
+                "version_added": "18"
+              },
+              "chrome_android": {
+                "version_added": "53"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "35"
+              },
+              "firefox_android": {
+                "version_added": "35"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "14"
+              },
+              "safari": {
+                "version_added": "6"
+              },
+              "safari_ios": {
+                "version_added": "6"
+              },
+              "samsunginternet_android": {
+                "version_added": "6.0"
+              },
+              "webview_android": {
+                "version_added": "4.4"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "sepia": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/sepia()",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#funcdef-filter-sepia",
+            "description": "<code>sepia()</code>",
+            "support": {
+              "chrome": {
+                "version_added": "18"
+              },
+              "chrome_android": {
+                "version_added": "53"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "35"
+              },
+              "firefox_android": {
+                "version_added": "35"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "14"
+              },
+              "safari": {
+                "version_added": "6"
+              },
+              "safari_ios": {
+                "version_added": "6"
+              },
+              "samsunginternet_android": {
+                "version_added": "6.0"
+              },
+              "webview_android": {
+                "version_added": "4.4"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is the second and last bcd PR for #11301 (it can be landed independantly).

Initially there wasn't a `<filter-function>` CSS types, the 10 functions were defined directly on the CSS `filter`property.

With the addition of `backdrop-filter`, supporting the same filters, this changed and the 10 CSS functions are now defined on a type. MDN has created these pages long ago, but always linked to the bcd of the CSS `filter` property (that don't individualize the functions).

This fixes this by adding bcd for `<filter-function>`(implicitely added to the platform when `filter` has been added) and for each of the 10 functions, as subfeatures (added at the same time, but more were added in the future).

The `mdn_url` (already existing) and `spec_url` have been added too to point to the right pages/fragments.

This can land independantly of any other PR, nothing will break (even temporarily)