### PR TITLE
Object.hasOwn added - Planned FF92/Chromium 93

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -942,10 +942,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "91"
+                "version_added": "92"
               },
               "firefox_android": {
-                "version_added": "91"
+                "version_added": "92"
               },
               "ie": {
                 "version_added": false

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -930,7 +930,7 @@
         "hasOwn": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn",
-            "spec_url": "https://tc39.es/proposal-accessible-object-hasownproperty/",
+            "spec_url": "https://tc39.es/proposal-accessible-object-hasownproperty/#sec-object.hasown",
             "support": {
               "chrome": {
                 "version_added": false

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -927,6 +927,58 @@
             }
           }
         },
+        "hasOwn": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn",
+            "spec_url": "https://tc39.es/proposal-accessible-object-hasownproperty/",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "91"
+              },
+              "firefox_android": {
+                "version_added": "91"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "hasOwnProperty": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty",

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -942,10 +942,12 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "92"
+                "version_added": "91",
+                "notes": "Available only in nightly builds.",
               },
               "firefox_android": {
-                "version_added": "92"
+                "version_added": "91",
+                "notes": "Available only in nightly builds.",
               },
               "ie": {
                 "version_added": false

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -943,11 +943,11 @@
               },
               "firefox": {
                 "version_added": "91",
-                "notes": "Available only in nightly builds.",
+                "notes": "Available only in nightly builds."
               },
               "firefox_android": {
                 "version_added": "91",
-                "notes": "Available only in nightly builds.",
+                "notes": "Available only in nightly builds."
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
FF92 plans add a new method `Object.hasOwn()` which is a safer/more convenient alternative to [Object.prototype.hasOwnProperty()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty).
- Bug report for new feature addition in FF91 nightly is here: https://bugzilla.mozilla.org/show_bug.cgi?id=1711872
- Intent to ship on Firefox 92 is here: https://bugzilla.mozilla.org/show_bug.cgi?id=1721149
- MDN tracking for docs here:
- Spec: https://github.com/tc39/proposal-accessible-object-hasownproperty

I tested for existence by running
```
let object = { foo: false }
console.log(Object.hasOwn(object, "foo"))  // true
```
This works in FF91 nightly but not chrome 91 and friends. Did not test in other browsers.

1. Apparently this works in v8 - [see here](https://github.com/tc39/proposal-accessible-object-hasownproperty#implementations) - what's best way to find the matching release version?
1. I put the method at the same level as hasOwnProperties, even though this new method is on Object and the other is on prototype (i.e. I assume we don't have to have as subfeature of prototype.)
1. This fails locally on the spec_url. Can you advise on how to fix?
1. Note the MDN URL does not exist. Doing this as first step.
