### PR TITLE
Add missing features for FetchEvent API

### DIFF
--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -150,6 +150,54 @@
           }
         }
       },
+      "handled": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/ServiceWorker/#dom-fetchevent-handled",
+          "support": {
+            "chrome": {
+              "version_added": "86"
+            },
+            "chrome_android": {
+              "version_added": "86"
+            },
+            "edge": {
+              "version_added": "86"
+            },
+            "firefox": {
+              "version_added": "84"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "72"
+            },
+            "opera_android": {
+              "version_added": "61"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "14.0"
+            },
+            "webview_android": {
+              "version_added": "86"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "isReload": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FetchEvent/isReload",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing features of the FetchEvent API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10).

Spec: https://w3c.github.io/ServiceWorker/#dom-fetchevent-handled

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FetchEvent
