### PR TITLE
Add missing features for WorkerNavigator API

### DIFF
--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -902,10 +902,10 @@
           "spec_url": "https://wicg.github.io/webusb/#dom-workernavigator-usb",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "69"
+              "version_added": "70"
             },
             "edge": {
               "version_added": "79"
@@ -920,10 +920,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "56"
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -935,7 +935,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "69"
+              "version_added": "70"
             }
           },
           "status": {

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -244,6 +244,54 @@
           }
         }
       },
+      "deviceMemory": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/device-memory/#sec-device-memory-js-api",
+          "support": {
+            "chrome": {
+              "version_added": "65"
+            },
+            "chrome_android": {
+              "version_added": "65"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "52"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "9.0"
+            },
+            "webview_android": {
+              "version_added": "65"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "hardwareConcurrency": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/hardwareConcurrency",
@@ -396,6 +444,102 @@
           },
           "status": {
             "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "locks": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/web-locks/#dom-navigatorlocks-locks",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mediaCapabilities": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/media-capabilities/#dom-navigator-mediacapabilities",
+          "support": {
+            "chrome": {
+              "version_added": "76"
+            },
+            "chrome_android": {
+              "version_added": "76"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "63"
+            },
+            "firefox_android": {
+              "version_added": "63"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "63"
+            },
+            "opera_android": {
+              "version_added": "54"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "12.0"
+            },
+            "webview_android": {
+              "version_added": "76"
+            }
+          },
+          "status": {
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -744,6 +888,54 @@
             },
             "webview_android": {
               "version_added": "55"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "usb": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/webusb/#dom-workernavigator-usb",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
             }
           },
           "status": {


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing features of the WorkerNavigator API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WorkerNavigator
