### PR TITLE
Replace httpwg.org redirect spec URLs

### DIFF
--- a/http/headers/accept-encoding.json
+++ b/http/headers/accept-encoding.json
@@ -4,7 +4,7 @@
       "Accept-Encoding": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-Encoding",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-5.3.4",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.5.3.4",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/accept-language.json
+++ b/http/headers/accept-language.json
@@ -4,7 +4,7 @@
       "Accept-Language": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-Language",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-5.3.5",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.5.3.5",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/accept-ranges.json
+++ b/http/headers/accept-ranges.json
@@ -4,7 +4,7 @@
       "Accept-Ranges": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-Ranges",
-          "spec_url": "https://httpwg.org/specs/rfc7233.html#section-2.3",
+          "spec_url": "https://httpwg.org/specs/rfc7233.html#rfc.section.2.3",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/accept.json
+++ b/http/headers/accept.json
@@ -4,7 +4,7 @@
       "Accept": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-5.3.2",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.5.3.2",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/age.json
+++ b/http/headers/age.json
@@ -4,7 +4,7 @@
       "Age": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Age",
-          "spec_url": "https://httpwg.org/specs/rfc7234.html#section-5.1",
+          "spec_url": "https://httpwg.org/specs/rfc7234.html#rfc.section.5.1",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/alt-svc.json
+++ b/http/headers/alt-svc.json
@@ -4,7 +4,7 @@
       "Alt-Svc": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Alt-Svc",
-          "spec_url": "https://httpwg.org/specs/rfc7838.html#section-3",
+          "spec_url": "https://httpwg.org/specs/rfc7838.html#rfc.section.3",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/cache-control.json
+++ b/http/headers/cache-control.json
@@ -5,8 +5,8 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control",
           "spec_url": [
-            "https://httpwg.org/specs/rfc7234.html#section-5.2",
-            "https://httpwg.org/specs/rfc8246.html#section-2"
+            "https://httpwg.org/specs/rfc7234.html#rfc.section.5.2",
+            "https://httpwg.org/specs/rfc8246.html#rfc.section.2"
           ],
           "support": {
             "chrome": {

--- a/http/headers/connection.json
+++ b/http/headers/connection.json
@@ -4,7 +4,7 @@
       "Connection": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Connection",
-          "spec_url": "https://httpwg.org/specs/rfc7230.html#section-6.1",
+          "spec_url": "https://httpwg.org/specs/rfc7230.html#rfc.section.6.1",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/content-disposition.json
+++ b/http/headers/content-disposition.json
@@ -5,7 +5,7 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Disposition",
           "spec_url": [
-            "https://httpwg.org/specs/rfc6266.html#section-4",
+            "https://httpwg.org/specs/rfc6266.html#rfc.section.4",
             "https://datatracker.ietf.org/doc/html/rfc7578#section-4.2"
           ],
           "support": {

--- a/http/headers/content-encoding.json
+++ b/http/headers/content-encoding.json
@@ -4,7 +4,7 @@
       "Content-Encoding": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Encoding",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-3.1.2.2",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.3.1.2.2",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/content-language.json
+++ b/http/headers/content-language.json
@@ -4,7 +4,7 @@
       "Content-Language": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Language",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-3.1.3.2",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.3.1.3.2",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/content-length.json
+++ b/http/headers/content-length.json
@@ -4,7 +4,7 @@
       "Content-Length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Length",
-          "spec_url": "https://httpwg.org/specs/rfc7230.html#section-3.3.2",
+          "spec_url": "https://httpwg.org/specs/rfc7230.html#rfc.section.3.3.2",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/content-location.json
+++ b/http/headers/content-location.json
@@ -4,7 +4,7 @@
       "Content-Location": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Location",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-3.1.4.2",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.3.1.4.2",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/content-range.json
+++ b/http/headers/content-range.json
@@ -4,7 +4,7 @@
       "Content-Range": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Range",
-          "spec_url": "https://httpwg.org/specs/rfc7233.html#section-4.2",
+          "spec_url": "https://httpwg.org/specs/rfc7233.html#rfc.section.4.2",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/content-type.json
+++ b/http/headers/content-type.json
@@ -5,8 +5,8 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Type",
           "spec_url": [
-            "https://httpwg.org/specs/rfc7233.html#section-4.1",
-            "https://httpwg.org/specs/rfc7231.html#section-3.1.1.5"
+            "https://httpwg.org/specs/rfc7233.html#rfc.section.4.1",
+            "https://httpwg.org/specs/rfc7231.html#rfc.section.3.1.1.5"
           ],
           "support": {
             "chrome": {

--- a/http/headers/cookie.json
+++ b/http/headers/cookie.json
@@ -4,7 +4,7 @@
       "Cookie": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Cookie",
-          "spec_url": "https://httpwg.org/specs/rfc6265.html#section-5.4",
+          "spec_url": "https://httpwg.org/specs/rfc6265.html#rfc.section.5.4",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/date.json
+++ b/http/headers/date.json
@@ -4,7 +4,7 @@
       "Date": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Date",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-7.1.1.2",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.7.1.1.2",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/early-data.json
+++ b/http/headers/early-data.json
@@ -4,7 +4,7 @@
       "Early-Data": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Early-Data",
-          "spec_url": "https://httpwg.org/specs/rfc8470.html#section-5.1",
+          "spec_url": "https://httpwg.org/specs/rfc8470.html#rfc.section.5.1",
           "support": {
             "chrome": {
               "version_added": null

--- a/http/headers/etag.json
+++ b/http/headers/etag.json
@@ -4,7 +4,7 @@
       "ETag": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/ETag",
-          "spec_url": "https://httpwg.org/specs/rfc7232.html#section-2.3",
+          "spec_url": "https://httpwg.org/specs/rfc7232.html#rfc.section.2.3",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/expect.json
+++ b/http/headers/expect.json
@@ -4,7 +4,7 @@
       "Expect": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Expect",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-5.1.1",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.5.1.1",
           "support": {
             "chrome": {
               "version_added": null

--- a/http/headers/expires.json
+++ b/http/headers/expires.json
@@ -4,7 +4,7 @@
       "Expires": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Expires",
-          "spec_url": "https://httpwg.org/specs/rfc7234.html#section-5.3",
+          "spec_url": "https://httpwg.org/specs/rfc7234.html#rfc.section.5.3",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/from.json
+++ b/http/headers/from.json
@@ -4,7 +4,7 @@
       "From": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/From",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-5.5.1",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.5.5.1",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/host.json
+++ b/http/headers/host.json
@@ -4,7 +4,7 @@
       "Host": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Host",
-          "spec_url": "https://httpwg.org/specs/rfc7230.html#section-5.4",
+          "spec_url": "https://httpwg.org/specs/rfc7230.html#rfc.section.5.4",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/if-match.json
+++ b/http/headers/if-match.json
@@ -4,7 +4,7 @@
       "If-Match": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-Match",
-          "spec_url": "https://httpwg.org/specs/rfc7232.html#section-3.1",
+          "spec_url": "https://httpwg.org/specs/rfc7232.html#rfc.section.3.1",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/if-modified-since.json
+++ b/http/headers/if-modified-since.json
@@ -4,7 +4,7 @@
       "If-Modified-Since": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-Modified-Since",
-          "spec_url": "https://httpwg.org/specs/rfc7232.html#section-3.3",
+          "spec_url": "https://httpwg.org/specs/rfc7232.html#rfc.section.3.3",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/if-none-match.json
+++ b/http/headers/if-none-match.json
@@ -4,7 +4,7 @@
       "If-None-Match": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-None-Match",
-          "spec_url": "https://httpwg.org/specs/rfc7232.html#section-3.2",
+          "spec_url": "https://httpwg.org/specs/rfc7232.html#rfc.section.3.2",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/if-range.json
+++ b/http/headers/if-range.json
@@ -4,7 +4,7 @@
       "If-Range": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-Range",
-          "spec_url": "https://httpwg.org/specs/rfc7233.html#section-3.2",
+          "spec_url": "https://httpwg.org/specs/rfc7233.html#rfc.section.3.2",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/if-unmodified-since.json
+++ b/http/headers/if-unmodified-since.json
@@ -4,7 +4,7 @@
       "If-Unmodified-Since": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-Unmodified-Since",
-          "spec_url": "https://httpwg.org/specs/rfc7232.html#section-3.4",
+          "spec_url": "https://httpwg.org/specs/rfc7232.html#rfc.section.3.4",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/keep-alive.json
+++ b/http/headers/keep-alive.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Keep-Alive",
           "spec_url": [
             "https://datatracker.ietf.org/doc/html/draft-thomson-hybi-http-timeout-03#section-2",
-            "https://httpwg.org/specs/rfc7230.html#appendix-A.1.2"
+            "https://httpwg.org/specs/rfc7230.html#rfc.section.A.1.2"
           ],
           "support": {
             "chrome": {

--- a/http/headers/last-modified.json
+++ b/http/headers/last-modified.json
@@ -4,7 +4,7 @@
       "Last-Modified": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Last-Modified",
-          "spec_url": "https://httpwg.org/specs/rfc7232.html#section-2.2",
+          "spec_url": "https://httpwg.org/specs/rfc7232.html#rfc.section.2.2",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/location.json
+++ b/http/headers/location.json
@@ -4,7 +4,7 @@
       "Location": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Location",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-7.1.2",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.7.1.2",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/pragma.json
+++ b/http/headers/pragma.json
@@ -4,7 +4,7 @@
       "Pragma": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Pragma",
-          "spec_url": "https://httpwg.org/specs/rfc7234.html#section-5.4",
+          "spec_url": "https://httpwg.org/specs/rfc7234.html#rfc.section.5.4",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/proxy-authenticate.json
+++ b/http/headers/proxy-authenticate.json
@@ -4,7 +4,7 @@
       "Proxy-Authenticate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Proxy-Authenticate",
-          "spec_url": "https://httpwg.org/specs/rfc7235.html#section-4.3",
+          "spec_url": "https://httpwg.org/specs/rfc7235.html#rfc.section.4.3",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/range.json
+++ b/http/headers/range.json
@@ -4,7 +4,7 @@
       "Range": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Range",
-          "spec_url": "https://httpwg.org/specs/rfc7233.html#section-3.1",
+          "spec_url": "https://httpwg.org/specs/rfc7233.html#rfc.section.3.1",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/referer.json
+++ b/http/headers/referer.json
@@ -4,7 +4,7 @@
       "Referer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Referer",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-5.5.2",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.5.5.2",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/retry-after.json
+++ b/http/headers/retry-after.json
@@ -4,7 +4,7 @@
       "Retry-After": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Retry-After",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-7.1.3",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.7.1.3",
           "support": {
             "chrome": {
               "version_added": null

--- a/http/headers/server.json
+++ b/http/headers/server.json
@@ -4,7 +4,7 @@
       "Server": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Server",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-7.4.2",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.7.4.2",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -4,7 +4,7 @@
       "Set-Cookie": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie",
-          "spec_url": "https://httpwg.org/specs/rfc6265.html#section-4.1",
+          "spec_url": "https://httpwg.org/specs/rfc6265.html#rfc.section.4.1",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/te.json
+++ b/http/headers/te.json
@@ -4,7 +4,7 @@
       "TE": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/TE",
-          "spec_url": "https://httpwg.org/specs/rfc7230.html#section-4.3",
+          "spec_url": "https://httpwg.org/specs/rfc7230.html#rfc.section.4.3",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/trailer.json
+++ b/http/headers/trailer.json
@@ -5,8 +5,8 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Trailer",
           "spec_url": [
-            "https://httpwg.org/specs/rfc7230.html#section-4.4",
-            "https://httpwg.org/specs/rfc7230.html#section-4.1.2"
+            "https://httpwg.org/specs/rfc7230.html#rfc.section.4.4",
+            "https://httpwg.org/specs/rfc7230.html#rfc.section.4.1.2"
           ],
           "support": {
             "chrome": {

--- a/http/headers/transfer-encoding.json
+++ b/http/headers/transfer-encoding.json
@@ -4,7 +4,7 @@
       "Transfer-Encoding": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Transfer-Encoding",
-          "spec_url": "https://httpwg.org/specs/rfc7230.html#section-3.3.1",
+          "spec_url": "https://httpwg.org/specs/rfc7230.html#rfc.section.3.3.1",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/upgrade.json
+++ b/http/headers/upgrade.json
@@ -5,9 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Upgrade",
           "spec_url": [
-            "https://httpwg.org/specs/rfc7230.html#section-6.7",
-            "https://httpwg.org/specs/rfc7231.html#section-6.5.15",
-            "https://httpwg.org/specs/rfc7540.html#section-8.1.1"
+            "https://httpwg.org/specs/rfc7230.html#rfc.section.6.7",
+            "https://httpwg.org/specs/rfc7231.html#rfc.section.6.5.15",
+            "https://httpwg.org/specs/rfc7540.html#rfc.section.8.1.1"
           ],
           "support": {
             "chrome": {

--- a/http/headers/user-agent.json
+++ b/http/headers/user-agent.json
@@ -4,7 +4,7 @@
       "User-Agent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/User-Agent",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-5.5.3",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.5.5.3",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/vary.json
+++ b/http/headers/vary.json
@@ -4,7 +4,7 @@
       "Vary": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Vary",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-7.1.4",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.7.1.4",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/via.json
+++ b/http/headers/via.json
@@ -4,7 +4,7 @@
       "Via": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Via",
-          "spec_url": "https://httpwg.org/specs/rfc7230.html#section-5.7.1",
+          "spec_url": "https://httpwg.org/specs/rfc7230.html#rfc.section.5.7.1",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/warning.json
+++ b/http/headers/warning.json
@@ -4,7 +4,7 @@
       "Warning": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Warning",
-          "spec_url": "https://httpwg.org/specs/rfc7234.html#section-5.5",
+          "spec_url": "https://httpwg.org/specs/rfc7234.html#rfc.section.5.5",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/www-authenticate.json
+++ b/http/headers/www-authenticate.json
@@ -4,7 +4,7 @@
       "WWW-Authenticate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/WWW-Authenticate",
-          "spec_url": "https://httpwg.org/specs/rfc7235.html#section-4.1",
+          "spec_url": "https://httpwg.org/specs/rfc7235.html#rfc.section.4.1",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/methods.json
+++ b/http/methods.json
@@ -4,7 +4,7 @@
       "CONNECT": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/CONNECT",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-4.3.6",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.4.3.6",
           "support": {
             "chrome": {
               "version_added": true
@@ -53,7 +53,7 @@
       "DELETE": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/DELETE",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-4.3.5",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.4.3.5",
           "support": {
             "chrome": {
               "version_added": true
@@ -102,7 +102,7 @@
       "GET": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/GET",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-4.3.1",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.4.3.1",
           "support": {
             "chrome": {
               "version_added": true
@@ -151,7 +151,7 @@
       "HEAD": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/HEAD",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-4.3.2",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.4.3.2",
           "support": {
             "chrome": {
               "version_added": true
@@ -200,7 +200,7 @@
       "OPTIONS": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/OPTIONS",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-4.3.7",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.4.3.7",
           "support": {
             "chrome": {
               "version_added": true
@@ -249,7 +249,7 @@
       "POST": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/POST",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-4.3.3",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.4.3.3",
           "support": {
             "chrome": {
               "version_added": true
@@ -298,7 +298,7 @@
       "PUT": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/PUT",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-4.3.4",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.4.3.4",
           "support": {
             "chrome": {
               "version_added": true
@@ -347,7 +347,7 @@
       "TRACE": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/TRACE",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-4.3.8",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.4.3.8",
           "support": {
             "chrome": {
               "version_added": null

--- a/http/status.json
+++ b/http/status.json
@@ -4,7 +4,7 @@
       "100": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/100",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-6.2.1",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.6.2.1",
           "support": {
             "chrome": {
               "version_added": true
@@ -53,7 +53,7 @@
       "200": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/200",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-6.3.1",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.6.3.1",
           "support": {
             "chrome": {
               "version_added": true
@@ -102,7 +102,7 @@
       "201": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/201",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-6.3.2",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.6.3.2",
           "support": {
             "chrome": {
               "version_added": true
@@ -151,7 +151,7 @@
       "204": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/204",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-6.3.5",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.6.3.5",
           "support": {
             "chrome": {
               "version_added": true
@@ -200,7 +200,7 @@
       "206": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/206",
-          "spec_url": "https://httpwg.org/specs/rfc7233.html#section-4.1",
+          "spec_url": "https://httpwg.org/specs/rfc7233.html#rfc.section.4.1",
           "support": {
             "chrome": {
               "version_added": true
@@ -249,7 +249,7 @@
       "301": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/301",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-6.4.2",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.6.4.2",
           "support": {
             "chrome": {
               "version_added": true
@@ -298,7 +298,7 @@
       "302": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/302",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-6.4.3",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.6.4.3",
           "support": {
             "chrome": {
               "version_added": true
@@ -347,7 +347,7 @@
       "303": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/303",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-6.4.4",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.6.4.4",
           "support": {
             "chrome": {
               "version_added": true
@@ -396,7 +396,7 @@
       "304": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/304",
-          "spec_url": "https://httpwg.org/specs/rfc7232.html#section-4.1",
+          "spec_url": "https://httpwg.org/specs/rfc7232.html#rfc.section.4.1",
           "support": {
             "chrome": {
               "version_added": true
@@ -445,7 +445,7 @@
       "307": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/307",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-6.4.7",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.6.4.7",
           "support": {
             "chrome": {
               "version_added": true
@@ -494,7 +494,7 @@
       "308": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/308",
-          "spec_url": "https://httpwg.org/specs/rfc7538.html#section-3",
+          "spec_url": "https://httpwg.org/specs/rfc7538.html#rfc.section.3",
           "support": {
             "chrome": {
               "version_added": "36"
@@ -544,7 +544,7 @@
       "401": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/401",
-          "spec_url": "https://httpwg.org/specs/rfc7235.html#section-3.1",
+          "spec_url": "https://httpwg.org/specs/rfc7235.html#rfc.section.3.1",
           "support": {
             "chrome": {
               "version_added": true
@@ -593,7 +593,7 @@
       "403": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/403",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-6.5.3",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.6.5.3",
           "support": {
             "chrome": {
               "version_added": true
@@ -642,7 +642,7 @@
       "404": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/404",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-6.5.4",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.6.5.4",
           "support": {
             "chrome": {
               "version_added": true
@@ -691,7 +691,7 @@
       "406": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/406",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-6.5.6",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.6.5.6",
           "support": {
             "chrome": {
               "version_added": true
@@ -740,7 +740,7 @@
       "407": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/407",
-          "spec_url": "https://httpwg.org/specs/rfc7235.html#section-3.2",
+          "spec_url": "https://httpwg.org/specs/rfc7235.html#rfc.section.3.2",
           "support": {
             "chrome": {
               "version_added": true
@@ -789,7 +789,7 @@
       "409": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/409",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-6.5.8",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.6.5.8",
           "support": {
             "chrome": {
               "version_added": true
@@ -838,7 +838,7 @@
       "410": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/410",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-6.5.9",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.6.5.9",
           "support": {
             "chrome": {
               "version_added": true
@@ -887,7 +887,7 @@
       "412": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/412",
-          "spec_url": "https://httpwg.org/specs/rfc7232.html#section-4.2",
+          "spec_url": "https://httpwg.org/specs/rfc7232.html#rfc.section.4.2",
           "support": {
             "chrome": {
               "version_added": true
@@ -936,7 +936,7 @@
       "416": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/416",
-          "spec_url": "https://httpwg.org/specs/rfc7233.html#section-4.4",
+          "spec_url": "https://httpwg.org/specs/rfc7233.html#rfc.section.4.4",
           "support": {
             "chrome": {
               "version_added": true
@@ -1034,7 +1034,7 @@
       "425": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/425",
-          "spec_url": "https://httpwg.org/specs/rfc8470.html#section-5.2",
+          "spec_url": "https://httpwg.org/specs/rfc8470.html#rfc.section.5.2",
           "support": {
             "chrome": {
               "version_added": null
@@ -1083,7 +1083,7 @@
       "451": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/451",
-          "spec_url": "https://httpwg.org/specs/rfc7725.html#section-3",
+          "spec_url": "https://httpwg.org/specs/rfc7725.html#rfc.section.3",
           "support": {
             "chrome": {
               "version_added": true
@@ -1132,7 +1132,7 @@
       "500": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/500",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-6.6.1",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.6.6.1",
           "support": {
             "chrome": {
               "version_added": true
@@ -1181,7 +1181,7 @@
       "501": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/501",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-6.6.2",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.6.6.2",
           "support": {
             "chrome": {
               "version_added": true
@@ -1230,7 +1230,7 @@
       "502": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/502",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-6.6.3",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.6.6.3",
           "support": {
             "chrome": {
               "version_added": true
@@ -1279,7 +1279,7 @@
       "503": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/503",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-6.6.4",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.6.6.4",
           "support": {
             "chrome": {
               "version_added": true
@@ -1328,7 +1328,7 @@
       "504": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/504",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#section-6.6.5",
+          "spec_url": "https://httpwg.org/specs/rfc7231.html#rfc.section.6.6.5",
           "support": {
             "chrome": {
               "version_added": true


### PR DESCRIPTION
httpwg.org specs apparently have frontend JavaScript that redirects URLs of the form https://httpwg.org/specs/rfc7231.html#section-5.3.4 to corresponding URLs of the form https://httpwg.org/specs/rfc7231.html#rfc.section.5.3.4

So this change replaces the current URLs with the ones they redirect to.