### PR TITLE
Add missing spec_url in api.*

### DIFF
--- a/api/MIDIOutput.json
+++ b/api/MIDIOutput.json
@@ -101,6 +101,7 @@
       "send": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIOutput/send",
+          "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midioutput-send",
           "support": {
             "chrome": {
               "version_added": "43"

--- a/api/MIDIPort.json
+++ b/api/MIDIPort.json
@@ -3,6 +3,7 @@
     "MIDIPort": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort",
+        "spec_url": "https://webaudio.github.io/web-midi-api/#MIDIPort",
         "support": {
           "chrome": {
             "version_added": "43"
@@ -50,6 +51,7 @@
       "close": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/close",
+          "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-close",
           "support": {
             "chrome": {
               "version_added": "43"
@@ -98,6 +100,7 @@
       "connection": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/connection",
+          "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-connection",
           "support": {
             "chrome": {
               "version_added": "43"
@@ -146,6 +149,7 @@
       "id": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/id",
+          "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-id",
           "support": {
             "chrome": {
               "version_added": "43"
@@ -194,6 +198,7 @@
       "manufacturer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/manufacturer",
+          "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-manufacturer",
           "support": {
             "chrome": {
               "version_added": "43"
@@ -242,6 +247,7 @@
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/name",
+          "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-name",
           "support": {
             "chrome": {
               "version_added": "43"
@@ -290,6 +296,7 @@
       "onstatechange": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/onstatechange",
+          "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-onstatechange",
           "support": {
             "chrome": {
               "version_added": "43"
@@ -338,6 +345,7 @@
       "open": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/open",
+          "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-open",
           "support": {
             "chrome": {
               "version_added": "43"
@@ -386,6 +394,7 @@
       "state": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/state",
+          "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-state",
           "support": {
             "chrome": {
               "version_added": "43"
@@ -483,6 +492,7 @@
       "type": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/type",
+          "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-type",
           "support": {
             "chrome": {
               "version_added": "43"
@@ -531,6 +541,7 @@
       "version": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/version",
+          "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-version",
           "support": {
             "chrome": {
               "version_added": "43"

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1791,6 +1791,7 @@
       "getTransceivers": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/getTransceivers",
+          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-peerconnection-gettranseceivers",
           "support": {
             "chrome": {
               "version_added": "69"

--- a/api/SVGPointList.json
+++ b/api/SVGPointList.json
@@ -3,6 +3,7 @@
     "SVGPointList": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList",
+        "spec_url": "https://svgwg.org/svg2-draft/shapes.html#InterfaceSVGPointList",
         "support": {
           "chrome": {
             "version_added": "5"
@@ -50,6 +51,7 @@
       "appendItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/appendItem",
+          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__appendItem",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -98,6 +100,7 @@
       "clear": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/clear",
+          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__clear",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -146,6 +149,7 @@
       "getItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/getItem",
+          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__getItem",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -194,6 +198,7 @@
       "initialize": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/initialize",
+          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__initialize",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -242,6 +247,7 @@
       "insertItemBefore": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/insertItemBefore",
+          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__insertItemBefore",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -290,6 +296,7 @@
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/length",
+          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__length",
           "support": {
             "chrome": {
               "version_added": true
@@ -338,6 +345,7 @@
       "numberOfItems": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/numberOfItems",
+          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__numberOfItems",
           "support": {
             "chrome": {
               "version_added": true
@@ -386,6 +394,7 @@
       "removeItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/removeItem",
+          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__removeItem",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -434,6 +443,7 @@
       "replaceItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/replaceItem",
+          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__replaceItem",
           "support": {
             "chrome": {
               "version_added": "5"


### PR DESCRIPTION
This is part of #11443.

It adds the detected missing `spec_url `to all the `api.*` keys.