### PR TITLE
Add IE/Edge versions for api.Element.select_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -7651,7 +7651,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -7660,7 +7660,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `select_event` member of the `Element` API, based upon manual testing.

Test Code Used:
```
<div id="test">
	<form>
		<input value="Lorem ipsum dolor sit amet" />
	</form>
</div>

<script>
	var el = document.forms[0].children[0];

	el.addEventListener('select', function() {
		alert('Event!');
	});
	el.attachEvent('select', function() {
		alert('Event!');
	});
</script>
```
