### PR TITLE
Add all browsers versions for api.Element.error_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2605,28 +2605,28 @@
           "spec_url": "https://w3c.github.io/uievents/#event-type-error",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "1"
@@ -2635,10 +2635,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for all browsers for the `error_event` member of the `Element` API, based upon manual testing.

Test Code Used:
```
<div id="test">
	<div class="controls">
	  <button id="img-error" type="button">Generate image error</button>
	  <img id="bad-img" />
	</div>
</div>

<script>
	var badImg = document.getElementById('bad-img');
	badImg.addEventListener('error', function(event) {
		alert('Error!');
	});

	var imgError = document.getElementById('img-error');
	imgError.addEventListener('click', function() {
	    badImg.setAttribute('src', 'i-dont-exist');
	});
</script>
```
