### PR TITLE
Add IE versions for UIEvent API

### DIFF
--- a/api/UIEvent.json
+++ b/api/UIEvent.json
@@ -21,7 +21,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "9"
           },
           "opera": {
             "version_added": true
@@ -70,7 +70,7 @@
               "version_added": "14"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -170,7 +170,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `UIEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/UIEvent
