### PR TITLE
Add IE versions for api.Element.fullscreen_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2868,7 +2868,7 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": [
               {
@@ -2988,7 +2988,7 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": [
               {


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `fullscreen_event` member of the `Element` API.  The data was copied from their event handler counterparts.
