### PR TITLE
Add spec URL for navigator.usb

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3238,6 +3238,7 @@
       },
       "usb": {
         "__compat": {
+          "spec_url": "https://wicg.github.io/webusb/#dom-workernavigator-usb",
           "support": {
             "chrome": {
               "version_added": "61"
@@ -3277,8 +3278,8 @@
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": false,
+            "experimental": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3238,7 +3238,7 @@
       },
       "usb": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/webusb/#dom-workernavigator-usb",
+          "spec_url": "https://wicg.github.io/webusb/#dom-navigator-usb",
           "support": {
             "chrome": {
               "version_added": "61"


### PR DESCRIPTION
And flip the statuses. Experimental is per this guideline:
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#choosing-an-experimental-status
