### PR TITLE
Remove deprecated DOMActivate_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -55,56 +55,6 @@
           "deprecated": false
         }
       },
-      "DOMActivate_event": {
-        "__compat": {
-          "description": "<code>DOMActivate</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/DOMActivate_event",
-          "spec_url": "https://w3c.github.io/uievents/#event-type-DOMActivate",
-          "support": {
-            "chrome": {
-              "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": true
-            },
-            "firefox_android": {
-              "version_added": true
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": true
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "DOMMouseScroll_event": {
         "__compat": {
           "description": "<code>DOMMouseScroll</code> event",


### PR DESCRIPTION
This PR removes the deprecated `DOMActivate` event from BCD due to lack of support.  I have not been able to get the example on the MDN page working in any browser I've tested (Chrome 1, 5, 12, 25, 91; Firefox 89; Safari 14.1), not to mention it has been deprecated.
