### PR TITLE
Update spec exception list for browser-specs 2.1

### DIFF
--- a/http/headers/keep-alive.json
+++ b/http/headers/keep-alive.json
@@ -4,10 +4,7 @@
       "Keep-Alive": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Keep-Alive",
-          "spec_url": [
-            "https://datatracker.ietf.org/doc/html/draft-thomson-hybi-http-timeout-03#section-2",
-            "https://httpwg.org/specs/rfc7230.html#appendix-A.1.2"
-          ],
+          "spec_url": "https://httpwg.org/specs/rfc7230.html#appendix-A.1.2",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/keep-alive.json
+++ b/http/headers/keep-alive.json
@@ -4,7 +4,7 @@
       "Keep-Alive": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Keep-Alive",
-          "spec_url": "https://httpwg.org/specs/rfc7230.html#appendix-A.1.2",
+          "spec_url": "https://httpwg.org/specs/rfc7230.html#rfc.section.A.1.2",
           "support": {
             "chrome": {
               "version_added": true

--- a/test/spec-urls.test.js
+++ b/test/spec-urls.test.js
@@ -31,21 +31,9 @@ describe('spec_url data', () => {
       // Remove once Window.{clearImmediate,setImmediate} are irrelevant and removed
       'https://w3c.github.io/setImmediate/',
 
-      // Remove if supported in browser-specs https://github.com/w3c/browser-specs/issues/338
-      'https://httpwg.org/specs/rfc7838.html', // Alt-Svc
-      'https://httpwg.org/specs/rfc8246.html', // Cache-Control immutable
-      'https://httpwg.org/specs/rfc6266.html', // Content-Disposition
-      'https://httpwg.org/specs/rfc7725.html', // 451 Status code
-
       // Remove if supported in browser-specs https://github.com/w3c/browser-specs/issues/339
-      'https://datatracker.ietf.org/doc/html/rfc7578', // Content-Disposition in multipart/form-data
-      'https://datatracker.ietf.org/doc/html/rfc2397', // Data URI scheme
-      'https://datatracker.ietf.org/doc/html/rfc8942', // Client Hints
       'https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers-05',
       'https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-expect-ct-08',
-      'https://datatracker.ietf.org/doc/html/draft-thomson-hybi-http-timeout-03',
-      'https://datatracker.ietf.org/doc/html/rfc6797', // HSTS
-      'https://datatracker.ietf.org/doc/html/rfc7034', // X-Frame-Options
 
       // Exception for April Fools' joke for "418 I'm a teapot"
       'https://datatracker.ietf.org/doc/html/rfc2324',


### PR DESCRIPTION
w3c/browser-specs version 2.1 supports a lot more IETF specs, so I'm updating our exception list.

Two IETF draft specs are remaining, see https://github.com/w3c/browser-specs/issues/339. 

The spec for the Keep-Alive header seems to be too outdated, so I removed it.