### PR TITLE
Add IE/Edge versions for api.Element.scroll_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -6906,7 +6906,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -6915,7 +6915,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `scroll_event` member of the `Element` API, based upon manual testing.

Test Code Used:
```
<style id="test-style">
	body {
		height: 3000px;
	}
</style>

<script>
	window.addEventListener('scroll', function() {alert('Event!');});
	window.attachEvent('scroll', function() {alert('Event!');});
</script>
```
