### PR TITLE
Fix data for focus() and blur() methods

### DIFF
--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -255,54 +255,6 @@
           }
         }
       },
-      "blur": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/blur",
-          "support": {
-            "chrome": {
-              "version_added": "1"
-            },
-            "chrome_android": {
-              "version_added": "18"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "1"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
-            "ie": {
-              "version_added": "5"
-            },
-            "opera": {
-              "version_added": "≤12.1"
-            },
-            "opera_android": {
-              "version_added": "≤12.1"
-            },
-            "safari": {
-              "version_added": "1"
-            },
-            "safari_ios": {
-              "version_added": "1"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.0"
-            },
-            "webview_android": {
-              "version_added": "1"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "checkValidity": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/checkValidity",
@@ -383,54 +335,6 @@
             },
             "safari": {
               "version_added": "3"
-            },
-            "safari_ios": {
-              "version_added": "1"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.0"
-            },
-            "webview_android": {
-              "version_added": "1"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "focus": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/focus",
-          "support": {
-            "chrome": {
-              "version_added": "1"
-            },
-            "chrome_android": {
-              "version_added": "18"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "1"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
-            "ie": {
-              "version_added": "5"
-            },
-            "opera": {
-              "version_added": "≤12.1"
-            },
-            "opera_android": {
-              "version_added": "≤12.1"
-            },
-            "safari": {
-              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -48,6 +48,54 @@
           "deprecated": false
         }
       },
+      "blur": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-blur-dev",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "51"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "className": {
         "__compat": {
           "support": {
@@ -196,7 +244,6 @@
       },
       "focus": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGElement/focus",
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-focus-dev",
           "support": {
             "chrome": {
@@ -206,7 +253,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "51"


### PR DESCRIPTION
For SVGElement.blur, the data for focus() was copied as a starting
point. Then http://mdn-bcd-collector.appspot.com/tests/api/SVGElement/blur
was tested on these browser versions:
 - Chrome 15 on Windows 7
 - Edge 16+17 on Windows 10
 - Firefox 50+51 on Windows 10
 - Opera 12.16 on Windows 7 (not supported)
 - Safari 4 on Mac OS X 10.6.8

Not all of the data can be inferred from the results, but it's
consistent with the results.

The HTMLSelectElement entries are removed, since they're not in any spec
and there are no MDN pages for them. Support on HTMLSelectElement may
have slightly preceded focus() and blur() on HTMLElement, but it's so
long ago that it's not worth capturing with notes.