### PR TITLE
Fix support for moz-prefixed WebRTC APIs

### DIFF
--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -14,12 +14,24 @@
           "edge": {
             "version_added": "15"
           },
-          "firefox": {
-            "version_added": "22"
-          },
-          "firefox_android": {
-            "version_added": "22"
-          },
+          "firefox": [
+            {
+              "version_added": "44"
+            },
+            {
+              "prefix": "moz",
+              "version_added": "22"
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "44"
+            },
+            {
+              "prefix": "moz",
+              "version_added": "22"
+            }
+          ],
           "ie": {
             "version_added": false
           },
@@ -63,14 +75,28 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": {
-              "version_added": "22",
-              "notes": "Before Firefox 68, the constructor's <code>options</code> parameter was required."
-            },
-            "firefox_android": {
-              "version_added": true,
-              "notes": "Before Firefox 68, the constructor's <code>options</code> parameter was required."
-            },
+            "firefox": [
+              {
+                "version_added": "44",
+                "notes": "Before Firefox 68, the constructor's <code>options</code> parameter was required."
+              },
+              {
+                "prefix": "moz",
+                "version_added": "22",
+                "notes": "Before Firefox 68, the constructor's <code>options</code> parameter was required."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "44",
+                "notes": "Before Firefox 68, the constructor's <code>options</code> parameter was required."
+              },
+              {
+                "prefix": "moz",
+                "version_added": "22",
+                "notes": "Before Firefox 68, the constructor's <code>options</code> parameter was required."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -98,12 +98,24 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": {
-              "version_added": "22"
-            },
-            "firefox_android": {
-              "version_added": "44"
-            },
+            "firefox": [
+              {
+                "version_added": "44"
+              },
+              {
+                "prefix": "moz",
+                "version_added": "22"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "44"
+              },
+              {
+                "prefix": "moz",
+                "version_added": "22"
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/RTCSessionDescription.json
+++ b/api/RTCSessionDescription.json
@@ -14,13 +14,24 @@
           "edge": {
             "version_added": "15"
           },
-          "firefox": {
-            "prefix": "moz",
-            "version_added": true
-          },
-          "firefox_android": {
-            "version_added": true
-          },
+          "firefox": [
+            {
+              "version_added": "44"
+            },
+            {
+              "prefix": "moz",
+              "version_added": "22"
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "44"
+            },
+            {
+              "prefix": "moz",
+              "version_added": "22"
+            }
+          ],
           "ie": {
             "version_added": false
           },
@@ -63,13 +74,24 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": {
-              "prefix": "moz",
-              "version_added": true
-            },
-            "firefox_android": {
-              "version_added": null
-            },
+            "firefox": [
+              {
+                "version_added": "44"
+              },
+              {
+                "prefix": "moz",
+                "version_added": "22"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "44"
+              },
+              {
+                "prefix": "moz",
+                "version_added": "22"
+              }
+            ],
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
They are still supported:
https://bugzilla.mozilla.org/show_bug.cgi?id=1531812

This is based on running the following tests in Firefox 22+43+44+89:
https://mdn-bcd-collector.appspot.com/tests/api/mozRTCIceCandidate
https://mdn-bcd-collector.appspot.com/tests/api/RTCIceCandidate
https://mdn-bcd-collector.appspot.com/tests/api/mozRTCPeerConnection
https://mdn-bcd-collector.appspot.com/tests/api/RTCPeerConnection
https://mdn-bcd-collector.appspot.com/tests/api/mozRTCSessionDescription
https://mdn-bcd-collector.appspot.com/tests/api/RTCSessionDescription

The note about the RTCIceCandidate constructor is not clearly useful,
but nevertheless preserved.

Firefox for Android is assumed to match but not tested.