### PR TITLE
Add missing api.SpeechRecognitionEvent.SpeechRecognitionEvent feature

### DIFF
--- a/api/SpeechRecognitionEvent.json
+++ b/api/SpeechRecognitionEvent.json
@@ -53,6 +53,59 @@
           "deprecated": false
         }
       },
+      "SpeechRecognitionEvent": {
+        "__compat": {
+          "description": "<code>SpeechRecognitionEvent()</code> constructor",
+          "support": {
+            "chrome": {
+              "prefix": "webkit",
+              "version_added": "33"
+            },
+            "chrome_android": {
+              "prefix": "webkit",
+              "version_added": true
+            },
+            "edge": {
+              "prefix": "webkit",
+              "version_added": "≤79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "14.1"
+            },
+            "safari_ios": {
+              "version_added": "14.5"
+            },
+            "samsunginternet_android": {
+              "prefix": "webkit",
+              "version_added": true
+            },
+            "webview_android": {
+              "prefix": "webkit",
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
       "emma": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionEvent/emma",

--- a/api/SpeechRecognitionEvent.json
+++ b/api/SpeechRecognitionEvent.json
@@ -100,9 +100,9 @@
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": false,
-            "deprecated": true
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `SpeechRecognitionEvent` member of the SpeechRecognitionEvent API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SpeechRecognitionEvent/SpeechRecognitionEvent
