### PR TITLE
Add missing features for HTMLSourceElement API

### DIFF
--- a/api/HTMLSourceElement.json
+++ b/api/HTMLSourceElement.json
@@ -48,6 +48,54 @@
           "deprecated": false
         }
       },
+      "height": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dom-dim-height",
+          "support": {
+            "chrome": {
+              "version_added": "90"
+            },
+            "chrome_android": {
+              "version_added": "90"
+            },
+            "edge": {
+              "version_added": "90"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "76"
+            },
+            "opera_android": {
+              "version_added": "64"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "15.0"
+            },
+            "webview_android": {
+              "version_added": "90"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "keySystem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSourceElement/keySystem",
@@ -338,6 +386,54 @@
             },
             "webview_android": {
               "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "width": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dom-dim-width",
+          "support": {
+            "chrome": {
+              "version_added": "90"
+            },
+            "chrome_android": {
+              "version_added": "90"
+            },
+            "edge": {
+              "version_added": "90"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "76"
+            },
+            "opera_android": {
+              "version_added": "64"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "15.0"
+            },
+            "webview_android": {
+              "version_added": "90"
             }
           },
           "status": {

--- a/api/HTMLSourceElement.json
+++ b/api/HTMLSourceElement.json
@@ -90,7 +90,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -437,7 +437,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing features of the HTMLSourceElement API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10).

Spec: https://html.spec.whatwg.org/multipage/embedded-content-other.html#dom-dim-height / https://html.spec.whatwg.org/multipage/embedded-content-other.html#dom-dim-width

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLSourceElement
