### PR TITLE
Update support for text-decoration-thickness

### DIFF
--- a/css/properties/text-decoration-thickness.json
+++ b/css/properties/text-decoration-thickness.json
@@ -73,7 +73,7 @@
               }
             ],
             "opera_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "safari": {
               "version_added": "12.1"

--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -189,7 +189,7 @@
                 "version_added": "73"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "62"
               },
               "safari": {
                 "version_added": false
@@ -198,7 +198,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "14.0"
               },
               "webview_android": {
                 "version_added": "87"


### PR DESCRIPTION
#### Summary

Update support for text-decoration-thickness

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Just copying blink data across to opera android and Samsung internet
