### PR TITLE
Lowercase console to match the name of the namespace and MDN

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -1,8 +1,8 @@
 {
   "api": {
-    "Console": {
+    "console": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/console",
         "spec_url": "https://console.spec.whatwg.org/#console-namespace",
         "support": {
           "chrome": {
@@ -54,7 +54,7 @@
       },
       "assert": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/assert",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/assert",
           "spec_url": "https://console.spec.whatwg.org/#assert",
           "support": {
             "chrome": {
@@ -113,7 +113,7 @@
       },
       "clear": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/clear",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/clear",
           "spec_url": "https://console.spec.whatwg.org/#clear",
           "support": {
             "chrome": {
@@ -165,7 +165,7 @@
       },
       "count": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/count",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/count",
           "spec_url": "https://console.spec.whatwg.org/#count",
           "support": {
             "chrome": {
@@ -217,7 +217,7 @@
       },
       "countReset": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/countReset",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/countReset",
           "spec_url": "https://console.spec.whatwg.org/#countreset",
           "support": {
             "chrome": {
@@ -269,7 +269,7 @@
       },
       "debug": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/debug",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/debug",
           "spec_url": "https://console.spec.whatwg.org/#debug",
           "support": {
             "chrome": {
@@ -390,7 +390,7 @@
       },
       "dir": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/dir",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/dir",
           "spec_url": "https://console.spec.whatwg.org/#dir",
           "support": {
             "chrome": {
@@ -442,7 +442,7 @@
       },
       "dirxml": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/dirxml",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/dirxml",
           "spec_url": "https://console.spec.whatwg.org/#dirxml",
           "support": {
             "chrome": {
@@ -501,7 +501,7 @@
       },
       "error": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/error",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/error",
           "spec_url": "https://console.spec.whatwg.org/#error",
           "support": {
             "chrome": {
@@ -612,7 +612,6 @@
       },
       "exception": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/exception",
           "description": "<code>exception</code> (an alias for <code>error</code>)",
           "support": {
             "chrome": {
@@ -711,7 +710,7 @@
       },
       "group": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/group",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/group",
           "spec_url": "https://console.spec.whatwg.org/#group",
           "support": {
             "chrome": {
@@ -763,7 +762,7 @@
       },
       "groupCollapsed": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/groupCollapsed",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/groupCollapsed",
           "spec_url": "https://console.spec.whatwg.org/#groupcollapsed",
           "support": {
             "chrome": {
@@ -816,7 +815,7 @@
       },
       "groupEnd": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/groupEnd",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/groupEnd",
           "spec_url": "https://console.spec.whatwg.org/#groupend",
           "support": {
             "chrome": {
@@ -868,7 +867,7 @@
       },
       "info": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/info",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/info",
           "spec_url": "https://console.spec.whatwg.org/#info",
           "support": {
             "chrome": {
@@ -980,7 +979,7 @@
       },
       "log": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/log",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/log",
           "spec_url": "https://console.spec.whatwg.org/#log",
           "support": {
             "chrome": {
@@ -1095,7 +1094,7 @@
       },
       "profile": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/profile",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/profile",
           "support": {
             "chrome": {
               "version_added": "4"
@@ -1152,7 +1151,7 @@
       },
       "profileEnd": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/profileEnd",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/profileEnd",
           "support": {
             "chrome": {
               "version_added": "4"
@@ -1209,7 +1208,7 @@
       },
       "table": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/table",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/table",
           "spec_url": "https://console.spec.whatwg.org/#table",
           "support": {
             "chrome": {
@@ -1261,7 +1260,7 @@
       },
       "time": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/time",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/time",
           "spec_url": "https://console.spec.whatwg.org/#time",
           "support": {
             "chrome": {
@@ -1313,7 +1312,7 @@
       },
       "timeEnd": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/timeEnd",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/timeEnd",
           "spec_url": "https://console.spec.whatwg.org/#timeend",
           "support": {
             "chrome": {
@@ -1365,7 +1364,7 @@
       },
       "timeLog": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/timeLog",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/timeLog",
           "spec_url": "https://console.spec.whatwg.org/#timelog",
           "support": {
             "chrome": {
@@ -1417,7 +1416,7 @@
       },
       "timeStamp": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/timeStamp",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/timeStamp",
           "support": {
             "chrome": {
               "version_added": "14"
@@ -1474,7 +1473,7 @@
       },
       "trace": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/trace",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/trace",
           "spec_url": "https://console.spec.whatwg.org/#trace",
           "support": {
             "chrome": {
@@ -1526,7 +1525,7 @@
       },
       "warn": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Console/warn",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/console/warn",
           "spec_url": "https://console.spec.whatwg.org/#warn",
           "support": {
             "chrome": {


### PR DESCRIPTION
It has been lowercases on MDN:
https://github.com/mdn/content/pull/6908

The BCD paths on MDN will also need updating.

All of the updated URLs were manually checked, and the one for exception
removed since it's a 404.

Fixes https://github.com/mdn/browser-compat-data/issues/7361.