### PR TITLE
Add Firefox versions for TextTrackCue API

### DIFF
--- a/api/TextTrackCue.json
+++ b/api/TextTrackCue.json
@@ -111,10 +111,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "31"
             },
             "ie": {
               "version_added": null
@@ -160,10 +160,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "31"
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `TextTrackCue` API.  The data was mirrored from the event handler attributes (aka `on*`), since they were implemented right when the API itself was.
