### PR TITLE
Update Chromium support for Fullscreen API

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4553,13 +4553,24 @@
               "version_added": "11",
               "alternative_name": "msExitFullscreen"
             },
-            "opera": {
-              "version_added": "15",
-              "prefix": "webkit"
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "58"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "version_added": "14",
+                "prefix": "webkit"
+              }
+            ],
             "safari": {
               "version_added": "5.1",
               "prefix": "webkit"
@@ -5291,7 +5302,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": "45",
+                "version_added": "15",
                 "alternative_name": "webkitfullscreenchange"
               }
             ],
@@ -5300,7 +5311,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": "45",
+                "version_added": "18",
                 "alternative_name": "webkitfullscreenchange"
               }
             ],
@@ -5329,12 +5340,24 @@
               "version_added": "11",
               "alternative_name": "MSFullscreenChange"
             },
-            "opera": {
-              "version_added": "32"
-            },
-            "opera_android": {
-              "version_added": "32"
-            },
+            "opera": [
+              {
+                "version_added": "58"
+              },
+              {
+                "version_added": "15",
+                "alternative_name": "webkitfullscreenchange"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "version_added": "14",
+                "alternative_name": "webkitfullscreenchange"
+              }
+            ],
             "safari": {
               "version_added": "5.1",
               "alternative_name": "webkitfullscreenchange"
@@ -5345,15 +5368,21 @@
               "partial_implementation": true,
               "notes": "Only available on iPad, not on iPhone."
             },
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "10.0"
+              },
+              {
+                "version_added": "1.0",
+                "alternative_name": "webkitfullscreenchange"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "71"
               },
               {
-                "version_added": "45",
+                "version_added": "≤37",
                 "alternative_name": "webkitfullscreenchange"
               }
             ]
@@ -5375,7 +5404,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": true,
+                "version_added": "20",
                 "prefix": "webkit"
               }
             ],
@@ -5384,7 +5413,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": true,
+                "version_added": "25",
                 "prefix": "webkit"
               }
             ],
@@ -5413,12 +5442,24 @@
               "version_added": "11",
               "alternative_name": "msFullscreenEnabled"
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "58"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "version_added": "14",
+                "prefix": "webkit"
+              }
+            ],
             "safari": {
               "version_added": "6",
               "prefix": "webkit"
@@ -5434,7 +5475,7 @@
                 "version_added": "10.0"
               },
               {
-                "version_added": true,
+                "version_added": "1.5",
                 "prefix": "webkit"
               }
             ],
@@ -5466,7 +5507,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": "45",
+                "version_added": "18",
                 "alternative_name": "webkitfullscreenerror"
               }
             ],
@@ -5475,7 +5516,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": "45",
+                "version_added": "18",
                 "alternative_name": "webkitfullscreenerror"
               }
             ],
@@ -5504,12 +5545,24 @@
               "version_added": "11",
               "alternative_name": "MSFullscreenError"
             },
-            "opera": {
-              "version_added": "32"
-            },
-            "opera_android": {
-              "version_added": "32"
-            },
+            "opera": [
+              {
+                "version_added": "58"
+              },
+              {
+                "version_added": "15",
+                "alternative_name": "webkitfullscreenerror"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "version_added": "14",
+                "alternative_name": "webkitfullscreenerror"
+              }
+            ],
             "safari": {
               "version_added": "6",
               "alternative_name": "webkitfullscreenerror"
@@ -5520,15 +5573,21 @@
               "partial_implementation": true,
               "notes": "Only available on iPad, not on iPhone."
             },
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "10.0"
+              },
+              {
+                "version_added": "1.0",
+                "alternative_name": "webkitfullscreenerror"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "71"
               },
               {
-                "version_added": "45",
+                "version_added": "≤37",
                 "alternative_name": "webkitfullscreenerror"
               }
             ]
@@ -7377,7 +7436,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": "45",
+                "version_added": "15",
                 "alternative_name": "onwebkitfullscreenchange"
               }
             ],
@@ -7386,7 +7445,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": "45",
+                "version_added": "18",
                 "alternative_name": "onwebkitfullscreenchange"
               }
             ],
@@ -7415,12 +7474,24 @@
               "version_added": "11",
               "alternative_name": "onmsfullscreenchange"
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "58"
+              },
+              {
+                "version_added": "15",
+                "alternative_name": "onwebkitfullscreenchange"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "version_added": "14",
+                "alternative_name": "onwebkitfullscreenchange"
+              }
+            ],
             "safari": {
               "version_added": "5.1",
               "alternative_name": "onwebkitfullscreenchange"
@@ -7431,15 +7502,21 @@
               "partial_implementation": true,
               "notes": "Only available on iPad, not on iPhone."
             },
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "10.0"
+              },
+              {
+                "version_added": "1.0",
+                "alternative_name": "onwebkitfullscreenchange"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "71"
               },
               {
-                "version_added": "45",
+                "version_added": "≤37",
                 "alternative_name": "onwebkitfullscreenchange"
               }
             ]
@@ -7461,7 +7538,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": "45",
+                "version_added": "18",
                 "alternative_name": "onwebkitfullscreenerror"
               }
             ],
@@ -7470,7 +7547,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": "45",
+                "version_added": "18",
                 "alternative_name": "onwebkitfullscreenerror"
               }
             ],
@@ -7499,12 +7576,24 @@
               "version_added": "11",
               "alternative_name": "onmsfullscreenerror"
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "58"
+              },
+              {
+                "version_added": "15",
+                "alternative_name": "onwebkitfullscreenerror"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "version_added": "14",
+                "alternative_name": "onwebkitfullscreenerror"
+              }
+            ],
             "safari": {
               "version_added": "6",
               "alternative_name": "onwebkitfullscreenerror"
@@ -7515,15 +7604,21 @@
               "partial_implementation": true,
               "notes": "Only available on iPad, not on iPhone."
             },
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "10.0"
+              },
+              {
+                "version_added": "1.0",
+                "alternative_name": "onwebkitfullscreenerror"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "71"
               },
               {
-                "version_added": "45",
+                "version_added": "≤37",
                 "alternative_name": "onwebkitfullscreenerror"
               }
             ]

--- a/api/Element.json
+++ b/api/Element.json
@@ -2824,7 +2824,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": "57",
+                "version_added": "15",
                 "alternative_name": "webkitfullscreenchange"
               }
             ],
@@ -2833,7 +2833,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": "57",
+                "version_added": "18",
                 "alternative_name": "webkitfullscreenchange"
               }
             ],
@@ -2861,12 +2861,24 @@
             "ie": {
               "version_added": null
             },
-            "opera": {
-              "version_added": "44"
-            },
-            "opera_android": {
-              "version_added": "43"
-            },
+            "opera": [
+              {
+                "version_added": "58"
+              },
+              {
+                "version_added": "15",
+                "alternative_name": "webkitfullscreenchange"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "version_added": "14",
+                "alternative_name": "webkitfullscreenchange"
+              }
+            ],
             "safari": {
               "version_added": "5.1",
               "prefix": "webkit"
@@ -2876,15 +2888,21 @@
               "prefix": "webkit",
               "notes": "Only available on iPad, not on iPhone. Shows an overlay button which can not be disabled."
             },
-            "samsunginternet_android": {
-              "version_added": "7.0"
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "10.0"
+              },
+              {
+                "version_added": "1.0",
+                "alternative_name": "webkitfullscreenchange"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "71"
               },
               {
-                "version_added": "57",
+                "version_added": "≤37",
                 "alternative_name": "webkitfullscreenchange"
               }
             ]
@@ -2907,7 +2925,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": "57",
+                "version_added": "18",
                 "alternative_name": "webkitfullscreenerror"
               }
             ],
@@ -2916,7 +2934,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": "57",
+                "version_added": "18",
                 "alternative_name": "webkitfullscreenerror"
               }
             ],
@@ -2944,12 +2962,24 @@
             "ie": {
               "version_added": null
             },
-            "opera": {
-              "version_added": "44"
-            },
-            "opera_android": {
-              "version_added": "43"
-            },
+            "opera": [
+              {
+                "version_added": "58"
+              },
+              {
+                "version_added": "15",
+                "alternative_name": "webkitfullscreenerror"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "version_added": "14",
+                "alternative_name": "webkitfullscreenerror"
+              }
+            ],
             "safari": {
               "version_added": "6",
               "prefix": "webkit"
@@ -2959,15 +2989,21 @@
               "prefix": "webkit",
               "notes": "Only available on iPad, not on iPhone. Shows an overlay button which can not be disabled."
             },
-            "samsunginternet_android": {
-              "version_added": "7.0"
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "10.0"
+              },
+              {
+                "version_added": "1.0",
+                "alternative_name": "webkitfullscreenerror"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "71"
               },
               {
-                "version_added": "57",
+                "version_added": "≤37",
                 "alternative_name": "webkitfullscreenerror"
               }
             ]
@@ -5484,7 +5520,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": "57",
+                "version_added": "15",
                 "alternative_name": "onwebkitfullscreenchange"
               }
             ],
@@ -5493,7 +5529,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": "57",
+                "version_added": "18",
                 "alternative_name": "onwebkitfullscreenchange"
               }
             ],
@@ -5521,12 +5557,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "58"
+              },
+              {
+                "version_added": "15",
+                "alternative_name": "onwebkitfullscreenchange"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "version_added": "14",
+                "alternative_name": "onwebkitfullscreenchange"
+              }
+            ],
             "safari": {
               "version_added": "5.1",
               "alternative_name": "onwebkitfullscreenchange"
@@ -5536,15 +5584,21 @@
               "alternative_name": "onwebkitfullscreenchange",
               "notes": "Only available on iPad, not on iPhone. Shows an overlay button which can not be disabled."
             },
-            "samsunginternet_android": {
-              "version_added": "7.0"
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "10.0"
+              },
+              {
+                "version_added": "1.0",
+                "alternative_name": "onwebkitfullscreenchange"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "71"
               },
               {
-                "version_added": "57",
+                "version_added": "≤37",
                 "alternative_name": "onwebkitfullscreenchange"
               }
             ]
@@ -5566,7 +5620,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": "57",
+                "version_added": "18",
                 "alternative_name": "onwebkitfullscreenerror"
               }
             ],
@@ -5575,7 +5629,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": "57",
+                "version_added": "18",
                 "alternative_name": "onwebkitfullscreenerror"
               }
             ],
@@ -5603,12 +5657,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "58"
+              },
+              {
+                "version_added": "15",
+                "alternative_name": "onwebkitfullscreenerror"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "version_added": "14",
+                "alternative_name": "onwebkitfullscreenerror"
+              }
+            ],
             "safari": {
               "version_added": "6",
               "alternative_name": "onwebkitfullscreenerror"
@@ -5618,15 +5684,21 @@
               "alternative_name": "onwebkitfullscreenerror",
               "notes": "Only available on iPad, not on iPhone. Shows an overlay button which can not be disabled."
             },
-            "samsunginternet_android": {
-              "version_added": "7.0"
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "10.0"
+              },
+              {
+                "version_added": "1.0",
+                "alternative_name": "onwebkitfullscreenerror"
+              }
+            ],
             "webview_android": [
               {
                 "version_added": "71"
               },
               {
-                "version_added": "57",
+                "version_added": "≤37",
                 "alternative_name": "onwebkitfullscreenerror"
               }
             ]

--- a/api/_mixins/DocumentOrShadowRoot__Document.json
+++ b/api/_mixins/DocumentOrShadowRoot__Document.json
@@ -227,7 +227,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": "53",
+                "version_added": "20",
                 "prefix": "webkit"
               }
             ],
@@ -236,7 +236,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": "53",
+                "version_added": "25",
                 "prefix": "webkit"
               }
             ],
@@ -280,7 +280,7 @@
                 "version_added": "58"
               },
               {
-                "version_added": "40",
+                "version_added": "15",
                 "prefix": "webkit"
               }
             ],
@@ -289,7 +289,7 @@
                 "version_added": "50"
               },
               {
-                "version_added": "41",
+                "version_added": "14",
                 "prefix": "webkit"
               }
             ],
@@ -308,7 +308,7 @@
                 "version_added": "10.0"
               },
               {
-                "version_added": "6.0",
+                "version_added": "1.5",
                 "prefix": "webkit"
               }
             ],
@@ -317,7 +317,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": "53",
+                "version_added": "≤37",
                 "prefix": "webkit"
               }
             ]


### PR DESCRIPTION
Chrome on Windows 7 was tested using these tests:

http://mdn-bcd-collector.appspot.com/tests/api/Document/onwebkitfullscreenchange
http://mdn-bcd-collector.appspot.com/tests/api/Document/onwebkitfullscreenerror
http://mdn-bcd-collector.appspot.com/tests/api/Document/webkitFullscreenEnabled
https://mdn-bcd-collector.appspot.com/tests/api/Element/onwebkitfullscreenchange
https://mdn-bcd-collector.appspot.com/tests/api/Element/onwebkitfullscreenerror

Data for Opera and Samsung Internet was mirrored. Edge was not updated.