### PR TITLE
Use partial_implementation and notes for Fullscreen API on iPad

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2874,7 +2874,8 @@
             "safari_ios": {
               "version_added": "12",
               "prefix": "webkit",
-              "notes": "Only available on iPad, not on iPhone. Shows an overlay button which can not be disabled."
+              "partial_implementation": true,
+              "notes": "Only available on iPad, not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -2957,7 +2958,8 @@
             "safari_ios": {
               "version_added": "12",
               "prefix": "webkit",
-              "notes": "Only available on iPad, not on iPhone. Shows an overlay button which can not be disabled."
+              "partial_implementation": true,
+              "notes": "Only available on iPad, not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -5534,7 +5536,8 @@
             "safari_ios": {
               "version_added": "12",
               "alternative_name": "onwebkitfullscreenchange",
-              "notes": "Only available on iPad, not on iPhone. Shows an overlay button which can not be disabled."
+              "partial_implementation": true,
+              "notes": "Only available on iPad, not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -5616,7 +5619,8 @@
             "safari_ios": {
               "version_added": "12",
               "alternative_name": "onwebkitfullscreenerror",
-              "notes": "Only available on iPad, not on iPhone. Shows an overlay button which can not be disabled."
+              "partial_implementation": true,
+              "notes": "Only available on iPad, not on iPhone."
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -6419,6 +6423,7 @@
             "safari_ios": {
               "version_added": "12",
               "prefix": "webkit",
+              "partial_implementation": true,
               "notes": "Only available on iPad, not on iPhone. Shows an overlay button which can not be disabled."
             },
             "samsunginternet_android": [

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -189,6 +189,7 @@
             },
             "safari_ios": {
               "version_added": "12",
+              "partial_implementation": true,
               "notes": "Only available on iPad, not on iPhone."
             },
             "samsunginternet_android": {

--- a/api/_mixins/DocumentOrShadowRoot__Document.json
+++ b/api/_mixins/DocumentOrShadowRoot__Document.json
@@ -301,7 +301,7 @@
               "version_added": "12",
               "prefix": "webkit",
               "partial_implementation": true,
-              "notes": "Full-screen mode is only supported on the iPad."
+              "notes": "Only available on iPad, not on iPhone."
             },
             "samsunginternet_android": [
               {


### PR DESCRIPTION
This is now consistent with the style used in api/Document.json.
