### PR TITLE
Fix capitalization of webkitIsFullScreen alt. name entries

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -5275,7 +5275,7 @@
               },
               {
                 "version_added": "15",
-                "alternative_name": "webkitIsFullscreen"
+                "alternative_name": "webkitIsFullScreen"
               }
             ],
             "chrome_android": [
@@ -5284,7 +5284,7 @@
               },
               {
                 "version_added": "18",
-                "alternative_name": "webkitIsFullscreen"
+                "alternative_name": "webkitIsFullScreen"
               }
             ],
             "edge": [
@@ -5293,7 +5293,7 @@
               },
               {
                 "version_added": "≤79",
-                "alternative_name": "webkitIsFullscreen"
+                "alternative_name": "webkitIsFullScreen"
               }
             ],
             "firefox": [
@@ -5323,7 +5323,7 @@
               },
               {
                 "version_added": "15",
-                "alternative_name": "webkitIsFullscreen"
+                "alternative_name": "webkitIsFullScreen"
               }
             ],
             "opera_android": [
@@ -5332,7 +5332,7 @@
               },
               {
                 "version_added": "14",
-                "alternative_name": "webkitIsFullscreen"
+                "alternative_name": "webkitIsFullScreen"
               }
             ],
             "safari": {
@@ -5349,7 +5349,7 @@
               },
               {
                 "version_added": "1.0",
-                "alternative_name": "webkitIsFullscreen"
+                "alternative_name": "webkitIsFullScreen"
               }
             ],
             "webview_android": [
@@ -5358,7 +5358,7 @@
               },
               {
                 "version_added": "≤37",
-                "alternative_name": "webkitIsFullscreen"
+                "alternative_name": "webkitIsFullScreen"
               }
             ]
           },


### PR DESCRIPTION
This followed the original Mozilla capitalization and has only ever been
captilized as webkitIsFullScreen in WebKit:
https://github.com/WebKit/WebKit/blob/949dd4022c28b190f2774292bf5ef549b2b40483/Source/WebCore/dom/Document%2BFullscreen.idl#L39
