### PR TITLE
Update Edge support from String.prototype.trimStart/trimEnd

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -3007,10 +3007,15 @@
                   "alternative_name": "trimRight"
                 }
               ],
-              "edge": {
-                "version_added": "12",
-                "alternative_name": "trimRight"
-              },
+              "edge": [
+                {
+                  "version_added": "79"
+                },
+                {
+                  "version_added": "12",
+                  "alternative_name": "trimRight"
+                }
+              ],
               "firefox": [
                 {
                   "version_added": "61"
@@ -3114,10 +3119,15 @@
                   "alternative_name": "trimLeft"
                 }
               ],
-              "edge": {
-                "version_added": "12",
-                "alternative_name": "trimLeft"
-              },
+              "edge": [
+                {
+                  "version_added": "79"
+                },
+                {
+                  "version_added": "12",
+                  "alternative_name": "trimLeft"
+                }
+              ],
               "firefox": [
                 {
                   "version_added": "61"


### PR DESCRIPTION
Confirmed by testing in Edge 18 and 79 on Sauce using these tests:
https://mdn-bcd-collector.appspot.com/tests/javascript/builtins/String