### PR TITLE
Add Firefox versions for TextTrackList API

### DIFF
--- a/api/TextTrackList.json
+++ b/api/TextTrackList.json
@@ -15,10 +15,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "31"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "31"
           },
           "ie": {
             "version_added": "10"
@@ -64,10 +64,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "31"
             },
             "ie": {
               "version_added": null
@@ -114,10 +114,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "31"
             },
             "ie": {
               "version_added": null
@@ -163,10 +163,10 @@
               "version_added": "18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "31"
             },
             "ie": {
               "version_added": false
@@ -212,10 +212,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "31"
             },
             "ie": {
               "version_added": "10"
@@ -421,10 +421,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "31"
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `TextTrackList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TextTrackList
