### PR TITLE
Add missing features for XSLTProcessor API

### DIFF
--- a/api/XSLTProcessor.json
+++ b/api/XSLTProcessor.json
@@ -47,6 +47,55 @@
           "deprecated": false
         }
       },
+      "XSLTProcessor": {
+        "__compat": {
+          "description": "<code>XSLTProcessor()</code> constructor",
+          "spec_url": "https://dom.spec.whatwg.org/#dom-xsltprocessor-xsltprocessor",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "clearParameters": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XSLTProcessor/clearParameters",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing features of the XSLTProcessor API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/XSLTProcessor
