### PR TITLE
Add Firefox versions for api.Document.exitPointerEvent

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -7791,12 +7791,26 @@
             "edge": {
               "version_added": "13"
             },
-            "firefox": {
-              "version_added": "50"
-            },
-            "firefox_android": {
-              "version_added": "50"
-            },
+            "firefox": [
+              {
+                "version_added": "50"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "50",
+                "alternative_name": "onmozpointerlockchange"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "50",
+                "alternative_name": "onmozpointerlockchange"
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -7839,12 +7853,26 @@
             "edge": {
               "version_added": "13"
             },
-            "firefox": {
-              "version_added": "50"
-            },
-            "firefox_android": {
-              "version_added": "50"
-            },
+            "firefox": [
+              {
+                "version_added": "50"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "50",
+                "alternative_name": "onmozpointerlockerror"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "50",
+                "alternative_name": "onmozpointerlockerror"
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/Document.json
+++ b/api/Document.json
@@ -4753,7 +4753,8 @@
                 "version_added": "50"
               },
               {
-                "version_added": true,
+                "version_added": "14",
+                "version_removed": "50",
                 "prefix": "moz"
               }
             ],
@@ -4762,7 +4763,8 @@
                 "version_added": "50"
               },
               {
-                "version_added": true,
+                "version_added": "14",
+                "version_removed": "50",
                 "prefix": "moz"
               }
             ],


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `exitPointerEvent` member of the `Document` API, based upon manual testing.

Test Code Used: `document.mozExitPointerEvent`
