### PR TITLE
Add Firefox versions for api.KeyboardEvent.KeyboardEvent.code_and_key_in_init

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -111,10 +111,10 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "38"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "38"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `KeyboardEvent.code_and_key_in_init` member of the `KeyboardEvent` API.  The `key` attribute had been around since the constructor's implementation (https://bugzil.la/930893), and the `code` attribute when it was added to the interface (https://bugzil.la/865649).
