### PR TITLE
Add spec_url for window.closed

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1373,59 +1373,6 @@
           }
         }
       },
-      "console": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/console",
-          "spec_url": "https://console.spec.whatwg.org/#console-namespace",
-          "support": {
-            "chrome": {
-              "version_added": "1"
-            },
-            "chrome_android": {
-              "version_added": "18"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "4"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
-            "ie": {
-              "version_added": "8",
-              "notes": "In Internet Explorer 8 and 9, the <code>console</code> object is <code>undefined</code> when the developer tools are not open. This behavior was fixed in Internet Explorer 10."
-            },
-            "nodejs": {
-              "version_added": "0.10.0"
-            },
-            "opera": {
-              "version_added": "10.5"
-            },
-            "opera_android": {
-              "version_added": "11"
-            },
-            "safari": {
-              "version_added": "3"
-            },
-            "safari_ios": {
-              "version_added": "1"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.0"
-            },
-            "webview_android": {
-              "version_added": "1"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "cookieStore": {
         "__compat": {
           "support": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -1272,7 +1272,7 @@
       "closed": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/closed",
-          "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-window-closed",
+          "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-window-closed-dev",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/Window.json
+++ b/api/Window.json
@@ -1271,6 +1271,8 @@
       },
       "closed": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/closed",
+          "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-window-closed",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -1362,6 +1364,59 @@
             "webview_android": {
               "version_added": "1",
               "notes": "Starting with Chrome 46, this method is blocked inside an <code>&lt;iframe&gt;</code> unless its sandbox attribute has the value <code>allow-modals</code>."
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "console": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/console",
+          "spec_url": "https://heycam.github.io/webidl/#dfn-namespace-object",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "8",
+              "notes": "In Internet Explorer 8 and 9, the <code>console</code> object is <code>undefined</code> when the developer tools are not open. This behavior was fixed in Internet Explorer 10."
+            },
+            "nodejs": {
+              "version_added": "0.10.0"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": "11"
+            },
+            "safari": {
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -1376,7 +1376,7 @@
       "console": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/console",
-          "spec_url": "https://heycam.github.io/webidl/#dfn-namespace-object",
+          "spec_url": "https://console.spec.whatwg.org/#console-namespace",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
`window.console` had no bcd. It was added at the same time as `Console`, so I copied the bcd. For the `spec_url` entry, as `Console` is a namespace and not an interface, I linked to the webidl entry that explain that a property is automatically on the global scope for namespaces. (This is similar to what we do for iterator methods like `foreach()`, or for `toString`: we link to the webidl spec.

`window.closed` was just missing the `spec_url` clause.