### PR TITLE
Add Safari versions for copy/cut/paste_event

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -1766,10 +1766,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -3050,10 +3050,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -8166,10 +8166,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/Document.json
+++ b/api/Document.json
@@ -1812,10 +1812,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"
@@ -3096,10 +3096,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"
@@ -8212,10 +8212,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"

--- a/api/Document.json
+++ b/api/Document.json
@@ -1766,7 +1766,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "3"
@@ -3050,7 +3050,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "3"
@@ -8166,7 +8166,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "3"

--- a/api/Element.json
+++ b/api/Element.json
@@ -2383,10 +2383,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"
@@ -2618,10 +2618,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"
@@ -6007,10 +6007,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"

--- a/api/Element.json
+++ b/api/Element.json
@@ -2337,7 +2337,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "3"
@@ -2572,7 +2572,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "3"
@@ -5961,7 +5961,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "3"

--- a/api/Element.json
+++ b/api/Element.json
@@ -2337,10 +2337,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2572,10 +2572,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -5961,10 +5961,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4.2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/Window.json
+++ b/api/Window.json
@@ -1449,10 +1449,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1645,10 +1645,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -6393,10 +6393,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/Window.json
+++ b/api/Window.json
@@ -1449,7 +1449,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "3"
@@ -1645,7 +1645,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "3"
@@ -6393,7 +6393,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
               "version_added": "3"

--- a/api/Window.json
+++ b/api/Window.json
@@ -1495,10 +1495,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"
@@ -1691,10 +1691,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"
@@ -6439,10 +6439,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `copy_event`, `cut-_event`, and `paste_event` members of the `Document`, `Element`, and `Window` APIs.  The data for Safari Desktop was mirrored from Chrome, whereas the Safari iOS version was explicitly set to 3.0 based upon an [article](https://www.engadget.com/2009-03-17-iphone-finally-gets-copy-and-paste.html) stating that clipboard support was introduced in iOS 3.0.  For the `clipboardData` member, the data was collected by running the live test on the [MDN article](https://developer.mozilla.org/en-US/docs/Web/API/Element/copy_event) and checking the result.
