### PR TITLE
adds spec URLs for LargestContentfulPaint subpages

### DIFF
--- a/api/LargestContentfulPaint.json
+++ b/api/LargestContentfulPaint.json
@@ -51,6 +51,7 @@
       "element": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/element",
+          "spec_url": "https://wicg.github.io/largest-contentful-paint/#dom-largestcontentfulpaint-element",
           "support": {
             "chrome": {
               "version_added": "77"
@@ -99,6 +100,7 @@
       "id": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/id",
+          "spec_url": "https://wicg.github.io/largest-contentful-paint/#dom-largestcontentfulpaint-id",
           "support": {
             "chrome": {
               "version_added": "77"
@@ -147,6 +149,7 @@
       "loadTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/loadTime",
+          "spec_url": "https://wicg.github.io/largest-contentful-paint/#dom-largestcontentfulpaint-loadtime",
           "support": {
             "chrome": {
               "version_added": "77"
@@ -195,6 +198,7 @@
       "renderTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/renderTime",
+          "spec_url": "https://wicg.github.io/largest-contentful-paint/#dom-largestcontentfulpaint-rendertime",
           "support": {
             "chrome": {
               "version_added": "77"
@@ -243,6 +247,7 @@
       "size": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/size",
+          "spec_url": "https://wicg.github.io/largest-contentful-paint/#dom-largestcontentfulpaint-size",
           "support": {
             "chrome": {
               "version_added": "77"
@@ -291,6 +296,7 @@
       "toJSON": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/toJSON",
+          "spec_url": "https://wicg.github.io/largest-contentful-paint/#dom-largestcontentfulpaint-tojson",
           "support": {
             "chrome": {
               "version_added": "77"
@@ -339,6 +345,7 @@
       "url": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/url",
+          "spec_url": "https://wicg.github.io/largest-contentful-paint/#dom-largestcontentfulpaint-url",
           "support": {
             "chrome": {
               "version_added": "77"


### PR DESCRIPTION
Working on LCP docs in https://github.com/mdn/content/pull/6674

This adds the spec URLs for the property and method pages.
