### PR TITLE
Remove ClientRect alternative name and notes from DOMRectReadOnly

### DIFF
--- a/api/DOMRectReadOnly.json
+++ b/api/DOMRectReadOnly.json
@@ -11,30 +11,18 @@
           "chrome_android": {
             "version_added": "61"
           },
-          "edge": [
-            {
-              "version_added": "79"
-            },
-            {
-              "alternative_name": "ClientRect",
-              "version_added": "12"
-            }
-          ],
+          "edge": {
+            "version_added": "79"
+          },
           "firefox": {
             "version_added": "31"
           },
           "firefox_android": {
             "version_added": "31"
           },
-          "ie": [
-            {
-              "version_added": false
-            },
-            {
-              "alternative_name": "ClientRect",
-              "version_added": true
-            }
-          ],
+          "ie": {
+            "version_added": false
+          },
           "opera": {
             "version_added": "48"
           },
@@ -131,8 +119,7 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": false,
-              "notes": "Implemented on the proprietary <code><a href='https://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a></code> interface."
+              "version_added": false
             },
             "opera": {
               "version_added": "48"
@@ -231,8 +218,7 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": false,
-              "notes": "Implemented on the proprietary <code><a href='https://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a></code> interface."
+              "version_added": false
             },
             "opera": {
               "version_added": "48"
@@ -281,8 +267,7 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": false,
-              "notes": "Implemented on the proprietary <code><a href='https://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a></code> interface."
+              "version_added": false
             },
             "opera": {
               "version_added": "48"
@@ -331,8 +316,7 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": false,
-              "notes": "Implemented on the proprietary <code><a href='https://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a></code> interface."
+              "version_added": false
             },
             "opera": {
               "version_added": "48"
@@ -428,8 +412,7 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": false,
-              "notes": "Implemented on the proprietary <code><a href='https://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a></code> interface."
+              "version_added": false
             },
             "opera": {
               "version_added": "48"
@@ -478,8 +461,7 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": false,
-              "notes": "Implemented on the proprietary <code><a href='https://msdn.microsoft.com/en-us/library/hh826029(VS.85).aspx'>ClientRect</a></code> interface."
+              "version_added": false
             },
             "opera": {
               "version_added": "48"


### PR DESCRIPTION
This is already represented on DOMRect for all browsers.