### PR TITLE
Add Firefox versions for api.CanvasRenderingContext2D.imageSmoothingEnabled

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2125,15 +2125,21 @@
                 "prefix": "webkit"
               }
             ],
-            "edge": {
-              "version_added": "15"
-            },
+            "edge": [
+              {
+                "version_added": "15"
+              },
+              {
+                "version_added": "12",
+                "prefix": "ms"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "51"
               },
               {
-                "version_added": true,
+                "version_added": "3.6",
                 "version_removed": "51",
                 "prefix": "moz"
               }
@@ -2143,7 +2149,7 @@
                 "version_added": "51"
               },
               {
-                "version_added": true,
+                "version_added": "4",
                 "version_removed": "51",
                 "prefix": "moz"
               }

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2125,15 +2125,9 @@
                 "prefix": "webkit"
               }
             ],
-            "edge": [
-              {
-                "version_added": "15"
-              },
-              {
-                "version_added": "12",
-                "prefix": "ms"
-              }
-            ],
+            "edge": {
+              "version_added": "15"
+            },
             "firefox": [
               {
                 "version_added": "51"


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `imageSmoothingEnabled` member of the `CanvasRenderingContext2D` API, based upon manual testing.

Test Code Used:
```html
<canvas id="canvas"></canvas>

<script>
	var canvas = document.createElement('canvas');
	var ctx = canvas.getContext('2d');
	alert(ctx.mozImageSmoothingEnabled);
</script>
```
