### PR TITLE
Add missing api.SVGAElement.href feature

### DIFF
--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -95,6 +95,54 @@
           }
         }
       },
+      "href": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/links.html#dom-hyperlink-href",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "hreflang": {
         "__compat": {
           "support": {


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `href` member of the SVGAElement API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10).

Spec: https://html.spec.whatwg.org/multipage/links.html#dom-hyperlink-href

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGAElement/href
