### PR TITLE
Adds spec and MDN URL to stringifier.

### DIFF
--- a/api/CSSStyleValue.json
+++ b/api/CSSStyleValue.json
@@ -148,6 +148,8 @@
       },
       "toString": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleValue/toString",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#CSSStyleValue-stringification-behavior",
           "support": {
             "chrome": {
               "version_added": "66"


### PR DESCRIPTION
Adding a spec and MDN URL to the CSSStyleValue stringifier, as I'm adding the missing page. 