### PR TITLE
Add missing api.Performance.measureUserAgentSpecificMemory feature

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -699,6 +699,54 @@
           }
         }
       },
+      "measureUserAgentSpecificMemory": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/performance-measure-memory/#ref-for-dom-performance-measureuseragentspecificmemory⑤",
+          "support": {
+            "chrome": {
+              "version_added": "89"
+            },
+            "chrome_android": {
+              "version_added": "89"
+            },
+            "edge": {
+              "version_added": "89"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "75"
+            },
+            "opera_android": {
+              "version_added": "63"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "89"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "memory": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Performance/memory",

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -741,7 +741,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `measureUserAgentSpecificMemory` member of the Performance API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10).

Spec: https://wicg.github.io/performance-measure-memory/#ref-for-dom-performance-measureuseragentspecificmemory⑤

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Performance/measureUserAgentSpecificMemory
