### PR TITLE
Update Chromium versions for StorageManager API

### DIFF
--- a/api/StorageManager.json
+++ b/api/StorageManager.json
@@ -6,10 +6,10 @@
         "spec_url": "https://storage.spec.whatwg.org/#storagemanager",
         "support": {
           "chrome": {
-            "version_added": "48"
+            "version_added": "55"
           },
           "chrome_android": {
-            "version_added": "48"
+            "version_added": "55"
           },
           "edge": {
             "version_added": "79"
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "42"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "42"
           },
           "safari": {
             "version_added": false
@@ -36,10 +36,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "5.0"
+            "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": "48"
+            "version_added": "55"
           }
         },
         "status": {
@@ -54,10 +54,10 @@
           "spec_url": "https://storage.spec.whatwg.org/#ref-for-dom-storagemanager-estimate",
           "support": {
             "chrome": {
-              "version_added": "52"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "52"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "safari": {
               "version_added": false
@@ -84,10 +84,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "52"
+              "version_added": "61"
             }
           },
           "status": {
@@ -149,26 +149,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageManager/persist",
           "spec_url": "https://storage.spec.whatwg.org/#ref-for-dom-storagemanager-persist",
           "support": {
-            "chrome": [
-              {
-                "version_added": "52"
-              },
-              {
-                "alternative_name": "requestPersistent",
-                "version_added": "48",
-                "version_removed": "52"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "alternative_name": "requestPersistent",
-                "version_added": "48",
-                "version_removed": "52"
-              }
-            ],
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "55"
+            },
             "edge": {
               "version_added": "79"
             },
@@ -182,10 +168,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "42"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -193,26 +179,12 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "6.0"
-              },
-              {
-                "alternative_name": "requestPersistent",
-                "version_added": "5.0",
-                "version_removed": "6.0"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "alternative_name": "requestPersistent",
-                "version_added": "48",
-                "version_removed": "52"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": "55"
+            }
           },
           "status": {
             "experimental": false,
@@ -226,26 +198,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageManager/persisted",
           "spec_url": "https://storage.spec.whatwg.org/#dom-storagemanager-persisted",
           "support": {
-            "chrome": [
-              {
-                "version_added": "52"
-              },
-              {
-                "alternative_name": "persistentPermission",
-                "version_added": "48",
-                "version_removed": "52"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "alternative_name": "persistentPermission",
-                "version_added": "48",
-                "version_removed": "52"
-              }
-            ],
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "55"
+            },
             "edge": {
               "version_added": "79"
             },
@@ -259,10 +217,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "42"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "42"
             },
             "safari": {
               "version_added": false
@@ -270,26 +228,12 @@
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "6.0"
-              },
-              {
-                "alternative_name": "persistentPermission",
-                "version_added": "5.0",
-                "version_removed": "6.0"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "alternative_name": "persistentPermission",
-                "version_added": "48",
-                "version_removed": "52"
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": "55"
+            }
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `StorageManager` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/StorageManager
