### PR TITLE
Use rfc-editor.org as URL targets for IETF RFCs

### DIFF
--- a/http/data-url.json
+++ b/http/data-url.json
@@ -3,7 +3,7 @@
     "data-url": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Basics_of_HTTP/Data_URIs",
-        "spec_url": "https://datatracker.ietf.org/doc/html/rfc2397#section-2",
+        "spec_url": "https://www.rfc-editor.org/rfc/rfc2397#section-2",
         "description": "data URL scheme",
         "support": {
           "chrome": {

--- a/http/headers/accept-ch.json
+++ b/http/headers/accept-ch.json
@@ -4,7 +4,7 @@
       "Accept-CH": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-CH",
-          "spec_url": "https://datatracker.ietf.org/doc/html/rfc8942#section-3.1",
+          "spec_url": "https://www.rfc-editor.org/rfc/rfc8942#section-3.1",
           "support": {
             "chrome": {
               "version_added": "46"

--- a/http/headers/content-disposition.json
+++ b/http/headers/content-disposition.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Disposition",
           "spec_url": [
             "https://httpwg.org/specs/rfc6266.html#header.field.definition",
-            "https://datatracker.ietf.org/doc/html/rfc7578#section-4.2"
+            "https://www.rfc-editor.org/rfc/rfc7578#section-4.2"
           ],
           "support": {
             "chrome": {

--- a/http/headers/forwarded.json
+++ b/http/headers/forwarded.json
@@ -4,7 +4,7 @@
       "Forwarded": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Forwarded",
-          "spec_url": "https://datatracker.ietf.org/doc/html/rfc7239#section-4",
+          "spec_url": "https://www.rfc-editor.org/rfc/rfc7239#section-4",
           "support": {
             "chrome": {
               "version_added": null

--- a/http/headers/origin.json
+++ b/http/headers/origin.json
@@ -5,7 +5,7 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Origin",
           "spec_url": [
-            "https://datatracker.ietf.org/doc/html/rfc6454#section-7",
+            "https://www.rfc-editor.org/rfc/rfc6454#section-7",
             "https://fetch.spec.whatwg.org/#origin-header"
           ],
           "support": {

--- a/http/headers/public-key-pins-report-only.json
+++ b/http/headers/public-key-pins-report-only.json
@@ -4,7 +4,7 @@
       "Public-Key-Pins-Report-Only": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Public-Key-Pins-Report-Only",
-          "spec_url": "https://datatracker.ietf.org/doc/html/rfc7469#section-2.1",
+          "spec_url": "https://www.rfc-editor.org/rfc/rfc7469#section-2.1",
           "support": {
             "chrome": {
               "version_added": "46",

--- a/http/headers/public-key-pins.json
+++ b/http/headers/public-key-pins.json
@@ -4,7 +4,7 @@
       "Public-Key-Pins": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Public-Key-Pins",
-          "spec_url": "https://datatracker.ietf.org/doc/html/rfc7469#section-2.1",
+          "spec_url": "https://www.rfc-editor.org/rfc/rfc7469#section-2.1",
           "support": {
             "chrome": {
               "version_added": true,

--- a/http/headers/strict-transport-security.json
+++ b/http/headers/strict-transport-security.json
@@ -4,7 +4,7 @@
       "Strict-Transport-Security": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Strict-Transport-Security",
-          "spec_url": "https://datatracker.ietf.org/doc/html/rfc6797#section-6.1",
+          "spec_url": "https://www.rfc-editor.org/rfc/rfc6797#section-6.1",
           "support": {
             "chrome": {
               "version_added": "4"

--- a/http/headers/x-frame-options.json
+++ b/http/headers/x-frame-options.json
@@ -4,7 +4,7 @@
       "X-Frame-Options": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/X-Frame-Options",
-          "spec_url": "https://datatracker.ietf.org/doc/html/rfc7034#section-2",
+          "spec_url": "https://www.rfc-editor.org/rfc/rfc7034#section-2",
           "support": {
             "chrome": {
               "version_added": "4"

--- a/http/status.json
+++ b/http/status.json
@@ -985,7 +985,7 @@
       "418": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/418",
-          "spec_url": "https://datatracker.ietf.org/doc/html/rfc2324#section-2.3.2",
+          "spec_url": "https://www.rfc-editor.org/rfc/rfc2324#section-2.3.2",
           "support": {
             "chrome": {
               "version_added": true

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "ajv": "~6.12.2",
     "better-ajv-errors": "~0.7.0",
-    "browser-specs": "~2.1.0",
+    "browser-specs": "~2.2.0",
     "chalk": "~4.1.0",
     "compare-versions": "~3.6.0",
     "mdn-confluence": "~2.2.2",

--- a/test/spec-urls.test.js
+++ b/test/spec-urls.test.js
@@ -36,7 +36,7 @@ describe('spec_url data', () => {
       'https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-expect-ct-08',
 
       // Exception for April Fools' joke for "418 I'm a teapot"
-      'https://datatracker.ietf.org/doc/html/rfc2324',
+      'https://www.rfc-editor.org/rfc/rfc2324',
 
       // Unfortunately this doesn't produce a rendered spec, so it isn't in browser-specs
       // Remove if it is in the main ECMA spec


### PR DESCRIPTION
Starting from 8650, they're much more readable on rfc-editor.org than on datatracker.ietf.org; browser-specs is aligning to using this as the default target https://github.com/w3c/browser-specs/issues/342 starting with release 2.2.0
