### PR TITLE
Add missing api.SVGTextPathElement.href feature

### DIFF
--- a/api/SVGTextPathElement.json
+++ b/api/SVGTextPathElement.json
@@ -48,6 +48,54 @@
           "deprecated": false
         }
       },
+      "href": {
+        "__compat": {
+          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGURIReference__href",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "2"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "method": {
         "__compat": {
           "support": {


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `href` member of the SVGTextPathElement API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGTextPathElement/href
