### PR TITLE
Add missing api.RTCTrackEvent.RTCTrackEvent feature

### DIFF
--- a/api/RTCTrackEvent.json
+++ b/api/RTCTrackEvent.json
@@ -48,6 +48,55 @@
           "deprecated": false
         }
       },
+      "RTCTrackEvent": {
+        "__compat": {
+          "description": "<code>RTCTrackEvent()</code> constructor",
+          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtctrackevent-constructor",
+          "support": {
+            "chrome": {
+              "version_added": "64"
+            },
+            "chrome_android": {
+              "version_added": "64"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "46"
+            },
+            "firefox_android": {
+              "version_added": "46"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "51"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "9.0"
+            },
+            "webview_android": {
+              "version_added": "64"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "receiver": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCTrackEvent/receiver",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `constructor` member of the RTCTrackEvent API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10).

Spec: https://w3c.github.io/webrtc-pc/#dom-rtctrackevent-constructor

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCTrackEvent/RTCTrackEvent
