### PR TITLE
Add missing features for api.BeforeUnloadEvent.returnValue

### DIFF
--- a/api/BeforeUnloadEvent.json
+++ b/api/BeforeUnloadEvent.json
@@ -48,6 +48,54 @@
           "deprecated": false
         }
       },
+      "returnValue": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#dom-beforeunloadevent-returnvalue",
+          "support": {
+            "chrome": {
+              "version_added": "30"
+            },
+            "chrome_android": {
+              "version_added": "30"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1.5"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "17"
+            },
+            "opera_android": {
+              "version_added": "18"
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "user_interaction": {
         "__compat": {
           "description": "User interaction required for dialog box",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds missing features, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10), for the `BeforeUnloadEvent` API.

Spec: https://html.spec.whatwg.org/multipage/browsing-the-web.html#dom-beforeunloadevent-returnvalue

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/BeforeUnloadEvent/returnValue

Note: Chrome and Safari data were derived from commit history, rather than the collector results.  See the relevant [Chrome](https://source.chromium.org/chromium/chromium/src/+/cc11df54c07cc93f303b126f196acd5a59697844) and [Safari](https://github.com/WebKit/WebKit/commit/c66b63956c81799695537e4cabb5629c9432781c) commits.
