### PR TITLE
Add missing api.BluetoothRemoteGATTCharacteristic.oncharacteristicvaluechanged feature

### DIFF
--- a/api/BluetoothRemoteGATTCharacteristic.json
+++ b/api/BluetoothRemoteGATTCharacteristic.json
@@ -308,6 +308,54 @@
           }
         }
       },
+      "oncharacteristicvaluechanged": {
+        "__compat": {
+          "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-characteristiceventhandlers-oncharacteristicvaluechanged",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "56"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "properties": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTCharacteristic/properties",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `oncharacteristicvaluechanged` member of the BluetoothRemoteGATTCharacteristic API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/BluetoothRemoteGATTCharacteristic/oncharacteristicvaluechanged
