### PR TITLE
Make entries for parameter object features more consistent

### DIFF
--- a/api/CSSStyleSheet.json
+++ b/api/CSSStyleSheet.json
@@ -294,9 +294,9 @@
             "deprecated": false
           }
         },
-        "optional_index": {
+        "index_parameter_optional": {
           "__compat": {
-            "description": "<code>index</code> is optional",
+            "description": "<code>index</code> parameter is optional",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/api/Clients.json
+++ b/api/Clients.json
@@ -215,9 +215,10 @@
             "deprecated": false
           }
         },
-        "includeUncontrolled_option": {
+        "options_includeUncontrolled_parameter": {
           "__compat": {
-            "description": "<code>includeUncontrolled</code> option",
+            "description": "<code>options.includeUncontrolled</code> parameter",
+            "spec_url": "https://w3c.github.io/ServiceWorker/#dom-clientqueryoptions-includeuncontrolled",
             "support": {
               "chrome": {
                 "version_added": "47",

--- a/api/Document.json
+++ b/api/Document.json
@@ -2921,9 +2921,9 @@
             }
           }
         },
-        "whatToShow_filter_optional": {
+        "whatToShow_filter_parameters_optional": {
           "__compat": {
-            "description": "<code>whatToShow</code> and <code>filter</code> optional",
+            "description": "<code>whatToShow</code> and <code>filter</code> parameters are optional",
             "support": {
               "chrome": {
                 "version_added": "4"
@@ -6481,9 +6481,9 @@
             "deprecated": false
           }
         },
-        "deep_optional": {
+        "deep_parameter_optional": {
           "__compat": {
-            "description": "<code>deep</code> parameter optional",
+            "description": "<code>deep</code> parameter is optional",
             "support": {
               "chrome": {
                 "version_added": true

--- a/api/Element.json
+++ b/api/Element.json
@@ -715,6 +715,61 @@
             "deprecated": false
           }
         },
+        "implicit_tofrom": {
+          "__compat": {
+            "description": "Implicit to/from keyframes are supported",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/animate#Implicit_tofrom_keyframes",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "notes": "Currently Chrome Canary only"
+              },
+              "chrome_android": {
+                "version_added": false,
+                "notes": "Currently Chrome Canary only"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "75"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "13.1",
+                "partial_implementation": true,
+                "notes": "Implementation seems somewhat buggy. More information will follow when available."
+              },
+              "safari_ios": {
+                "version_added": "13.4",
+                "partial_implementation": true,
+                "notes": "Implementation seems somewhat buggy. More information will follow when available."
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "options_composite_parameter": {
           "__compat": {
             "description": "<code>options.composite</code> parameter",
@@ -847,61 +902,6 @@
               },
               "webview_android": {
                 "version_added": "50"
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "implicit_tofrom": {
-          "__compat": {
-            "description": "Implicit to/from keyframes are supported",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/animate#Implicit_tofrom_keyframes",
-            "support": {
-              "chrome": {
-                "version_added": false,
-                "notes": "Currently Chrome Canary only"
-              },
-              "chrome_android": {
-                "version_added": false,
-                "notes": "Currently Chrome Canary only"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "75"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": "13.1",
-                "partial_implementation": true,
-                "notes": "Implementation seems somewhat buggy. More information will follow when available."
-              },
-              "safari_ios": {
-                "version_added": "13.4",
-                "partial_implementation": true,
-                "notes": "Implementation seems somewhat buggy. More information will follow when available."
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
               }
             },
             "status": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -715,9 +715,10 @@
             "deprecated": false
           }
         },
-        "composite_option": {
+        "options_composite_parameter": {
           "__compat": {
-            "description": "<code>composite</code> option",
+            "description": "<code>options.composite</code> parameter",
+            "spec_url": "https://drafts.csswg.org/web-animations/#dom-keyframeeffectoptions-composite",
             "support": {
               "chrome": {
                 "version_added": "79",
@@ -806,9 +807,10 @@
             }
           }
         },
-        "id_option": {
+        "options_id_parameter": {
           "__compat": {
-            "description": "<code>id</code> option",
+            "description": "<code>options.id</code> parameter",
+            "spec_url": "https://drafts.csswg.org/web-animations/#dom-keyframeanimationoptions-id",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -909,9 +911,10 @@
             }
           }
         },
-        "iterationcomposite_option": {
+        "options_iterationComposite_parameter": {
           "__compat": {
-            "description": "<code>iterationComposite</code> option",
+            "description": "<code>options.iterationComposite</code> parameter",
+            "spec_url": "https://drafts.csswg.org/web-animations-2/#dom-keyframeeffectoptions-iterationcomposite",
             "support": {
               "chrome": {
                 "version_added": false
@@ -976,9 +979,10 @@
             }
           }
         },
-        "pseudoElement_option": {
+        "options_pseudoElement_parameter": {
           "__compat": {
-            "description": "<code>pseudoElement</code> option",
+            "description": "<code>options.pseudoElement</code> parameter",
+            "spec_url": "https://drafts.csswg.org/web-animations/#dom-keyframeeffectoptions-pseudoelement",
             "support": {
               "chrome": {
                 "version_added": "81",
@@ -7145,9 +7149,9 @@
             "deprecated": false
           }
         },
-        "scrollIntoViewOptions": {
+        "options_parameter": {
           "__compat": {
-            "description": "<code>scrollIntoViewOptions</code>",
+            "description": "<code>options</code> parameter",
             "support": {
               "chrome": {
                 "version_added": "61",

--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -175,9 +175,9 @@
             "deprecated": false
           }
         },
-        "optional_usecapture": {
+        "useCapture_parameter_optional": {
           "__compat": {
-            "description": "<code>useCapture</code> parameter made optional",
+            "description": "<code>useCapture</code> parameter is optional",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -226,7 +226,7 @@
             }
           }
         },
-        "options": {
+        "options_parameter": {
           "__compat": {
             "description": "Form with <code>options</code> object supported (third parameter can be either options or a <code>Boolean</code>, for backwards compatibility)",
             "support": {
@@ -276,9 +276,10 @@
               "deprecated": false
             }
           },
-          "capture": {
+          "options_capture_parameter": {
             "__compat": {
-              "description": "<code>capture</code> option",
+              "description": "<code>options.capture</code> parameter",
+              "spec_url": "https://dom.spec.whatwg.org/#dom-eventlisteneroptions-capture",
               "support": {
                 "chrome": {
                   "version_added": "52"
@@ -327,9 +328,10 @@
               }
             }
           },
-          "once": {
+          "options_once_parameter": {
             "__compat": {
-              "description": "<code>once</code> option",
+              "description": "<code>options.once</code> parameter",
+              "spec_url": "https://dom.spec.whatwg.org/#dom-addeventlisteneroptions-once",
               "support": {
                 "chrome": {
                   "version_added": "55"
@@ -378,9 +380,10 @@
               }
             }
           },
-          "passive": {
+          "options_passive_parameter": {
             "__compat": {
-              "description": "<code>passive</code> option",
+              "description": "<code>options.passive</code> parameter",
+              "spec_url": "https://dom.spec.whatwg.org/#dom-addeventlisteneroptions-passive",
               "support": {
                 "chrome": {
                   "version_added": "51"
@@ -429,9 +432,9 @@
               }
             }
           },
-          "passive_true_touch": {
+          "options_passive_parameter_default_true_touch": {
             "__compat": {
-              "description": "<code>passive</code> option defaults to <code>true</code> for <code>touchstart</code> and <code>touchmove</code> events",
+              "description": "<code>options.passive</code> parameter defaults to <code>true</code> for <code>touchstart</code> and <code>touchmove</code> events",
               "support": {
                 "chrome": {
                   "version_added": "55"
@@ -480,9 +483,9 @@
               }
             }
           },
-          "passive_true_wheel": {
+          "options_passive_parameter_default_true_wheel": {
             "__compat": {
-              "description": "<code>passive</code> option defaults to <code>true</code> for <code>wheel</code> and <code>mousewheel</code> events",
+              "description": "<code>options.passive</code> parameter defaults to <code>true</code> for <code>wheel</code> and <code>mousewheel</code> events",
               "support": {
                 "chrome": {
                   "version_added": "73"
@@ -531,9 +534,10 @@
               }
             }
           },
-          "signal": {
+          "options_signal_parameter": {
             "__compat": {
-              "description": "<code>signal</code> option",
+              "description": "<code>options.signal</code> parameter",
+              "spec_url": "https://dom.spec.whatwg.org/#dom-addeventlisteneroptions-signal",
               "support": {
                 "chrome": {
                   "version_added": "90"
@@ -703,9 +707,9 @@
             "deprecated": false
           }
         },
-        "optional_type_listener": {
+        "type_listener_parameters_optional": {
           "__compat": {
-            "description": "<code>type</code> and <code>listener</code> parameters optional.",
+            "description": "<code>type</code> and <code>listener</code> parameters are optional",
             "support": {
               "chrome": {
                 "version_added": "1",
@@ -759,9 +763,9 @@
             }
           }
         },
-        "optional_usecapture": {
+        "useCapture_parameter_optional": {
           "__compat": {
-            "description": "<code>useCapture</code> parameter optional",
+            "description": "<code>useCapture</code> parameter is optional",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -810,7 +814,7 @@
             }
           }
         },
-        "options": {
+        "options_parameter": {
           "__compat": {
             "description": "Form with <code>options</code> object supported (third parameter can be either options or a <code>Boolean</code>, for backwards compatibility)",
             "support": {

--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -175,57 +175,6 @@
             "deprecated": false
           }
         },
-        "useCapture_parameter_optional": {
-          "__compat": {
-            "description": "<code>useCapture</code> parameter is optional",
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "6"
-              },
-              "firefox_android": {
-                "version_added": "6"
-              },
-              "ie": {
-                "version_added": "9"
-              },
-              "nodejs": {
-                "version_added": "14.5.0"
-              },
-              "opera": {
-                "version_added": "11.6"
-              },
-              "opera_android": {
-                "version_added": "12"
-              },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0"
-              },
-              "webview_android": {
-                "version_added": "1"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "options_parameter": {
           "__compat": {
             "description": "Form with <code>options</code> object supported (third parameter can be either options or a <code>Boolean</code>, for backwards compatibility)",
@@ -586,6 +535,57 @@
               }
             }
           }
+        },
+        "useCapture_parameter_optional": {
+          "__compat": {
+            "description": "<code>useCapture</code> parameter is optional",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "6"
+              },
+              "firefox_android": {
+                "version_added": "6"
+              },
+              "ie": {
+                "version_added": "9"
+              },
+              "nodejs": {
+                "version_added": "14.5.0"
+              },
+              "opera": {
+                "version_added": "11.6"
+              },
+              "opera_android": {
+                "version_added": "12"
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": "1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "dispatchEvent": {
@@ -707,6 +707,57 @@
             "deprecated": false
           }
         },
+        "options_parameter": {
+          "__compat": {
+            "description": "Form with <code>options</code> object supported (third parameter can be either options or a <code>Boolean</code>, for backwards compatibility)",
+            "support": {
+              "chrome": {
+                "version_added": "49"
+              },
+              "chrome_android": {
+                "version_added": "49"
+              },
+              "edge": {
+                "version_added": "≤18"
+              },
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": {
+                "version_added": "49"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "14.5.0"
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": "10"
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "49"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "type_listener_parameters_optional": {
           "__compat": {
             "description": "<code>type</code> and <code>listener</code> parameters are optional",
@@ -805,57 +856,6 @@
               },
               "webview_android": {
                 "version_added": "1"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "options_parameter": {
-          "__compat": {
-            "description": "Form with <code>options</code> object supported (third parameter can be either options or a <code>Boolean</code>, for backwards compatibility)",
-            "support": {
-              "chrome": {
-                "version_added": "49"
-              },
-              "chrome_android": {
-                "version_added": "49"
-              },
-              "edge": {
-                "version_added": "≤18"
-              },
-              "firefox": {
-                "version_added": "49"
-              },
-              "firefox_android": {
-                "version_added": "49"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "14.5.0"
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": "10"
-              },
-              "safari_ios": {
-                "version_added": "10"
-              },
-              "samsunginternet_android": {
-                "version_added": "5.0"
-              },
-              "webview_android": {
-                "version_added": "49"
               }
             },
             "status": {

--- a/api/HTMLTableRowElement.json
+++ b/api/HTMLTableRowElement.json
@@ -384,9 +384,9 @@
             "deprecated": false
           }
         },
-        "negative_one_index_parameter": {
+        "index_parameter_negative_one": {
           "__compat": {
-            "description": "Support for <code>-1</code> as an <code>index</code> parameter",
+            "description": "<code>index</code> parameter can be <code>-1</code>",
             "support": {
               "chrome": {
                 "version_added": true
@@ -432,9 +432,9 @@
             }
           }
         },
-        "optional_index_parameter": {
+        "index_parameter_optional": {
           "__compat": {
-            "description": "Index parameter is optional",
+            "description": "<code>index</code> parameter is optional",
             "support": {
               "chrome": {
                 "version_added": true

--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -94,9 +94,9 @@
             "deprecated": false
           }
         },
-        "document_as_root": {
+        "options_root_parameter_Document": {
           "__compat": {
-            "description": "<code>root</code> option can be a <code>Document</code>",
+            "description": "<code>options.root</code> parameter can be a <code>Document</code>",
             "support": {
               "chrome": {
                 "version_added": "81"

--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -99,9 +99,9 @@
             "deprecated": false
           }
         },
-        "options": {
+        "options_parameter": {
           "__compat": {
-            "description": "<code>options</code> object",
+            "description": "<code>options</code> parameter",
             "support": {
               "chrome": {
                 "version_added": "49"

--- a/api/Node.json
+++ b/api/Node.json
@@ -251,9 +251,9 @@
             "deprecated": false
           }
         },
-        "deep_defaults_to_false": {
+        "deep_parameter_default_false": {
           "__compat": {
-            "description": "<code>deep</code> defaults to <code>false</code>",
+            "description": "<code>deep</code> parameter defaults to <code>false</code>",
             "support": {
               "chrome": {
                 "version_added": true

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -3638,9 +3638,9 @@
             "deprecated": false
           }
         },
-        "optional_description": {
+        "description_parameter_optional": {
           "__compat": {
-            "description": "Description is optional",
+            "description": "<code>description</code> parameter is optional",
             "support": {
               "chrome": {
                 "version_added": "80"
@@ -3822,9 +3822,9 @@
             }
           }
         },
-        "optional_description": {
+        "description_parameter_optional": {
           "__compat": {
-            "description": "Description is optional",
+            "description": "<code>description</code> parameter is optional",
             "support": {
               "chrome": {
                 "version_added": "80"

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -3774,9 +3774,9 @@
             "deprecated": false
           }
         },
-        "implicit_rollback": {
+        "description_parameter_optional": {
           "__compat": {
-            "description": "Implicit rollback",
+            "description": "<code>description</code> parameter is optional",
             "support": {
               "chrome": {
                 "version_added": "80"
@@ -3788,7 +3788,7 @@
                 "version_added": "80"
               },
               "firefox": {
-                "version_added": "70"
+                "version_added": "75"
               },
               "firefox_android": {
                 "version_added": false
@@ -3822,9 +3822,9 @@
             }
           }
         },
-        "description_parameter_optional": {
+        "implicit_rollback": {
           "__compat": {
-            "description": "<code>description</code> parameter is optional",
+            "description": "Implicit rollback",
             "support": {
               "chrome": {
                 "version_added": "80"
@@ -3836,7 +3836,7 @@
                 "version_added": "80"
               },
               "firefox": {
-                "version_added": "75"
+                "version_added": "70"
               },
               "firefox_android": {
                 "version_added": false

--- a/api/Range.json
+++ b/api/Range.json
@@ -252,7 +252,7 @@
         },
         "toStart_parameter_optional": {
           "__compat": {
-            "description": "<code>toStart</code> parameter optional",
+            "description": "<code>toStart</code> parameter is optional",
             "support": {
               "chrome": {
                 "version_added": true

--- a/api/Request.json
+++ b/api/Request.json
@@ -154,6 +154,55 @@
             }
           }
         },
+        "init_referrer_parameter": {
+          "__compat": {
+            "description": "<code>init.referrer</code> parameter",
+            "spec_url": "https://fetch.spec.whatwg.org/#dom-requestinit-referrer",
+            "support": {
+              "chrome": {
+                "version_added": "47"
+              },
+              "chrome_android": {
+                "version_added": "47"
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "version_added": "47"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "34"
+              },
+              "opera_android": {
+                "version_added": "34"
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "47"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "navigate_mode": {
           "__compat": {
             "description": "<code>navigate</code> mode",
@@ -241,55 +290,6 @@
               },
               "webview_android": {
                 "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "init_referrer_parameter": {
-          "__compat": {
-            "description": "<code>init.referrer</code> parameter",
-            "spec_url": "https://fetch.spec.whatwg.org/#dom-requestinit-referrer",
-            "support": {
-              "chrome": {
-                "version_added": "47"
-              },
-              "chrome_android": {
-                "version_added": "47"
-              },
-              "edge": {
-                "version_added": "15"
-              },
-              "firefox": {
-                "version_added": "47"
-              },
-              "firefox_android": {
-                "version_added": true
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "34"
-              },
-              "opera_android": {
-                "version_added": "34"
-              },
-              "safari": {
-                "version_added": "10.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3"
-              },
-              "samsunginternet_android": {
-                "version_added": "5.0"
-              },
-              "webview_android": {
-                "version_added": "47"
               }
             },
             "status": {

--- a/api/Request.json
+++ b/api/Request.json
@@ -250,9 +250,10 @@
             }
           }
         },
-        "referrer_init": {
+        "init_referrer_parameter": {
           "__compat": {
-            "description": "<code>referrer</code> init option",
+            "description": "<code>init.referrer</code> parameter",
+            "spec_url": "https://fetch.spec.whatwg.org/#dom-requestinit-referrer",
             "support": {
               "chrome": {
                 "version_added": "47"

--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -160,9 +160,9 @@
             }
           }
         },
-        "name_option": {
+        "options_name_parameter": {
           "__compat": {
-            "description": "<code>name</code> option",
+            "description": "<code>options.name</code> parameter",
             "support": {
               "chrome": {
                 "version_added": true

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -1919,9 +1919,9 @@
               "deprecated": false
             }
           },
-          "locales": {
+          "locales_parameter": {
             "__compat": {
-              "description": "Optional <code>locales</code> parameter",
+              "description": "<code>locales</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -1977,9 +1977,9 @@
               }
             }
           },
-          "options": {
+          "options_parameter": {
             "__compat": {
-              "description": "Optional <code>options</code> parameter",
+              "description": "<code>options</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": "24"

--- a/javascript/builtins/intl/Collator.json
+++ b/javascript/builtins/intl/Collator.json
@@ -113,9 +113,9 @@
                 "deprecated": false
               }
             },
-            "caseFirst": {
+            "options_caseFirst_parameter": {
               "__compat": {
-                "description": "<code>caseFirst</code> option",
+                "description": "<code>options.caseFirst</code> parameter",
                 "support": {
                   "chrome": {
                     "version_added": "24"
@@ -164,9 +164,9 @@
                 }
               }
             },
-            "collation": {
+            "options_collation_parameter": {
               "__compat": {
-                "description": "<code>collation</code> option",
+                "description": "<code>options.collation</code> parameter",
                 "support": {
                   "chrome": {
                     "version_added": "87"

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -113,9 +113,9 @@
                 "deprecated": false
               }
             },
-            "compactDisplay": {
+            "options_compactDisplay_parameter": {
               "__compat": {
-                "description": "<code>compactDisplay</code> option",
+                "description": "<code>options.compactDisplay</code> parameter",
                 "support": {
                   "chrome": {
                     "version_added": "77"
@@ -164,9 +164,9 @@
                 }
               }
             },
-            "currencyDisplay": {
+            "options_currencyDisplay_parameter": {
               "__compat": {
-                "description": "<code>currencyDisplay</code> option",
+                "description": "<code>options.currencyDisplay</code> parameter",
                 "support": {
                   "chrome": {
                     "version_added": "77"
@@ -231,9 +231,9 @@
                 }
               }
             },
-            "currencySign": {
+            "options_currencySign_parameter": {
               "__compat": {
-                "description": "<code>currencySign</code> option",
+                "description": "<code>options.currencySign</code> parameter",
                 "support": {
                   "chrome": {
                     "version_added": "77"
@@ -282,9 +282,9 @@
                 }
               }
             },
-            "notation": {
+            "options_notation_parameter": {
               "__compat": {
-                "description": "<code>notation</code> option",
+                "description": "<code>options.notation</code> parameter",
                 "support": {
                   "chrome": {
                     "version_added": "77"
@@ -333,9 +333,9 @@
                 }
               }
             },
-            "signDisplay": {
+            "options_signDisplay_parameter": {
               "__compat": {
-                "description": "<code>signDisplay</code> option",
+                "description": "<code>options.signDisplay</code> parameter",
                 "support": {
                   "chrome": {
                     "version_added": "77"
@@ -384,9 +384,9 @@
                 }
               }
             },
-            "unit": {
+            "options_unit_parameter": {
               "__compat": {
-                "description": "<code>unit</code> option",
+                "description": "<code>options.unit</code> parameter",
                 "support": {
                   "chrome": {
                     "version_added": "77"
@@ -435,9 +435,9 @@
                 }
               }
             },
-            "unitDisplay": {
+            "options_unitDisplay_parameter": {
               "__compat": {
-                "description": "<code>unitDisplay</code> option",
+                "description": "<code>options.unitDisplay</code> parameter",
                 "support": {
                   "chrome": {
                     "version_added": "77"


### PR DESCRIPTION
This updates lots of entries that have "option" somewhere in the
description, but isn't exhaustive.

This largely aligns with this guideline:
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#parameters-and-parameter-object-features

Not everything is covered by the guideline, but a consistent style was
used for parameters being optional and having default values.

Spec links were added where possible.