### PR TITLE
Add real versions for DOMActivate event support

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -62,40 +62,40 @@
           "spec_url": "https://w3c.github.io/uievents/#event-type-DOMActivate",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
Support in WebKit goes back to the initial checkin:
https://trac.webkit.org/changeset/4/webkit

Gecko support goes back to before the release of Firefox 1:
https://github.com/mozilla/gecko-dev/commit/7d1dbeb3a8c323cb2af962c52276ed5e713a67bb
https://bugzilla.mozilla.org/show_bug.cgi?id=60212

This test can be used to confirm support:
http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=9472

It was used to confirm no support in Opera 12.1 and Edge 18.