### PR TITLE
Add missing api.Navigator.storage feature

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3134,7 +3134,7 @@
       },
       "storage": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/Navigator/storage",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/storage",
           "spec_url": "https://storage.spec.whatwg.org/#dom-navigatorstorage-storage",
           "support": {
             "chrome": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3132,6 +3132,54 @@
           }
         }
       },
+      "storage": {
+        "__compat": {
+          "spec_url": "https://storage.spec.whatwg.org/#dom-navigatorstorage-storage",
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "55"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "57"
+            },
+            "firefox_android": {
+              "version_added": "57"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42"
+            },
+            "opera_android": {
+              "version_added": "42"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": "55"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "taintEnabled": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/taintEnabled",

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3134,6 +3134,7 @@
       },
       "storage": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/Navigator/storage",
           "spec_url": "https://storage.spec.whatwg.org/#dom-navigatorstorage-storage",
           "support": {
             "chrome": {


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `storage` member of the Navigator API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Navigator/storage
