### PR TITLE
Rename/move entries for Selection method parameters

### DIFF
--- a/api/Selection.json
+++ b/api/Selection.json
@@ -244,6 +244,102 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "node_parameter_nullable": {
+          "__compat": {
+            "description": "<code>node</code> parameter is nullable",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "≤79"
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "offset_parameter_optional": {
+          "__compat": {
+            "description": "<code>offset</code> parameter is optional",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "≤79"
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": {
+                "version_added": "55"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": true
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "collapseToEnd": {
@@ -394,7 +490,7 @@
             "deprecated": false
           }
         },
-        "partialContainment": {
+        "partialContainment_parameter_optional": {
           "__compat": {
             "description": "<code>partialContainment</code> parameter is optional",
             "support": {
@@ -590,7 +686,7 @@
             "deprecated": false
           }
         },
-        "offset": {
+        "offset_parameter_optional": {
           "__compat": {
             "description": "<code>offset</code> parameter is optional",
             "support": {
@@ -880,102 +976,6 @@
             "experimental": true,
             "standard_track": false,
             "deprecated": false
-          }
-        },
-        "node": {
-          "__compat": {
-            "description": "<code>node</code> parameter is nullable",
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": {
-                "version_added": "55"
-              },
-              "firefox_android": {
-                "version_added": "55"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "offset": {
-          "__compat": {
-            "description": "<code>offset</code> parameter is optional",
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": {
-                "version_added": "55"
-              },
-              "firefox_android": {
-                "version_added": "55"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              },
-              "samsunginternet_android": {
-                "version_added": true
-              },
-              "webview_android": {
-                "version_added": true
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },


### PR DESCRIPTION
 Rename two of them to be more consistent with other parameter entries in BCD and importantly to have underscores in the name.
 
 The subfeatures for modify() are moved to collapse(). The modify() method doesn't have a node or offset parameter, and this data originates from https://github.com/mdn/browser-compat-data/pull/1738 where there appears to have been a mishap while splitting a "params" subfeature for collapse().