### PR TITLE
Adds information about content:none

### DIFF
--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -147,7 +147,7 @@
         },
         "none": {
           "__compat": {
-            "description": "<code>content: none</code> for elements.",
+            "description": "<code>content: none</code> for elements",
             "support": {
               "chrome": {
                 "version_added": false

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -145,6 +145,66 @@
             }
           }
         },
+        "none": {
+          "__compat": {
+            "description": "<code>content: none</code> for elements.",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "91",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.element-content-none.enabled"
+                  }
+                ]
+              },
+              "firefox_android": {
+                "version_added": "91",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.element-content-none.enabled"
+                  }
+                ]
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "url": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/url()",

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -145,7 +145,7 @@
             }
           }
         },
-        "none": {
+        "none_applies_to_elements": {
           "__compat": {
             "description": "<code>content: none</code> for elements",
             "support": {


### PR DESCRIPTION
Working on https://github.com/mdn/content/issues/6716

Firefox 91 implements `content: none` on elements. I do not believe any other UA has shipped this.

Intent to Ship: https://groups.google.com/a/mozilla.org/g/dev-platform/c/oWc1K4Uur2Y

