### PR TITLE
Add missing api.DOMRect.fromRect feature

### DIFF
--- a/api/DOMRect.json
+++ b/api/DOMRect.json
@@ -176,6 +176,54 @@
           }
         }
       },
+      "fromRect": {
+        "__compat": {
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrect-fromrect",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "69"
+            },
+            "firefox_android": {
+              "version_added": "79"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "worker_support": {
         "__compat": {
           "description": "Available in workers",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing DOMRect API feature, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10).

Spec: https://drafts.fxtf.org/geometry/#dom-domrect-fromrect

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DOMRect/fromRect
