### PR TITLE
Add missing api.Document.rootElement feature

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -10121,6 +10121,54 @@
           }
         }
       },
+      "rootElement": {
+        "__compat": {
+          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGDocument__rootElement",
+          "support": {
+            "chrome": {
+              "version_added": "34"
+            },
+            "chrome_android": {
+              "version_added": "34"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "21"
+            },
+            "opera_android": {
+              "version_added": "21"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "2.0"
+            },
+            "webview_android": {
+              "version_added": "37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
       "routeEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/routeEvent",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing Document API feature, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10).

Spec: https://svgwg.org/svg2-draft/struct.html#__svg__SVGDocument__rootElement

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Document/rootElement
