### PR TITLE
Add `::-ms-browse` as alternative name to `::file-selector-button`

### DIFF
--- a/css/selectors/file-selector-button.json
+++ b/css/selectors/file-selector-button.json
@@ -32,6 +32,11 @@
               {
                 "version_added": "79",
                 "alternative_name": "::-webkit-file-upload-button"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79",
+                "alternative_name": "::-ms-browse"
               }
             ],
             "firefox": {
@@ -41,7 +46,8 @@
               "version_added": "82"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10",
+              "alternative_name": "::-ms-browse"
             },
             "opera": [
               {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

This PR adds `::-ms-browse` as alternative name to `::file-selector-button` for IE and Legacy Edge.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Tested IE 9, 10, and 11 in browser stack and only worked in 10 and 11. And also tested Edge 15 in browser stack and it worked. I can't test lower than that but I assume it was added from the beginning hence using 12 as the Edge version.
