### PR TITLE
Add missing api.RTCPeerConnectionIceErrorEvent.RTCPeerConnectionIceErrorEvent feature

### DIFF
--- a/api/RTCPeerConnectionIceErrorEvent.json
+++ b/api/RTCPeerConnectionIceErrorEvent.json
@@ -48,6 +48,55 @@
           "deprecated": false
         }
       },
+      "RTCPeerConnectionIceErrorEvent": {
+        "__compat": {
+          "description": "<code>RTCPeerConnectionIceErrorEvent()</code> constructor",
+          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnectioniceerrorevent-constructor",
+          "support": {
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "77"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "64"
+            },
+            "opera_android": {
+              "version_added": "55"
+            },
+            "safari": {
+              "version_added": "14.1"
+            },
+            "safari_ios": {
+              "version_added": "14.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "12.0"
+            },
+            "webview_android": {
+              "version_added": "77"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "address": {
         "__compat": {
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnectioniceerrorevent-address",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `RTCPeerConnectionIceErrorEvent` member of the RTCPeerConnectionIceErrorEvent API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCPeerConnectionIceErrorEvent/RTCPeerConnectionIceErrorEvent
