### PR TITLE
Update CSS accent-color spec URL

### DIFF
--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -4,7 +4,7 @@
       "accent-color": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/accent-color",
-          "spec_url": "https://drafts.csswg.org/css-ui-4/#widget-accent",
+          "spec_url": "https://drafts.csswg.org/css-ui/#widget-accent",
           "support": {
             "chrome": {
               "version_added": "91",


### PR DESCRIPTION
For spec URLs, one of the practices we’ve been following is to prefer un-leveled (un-versioned) spec URLs.

So, for example, https://drafts.csswg.org/css-ui/#widget-accent rather than https://drafts.csswg.org/css-ui-4/#widget-accent.

The exception to that rule is the case of spec URLs such as https://drafts.csswg.org/css-color-5/#color-mix — that is, spec URLs for any features that are not in the un-leveled spec, but instead only in a leveled version.