### PR TITLE
Add missing DOMRectList API

### DIFF
--- a/api/DOMRectList.json
+++ b/api/DOMRectList.json
@@ -1,0 +1,148 @@
+{
+  "api": {
+    "DOMRectList": {
+      "__compat": {
+        "spec_url": "https://drafts.fxtf.org/geometry/#DOMRectList",
+        "support": {
+          "chrome": {
+            "version_added": "2"
+          },
+          "chrome_android": {
+            "version_added": "18"
+          },
+          "edge": {
+            "version_added": "12"
+          },
+          "firefox": {
+            "version_added": "3"
+          },
+          "firefox_android": {
+            "version_added": "4"
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": "≤12.1"
+          },
+          "opera_android": {
+            "version_added": "≤12.1"
+          },
+          "safari": {
+            "version_added": "≤4"
+          },
+          "safari_ios": {
+            "version_added": "≤3"
+          },
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
+          "webview_android": {
+            "version_added": "≤37"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "item": {
+        "__compat": {
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrectlist-item",
+          "support": {
+            "chrome": {
+              "version_added": "2"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "3"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "length": {
+        "__compat": {
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrectlist-length",
+          "support": {
+            "chrome": {
+              "version_added": "2"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "3"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "≤4"
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/DOMRectList.json
+++ b/api/DOMRectList.json
@@ -4,42 +4,120 @@
       "__compat": {
         "spec_url": "https://drafts.fxtf.org/geometry/#DOMRectList",
         "support": {
-          "chrome": {
-            "version_added": "2"
-          },
-          "chrome_android": {
-            "version_added": "18"
-          },
-          "edge": {
-            "version_added": "12"
-          },
-          "firefox": {
-            "version_added": "3"
-          },
-          "firefox_android": {
-            "version_added": "4"
-          },
+          "chrome": [
+            {
+              "version_added": "61"
+            },
+            {
+              "alternative_name": "ClientRectList",
+              "version_added": "2",
+              "version_removed": "61"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "61"
+            },
+            {
+              "alternative_name": "ClientRectList",
+              "version_added": "18",
+              "version_removed": "61"
+            }
+          ],
+          "edge": [
+            {
+              "version_added": "79"
+            },
+            {
+              "alternative_name": "ClientRectList",
+              "version_added": "12",
+              "version_removed": "79"
+            }
+          ],
+          "firefox": [
+            {
+              "version_added": "27"
+            },
+            {
+              "alternative_name": "ClientRectList",
+              "version_added": "3",
+              "version_removed": "27"
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "27"
+            },
+            {
+              "alternative_name": "ClientRectList",
+              "version_added": "4",
+              "version_removed": "27"
+            }
+          ],
           "ie": {
+            "alternative_name": "ClientRectList",
             "version_added": "9"
           },
-          "opera": {
-            "version_added": "≤12.1"
-          },
-          "opera_android": {
-            "version_added": "≤12.1"
-          },
-          "safari": {
-            "version_added": "≤4"
-          },
-          "safari_ios": {
-            "version_added": "≤3"
-          },
-          "samsunginternet_android": {
-            "version_added": "1.0"
-          },
-          "webview_android": {
-            "version_added": "≤37"
-          }
+          "opera": [
+            {
+              "version_added": "48"
+            },
+            {
+              "alternative_name": "ClientRectList",
+              "version_added": "≤12.1",
+              "version_removed": "48"
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "45"
+            },
+            {
+              "alternative_name": "ClientRectList",
+              "version_added": "≤12.1",
+              "version_removed": "45"
+            }
+          ],
+          "safari": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "alternative_name": "ClientRectList",
+              "version_added": "≤4",
+              "version_removed": "11"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "10.3"
+            },
+            {
+              "alternative_name": "ClientRectList",
+              "version_added": "≤3",
+              "version_removed": "11"
+            }
+          ],
+          "samsunginternet_android": [
+            {
+              "version_added": "8.0"
+            },
+            {
+              "alternative_name": "ClientRectList",
+              "version_added": "1.0",
+              "version_removed": "8.0"
+            }
+          ],
+          "webview_android": [
+            {
+              "version_added": "61"
+            },
+            {
+              "alternative_name": "ClientRectList",
+              "version_added": "≤37",
+              "version_removed": "61"
+            }
+          ]
         },
         "status": {
           "experimental": false,


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `DOMRectList` API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DOMRectList
