### PR TITLE
Add missing api.PopStateEvent.PopStateEvent feature

### DIFF
--- a/api/PopStateEvent.json
+++ b/api/PopStateEvent.json
@@ -48,6 +48,55 @@
           "deprecated": false
         }
       },
+      "PopStateEvent": {
+        "__compat": {
+          "description": "<code>PopStateEvent()</code> constructor",
+          "spec_url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-popstateevent-interface",
+          "support": {
+            "chrome": {
+              "version_added": "16"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "11"
+            },
+            "firefox_android": {
+              "version_added": "14"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "state": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PopStateEvent/state",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `constructor` member of the PopStateEvent API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10).

Spec: https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-popstateevent-interface

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PopStateEvent/PopStateEvent
