### PR TITLE
Add IE/Edge versions for api.CanvasRenderingContext2D.imageSmoothingEnabled

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2149,7 +2149,7 @@
               }
             ],
             "ie": {
-              "version_added": true,
+              "version_added": "11",
               "prefix": "ms"
             },
             "opera": [

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2125,9 +2125,15 @@
                 "prefix": "webkit"
               }
             ],
-            "edge": {
-              "version_added": "15"
-            },
+            "edge": [
+              {
+                "version_added": "15"
+              },
+              {
+                "version_added": "12",
+                "prefix": "ms"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "51"

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2131,6 +2131,7 @@
               },
               {
                 "version_added": "12",
+                "version_removed": "15",
                 "prefix": "ms"
               }
             ],


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `imageSmoothingEnabled` member of the `CanvasRenderingContext2D` API, based upon manual testing.

Test Code Used: 
```html
<canvas id="canvas"></canvas>

<script>
	var canvas = document.createElement('canvas');
	var ctx = canvas.getContext('2d');
	alert(ctx.msImageSmoothingEnabled);
</script>
```
