### PR TITLE
Remove api.KeyboardEvent.KeyboardEvent.code_and_key_in_init entry

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -96,54 +96,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "code_and_key_in_init": {
-          "__compat": {
-            "description": "Added <code>code</code> and <code>key</code> to <em><code>KeyboardEventInit</code></em>",
-            "support": {
-              "chrome": {
-                "version_added": "49"
-              },
-              "chrome_android": {
-                "version_added": "49"
-              },
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": {
-                "version_added": "38"
-              },
-              "firefox_android": {
-                "version_added": "38"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": "5.0"
-              },
-              "webview_android": {
-                "version_added": "49"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "altKey": {


### PR DESCRIPTION
This is similar to https://github.com/mdn/browser-compat-data/pull/11499.

The constructor isn't especially useful to begin with, keeping track of
when individual object parameters were supported isn't practically
useful. What matters in practice is when the properties on the event
were supported, which is already captured.