### PR TITLE
Add Safari versions for api.Element.keyboard_events

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -4694,10 +4694,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -4748,10 +4748,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true,
@@ -4800,10 +4800,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the keyboard events members of the `Element` API, based upon manual testing.

Test Code Used:
```js
document.body.addEventListener('keydown', function(e) {
	alert('keydown');
});
document.body.addEventListener('keypress', function(e) {
	alert('keypress');
});
document.body.addEventListener('keyup', function(e) {
	alert('keyup');
});
```
