### PR TITLE
Mark originAgentCluster as shipped in Opera

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -5992,10 +5992,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "76"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/issues/8891.