### PR TITLE
Correct support of WebRTC Identity APIs in Firefox

### DIFF
--- a/api/RTCIdentityAssertion.json
+++ b/api/RTCIdentityAssertion.json
@@ -15,10 +15,14 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": false
+            "version_added": "40",
+            "partial_implementation": true,
+            "notes": "The <code>RTCIdentityAssertion</code> interface itself is not present, but an object with the same properties is used"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "40",
+            "partial_implementation": true,
+            "notes": "The <code>RTCIdentityAssertion</code> interface itself is not present, but an object with the same properties is used"
           },
           "ie": {
             "version_added": false
@@ -62,10 +66,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "40"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "40"
             },
             "ie": {
               "version_added": false
@@ -110,10 +114,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "40"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "40"
             },
             "ie": {
               "version_added": false

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1259,10 +1259,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "40"
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "40"
             },
             "ie": {
               "version_added": false
@@ -2183,10 +2183,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": "40"
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "40"
             },
             "ie": {
               "version_added": false
@@ -3017,10 +3017,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "40"
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "40"
             },
             "ie": {
               "version_added": false
@@ -3607,10 +3607,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "40"
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "40"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
https://mdn-bcd-collector.appspot.com/tests/api/RTCPeerConnection was
tested in Firefox 39 and 40 on Windows 7 to determine this. Firefox for
Android is assumed to match.

RTCIdentityAssertion is a dictionary in Gecko and not an interface:
https://github.com/mozilla/gecko-dev/blob/679b5e2db1bc607cff5ad8640eb9a4b3626e4cf9/dom/webidl/RTCIdentityAssertion.webidl