### PR TITLE
Add missing api.WebGLContextEvent.WebGLContextEvent feature

### DIFF
--- a/api/WebGLContextEvent.json
+++ b/api/WebGLContextEvent.json
@@ -48,6 +48,55 @@
           "deprecated": false
         }
       },
+      "WebGLContextEvent": {
+        "__compat": {
+          "description": "<code>WebGLContextEvent()</code> constructor",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15",
+          "support": {
+            "chrome": {
+              "version_added": "17"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": {
+              "version_added": "49"
+            },
+            "ie": {
+              "version_added": "11"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "8"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "statusMessage": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLContextEvent/statusMessage",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `WebGLContextEvent` member of the WebGLContextEvent API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WebGLContextEvent/WebGLContextEvent
