### PR TITLE
Add missing features for XRView API

### DIFF
--- a/api/XRView.json
+++ b/api/XRView.json
@@ -193,6 +193,102 @@
           }
         }
       },
+      "recommendedViewportScale": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrview-recommendedviewportscale",
+          "support": {
+            "chrome": {
+              "version_added": "90"
+            },
+            "chrome_android": {
+              "version_added": "90"
+            },
+            "edge": {
+              "version_added": "90"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "requestViewportScale": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrview-requestviewportscale",
+          "support": {
+            "chrome": {
+              "version_added": "90"
+            },
+            "chrome_android": {
+              "version_added": "90"
+            },
+            "edge": {
+              "version_added": "90"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "transform": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRView/transform",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing features of the XRView API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/XRView
