### PR TITLE
Add missing WorkletGlobalScope API

### DIFF
--- a/api/WorkletGlobalScope.json
+++ b/api/WorkletGlobalScope.json
@@ -1,0 +1,52 @@
+{
+  "api": {
+    "WorkletGlobalScope": {
+      "__compat": {
+        "spec_url": "https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope",
+        "support": {
+          "chrome": {
+            "version_added": "65"
+          },
+          "chrome_android": {
+            "version_added": "65"
+          },
+          "edge": {
+            "version_added": "79"
+          },
+          "firefox": {
+            "version_added": "76"
+          },
+          "firefox_android": {
+            "version_added": "79"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "52"
+          },
+          "opera_android": {
+            "version_added": "47"
+          },
+          "safari": {
+            "version_added": "14.1"
+          },
+          "safari_ios": {
+            "version_added": "14.5"
+          },
+          "samsunginternet_android": {
+            "version_added": "9.0"
+          },
+          "webview_android": {
+            "version_added": "65"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `WorkletGlobalScope` API by copying the version numbers from the Worker API itself.
