### PR TITLE
Add missing api.KeyboardEvent.initKeyboardEvent feature

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -1163,6 +1163,54 @@
           }
         }
       },
+      "initKeyboardEvent": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/uievents/#dom-keyboardevent-initkeyboardevent",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "57"
+            },
+            "firefox_android": {
+              "version_added": "57"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
       "isComposing": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyboardEvent/isComposing",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing  member of the KeyboardEvent API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10).

Spec: https://w3c.github.io/uievents/#dom-keyboardevent-initkeyboardevent

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/KeyboardEvent/initKeyboardEvent
