### PR TITLE
Add missing features for DocumentFragment API

### DIFF
--- a/api/DocumentFragment.json
+++ b/api/DocumentFragment.json
@@ -97,6 +97,54 @@
             "deprecated": false
           }
         }
+      },
+      "getElementById": {
+        "__compat": {
+          "spec_url": "https://dom.spec.whatwg.org/#dom-nonelementparentnode-getelementbyid",
+          "support": {
+            "chrome": {
+              "version_added": "36"
+            },
+            "chrome_android": {
+              "version_added": "36"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "28"
+            },
+            "firefox_android": {
+              "version_added": "28"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "23"
+            },
+            "opera_android": {
+              "version_added": "24"
+            },
+            "safari": {
+              "version_added": "9"
+            },
+            "safari_ios": {
+              "version_added": "9"
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
+            "webview_android": {
+              "version_added": "37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing features of the DocumentFragment API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10).

Spec: https://dom.spec.whatwg.org/#dom-nonelementparentnode-getelementbyid

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DocumentFragment
