### PR TITLE
Add missing features for DOMMatrix API

### DIFF
--- a/api/DOMMatrix.json
+++ b/api/DOMMatrix.json
@@ -100,7 +100,6 @@
       },
       "a": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/a",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-a",
           "support": {
             "chrome": {
@@ -149,7 +148,6 @@
       },
       "b": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/b",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-b",
           "support": {
             "chrome": {
@@ -198,7 +196,6 @@
       },
       "c": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/c",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-c",
           "support": {
             "chrome": {
@@ -247,7 +244,6 @@
       },
       "d": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/d",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-d",
           "support": {
             "chrome": {
@@ -296,7 +292,6 @@
       },
       "e": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/e",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-e",
           "support": {
             "chrome": {
@@ -345,7 +340,6 @@
       },
       "f": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/f",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-f",
           "support": {
             "chrome": {
@@ -588,7 +582,6 @@
       },
       "m11": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m11",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m11",
           "support": {
             "chrome": {
@@ -637,7 +630,6 @@
       },
       "m12": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m12",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m12",
           "support": {
             "chrome": {
@@ -686,7 +678,6 @@
       },
       "m13": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m13",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m13",
           "support": {
             "chrome": {
@@ -735,7 +726,6 @@
       },
       "m14": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m14",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m14",
           "support": {
             "chrome": {
@@ -784,7 +774,6 @@
       },
       "m21": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m21",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m21",
           "support": {
             "chrome": {
@@ -833,7 +822,6 @@
       },
       "m22": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m22",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m22",
           "support": {
             "chrome": {
@@ -882,7 +870,6 @@
       },
       "m23": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m23",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m23",
           "support": {
             "chrome": {
@@ -931,7 +918,6 @@
       },
       "m24": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m24",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m24",
           "support": {
             "chrome": {
@@ -980,7 +966,6 @@
       },
       "m31": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m31",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m31",
           "support": {
             "chrome": {
@@ -1029,7 +1014,6 @@
       },
       "m32": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m32",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m32",
           "support": {
             "chrome": {
@@ -1078,7 +1062,6 @@
       },
       "m33": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m33",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m33",
           "support": {
             "chrome": {
@@ -1127,7 +1110,6 @@
       },
       "m34": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m34",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m34",
           "support": {
             "chrome": {
@@ -1176,7 +1158,6 @@
       },
       "m41": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m41",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m41",
           "support": {
             "chrome": {
@@ -1225,7 +1206,6 @@
       },
       "m42": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m42",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m42",
           "support": {
             "chrome": {
@@ -1274,7 +1254,6 @@
       },
       "m43": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m43",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m43",
           "support": {
             "chrome": {
@@ -1323,7 +1302,6 @@
       },
       "m44": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m44",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m44",
           "support": {
             "chrome": {

--- a/api/DOMMatrix.json
+++ b/api/DOMMatrix.json
@@ -98,6 +98,300 @@
           }
         }
       },
+      "a": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/a",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-a",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "b": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/b",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-b",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "c": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/c",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-c",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "d": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/d",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-d",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "e": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/e",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-e",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "f": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/f",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-f",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "fromFloat32Array": {
         "__compat": {
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrix-fromfloat32array",
@@ -247,6 +541,790 @@
       },
       "invertSelf": {
         "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "m11": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m11",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m11",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "m12": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m12",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m12",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "m13": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m13",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m13",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "m14": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m14",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m14",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "m21": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m21",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m21",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "m22": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m22",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m22",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "m23": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m23",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m23",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "m24": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m24",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m24",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "m31": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m31",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m31",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "m32": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m32",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m32",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "m33": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m33",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m33",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "m34": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m34",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m34",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "m41": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m41",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m41",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "m42": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m42",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m42",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "m43": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m43",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m43",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "33"
+            },
+            "firefox_android": {
+              "version_added": "33"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "11"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "m44": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/m44",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m44",
           "support": {
             "chrome": {
               "version_added": "61"


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing features of the DOMMatrix API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DOMMatrix
