### PR TITLE
Add missing XRWebGLDepthInformation API

### DIFF
--- a/api/XRWebGLDepthInformation.json
+++ b/api/XRWebGLDepthInformation.json
@@ -1,0 +1,100 @@
+{
+  "api": {
+    "XRWebGLDepthInformation": {
+      "__compat": {
+        "spec_url": "https://immersive-web.github.io/depth-sensing/#xrwebgldepthinformation",
+        "support": {
+          "chrome": {
+            "version_added": "90"
+          },
+          "chrome_android": {
+            "version_added": "90"
+          },
+          "edge": {
+            "version_added": "90"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "76"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "texture": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/depth-sensing/#dom-xrwebgldepthinformation-texture",
+          "support": {
+            "chrome": {
+              "version_added": "90"
+            },
+            "chrome_android": {
+              "version_added": "90"
+            },
+            "edge": {
+              "version_added": "90"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "76"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `XRWebGLDepthInformation` API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10).

Spec: https://immersive-web.github.io/depth-sensing

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/XRWebGLDepthInformation
