### PR TITLE
Update Chromium versions for BluetoothDevice API

### DIFF
--- a/api/BluetoothDevice.json
+++ b/api/BluetoothDevice.json
@@ -5,15 +5,51 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice",
         "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#bluetoothdevice-interface",
         "support": {
-          "chrome": {
-            "version_added": "74"
-          },
+          "chrome": [
+            {
+              "version_added": "56",
+              "notes": "macOS only."
+            },
+            {
+              "version_added": "56",
+              "notes": "Linux and versions of Windows earlier than 10.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "70",
+              "notes": "Windows 10."
+            }
+          ],
           "chrome_android": {
-            "version_added": "74"
+            "version_added": "56"
           },
-          "edge": {
-            "version_added": "79"
-          },
+          "edge": [
+            {
+              "version_added": "79",
+              "notes": "macOS only."
+            },
+            {
+              "version_added": "79",
+              "notes": "Linux and versions of Windows earlier than 10.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "79",
+              "notes": "Windows 10."
+            }
+          ],
           "firefox": {
             "version_added": false
           },
@@ -23,11 +59,29 @@
           "ie": {
             "version_added": false
           },
-          "opera": {
-            "version_added": "62"
-          },
+          "opera": [
+            {
+              "version_added": "43",
+              "notes": "macOS only."
+            },
+            {
+              "version_added": "43",
+              "notes": "Linux and versions of Windows earlier than 10.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "57",
+              "notes": "Windows 10."
+            }
+          ],
           "opera_android": {
-            "version_added": "53"
+            "version_added": "43"
           },
           "safari": {
             "version_added": false
@@ -36,7 +90,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "11.0"
+            "version_added": "6.0"
           },
           "webview_android": {
             "version_added": false
@@ -54,10 +108,10 @@
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-gatt",
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": "74"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "79"
@@ -72,10 +126,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "62"
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": "53"
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -84,7 +138,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "11.0"
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -103,10 +157,10 @@
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-id",
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": "74"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "79"
@@ -121,10 +175,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "62"
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": "53"
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -133,7 +187,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "11.0"
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -152,10 +206,10 @@
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-name",
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": "74"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "79"
@@ -170,10 +224,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "62"
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": "53"
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -182,7 +236,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "11.0"
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
This PR corrects the version numbers for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `BluetoothDevice` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/BluetoothDevice
