### PR TITLE
Correct data for SpeechRecognitionErrorEvent and add its constructor

### DIFF
--- a/api/SpeechRecognitionErrorEvent.json
+++ b/api/SpeechRecognitionErrorEvent.json
@@ -62,10 +62,12 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognitionerrorevent-speechrecognitionerrorevent",
           "support": {
             "chrome": {
-              "version_added": false
+              "alternative_name": "webkitSpeechRecognitionError",
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": false
+              "alternative_name": "webkitSpeechRecognitionError",
+              "version_added": "33"
             },
             "edge": {
               "version_added": false
@@ -92,10 +94,12 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "alternative_name": "webkitSpeechRecognitionError",
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": false
+              "alternative_name": "webkitSpeechRecognitionError",
+              "version_added": "33"
             }
           },
           "status": {

--- a/api/SpeechRecognitionErrorEvent.json
+++ b/api/SpeechRecognitionErrorEvent.json
@@ -8,12 +8,12 @@
           "chrome": {
             "alternative_name": "webkitSpeechRecognitionError",
             "version_added": "33",
-            "notes": "Since Chrome 77, you'll need to serve your code through a web server for recognition to work."
+            "notes": "You'll need to serve your code through a web server for recognition to work."
           },
           "chrome_android": {
             "alternative_name": "webkitSpeechRecognitionError",
             "version_added": "33",
-            "notes": "Since Chrome 77, you'll need to serve your code through a web server for recognition to work."
+            "notes": "You'll need to serve your code through a web server for recognition to work."
           },
           "edge": {
             "version_added": "79"
@@ -42,12 +42,12 @@
           "samsunginternet_android": {
             "alternative_name": "webkitSpeechRecognitionError",
             "version_added": "2.0",
-            "notes": "Since Samsung Internet 12.0, you'll need to serve your code through a web server for recognition to work."
+            "notes": "You'll need to serve your code through a web server for recognition to work."
           },
           "webview_android": {
             "alternative_name": "webkitSpeechRecognitionError",
             "version_added": "≤37",
-            "notes": "Since Chrome 77, you'll need to serve your code through a web server for recognition to work."
+            "notes": "You'll need to serve your code through a web server for recognition to work."
           }
         },
         "status": {

--- a/api/SpeechRecognitionErrorEvent.json
+++ b/api/SpeechRecognitionErrorEvent.json
@@ -99,7 +99,7 @@
             },
             "webview_android": {
               "alternative_name": "webkitSpeechRecognitionError",
-              "version_added": "33"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/SpeechRecognitionErrorEvent.json
+++ b/api/SpeechRecognitionErrorEvent.json
@@ -5,28 +5,16 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionErrorEvent",
         "spec_url": "https://wicg.github.io/speech-api/#speechrecognitionerrorevent",
         "support": {
-          "chrome": [
-            {
-              "version_added": "77",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
-            },
-            {
-              "alternative_name": "webkitSpeechRecognitionError",
-              "version_added": "33",
-              "version_removed": "77"
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_added": "77",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
-            },
-            {
-              "alternative_name": "webkitSpeechRecognitionError",
-              "version_added": "33",
-              "version_removed": "77"
-            }
-          ],
+          "chrome": {
+            "alternative_name": "webkitSpeechRecognitionError",
+            "version_added": "33",
+            "notes": "Since Chrome 77, you'll need to serve your code through a web server for recognition to work."
+          },
+          "chrome_android": {
+            "alternative_name": "webkitSpeechRecognitionError",
+            "version_added": "33",
+            "notes": "Since Chrome 77, you'll need to serve your code through a web server for recognition to work."
+          },
           "edge": {
             "version_added": "79"
           },
@@ -51,28 +39,16 @@
           "safari_ios": {
             "version_added": "14.5"
           },
-          "samsunginternet_android": [
-            {
-              "version_added": "12.0",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
-            },
-            {
-              "alternative_name": "webkitSpeechRecognitionError",
-              "version_added": "2.0",
-              "version_removed": "12.0"
-            }
-          ],
-          "webview_android": [
-            {
-              "version_added": "77",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
-            },
-            {
-              "alternative_name": "webkitSpeechRecognitionError",
-              "version_added": "≤37",
-              "version_removed": "77"
-            }
-          ]
+          "samsunginternet_android": {
+            "alternative_name": "webkitSpeechRecognitionError",
+            "version_added": "2.0",
+            "notes": "Since Samsung Internet 12.0, you'll need to serve your code through a web server for recognition to work."
+          },
+          "webview_android": {
+            "alternative_name": "webkitSpeechRecognitionError",
+            "version_added": "≤37",
+            "notes": "Since Chrome 77, you'll need to serve your code through a web server for recognition to work."
+          }
         },
         "status": {
           "experimental": true,

--- a/api/SpeechRecognitionErrorEvent.json
+++ b/api/SpeechRecognitionErrorEvent.json
@@ -80,6 +80,55 @@
           "deprecated": false
         }
       },
+      "SpeechRecognitionErrorEvent": {
+        "__compat": {
+          "description": "<code>SpeechRecognitionErrorEvent()</code> constructor",
+          "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognitionerrorevent-speechrecognitionerrorevent",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "14.1"
+            },
+            "safari_ios": {
+              "version_added": "14.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "error": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionErrorEvent/error",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `SpeechRecognitionErrorEvent` member of the SpeechRecognitionErrorEvent API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SpeechRecognitionErrorEvent/SpeechRecognitionErrorEvent
