### PR TITLE
Remove repeated notes about Speech Recognition requirements

### DIFF
--- a/api/SpeechGrammarList.json
+++ b/api/SpeechGrammarList.json
@@ -7,18 +7,15 @@
         "support": {
           "chrome": {
             "prefix": "webkit",
-            "version_added": "33",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": "33"
           },
           "chrome_android": {
             "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": true
           },
           "edge": {
             "prefix": "webkit",
-            "version_added": "≤79",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": "≤79"
           },
           "firefox": {
             "version_added": false
@@ -43,13 +40,11 @@
           },
           "samsunginternet_android": {
             "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": true
           },
           "webview_android": {
             "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": true
           }
         },
         "status": {
@@ -66,17 +61,14 @@
           "support": {
             "chrome": {
               "prefix": "webkit",
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
               "prefix": "webkit",
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -100,13 +92,11 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
               "prefix": "webkit",
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -122,16 +112,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechgrammarlist-addfromstring",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -155,12 +142,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -176,16 +161,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechgrammarlist-addfromuri",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -209,12 +191,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -263,8 +243,7 @@
               "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -280,16 +259,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechgrammarlist-length",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -313,12 +289,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {

--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -68,18 +68,15 @@
           "support": {
             "chrome": {
               "prefix": "webkit",
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
               "prefix": "webkit",
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
               "prefix": "webkit",
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -106,13 +103,11 @@
             },
             "samsunginternet_android": {
               "prefix": "webkit",
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
               "prefix": "webkit",
-              "version_added": "37",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "37"
             }
           },
           "status": {
@@ -128,16 +123,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognition-abort",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -161,12 +153,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -282,16 +272,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognition-continuous",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -315,12 +302,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -436,16 +421,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognition-grammars",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -469,12 +451,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -490,16 +470,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognition-interimresults",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -523,12 +500,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -544,16 +519,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognition-lang",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -577,12 +549,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -598,16 +568,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognition-maxalternatives",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -631,12 +598,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -702,16 +667,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognition-onaudioend",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -735,12 +697,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -756,16 +716,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognition-onaudiostart",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -789,12 +746,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -810,16 +765,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognition-onend",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -843,12 +795,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -864,16 +814,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognition-onerror",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -897,12 +844,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -918,16 +863,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognition-onnomatch",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -951,12 +893,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -972,16 +912,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognition-onresult",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -1005,12 +942,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -1026,16 +961,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognition-onsoundend",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -1059,12 +991,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -1080,16 +1010,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognition-onsoundstart",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -1113,12 +1040,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -1134,16 +1059,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognition-onspeechend",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -1167,12 +1089,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -1188,16 +1108,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognition-onspeechstart",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -1221,12 +1138,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -1242,16 +1157,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognition-onstart",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -1275,12 +1187,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -1345,16 +1255,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognition/serviceURI",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -1378,12 +1285,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -1599,16 +1504,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognition-start",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -1632,12 +1534,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -1703,16 +1603,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognition-stop",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -1736,12 +1633,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {

--- a/api/SpeechRecognitionAlternative.json
+++ b/api/SpeechRecognitionAlternative.json
@@ -6,16 +6,13 @@
         "spec_url": "https://wicg.github.io/speech-api/#speechreco-alternative",
         "support": {
           "chrome": {
-            "version_added": "33",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": "33"
           },
           "chrome_android": {
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": true
           },
           "edge": {
-            "version_added": "≤79",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": "≤79"
           },
           "firefox": {
             "version_added": false
@@ -39,12 +36,10 @@
             "version_added": "14.5"
           },
           "samsunginternet_android": {
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": true
           },
           "webview_android": {
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": true
           }
         },
         "status": {
@@ -59,16 +54,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognitionalternative-confidence",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -92,12 +84,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -113,16 +103,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognitionalternative-transcript",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -146,12 +133,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {

--- a/api/SpeechRecognitionErrorEvent.json
+++ b/api/SpeechRecognitionErrorEvent.json
@@ -7,13 +7,11 @@
         "support": {
           "chrome": {
             "alternative_name": "webkitSpeechRecognitionError",
-            "version_added": "33",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": "33"
           },
           "chrome_android": {
             "alternative_name": "webkitSpeechRecognitionError",
-            "version_added": "33",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": "33"
           },
           "edge": {
             "version_added": "79"
@@ -41,13 +39,11 @@
           },
           "samsunginternet_android": {
             "alternative_name": "webkitSpeechRecognitionError",
-            "version_added": "2.0",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": "2.0"
           },
           "webview_android": {
             "alternative_name": "webkitSpeechRecognitionError",
-            "version_added": "≤37",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/SpeechRecognitionEvent.json
+++ b/api/SpeechRecognitionEvent.json
@@ -7,18 +7,15 @@
         "support": {
           "chrome": {
             "prefix": "webkit",
-            "version_added": "33",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": "33"
           },
           "chrome_android": {
             "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": true
           },
           "edge": {
             "prefix": "webkit",
-            "version_added": "≤79",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": "≤79"
           },
           "firefox": {
             "version_added": false
@@ -43,13 +40,11 @@
           },
           "samsunginternet_android": {
             "prefix": "webkit",
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": true
           },
           "webview_android": {
             "prefix": "webkit",
-            "version_added": "≤37",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -63,16 +58,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionEvent/emma",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -96,12 +88,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "≤37",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -116,16 +106,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionEvent/interpretation",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -149,12 +136,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "≤37",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -170,16 +155,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognitionevent-resultindex",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -203,12 +185,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "≤37",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -224,16 +204,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognitionevent-results",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -257,12 +234,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "≤37",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/SpeechRecognitionResult.json
+++ b/api/SpeechRecognitionResult.json
@@ -6,16 +6,13 @@
         "spec_url": "https://wicg.github.io/speech-api/#speechreco-result",
         "support": {
           "chrome": {
-            "version_added": "33",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": "33"
           },
           "chrome_android": {
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": true
           },
           "edge": {
-            "version_added": "≤79",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": "≤79"
           },
           "firefox": {
             "version_added": false
@@ -39,12 +36,10 @@
             "version_added": "14.5"
           },
           "samsunginternet_android": {
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": true
           },
           "webview_android": {
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": true
           }
         },
         "status": {
@@ -59,16 +54,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognitionresult-isfinal",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -92,12 +84,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -113,16 +103,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognitionresult-item",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -146,12 +133,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -167,16 +152,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognitionresult-length",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -200,12 +182,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {

--- a/api/SpeechRecognitionResultList.json
+++ b/api/SpeechRecognitionResultList.json
@@ -6,16 +6,13 @@
         "spec_url": "https://wicg.github.io/speech-api/#speechreco-resultlist",
         "support": {
           "chrome": {
-            "version_added": "33",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": "33"
           },
           "chrome_android": {
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": true
           },
           "edge": {
-            "version_added": "≤79",
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": "≤79"
           },
           "firefox": {
             "version_added": false
@@ -39,12 +36,10 @@
             "version_added": "14.5"
           },
           "samsunginternet_android": {
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": true
           },
           "webview_android": {
-            "version_added": true,
-            "notes": "You'll need to serve your code through a web server for recognition to work."
+            "version_added": true
           }
         },
         "status": {
@@ -59,16 +54,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognitionresultlist-item",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -92,12 +84,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {
@@ -113,16 +103,13 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognitionresultlist-length",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "edge": {
-              "version_added": "≤79",
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -146,12 +133,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             },
             "webview_android": {
-              "version_added": true,
-              "notes": "You'll need to serve your code through a web server for recognition to work."
+              "version_added": true
             }
           },
           "status": {


### PR DESCRIPTION
These notes don't need to be repeated everywhere. They are left on the
entry point to the API, api.SpeechRecognition.