### PR TITLE
Updated Edge support for `hyphens` property

### DIFF
--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -27,12 +27,25 @@
                 "version_added": "18"
               }
             ],
-            "edge": {
-              "prefix": "-ms-",
-              "version_added": "12",
-              "partial_implementation": true,
-              "notes": "Only works if the specified language is the same as the language of the underlying OS."
-            },
+            "edge": [
+              {
+                "partial_implementation": true,
+                "version_added": "79",
+                "notes": "<code>auto</code> value is only supported on macOS and Android and for languages the OS provides hyphenation for."
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "79",
+                "notes": "Only <code>-webkit-hyphens: none</code> is supported."
+              },
+              {
+                "prefix": "-ms-",
+                "version_added": "12",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Only works if the specified language is the same as the language of the underlying OS."
+              }
+            ],
             "firefox": [
               {
                 "version_added": "43"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Updates Edge support data for the `hyphens` CSS property

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Added chrome related support data to Edge. And marked the EdgeHTML specific support as removed in v79.
