### PR TITLE
Add missing features for SVGAnimatedTransformList API

### DIFF
--- a/api/SVGAnimatedTransformList.json
+++ b/api/SVGAnimatedTransformList.json
@@ -47,6 +47,102 @@
           "standard_track": true,
           "deprecated": false
         }
+      },
+      "animVal": {
+        "__compat": {
+          "spec_url": "https://svgwg.org/svg2-draft/coords.html#__svg__SVGAnimatedTransformList__animVal",
+          "support": {
+            "chrome": {
+              "version_added": "5"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "9"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "5"
+            },
+            "safari_ios": {
+              "version_added": "4"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "baseVal": {
+        "__compat": {
+          "spec_url": "https://svgwg.org/svg2-draft/coords.html#__svg__SVGAnimatedTransformList__baseVal",
+          "support": {
+            "chrome": {
+              "version_added": "5"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "9"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "5"
+            },
+            "safari_ios": {
+              "version_added": "4"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing features of the SVGAnimatedTransformList API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.1.10).

Spec: https://svgwg.org/svg2-draft/coords.html#InterfaceSVGAnimatedTransformList

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGAnimatedTransformList
