### PR TITLE
Add Chromium versions for WritableStreamDefaultController API

### DIFF
--- a/api/WritableStreamDefaultController.json
+++ b/api/WritableStreamDefaultController.json
@@ -12,7 +12,7 @@
             "version_added": "58"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "16"
           },
           "firefox": {
             "version_added": false
@@ -54,10 +54,10 @@
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-ws-default-controller-error①",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": "59"
             },
             "edge": {
               "version_added": "16"
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "14.1"
@@ -84,10 +84,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": null
+              "version_added": "58"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `WritableStreamDefaultController` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WritableStreamDefaultController
