### PR TITLE
Add missing XR depth features

### DIFF
--- a/api/XRFrame.json
+++ b/api/XRFrame.json
@@ -95,6 +95,54 @@
           }
         }
       },
+      "getDepthInformation": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/depth-sensing/#dom-xrframe-getdepthinformation",
+          "support": {
+            "chrome": {
+              "version_added": "90"
+            },
+            "chrome_android": {
+              "version_added": "90"
+            },
+            "edge": {
+              "version_added": "90"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "76"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getHitTestResults": {
         "__compat": {
           "support": {

--- a/api/XRFrame.json
+++ b/api/XRFrame.json
@@ -118,7 +118,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "76"
+              "version_added": false
             },
             "opera_android": {
               "version_added": false

--- a/api/XRSession.json
+++ b/api/XRSession.json
@@ -98,6 +98,102 @@
           }
         }
       },
+      "depthDataFormat": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/depth-sensing/#dom-xrsession-depthdataformat",
+          "support": {
+            "chrome": {
+              "version_added": "90"
+            },
+            "chrome_android": {
+              "version_added": "90"
+            },
+            "edge": {
+              "version_added": "90"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "76"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "depthUsage": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/depth-sensing/#dom-xrsession-depthusage",
+          "support": {
+            "chrome": {
+              "version_added": "90"
+            },
+            "chrome_android": {
+              "version_added": "90"
+            },
+            "edge": {
+              "version_added": "90"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "76"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "domOverlayState": {
         "__compat": {
           "support": {

--- a/api/XRSession.json
+++ b/api/XRSession.json
@@ -121,7 +121,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "76"
+              "version_added": false
             },
             "opera_android": {
               "version_added": false
@@ -169,7 +169,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "76"
+              "version_added": false
             },
             "opera_android": {
               "version_added": false


### PR DESCRIPTION
This PR is a continuation off of #11431, #11432, and #11433.  This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing depth-based features of the XR APIs, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10).

Spec: https://immersive-web.github.io/depth-sensing

Tests Used:
https://mdn-bcd-collector.appspot.com/tests/api/XRFrame/getDepthInformation
https://mdn-bcd-collector.appspot.com/tests/api/XRSession/depthDataFormat
https://mdn-bcd-collector.appspot.com/tests/api/XRSession/depthUsage

