### PR TITLE
Add missing Counter API

### DIFF
--- a/api/Counter.json
+++ b/api/Counter.json
@@ -1,0 +1,203 @@
+{
+  "api": {
+    "Counter": {
+      "__compat": {
+        "spec_url": "https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-Counter",
+        "support": {
+          "chrome": {
+            "version_added": "1",
+            "version_removed": "40"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "1",
+            "version_removed": "25"
+          },
+          "firefox_android": {
+            "version_added": "4",
+            "version_removed": "25"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "15",
+            "version_removed": "27"
+          },
+          "opera_android": {
+            "version_added": "14",
+            "version_removed": "27"
+          },
+          "safari": {
+            "version_added": "≤4"
+          },
+          "safari_ios": {
+            "version_added": "≤3"
+          },
+          "samsunginternet_android": {
+            "version_added": "1.0",
+            "version_removed": "4.0"
+          },
+          "webview_android": {
+            "version_added": "≤37",
+            "version_removed": "40"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": true
+        }
+      },
+      "identifier": {
+        "__compat": {
+          "spec_url": "https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-Counter-identifier",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "listStyle": {
+        "__compat": {
+          "spec_url": "https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-Counter-listStyle",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "separator": {
+        "__compat": {
+          "spec_url": "https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-Counter-separator",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `Counter` API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10).

Spec: https://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-Counter

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Counter
