### PR TITLE
Add Firefox versions for api.EventTarget.addEventListener.options.passive_true_wheel

### DIFF
--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -494,10 +494,10 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": null
+                  "version_added": "84"
                 },
                 "firefox_android": {
-                  "version_added": null
+                  "version_added": "84"
                 },
                 "ie": {
                   "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `addEventListener.options.passive_true_wheel` member of the `EventTarget` API, based upon information in a tracking bug.

Tracking Bug: https://bugzil.la/1673278
