### PR TITLE
Updates to font-size-adjust

### DIFF
--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -4,10 +4,11 @@
       "font-size-adjust": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-size-adjust",
-          "spec_url": "https://drafts.csswg.org/css-fonts/#font-size-adjust-prop",
+          "spec_url": "https://drafts.csswg.org/css-fonts-5/#font-size-adjust-prop",
           "support": {
             "chrome": {
               "version_added": "43",
+              "version_removed": "91",
               "flags": [
                 {
                   "type": "preference",
@@ -17,6 +18,7 @@
             },
             "chrome_android": {
               "version_added": "43",
+              "version_removed": "91",
               "flags": [
                 {
                   "type": "preference",
@@ -26,6 +28,7 @@
             },
             "edge": {
               "version_added": "79",
+              "version_removed": "91",
               "flags": [
                 {
                   "type": "preference",
@@ -87,6 +90,55 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "two-values": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-size-adjust",
+            "spec_url": "https://drafts.csswg.org/css-fonts-5/#font-size-adjust-prop",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "91"
+              },
+              "firefox_android": {
+                "version_added": "91"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -57,6 +57,7 @@
             },
             "opera": {
               "version_added": "30",
+              "version_removed": "77",
               "flags": [
                 {
                   "type": "preference",
@@ -66,6 +67,7 @@
             },
             "opera_android": {
               "version_added": "30",
+              "version_removed": "64",
               "flags": [
                 {
                   "type": "preference",
@@ -83,7 +85,14 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "43",
+              "version_removed": "91",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Enable experimental Web Platform features"
+                }
+              ]
             }
           },
           "status": {

--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -96,6 +96,7 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-size-adjust",
             "spec_url": "https://drafts.csswg.org/css-fonts-5/#font-size-adjust-prop",
+            "description": "Two-value syntax",
             "support": {
               "chrome": {
                 "version_added": false
@@ -107,10 +108,22 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "91"
+                "version_added": "91",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-size-adjust.basis.enabled"
+                  }
+                ]
               },
               "firefox_android": {
-                "version_added": "91"
+                "version_added": "91",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.font-size-adjust.basis.enabled"
+                  }
+                ]
               },
               "ie": {
                 "version_added": false

--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -85,14 +85,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "43",
-              "version_removed": "91",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Enable experimental Web Platform features"
-                }
-              ]
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
Various updates to `font-size-adjust`

I am working on https://github.com/mdn/content/issues/6720

This PR adds a section for the two-value syntax now supported in Firefox.

While testing I realized the single value did not work in Chrome. It was behind a flag, however has been moved to test and therefore does not seem to be accessible using Experimental Web Platform Features now. https://bugs.chromium.org/p/chromium/issues/detail?id=451346#c33 I have tested this and the removal seems to apply from Chrome 91.

I also updated the spec to point to the level 5 spec, as the level 4 spec does not include the two-value syntax.