### PR TITLE
Add IE versions for api.CloseEvent.CloseEvent

### DIFF
--- a/api/CloseEvent.json
+++ b/api/CloseEvent.json
@@ -74,7 +74,7 @@
               "version_added": "8"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `CloseEvent` member of the `CloseEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CloseEvent/CloseEvent
