### PR TITLE
Mark webkitfullscreenerror as supported since Safari 6 (not 5.1)

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -5605,7 +5605,7 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": "5.1",
+              "version_added": "6",
               "alternative_name": "webkitfullscreenerror"
             },
             "safari_ios": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -3045,7 +3045,7 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": "5.1",
+              "version_added": "6",
               "prefix": "webkit"
             },
             "safari_ios": {
@@ -5704,7 +5704,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "5.1",
+              "version_added": "6",
               "alternative_name": "onwebkitfullscreenerror"
             },
             "safari_ios": {


### PR DESCRIPTION
Confirmed by these tests showing false on Safari 5.1:
http://mdn-bcd-collector.appspot.com/tests/api/Document/onwebkitfullscreenerror
http://mdn-bcd-collector.appspot.com/tests/api/Element/onwebkitfullscreenerror

Further confirmed by the event being added separately in WebKit:
https://trac.webkit.org/changeset/104838/webkit
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=104838

api.Document.onfullscreenerror was already correctly marked.