### PR TITLE
DateTimeFormat - restructure constructor parameters

### DIFF
--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -113,209 +113,9 @@
                 "deprecated": false
               }
             },
-            "dateStyle": {
+            "locales_parameter": {
               "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": "76"
-                  },
-                  "chrome_android": {
-                    "version_added": "76"
-                  },
-                  "edge": {
-                    "version_added": "79"
-                  },
-                  "firefox": {
-                    "version_added": "79"
-                  },
-                  "firefox_android": {
-                    "version_added": "79"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": "12.9.0"
-                  },
-                  "opera": {
-                    "version_added": "63"
-                  },
-                  "opera_android": {
-                    "version_added": "54"
-                  },
-                  "safari": {
-                    "version_added": "14.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "14.5"
-                  },
-                  "samsunginternet_android": {
-                    "version_added": "12.0"
-                  },
-                  "webview_android": {
-                    "version_added": "76"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            },
-            "dayPeriod": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": "92"
-                  },
-                  "chrome_android": {
-                    "version_added": "92"
-                  },
-                  "edge": {
-                    "version_added": "92"
-                  },
-                  "firefox": {
-                    "version_added": "90"
-                  },
-                  "firefox_android": {
-                    "version_added": "90"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": false
-                  },
-                  "opera": {
-                    "version_added": false
-                  },
-                  "opera_android": {
-                    "version_added": false
-                  },
-                  "safari": {
-                    "version_added": "14.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "14.5"
-                  },
-                  "samsunginternet_android": {
-                    "version_added": false
-                  },
-                  "webview_android": {
-                    "version_added": "92"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            },
-            "fractionalSecondDigits": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": "84"
-                  },
-                  "chrome_android": {
-                    "version_added": "84"
-                  },
-                  "edge": {
-                    "version_added": "84"
-                  },
-                  "firefox": {
-                    "version_added": "84"
-                  },
-                  "firefox_android": {
-                    "version_added": "84"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": "14.6.0"
-                  },
-                  "opera": {
-                    "version_added": "70"
-                  },
-                  "opera_android": {
-                    "version_added": "60"
-                  },
-                  "safari": {
-                    "version_added": "14.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "14.5"
-                  },
-                  "samsunginternet_android": {
-                    "version_added": "14.0"
-                  },
-                  "webview_android": {
-                    "version_added": "84"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            },
-            "hourCycle": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": "73"
-                  },
-                  "chrome_android": {
-                    "version_added": "73"
-                  },
-                  "edge": {
-                    "version_added": "18"
-                  },
-                  "firefox": {
-                    "version_added": "58"
-                  },
-                  "firefox_android": {
-                    "version_added": "58"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": "12.0.0"
-                  },
-                  "opera": {
-                    "version_added": "60"
-                  },
-                  "opera_android": {
-                    "version_added": "52"
-                  },
-                  "safari": {
-                    "version_added": "13"
-                  },
-                  "safari_ios": {
-                    "version_added": "13"
-                  },
-                  "samsunginternet_android": {
-                    "version_added": "11.0"
-                  },
-                  "webview_android": {
-                    "version_added": "73"
-                  }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
-                }
-              }
-            },
-            "iana_time_zone_names": {
-              "__compat": {
-                "description": "IANA time zone names in <code>timeZone</code> option",
+                "description": "<code>locales</code> parameter",
                 "support": {
                   "chrome": {
                     "version_added": "24"
@@ -324,19 +124,77 @@
                     "version_added": "25"
                   },
                   "edge": {
-                    "version_added": "14"
+                    "version_added": "12"
                   },
                   "firefox": {
-                    "version_added": "52"
+                    "version_added": "29"
                   },
                   "firefox_android": {
                     "version_added": "56"
                   },
                   "ie": {
-                    "version_added": false
+                    "version_added": "11"
+                  },
+                  "nodejs": [
+                    {
+                      "version_added": "13.0.0"
+                    },
+                    {
+                      "version_added": "0.12.0",
+                      "partial_implementation": true,
+                      "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>DateTimeFormat</code> instance silently falls back to <code>en-US</code>. To make full ICU (locale) data available for versions prior to 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
+                    }
+                  ],
+                  "opera": {
+                    "version_added": "15"
+                  },
+                  "opera_android": {
+                    "version_added": "14"
+                  },
+                  "safari": {
+                    "version_added": "10"
+                  },
+                  "safari_ios": {
+                    "version_added": "10"
+                  },
+                  "samsunginternet_android": {
+                    "version_added": "1.5"
+                  },
+                  "webview_android": {
+                    "version_added": "4.4"
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "options_parameter": {
+              "__compat": {
+                "description": "<code>options</code> parameter",
+                "support": {
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": {
+                    "version_added": "25"
+                  },
+                  "edge": {
+                    "version_added": "12"
+                  },
+                  "firefox": {
+                    "version_added": "29"
+                  },
+                  "firefox_android": {
+                    "version_added": "56"
+                  },
+                  "ie": {
+                    "version_added": "11"
                   },
                   "nodejs": {
-                    "version_added": "4.0.0"
+                    "version_added": "0.12.0"
                   },
                   "opera": {
                     "version_added": "15"
@@ -354,7 +212,7 @@
                     "version_added": "1.5"
                   },
                   "webview_android": {
-                    "version_added": "37"
+                    "version_added": "4.4"
                   }
                 },
                 "status": {
@@ -362,55 +220,311 @@
                   "standard_track": true,
                   "deprecated": false
                 }
-              }
-            },
-            "timeStyle": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": "76"
+              },
+              "options_dateStyle_parameter": {
+                "__compat": {
+                  "description": "<code>options_dateStyle</code> parameter",
+                  "support": {
+                    "chrome": {
+                      "version_added": "76"
+                    },
+                    "chrome_android": {
+                      "version_added": "76"
+                    },
+                    "edge": {
+                      "version_added": "79"
+                    },
+                    "firefox": {
+                      "version_added": "79"
+                    },
+                    "firefox_android": {
+                      "version_added": "79"
+                    },
+                    "ie": {
+                      "version_added": false
+                    },
+                    "nodejs": {
+                      "version_added": "12.9.0"
+                    },
+                    "opera": {
+                      "version_added": "63"
+                    },
+                    "opera_android": {
+                      "version_added": "54"
+                    },
+                    "safari": {
+                      "version_added": "14.1"
+                    },
+                    "safari_ios": {
+                      "version_added": "14.5"
+                    },
+                    "samsunginternet_android": {
+                      "version_added": "12.0"
+                    },
+                    "webview_android": {
+                      "version_added": "76"
+                    }
                   },
-                  "chrome_android": {
-                    "version_added": "76"
-                  },
-                  "edge": {
-                    "version_added": "79"
-                  },
-                  "firefox": {
-                    "version_added": "79"
-                  },
-                  "firefox_android": {
-                    "version_added": "79"
-                  },
-                  "ie": {
-                    "version_added": false
-                  },
-                  "nodejs": {
-                    "version_added": "12.9.0"
-                  },
-                  "opera": {
-                    "version_added": "63"
-                  },
-                  "opera_android": {
-                    "version_added": "54"
-                  },
-                  "safari": {
-                    "version_added": "14.1"
-                  },
-                  "safari_ios": {
-                    "version_added": "14.5"
-                  },
-                  "samsunginternet_android": {
-                    "version_added": "12.0"
-                  },
-                  "webview_android": {
-                    "version_added": "76"
+                  "status": {
+                    "experimental": false,
+                    "standard_track": true,
+                    "deprecated": false
                   }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                }
+              },
+              "options_dayPeriod_parameter": {
+                "__compat": {
+                  "description": "<code>options_dayPeriod</code> parameter",
+                  "support": {
+                    "chrome": {
+                      "version_added": "92"
+                    },
+                    "chrome_android": {
+                      "version_added": "92"
+                    },
+                    "edge": {
+                      "version_added": "92"
+                    },
+                    "firefox": {
+                      "version_added": "90"
+                    },
+                    "firefox_android": {
+                      "version_added": "90"
+                    },
+                    "ie": {
+                      "version_added": false
+                    },
+                    "nodejs": {
+                      "version_added": false
+                    },
+                    "opera": {
+                      "version_added": false
+                    },
+                    "opera_android": {
+                      "version_added": false
+                    },
+                    "safari": {
+                      "version_added": "14.1"
+                    },
+                    "safari_ios": {
+                      "version_added": "14.5"
+                    },
+                    "samsunginternet_android": {
+                      "version_added": false
+                    },
+                    "webview_android": {
+                      "version_added": "92"
+                    }
+                  },
+                  "status": {
+                    "experimental": false,
+                    "standard_track": true,
+                    "deprecated": false
+                  }
+                }
+              },
+              "options_fractionalSecondDigits_parameter": {
+                "__compat": {
+                  "description": "<code>options_fractionalSecondDigits</code> parameter",
+                  "support": {
+                    "chrome": {
+                      "version_added": "84"
+                    },
+                    "chrome_android": {
+                      "version_added": "84"
+                    },
+                    "edge": {
+                      "version_added": "84"
+                    },
+                    "firefox": {
+                      "version_added": "84"
+                    },
+                    "firefox_android": {
+                      "version_added": "84"
+                    },
+                    "ie": {
+                      "version_added": false
+                    },
+                    "nodejs": {
+                      "version_added": "14.6.0"
+                    },
+                    "opera": {
+                      "version_added": "70"
+                    },
+                    "opera_android": {
+                      "version_added": "60"
+                    },
+                    "safari": {
+                      "version_added": "14.1"
+                    },
+                    "safari_ios": {
+                      "version_added": "14.5"
+                    },
+                    "samsunginternet_android": {
+                      "version_added": "14.0"
+                    },
+                    "webview_android": {
+                      "version_added": "84"
+                    }
+                  },
+                  "status": {
+                    "experimental": false,
+                    "standard_track": true,
+                    "deprecated": false
+                  }
+                }
+              },
+              "options_hourCycle_parameter": {
+                "__compat": {
+                  "description": "<code>options_hourCycle</code> parameter",
+                  "support": {
+                    "chrome": {
+                      "version_added": "73"
+                    },
+                    "chrome_android": {
+                      "version_added": "73"
+                    },
+                    "edge": {
+                      "version_added": "18"
+                    },
+                    "firefox": {
+                      "version_added": "58"
+                    },
+                    "firefox_android": {
+                      "version_added": "58"
+                    },
+                    "ie": {
+                      "version_added": false
+                    },
+                    "nodejs": {
+                      "version_added": "12.0.0"
+                    },
+                    "opera": {
+                      "version_added": "60"
+                    },
+                    "opera_android": {
+                      "version_added": "52"
+                    },
+                    "safari": {
+                      "version_added": "13"
+                    },
+                    "safari_ios": {
+                      "version_added": "13"
+                    },
+                    "samsunginternet_android": {
+                      "version_added": "11.0"
+                    },
+                    "webview_android": {
+                      "version_added": "73"
+                    }
+                  },
+                  "status": {
+                    "experimental": false,
+                    "standard_track": true,
+                    "deprecated": false
+                  }
+                }
+              },
+              "options_timeStyle_parameter": {
+                "__compat": {
+                  "description": "<code>options_timeStyle</code> parameter",
+                  "support": {
+                    "chrome": {
+                      "version_added": "76"
+                    },
+                    "chrome_android": {
+                      "version_added": "76"
+                    },
+                    "edge": {
+                      "version_added": "79"
+                    },
+                    "firefox": {
+                      "version_added": "79"
+                    },
+                    "firefox_android": {
+                      "version_added": "79"
+                    },
+                    "ie": {
+                      "version_added": false
+                    },
+                    "nodejs": {
+                      "version_added": "12.9.0"
+                    },
+                    "opera": {
+                      "version_added": "63"
+                    },
+                    "opera_android": {
+                      "version_added": "54"
+                    },
+                    "safari": {
+                      "version_added": "14.1"
+                    },
+                    "safari_ios": {
+                      "version_added": "14.5"
+                    },
+                    "samsunginternet_android": {
+                      "version_added": "12.0"
+                    },
+                    "webview_android": {
+                      "version_added": "76"
+                    }
+                  },
+                  "status": {
+                    "experimental": false,
+                    "standard_track": true,
+                    "deprecated": false
+                  }
+                }
+              },
+              "options_timeZone_parameter_iana": {
+                "__compat": {
+                  "description": "IANA time zone names in <code>options_timeZone</code> option",
+                  "support": {
+                    "chrome": {
+                      "version_added": "24"
+                    },
+                    "chrome_android": {
+                      "version_added": "25"
+                    },
+                    "edge": {
+                      "version_added": "14"
+                    },
+                    "firefox": {
+                      "version_added": "52"
+                    },
+                    "firefox_android": {
+                      "version_added": "56"
+                    },
+                    "ie": {
+                      "version_added": false
+                    },
+                    "nodejs": {
+                      "version_added": "4.0.0"
+                    },
+                    "opera": {
+                      "version_added": "15"
+                    },
+                    "opera_android": {
+                      "version_added": "14"
+                    },
+                    "safari": {
+                      "version_added": "10"
+                    },
+                    "safari_ios": {
+                      "version_added": "10"
+                    },
+                    "samsunginternet_android": {
+                      "version_added": "1.5"
+                    },
+                    "webview_android": {
+                      "version_added": "37"
+                    }
+                  },
+                  "status": {
+                    "experimental": false,
+                    "standard_track": true,
+                    "deprecated": false
+                  }
                 }
               }
             }

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -528,7 +528,7 @@
                 },
                 "options_timeZone_parameter_iana": {
                   "__compat": {
-                    "description": "IANA time zone names in <code>options_timeZone</code> option",
+                    "description": "IANA time zone names in <code>options.timeZone</code> option",
                     "support": {
                       "chrome": {
                         "version_added": "24"

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -223,7 +223,7 @@
               },
               "options_dateStyle_parameter": {
                 "__compat": {
-                  "description": "<code>options_dateStyle</code> parameter",
+                  "description": "<code>options.dateStyle</code> parameter",
                   "support": {
                     "chrome": {
                       "version_added": "76"

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -476,9 +476,9 @@
                   }
                 }
               },
-              "options_timeZone_parameter_iana": {
+              "options_timeZone_parameter": {
                 "__compat": {
-                  "description": "IANA time zone names in <code>options_timeZone</code> option",
+                  "description": "<code>options_timeZone</code> parameter",
                   "support": {
                     "chrome": {
                       "version_added": "24"
@@ -524,6 +524,57 @@
                     "experimental": false,
                     "standard_track": true,
                     "deprecated": false
+                  }
+                },
+                "options_timeZone_parameter_iana": {
+                  "__compat": {
+                    "description": "IANA time zone names in <code>options_timeZone</code> option",
+                    "support": {
+                      "chrome": {
+                        "version_added": "24"
+                      },
+                      "chrome_android": {
+                        "version_added": "25"
+                      },
+                      "edge": {
+                        "version_added": "14"
+                      },
+                      "firefox": {
+                        "version_added": "52"
+                      },
+                      "firefox_android": {
+                        "version_added": "56"
+                      },
+                      "ie": {
+                        "version_added": false
+                      },
+                      "nodejs": {
+                        "version_added": "4.0.0"
+                      },
+                      "opera": {
+                        "version_added": "15"
+                      },
+                      "opera_android": {
+                        "version_added": "14"
+                      },
+                      "safari": {
+                        "version_added": "10"
+                      },
+                      "safari_ios": {
+                        "version_added": "10"
+                      },
+                      "samsunginternet_android": {
+                        "version_added": "1.5"
+                      },
+                      "webview_android": {
+                        "version_added": "37"
+                      }
+                    },
+                    "status": {
+                      "experimental": false,
+                      "standard_track": true,
+                      "deprecated": false
+                    }
                   }
                 }
               }

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -376,7 +376,7 @@
               },
               "options_hourCycle_parameter": {
                 "__compat": {
-                  "description": "<code>options_hourCycle</code> parameter",
+                  "description": "<code>options.hourCycle</code> parameter",
                   "support": {
                     "chrome": {
                       "version_added": "73"

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -478,7 +478,7 @@
               },
               "options_timeZone_parameter": {
                 "__compat": {
-                  "description": "<code>options_timeZone</code> parameter",
+                  "description": "<code>options.timeZone</code> parameter",
                   "support": {
                     "chrome": {
                       "version_added": "24"

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -577,6 +577,108 @@
                     }
                   }
                 }
+              },
+              "options_timeZoneName_parameter": {
+                "__compat": {
+                  "description": "<code>options.timeZoneName</code> parameter",
+                  "support": {
+                    "chrome": {
+                      "version_added": "24"
+                    },
+                    "chrome_android": {
+                      "version_added": "25"
+                    },
+                    "edge": {
+                      "version_added": "12"
+                    },
+                    "firefox": {
+                      "version_added": "29"
+                    },
+                    "firefox_android": {
+                      "version_added": "56"
+                    },
+                    "ie": {
+                      "version_added": false
+                    },
+                    "nodejs": {
+                      "version_added": "0.12.0"
+                    },
+                    "opera": {
+                      "version_added": "15"
+                    },
+                    "opera_android": {
+                      "version_added": "14"
+                    },
+                    "safari": {
+                      "version_added": "10"
+                    },
+                    "safari_ios": {
+                      "version_added": "10"
+                    },
+                    "samsunginternet_android": {
+                      "version_added": "1.5"
+                    },
+                    "webview_android": {
+                      "version_added": "4.4"
+                    }
+                  },
+                  "status": {
+                    "experimental": false,
+                    "standard_track": true,
+                    "deprecated": false
+                  }
+                },
+                "options_timeZoneName_parameter_iana": {
+                  "__compat": {
+                    "description": "IANA time zone names in <code>options.timeZoneName</code> option",
+                    "support": {
+                      "chrome": {
+                        "version_added": false
+                      },
+                      "chrome_android": {
+                        "version_added": false
+                      },
+                      "edge": {
+                        "version_added": false
+                      },
+                      "firefox": {
+                        "version_added": "91"
+                      },
+                      "firefox_android": {
+                        "version_added": "91"
+                      },
+                      "ie": {
+                        "version_added": false
+                      },
+                      "nodejs": {
+                        "version_added": false
+                      },
+                      "opera": {
+                        "version_added": false
+                      },
+                      "opera_android": {
+                        "version_added": false
+                      },
+                      "safari": {
+                        "version_added": false
+                      },
+                      "safari_ios": {
+                        "version_added": false
+                      },
+                      "samsunginternet_android": {
+                        "version_added": false
+                      },
+                      "webview_android": {
+                        "version_added": false
+                      }
+                    },
+                    "status": {
+                      "experimental": false,
+                      "standard_track": true,
+                      "deprecated": false
+                    }
+                  }
+                }
               }
             }
           },

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -487,10 +487,10 @@
                       "version_added": "25"
                     },
                     "edge": {
-                      "version_added": "14"
+                      "version_added": "12"
                     },
                     "firefox": {
-                      "version_added": "52"
+                      "version_added": "29"
                     },
                     "firefox_android": {
                       "version_added": "56"
@@ -499,7 +499,7 @@
                       "version_added": false
                     },
                     "nodejs": {
-                      "version_added": "4.0.0"
+                      "version_added": "0.12.0"
                     },
                     "opera": {
                       "version_added": "15"
@@ -517,7 +517,7 @@
                       "version_added": "1.5"
                     },
                     "webview_android": {
-                      "version_added": "37"
+                      "version_added": "4.4"
                     }
                   },
                   "status": {

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -427,7 +427,7 @@
               },
               "options_timeStyle_parameter": {
                 "__compat": {
-                  "description": "<code>options_timeStyle</code> parameter",
+                  "description": "<code>options.timeStyle</code> parameter",
                   "support": {
                     "chrome": {
                       "version_added": "76"

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -325,7 +325,7 @@
               },
               "options_fractionalSecondDigits_parameter": {
                 "__compat": {
-                  "description": "<code>options_fractionalSecondDigits</code> parameter",
+                  "description": "<code>options.fractionalSecondDigits</code> parameter",
                   "support": {
                     "chrome": {
                       "version_added": "84"

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -274,7 +274,7 @@
               },
               "options_dayPeriod_parameter": {
                 "__compat": {
-                  "description": "<code>options_dayPeriod</code> parameter",
+                  "description": "<code>options.dayPeriod</code> parameter",
                   "support": {
                     "chrome": {
                       "version_added": "92"


### PR DESCRIPTION
This follows on from #11501

This is just the first step - restructure the constructor to use subfeatures for parameters, and subfeatures of those for options.

I am in no way sure this is "correct" so this is a first step.

Following on from this I will need to add the new values for **timeZoneName** added in FF91 - see https://bugzilla.mozilla.org/show_bug.cgi?id=1710429. 