### PR TITLE
Add missing features for CloseEvent API

### DIFF
--- a/api/CloseEvent.json
+++ b/api/CloseEvent.json
@@ -125,10 +125,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": "6"
@@ -224,10 +224,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": "6"
@@ -272,10 +272,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": "6"

--- a/api/CloseEvent.json
+++ b/api/CloseEvent.json
@@ -102,6 +102,54 @@
           }
         }
       },
+      "code": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-closeevent-code",
+          "support": {
+            "chrome": {
+              "version_added": "15"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "8"
+            },
+            "firefox_android": {
+              "version_added": "8"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "initCloseEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CloseEvent/initCloseEvent",
@@ -150,6 +198,102 @@
             "experimental": true,
             "standard_track": false,
             "deprecated": true
+          }
+        }
+      },
+      "reason": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-closeevent-reason",
+          "support": {
+            "chrome": {
+              "version_added": "15"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "8"
+            },
+            "firefox_android": {
+              "version_added": "8"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "wasClean": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-closeevent-wasclean",
+          "support": {
+            "chrome": {
+              "version_added": "13"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "8"
+            },
+            "firefox_android": {
+              "version_added": "8"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/CloseEvent.json
+++ b/api/CloseEvent.json
@@ -104,7 +104,7 @@
       },
       "code": {
         "__compat": {
-          "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-closeevent-code",
+          "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-closeevent-code-dev",
           "support": {
             "chrome": {
               "version_added": "15"
@@ -203,7 +203,7 @@
       },
       "reason": {
         "__compat": {
-          "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-closeevent-reason",
+          "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-closeevent-reason-dev",
           "support": {
             "chrome": {
               "version_added": "15"
@@ -251,7 +251,7 @@
       },
       "wasClean": {
         "__compat": {
-          "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-closeevent-wasclean",
+          "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-closeevent-wasclean-dev",
           "support": {
             "chrome": {
               "version_added": "13"


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing features of the CloseEvent API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10).

Spec: https://html.spec.whatwg.org/multipage/web-sockets.html#the-closeevent-interface

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CloseEvent

Note: Chrome/Safari data was derived from commit history instead -- see https://source.chromium.org/chromium/chromium/src/+/63fc605d4f4d52aafa6f568b096c44ff9dd55021 and https://source.chromium.org/chromium/chromium/src/+/cb8badea0d665f6bb1107f88626e38edf820767d.