### PR TITLE
Add consistent descriptions and URLs for DOM*.from* static methods

### DIFF
--- a/api/DOMMatrix.json
+++ b/api/DOMMatrix.json
@@ -100,7 +100,8 @@
       },
       "fromFloat32Array": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-fromfloat32array",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrix-fromfloat32array",
+          "description": "<code>fromFloat32Array()</code> static method",
           "support": {
             "chrome": {
               "version_added": "61"
@@ -148,7 +149,8 @@
       },
       "fromFloat64Array": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-fromfloat64array",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrix-fromfloat64array",
+          "description": "<code>fromFloat64Array()</code> static method",
           "support": {
             "chrome": {
               "version_added": "61"
@@ -197,6 +199,7 @@
       "fromMatrix": {
         "__compat": {
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrix-frommatrix",
+          "description": "<code>fromMatrix()</code> static method",
           "support": {
             "chrome": {
               "version_added": "61"

--- a/api/DOMMatrixReadOnly.json
+++ b/api/DOMMatrixReadOnly.json
@@ -487,6 +487,8 @@
       },
       "fromFloat32Array": {
         "__compat": {
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-fromfloat32array",
+          "description": "<code>fromFloat32Array()</code> static method",
           "support": {
             "chrome": {
               "version_added": "61"
@@ -534,6 +536,8 @@
       },
       "fromFloat64Array": {
         "__compat": {
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-fromfloat64array",
+          "description": "<code>fromFloat64Array()</code> static method",
           "support": {
             "chrome": {
               "version_added": "61"
@@ -581,8 +585,8 @@
       },
       "fromMatrix": {
         "__compat": {
-          "description": "<code>fromMatrix()</code> static function",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/fromMatrix",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-frommatrix",
+          "description": "<code>fromMatrix()</code> static method",
           "support": {
             "chrome": {
               "version_added": "61"

--- a/api/DOMPoint.json
+++ b/api/DOMPoint.json
@@ -102,6 +102,7 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPoint/fromPoint",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompoint-frompoint",
+          "description": "<code>fromPoint()</code> static method",
           "support": {
             "chrome": {
               "version_added": "61"

--- a/api/DOMPointReadOnly.json
+++ b/api/DOMPointReadOnly.json
@@ -102,7 +102,7 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMPointReadOnly/fromPoint",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dompointreadonly-frompoint",
-          "description": "<code>fromPoint()</code> static function",
+          "description": "<code>fromPoint()</code> static method",
           "support": {
             "chrome": {
               "version_added": "61"

--- a/api/DOMQuad.json
+++ b/api/DOMQuad.json
@@ -99,8 +99,8 @@
       },
       "fromQuad": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMQuad/fromQuad",
-          "description": "<code>fromQuad()</code> static function",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-domquad-fromquad",
+          "description": "<code>fromQuad()</code> static method",
           "support": {
             "chrome": {
               "version_added": "61"
@@ -148,8 +148,8 @@
       },
       "fromRect": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMQuad/fromRect",
-          "description": "<code>fromRect()</code> static function",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-domquad-fromrect",
+          "description": "<code>fromRect()</code> static method",
           "support": {
             "chrome": {
               "version_added": "61"

--- a/api/DOMRect.json
+++ b/api/DOMRect.json
@@ -179,6 +179,7 @@
       "fromRect": {
         "__compat": {
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrect-fromrect",
+          "description": "<code>fromRect()</code> static method",
           "support": {
             "chrome": {
               "version_added": "61"

--- a/api/DOMRectReadOnly.json
+++ b/api/DOMRectReadOnly.json
@@ -164,7 +164,7 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/fromRect",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrectreadonly-fromrect",
-          "description": "<code>fromRect()</code> static function",
+          "description": "<code>fromRect()</code> static method",
           "support": {
             "chrome": {
               "version_added": "61"


### PR DESCRIPTION
Add descriptions matching the existing ones, but with "method" instead
of "function".

Spec URLs are added and MDN URLs which are 404 are removed.