### PR TITLE
FF91 Window.clientInformation as alias for .navigator

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -4132,12 +4132,24 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
+            "firefox": [
+              {
+                "version_added": "1"
+              },
+              {
+                "version_added": "91",
+                "alternative_name": "clientInformation"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "4"
+              },
+              {
+                "version_added": "91",
+                "alternative_name": "clientInformation"
+              }
+            ],
             "ie": {
               "version_added": "4"
             },


### PR DESCRIPTION
`window.clientInformation` is an alias of `Window.navigator`. 

Historically this was non-spec but was present in Chrome (and others using same engine) and also Safari (since at least Feb 2017 according to https://github.com/whatwg/html/issues/2379).
It was added to the [spec here](https://html.spec.whatwg.org/multipage/window-object.html#the-window-object:dom-clientinformation) as a "legacy alias"  in [this PR](https://github.com/whatwg/html/pull/6721), 
FF91 added it as an alias in https://bugzilla.mozilla.org/show_bug.cgi?id=1717072. It is default enabled (but there is a preference to allow it to be disabled easily if needed).

This PR simply adds the alias information as a new version with `"alternative_name": "clientInformation"` for Firefox. 
- Is this correct?
- There is a preference but it is set `true` by default. Do I need to add a flag for it in this case (I have assumed not).

As per the notes, Chromium based browsers (Opera, Chrome, Edge etc.) and Safari supported this even though non-spec since Feb 2017. However I have no idea of what versions this would have been added. How would you like to handle this? Can you help find versions, or could we assume that for those platforms the alternative name as been there since day 1 (just add a new version for chrome etc with the same release number and the alterative name)?

FYI, this is one of the items linked in https://github.com/mdn/browser-compat-data/issues/7585