### PR TITLE
Fix browser support data for `:is()`

### DIFF
--- a/css/selectors/is.json
+++ b/css/selectors/is.json
@@ -41,6 +41,10 @@
             ],
             "edge": [
               {
+                "version_added": "88"
+              },
+              {
+                "version_removed": "88",
                 "version_added": "79",
                 "flags": [
                   {
@@ -81,19 +85,28 @@
                 ]
               }
             ],
-            "firefox_android": {
-              "version_added": "4",
-              "alternative_name": ":-moz-any()",
-              "notes": [
-                "Doesn't support combinators.",
-                "See <a href='https://bugzil.la/906353'>bug 906353</a>"
-              ]
-            },
+            "firefox_android": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "4",
+                "alternative_name": ":-moz-any()",
+                "notes": [
+                  "Doesn't support combinators.",
+                  "See <a href='https://bugzil.la/906353'>bug 906353</a>"
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },
             "opera": [
               {
+                "version_added": "74"
+              },
+              {
+                "version_removed": "74",
                 "version_added": "55",
                 "flags": [
                   {
@@ -112,15 +125,7 @@
             ],
             "opera_android": [
               {
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "Combinators in the selector list argument may not match correctly (see <a href='https://crbug.com/842157'>bug 842157</a>)."
+                "version_added": "63"
               },
               {
                 "version_added": "14",
@@ -196,7 +201,7 @@
                 "version_added": "88"
               },
               "edge": {
-                "version_added": false
+                "version_added": "88"
               },
               "firefox": {
                 "version_added": "82"
@@ -208,10 +213,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "74"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "63"
               },
               "safari": {
                 "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

This PR updates browser support data for the `:is()` pseudo class.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Most of this is just mirroring Chrome support to other blink browsers. The only change I'm unsure about is Firefox Android, it's marked as supported in Firefox 78 so I'm assuming it was included in Firefox Android 79 (there is no 78 in the version list).
