### PR TITLE
Remove duplicate/misplaced api.Element.attachInternals entry

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1110,55 +1110,6 @@
           }
         }
       },
-      "attachInternals": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/attachInternals",
-          "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#dom-attachinternals",
-          "support": {
-            "chrome": {
-              "version_added": "77"
-            },
-            "chrome_android": {
-              "version_added": "77"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "64"
-            },
-            "opera_android": {
-              "version_added": "55"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "12.0"
-            },
-            "webview_android": {
-              "version_added": "77"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "attachShadow": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/attachShadow",

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -378,6 +378,8 @@
       },
       "attachInternals": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/attachInternals",
+          "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#dom-attachinternals",
           "support": {
             "chrome": {
               "version_added": "77"


### PR DESCRIPTION
We accidentally added both:
https://github.com/mdn/browser-compat-data/pull/8112
https://github.com/mdn/browser-compat-data/pull/11245