### PR TITLE
Add missing XR lighting features

### DIFF
--- a/api/XRFrame.json
+++ b/api/XRFrame.json
@@ -189,6 +189,54 @@
           }
         }
       },
+      "getLightEstimate": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/lighting-estimation/#dom-xrframe-getlightestimate",
+          "support": {
+            "chrome": {
+              "version_added": "90"
+            },
+            "chrome_android": {
+              "version_added": "90"
+            },
+            "edge": {
+              "version_added": "90"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getPose": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRFrame/getPose",

--- a/api/XRSession.json
+++ b/api/XRSession.json
@@ -881,6 +881,54 @@
           }
         }
       },
+      "preferredReflectionFormat": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/lighting-estimation/#dom-xrsession-preferredreflectionformat",
+          "support": {
+            "chrome": {
+              "version_added": "90"
+            },
+            "chrome_android": {
+              "version_added": "90"
+            },
+            "edge": {
+              "version_added": "90"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "renderState": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSession/renderState",
@@ -1063,6 +1111,54 @@
             },
             "samsunginternet_android": {
               "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "requestLightProbe": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/lighting-estimation/#dom-xrsession-requestlightprobe",
+          "support": {
+            "chrome": {
+              "version_added": "90"
+            },
+            "chrome_android": {
+              "version_added": "90"
+            },
+            "edge": {
+              "version_added": "90"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
This PR is a continuation off of #11427 and #11428.  This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing lighting-based features of the XR APIs, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10).

Spec: https://immersive-web.github.io/lighting-estimation

Tests Used:
https://mdn-bcd-collector.appspot.com/tests/api/XRFrame/getLightEstimate
https://mdn-bcd-collector.appspot.com/tests/api/XRSession/preferredReflectionFormat
https://mdn-bcd-collector.appspot.com/tests/api/XRSession/requestLightProbe

