### PR TITLE
Add missing features for RTCErrorEvent API

### DIFF
--- a/api/RTCErrorEvent.json
+++ b/api/RTCErrorEvent.json
@@ -48,6 +48,55 @@
           "deprecated": false
         }
       },
+      "RTCErrorEvent": {
+        "__compat": {
+          "description": "<code>RTCErrorEvent()</code> constructor",
+          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcerrorevent-constructor",
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "74"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "62"
+            },
+            "opera_android": {
+              "version_added": "53"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "11.0"
+            },
+            "webview_android": {
+              "version_added": "74"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "error": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCErrorEvent/error",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing features of the RTCErrorEvent API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10).

Spec: https://w3c.github.io/webrtc-pc/#dom-rtcerrorevent-constructor

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCErrorEvent
