### PR TITLE
Add missing api.TrackEvent.TrackEvent feature

### DIFF
--- a/api/TrackEvent.json
+++ b/api/TrackEvent.json
@@ -24,10 +24,10 @@
             "version_added": "10"
           },
           "opera": {
-            "version_added": null
+            "version_added": true
           },
           "opera_android": {
-            "version_added": null
+            "version_added": true
           },
           "safari": {
             "version_added": true
@@ -46,6 +46,55 @@
           "experimental": false,
           "standard_track": true,
           "deprecated": false
+        }
+      },
+      "TrackEvent": {
+        "__compat": {
+          "description": "<code>TrackEvent()</code> constructor",
+          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#the-trackevent-interface",
+          "support": {
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
       },
       "track": {


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `TrackEvent` member of the TrackEvent API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TrackEvent/TrackEvent
