### PR TITLE
Remove api.WindowOrWorkerGlobalScope.setTimeout.tracking_throttling

### DIFF
--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -1283,57 +1283,6 @@
               "deprecated": false
             }
           }
-        },
-        "tracking_throttling": {
-          "__compat": {
-            "description": "Throttling of tracking timeout scripts",
-            "support": {
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": {
-                "version_added": null
-              },
-              "edge": {
-                "version_added": null
-              },
-              "firefox": {
-                "version_added": "55"
-              },
-              "firefox_android": {
-                "version_added": "55"
-              },
-              "ie": {
-                "version_added": null
-              },
-              "nodejs": {
-                "version_added": null
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": null
-              },
-              "webview_android": {
-                "version_added": null
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
This PR removes the `tracking_throttling` behavioral feature of the `setTimeout` function.  Reading the [MDN article](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout#throttling_of_tracking_scripts), this seems to be a Firefox-only behavior.
