### PR TITLE
Add IE/Edge versions for api.Document.pointercapture_event

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -6021,7 +6021,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "59"
@@ -6030,7 +6030,7 @@
               "version_added": "79"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "44"
@@ -7065,7 +7065,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "59"
@@ -7074,7 +7074,7 @@
               "version_added": "79"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "44"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `pointercapture_event` member of the `Document` API.  The data was mirrorred from their event handler counterparts from `GlobalEventHandlers`.
