### PR TITLE
Correct Safari version for Path2D API

### DIFF
--- a/api/Path2D.json
+++ b/api/Path2D.json
@@ -30,10 +30,10 @@
             "version_added": "24"
           },
           "safari": {
-            "version_added": "7"
+            "version_added": "8"
           },
           "safari_ios": {
-            "version_added": "7"
+            "version_added": "8"
           },
           "samsunginternet_android": {
             "version_added": "3.0"
@@ -80,10 +80,10 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": "3.0"


### PR DESCRIPTION
This PR is a follow-up to #7950.  In that PR, I had set this API to "7" -- however, this was before I knew that Safari 7.1 was a backport of 8.0.  This PR corrects the data, setting it to Safari 8.
