### PR TITLE
Remove redundant api.HTMLFrameSetElement.event_handlers feature

### DIFF
--- a/api/HTMLFrameSetElement.json
+++ b/api/HTMLFrameSetElement.json
@@ -95,54 +95,6 @@
           }
         }
       },
-      "event_handlers": {
-        "__compat": {
-          "description": "<code>onXYZ</code> event handlers",
-          "support": {
-            "chrome": {
-              "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": "≤79"
-            },
-            "firefox": {
-              "version_added": true
-            },
-            "firefox_android": {
-              "version_added": true
-            },
-            "ie": {
-              "version_added": null
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
-      },
       "onstorage": {
         "__compat": {
           "support": {


### PR DESCRIPTION
This PR removes api.HTMLFrameSetElement.event_handlers from our data.  Since the API doesn't define its own event handlers as the MDN article states (and I question whether this API actually has an `onstorage` event handler), there's no reason to have this feature around.
