### PR TITLE
Add missing XRWebGLBinding API

### DIFF
--- a/api/XRWebGLBinding.json
+++ b/api/XRWebGLBinding.json
@@ -1,0 +1,101 @@
+{
+  "api": {
+    "XRWebGLBinding": {
+      "__compat": {
+        "spec_url": "https://immersive-web.github.io/layers/#XRWebGLBindingtype",
+        "support": {
+          "chrome": {
+            "version_added": "89"
+          },
+          "chrome_android": {
+            "version_added": "89"
+          },
+          "edge": {
+            "version_added": "89"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "75"
+          },
+          "opera_android": {
+            "version_added": "63"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "XRWebGLBinding": {
+        "__compat": {
+          "description": "<code>XRWebGLBinding()</code> constructor",
+          "spec_url": "https://immersive-web.github.io/layers/#dom-xrwebglbinding-xrwebglbinding",
+          "support": {
+            "chrome": {
+              "version_added": "89"
+            },
+            "chrome_android": {
+              "version_added": "89"
+            },
+            "edge": {
+              "version_added": "89"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "75"
+            },
+            "opera_android": {
+              "version_added": "63"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `XRWebGLBinding` API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10).

Spec: https://immersive-web.github.io/layers/#XRWebGLBindingtype

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/XRWebGLBinding
