### PR TITLE
Adds unprefixed tab-size

### DIFF
--- a/css/properties/tab-size.json
+++ b/css/properties/tab-size.json
@@ -18,22 +18,26 @@
               "version_added": "79",
               "notes": "This property is not yet animatable."
             },
-            "firefox": {
-              "prefix": "-moz-",
-              "version_added": "4",
-              "notes": [
-                "See <a href='https://bugzil.la/737785'>bug 737785</a> for the status of unprefixing this property.",
-                "Before Firefox 53, this property was not animatable."
-              ]
-            },
-            "firefox_android": {
-              "prefix": "-moz-",
-              "version_added": "4",
-              "notes": [
-                "See <a href='https://bugzil.la/737785'>bug 737785</a> for the status of unprefixing this property.",
-                "Before Firefox 53, this property was not animatable."
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "91"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "4",
+                "notes": "Before Firefox 53, this property was not animatable."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "91"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "4",
+                "notes": "Before Firefox 53, this property was not animatable."
+              }
+            ],
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
Firefox 91 implements the unprefixed tab-size property, and maintains the prefixed version as an alias: https://bugzilla.mozilla.org/show_bug.cgi?id=737785

Fixes: https://github.com/mdn/content/issues/6718