### PR TITLE
Update Firefox and Safari support for `display-capture` feature-policy

### DIFF
--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -360,25 +360,25 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "67",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "74",
+                  "partial_implementation": true,
+                  "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+                },
+                {
+                  "version_added": "67",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": {
-                "version_added": "67",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false
@@ -390,7 +390,9 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "13",
+                "partial_implementation": true,
+                "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
               },
               "safari_ios": {
                 "version_added": false
@@ -403,7 +405,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

This PR updates Firefox and Safari support for the `display-capture` feature policy. Also unmarks as experimental as it has at least 2 stable implementations.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

For Safari it's an educated guess based on the fact Safari implemented getDisplayMedia in Safari 13, and [this commit ](https://github.com/WebKit/WebKit/commit/c06555f8c754ac0ffa5e3a3f8929150f2b81931f) which implements this feature was done in May 2019 which was before Safari 13 release.

I have also verified that it is at the very least implemented in Safari 14.1.

For the Firefox version, I tested with https://plastic-brief-carnation.glitch.me/ on browser stack and version 74 is when it worked as expected. I cannot find any mention of this in any Firefox release notes (I checked from version 67 onwards).

Tested on Firefox 92 and Safari 15 with https://demo.lukewarlow.uk/feature-policy/display-capture/ and can see that it doesn't support the header.

Firefox Android doesn't support get display media, and even when that's enabled (`media.getdisplaymedia.enabled`) it still doesn't actually work. So this feature policy can't be implemented in any meaningful way.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fixes #11554

Closes https://github.com/mdn/browser-compat-data/issues/12708

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
