### PR TITLE
Mark PaymentRequestEvent.p.instrumentKey deprecated and non-standard

### DIFF
--- a/api/PaymentRequestEvent.json
+++ b/api/PaymentRequestEvent.json
@@ -101,7 +101,6 @@
       "instrumentKey": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestEvent/instrumentKey",
-          "spec_url": "https://w3c.github.io/payment-handler/#dom-paymentrequestevent-instrumentkey",
           "support": {
             "chrome": {
               "version_added": "70"
@@ -142,8 +141,8 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },

--- a/api/PaymentRequestEvent.json
+++ b/api/PaymentRequestEvent.json
@@ -140,7 +140,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": true
           }


### PR DESCRIPTION
https://github.com/w3c/payment-handler/commit/20a0ca9 (https://github.com/w3c/payment-handler/pull/393) dropped PaymentRequestEvent.prototype.instrumentKey from the Payment Handler spec.

So, this change marks it deprecated and non-standard, and drops its spec_url.

Related MDN change: https://github.com/mdn/content/pull/6960