### PR TITLE
Add spec url for XRInputSource.gamepad

### DIFF
--- a/api/XRInputSource.json
+++ b/api/XRInputSource.json
@@ -51,6 +51,7 @@
       "gamepad": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRInputSource/gamepad",
+          "spec_url": "https://immersive-web.github.io/webxr-gamepads-module/#dom-xrinputsource-gamepad",
           "support": {
             "chrome": {
               "version_added": "79"


### PR DESCRIPTION
(I'm creating this missing MDN page)