### PR TITLE
Added Opera Android version 64

### DIFF
--- a/api/AbstractRange.json
+++ b/api/AbstractRange.json
@@ -30,10 +30,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "76"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "64"
           },
           "safari": {
             "version_added": "14.1"
@@ -84,10 +84,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "76"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": "14.1"
@@ -139,10 +139,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "76"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": "14.1"
@@ -194,10 +194,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "76"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": "14.1"
@@ -249,10 +249,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "76"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": "14.1"
@@ -304,10 +304,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "76"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": "14.1"

--- a/api/CSSCounterStyleRule.json
+++ b/api/CSSCounterStyleRule.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "77"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "64"
           },
           "safari": {
             "version_added": false
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "77"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "77"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false
@@ -170,10 +170,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "77"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false
@@ -219,10 +219,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "77"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false
@@ -268,10 +268,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "77"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false
@@ -317,10 +317,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "77"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false
@@ -366,10 +366,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "77"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false
@@ -415,10 +415,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "77"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false
@@ -464,10 +464,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "77"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false
@@ -513,10 +513,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "77"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false
@@ -562,10 +562,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "77"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false

--- a/api/GravitySensor.json
+++ b/api/GravitySensor.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "77"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "64"
           },
           "safari": {
             "version_added": false
@@ -73,10 +73,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "77"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "64"
             },
             "safari": {
               "version_added": false

--- a/api/TrustedHTML.json
+++ b/api/TrustedHTML.json
@@ -75,7 +75,7 @@
               "version_added": "76"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false

--- a/api/TrustedScript.json
+++ b/api/TrustedScript.json
@@ -75,7 +75,7 @@
               "version_added": "76"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false

--- a/api/TrustedScriptURL.json
+++ b/api/TrustedScriptURL.json
@@ -75,7 +75,7 @@
               "version_added": "76"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false

--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -345,9 +345,15 @@
         },
         "63": {
           "release_date": "2021-04-16",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "89"
+        },
+        "64": {
+          "release_date": "2021-05-25",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "91"
         }
       }
     }

--- a/css/at-rules/counter-style.json
+++ b/css/at-rules/counter-style.json
@@ -26,10 +26,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "77"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false
@@ -75,10 +75,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "77"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "64"
               },
               "safari": {
                 "version_added": false
@@ -125,10 +125,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "77"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "64"
               },
               "safari": {
                 "version_added": false
@@ -175,10 +175,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "77"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "64"
               },
               "safari": {
                 "version_added": false
@@ -225,10 +225,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "77"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "64"
               },
               "safari": {
                 "version_added": false
@@ -275,10 +275,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "77"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "64"
               },
               "safari": {
                 "version_added": false
@@ -325,10 +325,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "77"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "64"
               },
               "safari": {
                 "version_added": false
@@ -425,10 +425,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "77"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "64"
               },
               "safari": {
                 "version_added": false
@@ -485,10 +485,14 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "77",
+                "partial_implementation": true,
+                "notes": "Does not support <code>&lt;image&gt;</code> as a value for the <code>symbols</code> descriptor."
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "64",
+                "partial_implementation": true,
+                "notes": "Does not support <code>&lt;image&gt;</code> as a value for the <code>symbols</code> descriptor."
               },
               "safari": {
                 "version_added": false
@@ -537,10 +541,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "77"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "64"
               },
               "safari": {
                 "version_added": false

--- a/css/properties/overflow-clip-margin.json
+++ b/css/properties/overflow-clip-margin.json
@@ -26,10 +26,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "76"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -557,7 +557,7 @@
               "version_added": "77"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Added version 64 for Opera Android, and mirrored Chrome 90 and 91 data across to Opera Android. I've not updated WebXR data as that's missing previous Opera versions and I can't easily verify it.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

There's no release notes for the new Opera Android but I verified it by looking at the play store [release information](https://play.google.com/store/apps/details?id=com.opera.browser&hl=en_GB&gl=US).
