### PR TITLE
Add Firefox versions for api.RTCPeerConnection.onicecandidateerror

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -2478,10 +2478,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `onicecandidateerror` member of the `RTCPeerConnection` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCPeerConnection/onicecandidateerror
