### PR TITLE
Updates to CSSStyleSheet

### DIFF
--- a/api/CSSStyleSheet.json
+++ b/api/CSSStyleSheet.json
@@ -51,6 +51,8 @@
       "CSSStyleSheet": {
         "__compat": {
           "description": "<code>CSSStyleSheet()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/CSSStyleSheet",
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-cssstylesheet-cssstylesheet",
           "support": {
             "chrome": {
               "version_added": "73"
@@ -62,7 +64,15 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "73",
+              "notes": "See <a href='https://bugzil.la/1520690'>bug 1520690</a>",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.constructable-stylesheets.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -90,8 +100,8 @@
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": false,
+            "experimental": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -444,6 +454,8 @@
       },
       "replace": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/replace",
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-cssstylesheet-replace",
           "support": {
             "chrome": {
               "version_added": "73"
@@ -455,7 +467,15 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "75",
+              "notes": "See <a href='https://bugzil.la/1613746'>bug 1613746</a>",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.constructable-stylesheets.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -483,14 +503,16 @@
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": false,
+            "experimental": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
       },
       "replaceSync": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleSheet/replaceSync",
+          "spec_url": "https://drafts.csswg.org/cssom/#dom-cssstylesheet-replacesync",
           "support": {
             "chrome": {
               "version_added": "73"
@@ -502,7 +524,15 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "75",
+              "notes": "See <a href='https://bugzil.la/1613746'>bug 1613746</a>",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.constructable-stylesheets.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -530,8 +560,8 @@
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": false,
+            "experimental": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
Adds the spec and MDN URLs to the missing CSSStyleSheet constructor and replace, replaceSync pages.

Also, removed experimental and added to standard as these are in a spec, are in all the Chromium browsers, and are being implemented in Firefox.

While looking up the status of these I discovered that there is a behind a flag implementation in Firefox, so I have updated the Firefox support and linked to the bugs.