### PR TITLE
Add missing api.HTMLSlotElement.assign feature

### DIFF
--- a/api/HTMLSlotElement.json
+++ b/api/HTMLSlotElement.json
@@ -90,7 +90,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HTMLSlotElement.json
+++ b/api/HTMLSlotElement.json
@@ -48,6 +48,54 @@
           "deprecated": false
         }
       },
+      "assign": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#dom-slot-assign",
+          "support": {
+            "chrome": {
+              "version_added": "86"
+            },
+            "chrome_android": {
+              "version_added": "86"
+            },
+            "edge": {
+              "version_added": "86"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "72"
+            },
+            "opera_android": {
+              "version_added": "61"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "14.0"
+            },
+            "webview_android": {
+              "version_added": "86"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "assignedElements": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSlotElement/assignedElements",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing  member of the HTMLSlotElement API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10).

Spec: https://html.spec.whatwg.org/multipage/scripting.html#dom-slot-assign

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLSlotElement/assign
