### PR TITLE
Added accent-color CSS property

### DIFF
--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -1,0 +1,84 @@
+{
+  "css": {
+    "properties": {
+      "accent-color": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/accent-color",
+          "spec_url": "https://drafts.csswg.org/css-ui-4/#widget-accent",
+          "support": {
+            "chrome": {
+              "version_added": "91",
+              "flags": [
+                {
+                  "name": "#enable-experimental-web-platform-features",
+                  "type": "preference",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": "91",
+              "flags": [
+                {
+                  "name": "#enable-experimental-web-platform-features",
+                  "type": "preference",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "edge": {
+              "version_added": "91",
+              "flags": [
+                {
+                  "name": "#enable-experimental-web-platform-features",
+                  "type": "preference",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "firefox": {
+              "version_added": "90",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.accent-color.enabled",
+                  "value_to_set": "enabled"
+                }
+              ],
+              "notes": "Enabled by default in Firefox Nightly."
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

This PR adds support data for the `accent-color` css property from https://drafts.csswg.org/css-ui-4/#widget-accent.

I'm currently making the relevant PRs to add this to MDN. As the mdn_url is a 404 currently I don't know if I'm meant to include it in this PR or not. Happy to remove if necessary.

Corresponding PR to add the page in mdn/content https://github.com/mdn/content/pull/6767

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1092093

https://storage.googleapis.com/chromium-find-releases-static/8c9.html#8c9f1381dfb11c18406d5bea790ec4e8a59ab2e7

Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1705605

Verified Firefox version through manual testing
