### PR TITLE
Update RTCDataChannel (spec_url, flags)

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -57,7 +57,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -105,7 +105,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -154,7 +154,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -260,7 +260,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -430,10 +430,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -507,7 +507,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -556,7 +556,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -605,7 +605,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -704,7 +704,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -760,7 +760,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -809,7 +809,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -879,10 +879,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": true
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": true
             },
             "ie": {
               "version_added": false
@@ -907,7 +907,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -956,7 +956,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -1005,7 +1005,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -1104,7 +1104,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -1112,7 +1112,7 @@
       },
       "priority": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel/priority",
+          "spec_url": "https://w3c.github.io/webrtc-priority/#dom-rtcdatachannel-priority",
           "support": {
             "chrome": {
               "version_added": false
@@ -1152,7 +1152,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -1201,7 +1201,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -1250,7 +1250,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -1299,7 +1299,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }


### PR DESCRIPTION
So here is what I did:
- most of the entries are no more experimental (two implementations for years). I removed them
- `id` is supported by Firefox (see https://bugzilla.mozilla.org/show_bug.cgi?id=1531904 that _update_ it in Firefox 68). I updated it to `true` as there are alot of `true` entries for Fx on this interface. I removed the experimental flag there too.
- `onerror` is also supported by Firefox and therefore not experimental (was put in the webidl when the interface was added to Firefox)
- `reliable` is no more on the standard track
- `priority` was missing `spec_url` and its `mdn_url` was 404.
