### PR TITLE
Update Edge support for Fullscreen API

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4528,9 +4528,19 @@
                 "prefix": "webkit"
               }
             ],
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "prefix": "webkit"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "14"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "64"
@@ -5212,7 +5222,7 @@
                 "version_added": "79"
               },
               {
-                "version_added": "≤79",
+                "version_added": "12",
                 "alternative_name": "webkitIsFullScreen"
               }
             ],
@@ -5315,9 +5325,19 @@
                 "alternative_name": "webkitfullscreenchange"
               }
             ],
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "alternative_name": "webkitfullscreenchange"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "14"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "64"
@@ -5520,9 +5540,19 @@
                 "alternative_name": "webkitfullscreenerror"
               }
             ],
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "alternative_name": "webkitfullscreenerror"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "14"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "64"
@@ -7449,9 +7479,19 @@
                 "alternative_name": "onwebkitfullscreenchange"
               }
             ],
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "alternative_name": "onwebkitfullscreenchange"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "14"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "64"
@@ -7551,9 +7591,19 @@
                 "alternative_name": "onwebkitfullscreenerror"
               }
             ],
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "alternative_name": "onwebkitfullscreenerror"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "14"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "64"

--- a/api/Element.json
+++ b/api/Element.json
@@ -2788,9 +2788,19 @@
                 "alternative_name": "webkitfullscreenchange"
               }
             ],
-            "edge": {
-              "version_added": "≤79"
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "alternative_name": "webkitfullscreenchange"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "14"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "64"
@@ -2890,9 +2900,19 @@
                 "alternative_name": "webkitfullscreenerror"
               }
             ],
-            "edge": {
-              "version_added": "≤79"
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "alternative_name": "webkitfullscreenerror"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "14"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "64"
@@ -5486,9 +5506,19 @@
                 "alternative_name": "onwebkitfullscreenchange"
               }
             ],
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "alternative_name": "onwebkitfullscreenchange"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "14"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "64"
@@ -5587,9 +5617,19 @@
                 "alternative_name": "onwebkitfullscreenerror"
               }
             ],
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "alternative_name": "onwebkitfullscreenerror"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "14"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "64"
@@ -6380,12 +6420,11 @@
                 "version_added": "79"
               },
               {
-                "version_added": "79",
+                "version_added": "12",
                 "prefix": "webkit"
               },
               {
                 "version_added": "12",
-                "prefix": "webkit",
                 "version_removed": "14"
               }
             ],

--- a/api/_mixins/DocumentOrShadowRoot__Document.json
+++ b/api/_mixins/DocumentOrShadowRoot__Document.json
@@ -242,15 +242,15 @@
             ],
             "edge": [
               {
-                "version_added": "≤79"
+                "version_added": "79"
               },
               {
-                "version_added": "≤18",
+                "version_added": "12",
                 "prefix": "webkit"
               },
               {
                 "version_added": "12",
-                "prefix": "ms"
+                "version_removed": "14"
               }
             ],
             "firefox": [


### PR DESCRIPTION
Since Edge 12 is not available on BrowserStack or Sauce, Web API
Confluence was used for this:
http://web-confluence.appspot.com/#!/catalog?releases=%5B%22Edge_12.10240_Windows_10.0%22,%22Edge_13.10586_Windows_10.0%22,%22Edge_14.14393_Windows_10.0%22,%22Edge_15.15063_Windows_10.0%22,%22Edge_16.16299_Windows_10.0%22,%22Edge_17.17134_Windows_10.0%22,%22Edge_18.17763_Windows_10.0%22%5D&q=%22fullscreen%22

In short, the unprefixed API was in Edge 12-13, and then removed due to
web compat issues. The webkit-prefixed API remained.