### PR TITLE
Update Safari compatibility for BaseAudioContext.decodeAudioData()

### DIFF
--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -1265,10 +1265,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": false
+                "version_added": "14.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14.5"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

The latest version of Safari supports the promise-based version of `decodeAudioData()`.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

I think it is supported since https://developer.apple.com/documentation/safari-release-notes/safari-14_1-release-notes 

> Added support for Web Audio API, now unprefixed, compliant, and including Audio Worklets. This enables better compatibility for advanced audio processing, see Web Audio API for more information.

Though I didn't verify if it started from this exact version.
