### PR TITLE
Add missing features for SpeechSynthesisErrorEvent API

### DIFF
--- a/api/SpeechSynthesisErrorEvent.json
+++ b/api/SpeechSynthesisErrorEvent.json
@@ -49,6 +49,55 @@
           "deprecated": false
         }
       },
+      "SpeechSynthesisErrorEvent": {
+        "__compat": {
+          "description": "<code>SpeechSynthesisErrorEvent()</code> constructor",
+          "spec_url": "https://wicg.github.io/speech-api/#dom-speechsynthesiserrorevent-speechsynthesiserrorevent",
+          "support": {
+            "chrome": {
+              "version_added": "71"
+            },
+            "chrome_android": {
+              "version_added": "71"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": {
+              "version_added": "62"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "58"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "error": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechSynthesisErrorEvent/error",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing features of the SpeechSynthesisErrorEvent API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SpeechSynthesisErrorEvent
