### PR TITLE
Add missing features for DOMRect API

### DIFF
--- a/api/DOMRect.json
+++ b/api/DOMRect.json
@@ -248,10 +248,10 @@
               "version_added": "4"
             },
             "opera": {
-              "version_added": "≤12.1"
+              "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "4"
@@ -260,10 +260,10 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": "8.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "2"
             }
           },
           "status": {
@@ -296,10 +296,10 @@
               "version_added": "4"
             },
             "opera": {
-              "version_added": "≤12.1"
+              "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "4"
@@ -308,10 +308,10 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": "8.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "2"
             }
           },
           "status": {

--- a/api/DOMRect.json
+++ b/api/DOMRect.json
@@ -230,41 +230,40 @@
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrect-height",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "2"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "18"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": "27"
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": "27"
+              "version_added": "4"
             },
             "ie": {
-              "version_added": false,
-              "notes": "Implemented on the proprietary <code><a href='https://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a></code> interface."
+              "version_added": "4"
             },
             "opera": {
-              "version_added": "48"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "45"
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -279,41 +278,40 @@
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrect-width",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "2"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "18"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": "27"
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": "27"
+              "version_added": "4"
             },
             "ie": {
-              "version_added": false,
-              "notes": "Implemented on the proprietary <code><a href='https://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a></code> interface."
+              "version_added": "4"
             },
             "opera": {
-              "version_added": "48"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "45"
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -376,13 +374,13 @@
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrect-x",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "2"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "18"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "31"
@@ -391,25 +389,25 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": false
+              "version_added": "4"
             },
             "opera": {
-              "version_added": "48"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "45"
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -424,13 +422,13 @@
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrect-y",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "2"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "18"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "31"
@@ -439,25 +437,25 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": false
+              "version_added": "4"
             },
             "opera": {
-              "version_added": "48"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "45"
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/DOMRect.json
+++ b/api/DOMRect.json
@@ -227,7 +227,6 @@
       },
       "height": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/height",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrectreadonly-height",
           "support": {
             "chrome": {
@@ -277,7 +276,6 @@
       },
       "width": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/width",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrectreadonly-width",
           "support": {
             "chrome": {
@@ -375,7 +373,6 @@
       },
       "x": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/x",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrectreadonly-x",
           "support": {
             "chrome": {
@@ -424,7 +421,6 @@
       },
       "y": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/y",
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrectreadonly-y",
           "support": {
             "chrome": {

--- a/api/DOMRect.json
+++ b/api/DOMRect.json
@@ -225,6 +225,106 @@
           }
         }
       },
+      "height": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/height",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrectreadonly-height",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "27"
+            },
+            "firefox_android": {
+              "version_added": "27"
+            },
+            "ie": {
+              "version_added": false,
+              "notes": "Implemented on the proprietary <code><a href='https://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a></code> interface."
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "width": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/width",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrectreadonly-width",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "27"
+            },
+            "firefox_android": {
+              "version_added": "27"
+            },
+            "ie": {
+              "version_added": false,
+              "notes": "Implemented on the proprietary <code><a href='https://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a></code> interface."
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "worker_support": {
         "__compat": {
           "description": "Available in workers",
@@ -243,6 +343,104 @@
             },
             "firefox_android": {
               "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "x": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/x",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrectreadonly-x",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "61"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "y": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/y",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrectreadonly-y",
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "31"
             },
             "ie": {
               "version_added": false

--- a/api/DOMRect.json
+++ b/api/DOMRect.json
@@ -227,7 +227,7 @@
       },
       "height": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrectreadonly-height",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrect-height",
           "support": {
             "chrome": {
               "version_added": "61"
@@ -276,7 +276,7 @@
       },
       "width": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrectreadonly-width",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrect-width",
           "support": {
             "chrome": {
               "version_added": "61"
@@ -373,7 +373,7 @@
       },
       "x": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrectreadonly-x",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrect-x",
           "support": {
             "chrome": {
               "version_added": "61"
@@ -421,7 +421,7 @@
       },
       "y": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrectreadonly-y",
+          "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrect-y",
           "support": {
             "chrome": {
               "version_added": "61"

--- a/api/DOMRect.json
+++ b/api/DOMRect.json
@@ -374,13 +374,13 @@
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrect-x",
           "support": {
             "chrome": {
-              "version_added": "2"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "61"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "31"
@@ -389,25 +389,25 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": "4"
+              "version_added": false
             },
             "opera": {
-              "version_added": "≤12.1"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": "45"
             },
             "safari": {
-              "version_added": "4"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "61"
             }
           },
           "status": {
@@ -422,13 +422,13 @@
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrect-y",
           "support": {
             "chrome": {
-              "version_added": "2"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "61"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "31"
@@ -437,25 +437,25 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": "4"
+              "version_added": false
             },
             "opera": {
-              "version_added": "≤12.1"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": "45"
             },
             "safari": {
-              "version_added": "4"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "3.2"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "61"
             }
           },
           "status": {


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing features of the DOMRect API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DOMRect
