### PR TITLE
Use -dev URLs for two 2d canvas features

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1673,7 +1673,7 @@
       "filter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/filter",
-          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#filters",
+          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-filter-dev",
           "support": {
             "chrome": {
               "version_added": "52"
@@ -2209,7 +2209,7 @@
       "imageSmoothingQuality": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/imageSmoothingQuality",
-          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#2dcontext:imagesmoothingquality-2",
+          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-imagesmoothingquality-dev",
           "support": {
             "chrome": {
               "version_added": "54"


### PR DESCRIPTION
getContextAttributes() unfortunately doesn't have a good URL to use.