### PR TITLE
Add Firefox versions for api.WindowEventHandlers.onmessage

### DIFF
--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -365,10 +365,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "9"
             },
             "ie": {
               "version_added": "8"


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `onmessage` member of the `WindowEventHandlers` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Window/onmessage
