### PR TITLE
Add IE/Edge versions for api.Element.mousewheel_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -5362,7 +5362,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": false
@@ -5371,7 +5371,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤15"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `mousewheel_event` member of the `Element` API, based upon manual testing.

Test Code Used: `document.addEventListener('mousewheel', function() {alert('Wheel!');});`
