### PR TITLE
Fixed erroneous edge support data for some mask related CSS properties

### DIFF
--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -16,9 +16,16 @@
               "version_added": "18",
               "notes": "From version 8, Chrome added support for gradient values. Initially, Chrome supported only <code>-webkit-</code> prefixed values for gradients (such as <code>-webkit-linear-gradient()</code>). Later, support for unprefixed values was added."
             },
-            "edge": {
-              "version_added": "16"
-            },
+            "edge": [
+              {
+                "prefix": "-webkit-",
+                "version_added": "79"
+              },
+              {
+                "version_added": "16",
+                "version_removed": "79"
+              }
+            ],
             "firefox": {
               "version_added": "53"
             },

--- a/css/properties/mask-position.json
+++ b/css/properties/mask-position.json
@@ -14,9 +14,16 @@
               "prefix": "-webkit-",
               "version_added": "18"
             },
-            "edge": {
-              "version_added": "18"
-            },
+            "edge": [
+              {
+                "prefix": "-webkit-",
+                "version_added": "79"
+              },
+              {
+                "version_added": "18",
+                "version_removed": "79"
+              }
+            ],
             "firefox": {
               "version_added": "53"
             },

--- a/css/properties/mask-repeat.json
+++ b/css/properties/mask-repeat.json
@@ -14,9 +14,16 @@
               "prefix": "-webkit-",
               "version_added": "18"
             },
-            "edge": {
-              "version_added": "18"
-            },
+            "edge": [
+              {
+                "prefix": "-webkit-",
+                "version_added": "79"
+              },
+              {
+                "version_added": "18",
+                "version_removed": "79"
+              }
+            ],
             "firefox": {
               "version_added": "53"
             },

--- a/css/properties/mask-size.json
+++ b/css/properties/mask-size.json
@@ -14,9 +14,16 @@
               "prefix": "-webkit-",
               "version_added": "18"
             },
-            "edge": {
-              "version_added": "18"
-            },
+            "edge": [
+              {
+                "prefix": "-webkit-",
+                "version_added": "79"
+              },
+              {
+                "version_added": "18",
+                "version_removed": "79"
+              }
+            ],
             "firefox": {
               "version_added": "53"
             },

--- a/css/properties/mask.json
+++ b/css/properties/mask.json
@@ -30,9 +30,17 @@
                 "notes": "The prefixed property can be used with SVG and HTML with a slightly different syntax, which allows setting the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-attachment'><code>-webkit-mask-attachment</code></a> property."
               }
             ],
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "prefix": "-webkit-",
+                "version_added": "79",
+                "notes": "The prefixed property can be used with SVG and HTML with a slightly different syntax, which allows setting the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-attachment'><code>-webkit-mask-attachment</code></a> property."
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79"
+              }
+            ],
             "firefox": {
               "version_added": "2",
               "notes": "From Firefox 10, the default color space when handling masks is sRGB. Previously, the default and only supported color space was linear RGB. This changes the appearance of mask effects, but brings Firefox into compliance with the second edition of the SVG 1.1 specification."

--- a/css/properties/mask.json
+++ b/css/properties/mask.json
@@ -32,6 +32,11 @@
             ],
             "edge": [
               {
+                "version_added": "79",
+                "partial_implementation": true,
+                "notes": "While the property is recognized, values applied to it don't have any effect."
+              },
+              {
                 "prefix": "-webkit-",
                 "version_added": "79",
                 "notes": "The prefixed property can be used with SVG and HTML with a slightly different syntax, which allows setting the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-attachment'><code>-webkit-mask-attachment</code></a> property."


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Fixed erroneous edge support data for some mask related CSS properties

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Just changed Edge to reflect that version 79 onward matches Chromes support data.
