### PR TITLE
Update IE support for Fullscreen API

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -6530,7 +6530,7 @@
             ],
             "ie": {
               "version_added": "11",
-              "prefix": "ms"
+              "alternative_name": "msRequestFullscreen"
             },
             "opera": [
               {

--- a/api/_mixins/DocumentOrShadowRoot__Document.json
+++ b/api/_mixins/DocumentOrShadowRoot__Document.json
@@ -272,8 +272,8 @@
               }
             ],
             "ie": {
-              "version_added": true,
-              "prefix": "ms"
+              "version_added": "11",
+              "alternative_name": "msFullscreenElement"
             },
             "opera": [
               {


### PR DESCRIPTION
https://mdn-bcd-collector.appspot.com/tests/api/Element/msFullscreenElement was tested in IE 10 and 11.

`alternative_name` was used instead of `prefix` because there are capitalization differences in the prefixed APIs, and it seems good to spell it out in full.

(WebKit browsers have both capitalizations, and I intend to later update the data with both forms, since they weren't introduced at exactly the same time.)