### PR TITLE
Drop Sanitizer.p.sanitizeToString

### DIFF
--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -188,69 +188,6 @@
             "deprecated": false
           }
         }
-      },
-      "sanitizeToString": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Sanitizer/sanitizeToString",
-          "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-sanitizetostring",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": "83",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.sanitizer.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": {
-              "version_added": "83",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.sanitizer.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
https://github.com/WICG/sanitizer-api/commit/f1b12c1 (https://github.com/WICG/sanitizer-api/pull/99) completely removed `Sanitizer.prototype.sanitizeToString` from the HTML Sanitizer API spec.

It never shipped in any browsers other than Firefox, and in Firefox it only ever shipped behind a flag.

So there’s no value to developers in keeping it around forever in BCD and in MDN. It was never a cross-browser feature of the platform.