### PR TITLE
Migration 007: Set experimental to false

### DIFF
--- a/scripts/migrations/007-experimental-false.js
+++ b/scripts/migrations/007-experimental-false.js
@@ -1,0 +1,106 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+const { walk } = require('../../utils');
+
+/**
+ * @param {object} bcd Parsed BCD object to be updated in place.
+ */
+const fixExperimental = (bcd) => {
+  for (const { path, compat } of walk(undefined, bcd)) {
+    if (!compat?.status?.experimental) {
+      continue;
+    }
+
+    // This entry is marked as experimental. Check which browsers support it.
+
+    const supportedIn = new Set();
+
+    for (const [browser, support] of Object.entries(compat.support)) {
+      // Consider only the first part of an array statement.
+      const statement = Array.isArray(support) ? support[0] : support;
+      // Ignore anything behind flag, prefix or alternative name
+      if (statement.flags || statement.prefix || statement.alternative_name) {
+        continue;
+      }
+      if (statement.version_added && !statement.version_removed) {
+        supportedIn.add(browser);
+      }
+    }
+
+    const widelySupported = ['chrome', 'firefox', 'safari'].every((browser) =>
+      supportedIn.has(browser),
+    );
+    if (widelySupported) {
+      compat.status.experimental = false;
+    }
+  }
+};
+
+/**
+ * @param {string} filename Filename of BCD to be updated in place.
+ */
+const fixExperimentalFile = (filename) => {
+  const actual = fs.readFileSync(filename, 'utf-8').trim();
+  const bcd = JSON.parse(actual);
+  fixExperimental(bcd);
+  const expected = JSON.stringify(bcd, null, 2);
+
+  if (actual !== expected) {
+    fs.writeFileSync(filename, expected + '\n', 'utf-8');
+  }
+};
+
+if (require.main === module) {
+  /**
+   * @param {string[]} files
+   */
+  function load(...files) {
+    for (let file of files) {
+      if (file.indexOf(__dirname) !== 0) {
+        file = path.resolve(__dirname, '..', '..', file);
+      }
+
+      if (!fs.existsSync(file)) {
+        continue; // Ignore non-existent files
+      }
+
+      if (fs.statSync(file).isFile()) {
+        if (path.extname(file) === '.json') {
+          fixExperimentalFile(file);
+        }
+
+        continue;
+      }
+
+      const subFiles = fs.readdirSync(file).map((subfile) => {
+        return path.join(file, subfile);
+      });
+
+      load(...subFiles);
+    }
+  }
+
+  if (process.argv[2]) {
+    load(process.argv[2]);
+  } else {
+    load(
+      'api',
+      'css',
+      'html',
+      'http',
+      'svg',
+      'javascript',
+      'mathml',
+      'test',
+      'webdriver',
+      'webextensions',
+    );
+  }
+}
+
+module.exports = { fixExperimental };

--- a/scripts/migrations/007-experimental-false.test.js
+++ b/scripts/migrations/007-experimental-false.test.js
@@ -1,0 +1,69 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+'use strict';
+const assert = require('assert').strict;
+
+const { fixExperimental } = require('./007-experimental-false.js');
+
+describe('fixExperimental()', () => {
+  it('chrome + firefox + safari', () => {
+    const bcd = {
+      api: {
+        fetch: {
+          __compat: {
+            support: {
+              chrome: {
+                version_added: '100',
+              },
+              firefox: {
+                version_added: '100',
+              },
+              safari: {
+                version_added: '15',
+              },
+            },
+            status: {
+              experimental: true,
+              standard_track: true,
+              deprecated: false,
+            },
+          },
+        },
+      },
+    };
+    assert.equal(bcd.api.fetch.__compat.status.experimental, true);
+    fixExperimental(bcd);
+    assert.equal(bcd.api.fetch.__compat.status.experimental, false);
+  });
+
+  it('just chrome + firefox', () => {
+    const bcd = {
+      api: {
+        fetch: {
+          __compat: {
+            support: {
+              chrome: {
+                version_added: '100',
+              },
+              firefox: {
+                version_added: '100',
+              },
+              safari: {
+                version_added: false,
+              },
+            },
+            status: {
+              experimental: true,
+              standard_track: true,
+              deprecated: false,
+            },
+          },
+        },
+      },
+    };
+    assert.equal(bcd.api.fetch.__compat.status.experimental, true);
+    fixExperimental(bcd);
+    assert.equal(bcd.api.fetch.__compat.status.experimental, true);
+  });
+});

--- a/scripts/migrations/007-experimental-false.test.js
+++ b/scripts/migrations/007-experimental-false.test.js
@@ -64,6 +64,72 @@ describe('fixExperimental()', () => {
     };
     assert.equal(bcd.api.fetch.__compat.status.experimental, true);
     fixExperimental(bcd);
+    assert.equal(bcd.api.fetch.__compat.status.experimental, false);
+  });
+
+  it('just chrome', () => {
+    const bcd = {
+      api: {
+        fetch: {
+          __compat: {
+            support: {
+              chrome: {
+                version_added: '100',
+              },
+              firefox: {
+                version_added: false,
+              },
+              safari: {
+                version_added: false,
+              },
+            },
+            status: {
+              experimental: true,
+              standard_track: true,
+              deprecated: false,
+            },
+          },
+        },
+      },
+    };
     assert.equal(bcd.api.fetch.__compat.status.experimental, true);
+    fixExperimental(bcd);
+    assert.equal(bcd.api.fetch.__compat.status.experimental, true);
+  });
+
+  it('mobile chrome + safari', () => {
+    const bcd = {
+      api: {
+        fetch: {
+          __compat: {
+            support: {
+              chrome: {
+                version_added: false,
+              },
+              chrome_android: {
+                version_added: '100',
+              },
+              firefox: {
+                version_added: false,
+              },
+              safari: {
+                version_added: false,
+              },
+              safari_ios: {
+                version_added: '15',
+              },
+            },
+            status: {
+              experimental: true,
+              standard_track: true,
+              deprecated: false,
+            },
+          },
+        },
+      },
+    };
+    assert.equal(bcd.api.fetch.__compat.status.experimental, true);
+    fixExperimental(bcd);
+    assert.equal(bcd.api.fetch.__compat.status.experimental, false);
   });
 });


### PR DESCRIPTION
This is to bring the data in line with the recently added guideline:
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#choosing-an-experimental-status

Lots of features which are now widely supported are still marked as
experimental. This migration script conservatively sets experimental to
false for features which are supported in Chrome+Firefox+Safari.

It could later be tweaked to do the same for 2-engine support.