### PR TITLE
Update Firefox compat of URL.pathname, URL.search

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -627,26 +627,14 @@
             "edge": {
               "version_added": "13"
             },
-            "firefox": [
-              {
-                "version_added": "53"
-              },
-              {
-                "version_added": "22",
-                "version_removed": "53",
-                "notes": "<code>pathname</code> and <code>search</code> returned the wrong values so that for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return \"/x?a=true&b=false\" and <code>search</code> would return \"\", rather than \"/x\" and \"?a=true&b=false\" respectively."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "53"
-              },
-              {
-                "version_added": "22",
-                "version_removed": "53",
-                "notes": "<code>pathname</code> and <code>search</code> returned the wrong values so that for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return \"/x?a=true&b=false\" and <code>search</code> would return \"\", rather than \"/x\" and \"?a=true&b=false\" respectively."
-              }
-            ],
+            "firefox": {
+              "version_added": "22",
+              "notes": "Before Firefox 53, <code>pathname</code> and <code>search</code> returned wrong values for custom protocols. Given <code>protocol:host/x?a=true&b=false</code>, <code>pathname</code> would return \"/x?a=true&b=false\" and <code>search</code> would return \"\", rather than \"/x\" and \"?a=true&b=false\" respectively. See <a href='https://bugzil.la/1310483'>bug 1310483</a>."
+            },
+            "firefox_android": {
+              "version_added": "22",
+              "notes": "Before Firefox 53, <code>pathname</code> and <code>search</code> returned wrong values for custom protocols. Given <code>protocol:host/x?a=true&b=false</code>, <code>pathname</code> would return \"/x?a=true&b=false\" and <code>search</code> would return \"\", rather than \"/x\" and \"?a=true&b=false\" respectively. See <a href='https://bugzil.la/1310483'>bug 1310483</a>."
+            },
             "ie": {
               "version_added": false
             },
@@ -851,26 +839,14 @@
             "edge": {
               "version_added": "13"
             },
-            "firefox": [
-              {
-                "version_added": "53"
-              },
-              {
-                "version_added": "22",
-                "version_removed": "53",
-                "notes": "<code>pathname</code> and <code>search</code> returned the wrong values so that for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return \"/x?a=true&b=false\" and <code>search</code> would return \"\", rather than \"/x\" and \"?a=true&b=false\" respectively."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "53"
-              },
-              {
-                "version_added": "22",
-                "version_removed": "53",
-                "notes": "<code>pathname</code> and <code>search</code> returned the wrong values so that for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return \"/x?a=true&b=false\" and <code>search</code> would return \"\", rather than \"/x\" and \"?a=true&b=false\" respectively."
-              }
-            ],
+            "firefox": {
+              "version_added": "22",
+              "notes": "Before Firefox 53, <code>pathname</code> and <code>search</code> returned wrong values for custom protocols. Given <code>protocol:host/x?a=true&b=false</code>, <code>pathname</code> would return \"/x?a=true&b=false\" and <code>search</code> would return \"\", rather than \"/x\" and \"?a=true&b=false\" respectively. See <a href='https://bugzil.la/1310483'>bug 1310483</a>."
+            },
+            "firefox_android": {
+              "version_added": "22",
+              "notes": "Before Firefox 53, <code>pathname</code> and <code>search</code> returned wrong values for custom protocols. Given <code>protocol:host/x?a=true&b=false</code>, <code>pathname</code> would return \"/x?a=true&b=false\" and <code>search</code> would return \"\", rather than \"/x\" and \"?a=true&b=false\" respectively. See <a href='https://bugzil.la/1310483'>bug 1310483</a>."
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
# Summary

See #10817. Currently the compat table renders as below:
![image](https://user-images.githubusercontent.com/1437027/124773714-7c84a900-df3d-11eb-9163-a1d9075a9e02.png)

IMO the 🔴 for Firefox<53 is too much; the API *is* there; it has a bug, _but_ not for the common case (`http`/`https`).
(The release notes for Firefox 53 are wrong too BTW).
So I think 🟢 with a note is a better fit here.

Example of an existing article using this convention: [elementFromPoint](https://developer.mozilla.org/en-US/docs/Web/API/Document/elementFromPoint) article, Chrome support is `1*` and bug is put as a comment; it's not `66` due to the bug.
![image](https://user-images.githubusercontent.com/1437027/124924691-ff6c3900-dffb-11eb-96f0-9ead228cc64f.png)



But if you want I can bring the old schedule back and mark it with 🟠 `"partial_implementation": true`?

(The wording of the bug was also wrong; the example shows `http://` but the bug does not happen for `http://`; I updated the example too)

# Test results and supporting details

Relevant firefox bug: [bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1310483)

Tests in Firefox 48:
![image](https://user-images.githubusercontent.com/1437027/124775218-b99d6b00-df3e-11eb-8e79-56a00d44a95b.png)


# Related issues

Fixes #10817 

