### PR TITLE
Update Opera support for Fullscreen API

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4560,6 +4560,10 @@
               {
                 "version_added": "15",
                 "prefix": "webkit"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               }
             ],
             "opera_android": [
@@ -4569,6 +4573,10 @@
               {
                 "version_added": "14",
                 "prefix": "webkit"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "14"
               }
             ],
             "safari": {
@@ -5347,6 +5355,10 @@
               {
                 "version_added": "15",
                 "alternative_name": "webkitfullscreenchange"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               }
             ],
             "opera_android": [
@@ -5356,6 +5368,10 @@
               {
                 "version_added": "14",
                 "alternative_name": "webkitfullscreenchange"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "14"
               }
             ],
             "safari": {
@@ -5449,6 +5465,10 @@
               {
                 "version_added": "15",
                 "prefix": "webkit"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               }
             ],
             "opera_android": [
@@ -5458,6 +5478,10 @@
               {
                 "version_added": "14",
                 "prefix": "webkit"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "14"
               }
             ],
             "safari": {
@@ -5552,6 +5576,10 @@
               {
                 "version_added": "15",
                 "alternative_name": "webkitfullscreenerror"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               }
             ],
             "opera_android": [
@@ -5561,6 +5589,10 @@
               {
                 "version_added": "14",
                 "alternative_name": "webkitfullscreenerror"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "14"
               }
             ],
             "safari": {
@@ -7481,6 +7513,10 @@
               {
                 "version_added": "15",
                 "alternative_name": "onwebkitfullscreenchange"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               }
             ],
             "opera_android": [
@@ -7490,6 +7526,10 @@
               {
                 "version_added": "14",
                 "alternative_name": "onwebkitfullscreenchange"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "14"
               }
             ],
             "safari": {
@@ -7583,6 +7623,10 @@
               {
                 "version_added": "15",
                 "alternative_name": "onwebkitfullscreenerror"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               }
             ],
             "opera_android": [
@@ -7592,6 +7636,10 @@
               {
                 "version_added": "14",
                 "alternative_name": "onwebkitfullscreenerror"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "14"
               }
             ],
             "safari": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -2819,6 +2819,10 @@
               {
                 "version_added": "15",
                 "alternative_name": "webkitfullscreenchange"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               }
             ],
             "opera_android": [
@@ -2828,6 +2832,10 @@
               {
                 "version_added": "14",
                 "alternative_name": "webkitfullscreenchange"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "14"
               }
             ],
             "safari": {
@@ -2921,6 +2929,10 @@
               {
                 "version_added": "15",
                 "alternative_name": "webkitfullscreenerror"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               }
             ],
             "opera_android": [
@@ -2930,6 +2942,10 @@
               {
                 "version_added": "14",
                 "alternative_name": "webkitfullscreenerror"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "14"
               }
             ],
             "safari": {
@@ -5517,6 +5533,10 @@
               {
                 "version_added": "15",
                 "alternative_name": "onwebkitfullscreenchange"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               }
             ],
             "opera_android": [
@@ -5526,6 +5546,10 @@
               {
                 "version_added": "14",
                 "alternative_name": "onwebkitfullscreenchange"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "14"
               }
             ],
             "safari": {
@@ -5618,6 +5642,10 @@
               {
                 "version_added": "15",
                 "alternative_name": "onwebkitfullscreenerror"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               }
             ],
             "opera_android": [
@@ -5627,6 +5655,10 @@
               {
                 "version_added": "14",
                 "alternative_name": "onwebkitfullscreenerror"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "14"
               }
             ],
             "safari": {
@@ -6422,7 +6454,7 @@
                 "prefix": "webkit"
               },
               {
-                "version_added": "12",
+                "version_added": "12.1",
                 "version_removed": "15"
               }
             ],
@@ -6435,7 +6467,7 @@
                 "prefix": "webkit"
               },
               {
-                "version_added": "12",
+                "version_added": "12.1",
                 "version_removed": "14"
               }
             ],

--- a/api/_mixins/DocumentOrShadowRoot__Document.json
+++ b/api/_mixins/DocumentOrShadowRoot__Document.json
@@ -282,6 +282,10 @@
               {
                 "version_added": "15",
                 "prefix": "webkit"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "15"
               }
             ],
             "opera_android": [
@@ -291,6 +295,10 @@
               {
                 "version_added": "14",
                 "prefix": "webkit"
+              },
+              {
+                "version_added": "12.1",
+                "version_removed": "14"
               }
             ],
             "safari": {


### PR DESCRIPTION
These test return true in Opera 12.16 on Windows 7:
http://mdn-bcd-collector.appspot.com/tests/api/Document/exitFullscreen
http://mdn-bcd-collector.appspot.com/tests/api/Document/fullscreenElement
http://mdn-bcd-collector.appspot.com/tests/api/Document/fullscreenEnabled
http://mdn-bcd-collector.appspot.com/tests/api/Document/onfullscreenchange
http://mdn-bcd-collector.appspot.com/tests/api/Document/onfullscreenerror
http://mdn-bcd-collector.appspot.com/tests/api/Element/onfullscreenchange
http://mdn-bcd-collector.appspot.com/tests/api/Element/onfullscreenerror
http://mdn-bcd-collector.appspot.com/tests/api/Element/requestFullscreen

http://mdn-bcd-collector.appspot.com/tests/api/Document/fullscreen is notably
not supported, it was a much later addition to the spec.