### PR TITLE
Correct Chromium data for Bluetooth APIs and make consistent

### DIFF
--- a/api/Bluetooth.json
+++ b/api/Bluetooth.json
@@ -8,11 +8,12 @@
           "chrome": [
             {
               "version_added": "56",
-              "notes": "macOS only."
+              "partial_implementation": true,
+              "notes": "Before Chrome 70, this feature was only supported in macOS.  In Chrome 70, support was added for Windows 10. Linux support is not enabled by default."
             },
             {
               "version_added": "56",
-              "notes": "Linux and versions of Windows earlier than 10.",
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
@@ -20,10 +21,6 @@
                   "value_to_set": "enabled"
                 }
               ]
-            },
-            {
-              "version_added": "70",
-              "notes": "Windows 10."
             }
           ],
           "chrome_android": {
@@ -32,11 +29,12 @@
           "edge": [
             {
               "version_added": "79",
-              "notes": "macOS only."
+              "partial_implementation": true,
+              "notes": "Supported by default only on macOS and Windows 10. Linux support is not enabled by default."
             },
             {
               "version_added": "79",
-              "notes": "Linux and versions of Windows earlier than 10.",
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
@@ -44,10 +42,6 @@
                   "value_to_set": "enabled"
                 }
               ]
-            },
-            {
-              "version_added": "79",
-              "notes": "Windows 10."
             }
           ],
           "firefox": {
@@ -62,11 +56,12 @@
           "opera": [
             {
               "version_added": "43",
-              "notes": "macOS only."
+              "partial_implementation": true,
+              "notes": "Before Opera 57, this feature was only supported in macOS.  In Opera 57, support was added for Windows 10. Linux support is not enabled by default."
             },
             {
               "version_added": "43",
-              "notes": "Linux and versions of Windows earlier than 10.",
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
@@ -74,10 +69,6 @@
                   "value_to_set": "enabled"
                 }
               ]
-            },
-            {
-              "version_added": "57",
-              "notes": "Windows 10."
             }
           ],
           "opera_android": {
@@ -107,51 +98,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Bluetooth/getAvailability",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-getavailability",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -161,27 +116,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -287,51 +224,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Bluetooth/onavailabilitychanged",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#bluetooth",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -341,27 +242,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -390,51 +273,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Bluetooth/referringDevice",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-referringdevice",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -444,27 +291,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -493,51 +322,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Bluetooth/requestDevice",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-requestdevice",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -547,27 +340,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },

--- a/api/Bluetooth.json
+++ b/api/Bluetooth.json
@@ -84,7 +84,7 @@
             "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "56"
           }
         },
         "status": {
@@ -132,7 +132,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -258,7 +258,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -307,7 +307,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -356,7 +356,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {

--- a/api/Bluetooth.json
+++ b/api/Bluetooth.json
@@ -84,7 +84,7 @@
             "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": "56"
+            "version_added": false
           }
         },
         "status": {
@@ -132,7 +132,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -258,7 +258,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -307,7 +307,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -356,7 +356,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {

--- a/api/BluetoothCharacteristicProperties.json
+++ b/api/BluetoothCharacteristicProperties.json
@@ -8,11 +8,12 @@
           "chrome": [
             {
               "version_added": "56",
-              "notes": "ChromeOS and macOS only."
+              "partial_implementation": true,
+              "notes": "Before Chrome 70, this feature was only supported in macOS.  In Chrome 70, support was added for Windows 10. Linux support is not enabled by default."
             },
             {
               "version_added": "56",
-              "notes": "Linux and versions of Windows earlier than 10.",
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
@@ -20,10 +21,6 @@
                   "value_to_set": "enabled"
                 }
               ]
-            },
-            {
-              "version_added": "70",
-              "notes": "Windows 10."
             }
           ],
           "chrome_android": {
@@ -32,11 +29,12 @@
           "edge": [
             {
               "version_added": "79",
-              "notes": "macOS only."
+              "partial_implementation": true,
+              "notes": "Supported by default only on macOS and Windows 10. Linux support is not enabled by default."
             },
             {
               "version_added": "79",
-              "notes": "Linux and versions of Windows earlier than 10.",
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
@@ -44,10 +42,6 @@
                   "value_to_set": "enabled"
                 }
               ]
-            },
-            {
-              "version_added": "79",
-              "notes": "Windows 10."
             }
           ],
           "firefox": {
@@ -62,11 +56,12 @@
           "opera": [
             {
               "version_added": "43",
-              "notes": "macOS only."
+              "partial_implementation": true,
+              "notes": "Before Opera 57, this feature was only supported in macOS.  In Opera 57, support was added for Windows 10. Linux support is not enabled by default."
             },
             {
               "version_added": "43",
-              "notes": "Linux and versions of Windows earlier than 10.",
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
@@ -74,10 +69,6 @@
                   "value_to_set": "enabled"
                 }
               ]
-            },
-            {
-              "version_added": "57",
-              "notes": "Windows 10."
             }
           ],
           "opera_android": {
@@ -107,51 +98,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothCharacteristicProperties/authenticatedSignedWrites",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothcharacteristicproperties-authenticatedsignedwrites",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "ChromeOS and macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -161,27 +116,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -210,51 +147,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothCharacteristicProperties/broadcast",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothcharacteristicproperties-broadcast",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "ChromeOS and macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -264,27 +165,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -313,51 +196,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothCharacteristicProperties/indicate",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothcharacteristicproperties-indicate",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "ChromeOS and macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -367,27 +214,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -416,51 +245,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothCharacteristicProperties/notify",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothcharacteristicproperties-notify",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "ChromeOS and macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -470,27 +263,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -519,51 +294,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothCharacteristicProperties/read",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothcharacteristicproperties-read",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "ChromeOS and macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -573,27 +312,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -622,51 +343,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothCharacteristicProperties/reliableWrite",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothcharacteristicproperties-reliablewrite",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "ChromeOS and macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -676,27 +361,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -724,51 +391,15 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothCharacteristicProperties/writableAuxiliaries",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "ChromeOS and macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -778,27 +409,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -827,51 +440,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothCharacteristicProperties/write",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothcharacteristicproperties-write",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "ChromeOS and macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -881,27 +458,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -929,51 +488,15 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothCharacteristicProperties/writeWithoutResponse",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "ChromeOS and macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -983,27 +506,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },

--- a/api/BluetoothCharacteristicProperties.json
+++ b/api/BluetoothCharacteristicProperties.json
@@ -84,7 +84,7 @@
             "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": "56"
+            "version_added": false
           }
         },
         "status": {
@@ -132,7 +132,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -181,7 +181,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -230,7 +230,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -279,7 +279,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -328,7 +328,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -377,7 +377,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -425,7 +425,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -474,7 +474,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -522,7 +522,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {

--- a/api/BluetoothCharacteristicProperties.json
+++ b/api/BluetoothCharacteristicProperties.json
@@ -84,7 +84,7 @@
             "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "56"
           }
         },
         "status": {
@@ -132,7 +132,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -181,7 +181,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -230,7 +230,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -279,7 +279,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -328,7 +328,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -377,7 +377,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -425,7 +425,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -474,7 +474,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -522,7 +522,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {

--- a/api/BluetoothDevice.json
+++ b/api/BluetoothDevice.json
@@ -8,11 +8,12 @@
           "chrome": [
             {
               "version_added": "56",
-              "notes": "macOS only."
+              "partial_implementation": true,
+              "notes": "Before Chrome 70, this feature was only supported in macOS.  In Chrome 70, support was added for Windows 10. Linux support is not enabled by default."
             },
             {
               "version_added": "56",
-              "notes": "Linux and versions of Windows earlier than 10.",
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
@@ -20,10 +21,6 @@
                   "value_to_set": "enabled"
                 }
               ]
-            },
-            {
-              "version_added": "70",
-              "notes": "Windows 10."
             }
           ],
           "chrome_android": {
@@ -32,11 +29,12 @@
           "edge": [
             {
               "version_added": "79",
-              "notes": "macOS only."
+              "partial_implementation": true,
+              "notes": "Supported by default only on macOS and Windows 10. Linux support is not enabled by default."
             },
             {
               "version_added": "79",
-              "notes": "Linux and versions of Windows earlier than 10.",
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
@@ -44,10 +42,6 @@
                   "value_to_set": "enabled"
                 }
               ]
-            },
-            {
-              "version_added": "79",
-              "notes": "Windows 10."
             }
           ],
           "firefox": {
@@ -62,11 +56,12 @@
           "opera": [
             {
               "version_added": "43",
-              "notes": "macOS only."
+              "partial_implementation": true,
+              "notes": "Before Opera 57, this feature was only supported in macOS.  In Opera 57, support was added for Windows 10. Linux support is not enabled by default."
             },
             {
               "version_added": "43",
-              "notes": "Linux and versions of Windows earlier than 10.",
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
@@ -74,10 +69,6 @@
                   "value_to_set": "enabled"
                 }
               ]
-            },
-            {
-              "version_added": "57",
-              "notes": "Windows 10."
             }
           ],
           "opera_android": {

--- a/api/BluetoothDevice.json
+++ b/api/BluetoothDevice.json
@@ -5,15 +5,51 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice",
         "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#bluetoothdevice-interface",
         "support": {
-          "chrome": {
-            "version_added": "74"
-          },
+          "chrome": [
+            {
+              "version_added": "56",
+              "notes": "macOS only."
+            },
+            {
+              "version_added": "56",
+              "notes": "Linux and versions of Windows earlier than 10.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "70",
+              "notes": "Windows 10."
+            }
+          ],
           "chrome_android": {
-            "version_added": "74"
+            "version_added": "56"
           },
-          "edge": {
-            "version_added": "79"
-          },
+          "edge": [
+            {
+              "version_added": "79",
+              "notes": "macOS only."
+            },
+            {
+              "version_added": "79",
+              "notes": "Linux and versions of Windows earlier than 10.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "79",
+              "notes": "Windows 10."
+            }
+          ],
           "firefox": {
             "version_added": false
           },
@@ -23,11 +59,29 @@
           "ie": {
             "version_added": false
           },
-          "opera": {
-            "version_added": "62"
-          },
+          "opera": [
+            {
+              "version_added": "43",
+              "notes": "macOS only."
+            },
+            {
+              "version_added": "43",
+              "notes": "Linux and versions of Windows earlier than 10.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "57",
+              "notes": "Windows 10."
+            }
+          ],
           "opera_android": {
-            "version_added": "53"
+            "version_added": "43"
           },
           "safari": {
             "version_added": false
@@ -36,7 +90,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "11.0"
+            "version_added": "6.0"
           },
           "webview_android": {
             "version_added": false
@@ -54,10 +108,10 @@
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-gatt",
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": "74"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "79"
@@ -72,10 +126,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "62"
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": "53"
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -84,7 +138,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "11.0"
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -103,10 +157,10 @@
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-id",
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": "74"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "79"
@@ -121,10 +175,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "62"
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": "53"
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -133,7 +187,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "11.0"
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -152,10 +206,10 @@
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-name",
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": "74"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "79"
@@ -170,10 +224,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "62"
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": "53"
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -182,7 +236,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "11.0"
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/BluetoothDevice.json
+++ b/api/BluetoothDevice.json
@@ -93,7 +93,7 @@
             "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": "56"
+            "version_added": false
           }
         },
         "status": {
@@ -141,7 +141,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -190,7 +190,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -239,7 +239,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {

--- a/api/BluetoothDevice.json
+++ b/api/BluetoothDevice.json
@@ -93,7 +93,7 @@
             "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "56"
           }
         },
         "status": {
@@ -141,7 +141,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -190,7 +190,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -239,7 +239,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {

--- a/api/BluetoothRemoteGATTCharacteristic.json
+++ b/api/BluetoothRemoteGATTCharacteristic.json
@@ -84,7 +84,7 @@
             "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "56"
           }
         },
         "status": {
@@ -132,7 +132,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -181,7 +181,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -230,7 +230,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -279,7 +279,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -328,7 +328,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -377,7 +377,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -426,7 +426,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -475,7 +475,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -524,7 +524,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -573,7 +573,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {

--- a/api/BluetoothRemoteGATTCharacteristic.json
+++ b/api/BluetoothRemoteGATTCharacteristic.json
@@ -84,7 +84,7 @@
             "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": "56"
+            "version_added": false
           }
         },
         "status": {

--- a/api/BluetoothRemoteGATTCharacteristic.json
+++ b/api/BluetoothRemoteGATTCharacteristic.json
@@ -622,7 +622,7 @@
               "version_added": "14.0"
             },
             "webview_android": {
-              "version_added": "85"
+              "version_added": false
             }
           },
           "status": {
@@ -671,7 +671,7 @@
               "version_added": "14.0"
             },
             "webview_android": {
-              "version_added": "85"
+              "version_added": false
             }
           },
           "status": {

--- a/api/BluetoothRemoteGATTCharacteristic.json
+++ b/api/BluetoothRemoteGATTCharacteristic.json
@@ -8,11 +8,12 @@
           "chrome": [
             {
               "version_added": "56",
-              "notes": "macOS only."
+              "partial_implementation": true,
+              "notes": "Before Chrome 70, this feature was only supported in macOS.  In Chrome 70, support was added for Windows 10. Linux support is not enabled by default."
             },
             {
               "version_added": "56",
-              "notes": "Linux and versions of Windows earlier than 10.",
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
@@ -20,10 +21,6 @@
                   "value_to_set": "enabled"
                 }
               ]
-            },
-            {
-              "version_added": "70",
-              "notes": "Windows 10."
             }
           ],
           "chrome_android": {
@@ -32,11 +29,12 @@
           "edge": [
             {
               "version_added": "79",
-              "notes": "macOS only."
+              "partial_implementation": true,
+              "notes": "Supported by default only on macOS and Windows 10. Linux support is not enabled by default."
             },
             {
               "version_added": "79",
-              "notes": "Linux and versions of Windows earlier than 10.",
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
@@ -44,10 +42,6 @@
                   "value_to_set": "enabled"
                 }
               ]
-            },
-            {
-              "version_added": "79",
-              "notes": "Windows 10."
             }
           ],
           "firefox": {
@@ -62,11 +56,12 @@
           "opera": [
             {
               "version_added": "43",
-              "notes": "macOS only."
+              "partial_implementation": true,
+              "notes": "Before Opera 57, this feature was only supported in macOS.  In Opera 57, support was added for Windows 10. Linux support is not enabled by default."
             },
             {
               "version_added": "43",
-              "notes": "Linux and versions of Windows earlier than 10.",
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
@@ -74,10 +69,6 @@
                   "value_to_set": "enabled"
                 }
               ]
-            },
-            {
-              "version_added": "57",
-              "notes": "Windows 10."
             }
           ],
           "opera_android": {
@@ -93,7 +84,7 @@
             "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": "85"
+            "version_added": false
           }
         },
         "status": {
@@ -107,51 +98,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTCharacteristic/getDescriptor",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-getdescriptor",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -161,27 +116,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -210,51 +147,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTCharacteristic/getDescriptors",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-getdescriptors",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -264,27 +165,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -313,51 +196,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTCharacteristic/properties",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-properties",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -367,27 +214,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -416,51 +245,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTCharacteristic/readValue",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-readvalue",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -470,27 +263,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -519,51 +294,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTCharacteristic/service",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-service",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -573,27 +312,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -622,51 +343,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTCharacteristic/startNotifications",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-startnotifications",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -676,27 +361,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -725,51 +392,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTCharacteristic/stopNotifications",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-stopnotifications",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -779,27 +410,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -828,51 +441,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTCharacteristic/uuid",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-uuid",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -882,27 +459,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -931,51 +490,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTCharacteristic/value",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-value",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -985,27 +508,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -1034,51 +539,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTCharacteristic/writeValue",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-writevalue",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -1088,27 +557,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },

--- a/api/BluetoothRemoteGATTCharacteristic.json
+++ b/api/BluetoothRemoteGATTCharacteristic.json
@@ -132,7 +132,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -181,7 +181,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -230,7 +230,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -279,7 +279,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -328,7 +328,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -377,7 +377,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -426,7 +426,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -475,7 +475,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -524,7 +524,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -573,7 +573,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {

--- a/api/BluetoothRemoteGATTDescriptor.json
+++ b/api/BluetoothRemoteGATTDescriptor.json
@@ -84,7 +84,7 @@
             "version_added": "7.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "57"
           }
         },
         "status": {
@@ -132,7 +132,7 @@
               "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "57"
             }
           },
           "status": {
@@ -181,7 +181,7 @@
               "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "57"
             }
           },
           "status": {
@@ -230,7 +230,7 @@
               "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "57"
             }
           },
           "status": {
@@ -279,7 +279,7 @@
               "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "57"
             }
           },
           "status": {
@@ -328,7 +328,7 @@
               "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "57"
             }
           },
           "status": {

--- a/api/BluetoothRemoteGATTDescriptor.json
+++ b/api/BluetoothRemoteGATTDescriptor.json
@@ -8,11 +8,12 @@
           "chrome": [
             {
               "version_added": "57",
-              "notes": "macOS only."
+              "partial_implementation": true,
+              "notes": "Before Chrome 70, this feature was only supported in macOS.  In Chrome 70, support was added for Windows 10. Linux support is not enabled by default."
             },
             {
               "version_added": "57",
-              "notes": "Linux and versions of Windows earlier than 10.",
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
@@ -20,10 +21,6 @@
                   "value_to_set": "enabled"
                 }
               ]
-            },
-            {
-              "version_added": "70",
-              "notes": "Windows 10."
             }
           ],
           "chrome_android": {
@@ -32,11 +29,12 @@
           "edge": [
             {
               "version_added": "79",
-              "notes": "macOS only."
+              "partial_implementation": true,
+              "notes": "Supported by default only on macOS and Windows 10. Linux support is not enabled by default."
             },
             {
               "version_added": "79",
-              "notes": "Linux and versions of Windows earlier than 10.",
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
@@ -44,10 +42,6 @@
                   "value_to_set": "enabled"
                 }
               ]
-            },
-            {
-              "version_added": "79",
-              "notes": "Windows 10."
             }
           ],
           "firefox": {
@@ -62,11 +56,12 @@
           "opera": [
             {
               "version_added": "44",
-              "notes": "macOS only."
+              "partial_implementation": true,
+              "notes": "Before Opera 57, this feature was only supported in macOS.  In Opera 57, support was added for Windows 10. Linux support is not enabled by default."
             },
             {
               "version_added": "44",
-              "notes": "Linux and versions of Windows earlier than 10.",
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
@@ -74,10 +69,6 @@
                   "value_to_set": "enabled"
                 }
               ]
-            },
-            {
-              "version_added": "57",
-              "notes": "Windows 10."
             }
           ],
           "opera_android": {
@@ -107,51 +98,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTDescriptor/characteristic",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattdescriptor-characteristic",
           "support": {
-            "chrome": [
-              {
-                "version_added": "57",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "57",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "57"
+            },
             "chrome_android": {
               "version_added": "57"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -161,27 +116,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "44",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "44",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "44"
+            },
             "opera_android": {
               "version_added": "44"
             },
@@ -210,51 +147,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTDescriptor/readValue",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattdescriptor-readvalue",
           "support": {
-            "chrome": [
-              {
-                "version_added": "57",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "57",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "57"
+            },
             "chrome_android": {
               "version_added": "57"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -264,27 +165,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "44",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "44",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "44"
+            },
             "opera_android": {
               "version_added": "44"
             },
@@ -313,51 +196,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTDescriptor/uuid",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattdescriptor-uuid",
           "support": {
-            "chrome": [
-              {
-                "version_added": "57",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "57",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "57"
+            },
             "chrome_android": {
               "version_added": "57"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -367,27 +214,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "44",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "44",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "44"
+            },
             "opera_android": {
               "version_added": "44"
             },
@@ -416,51 +245,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTDescriptor/value",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattdescriptor-value",
           "support": {
-            "chrome": [
-              {
-                "version_added": "57",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "57",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "57"
+            },
             "chrome_android": {
               "version_added": "57"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -470,27 +263,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "44",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "44",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "44"
+            },
             "opera_android": {
               "version_added": "44"
             },
@@ -519,51 +294,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTDescriptor/writeValue",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattdescriptor-writevalue",
           "support": {
-            "chrome": [
-              {
-                "version_added": "57",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "57",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "57"
+            },
             "chrome_android": {
               "version_added": "57"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -573,27 +312,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "44",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "44",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "44"
+            },
             "opera_android": {
               "version_added": "44"
             },

--- a/api/BluetoothRemoteGATTDescriptor.json
+++ b/api/BluetoothRemoteGATTDescriptor.json
@@ -84,7 +84,7 @@
             "version_added": "7.0"
           },
           "webview_android": {
-            "version_added": "57"
+            "version_added": false
           }
         },
         "status": {
@@ -132,7 +132,7 @@
               "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": "57"
+              "version_added": false
             }
           },
           "status": {
@@ -181,7 +181,7 @@
               "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": "57"
+              "version_added": false
             }
           },
           "status": {
@@ -230,7 +230,7 @@
               "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": "57"
+              "version_added": false
             }
           },
           "status": {
@@ -279,7 +279,7 @@
               "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": "57"
+              "version_added": false
             }
           },
           "status": {
@@ -328,7 +328,7 @@
               "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": "57"
+              "version_added": false
             }
           },
           "status": {

--- a/api/BluetoothRemoteGATTServer.json
+++ b/api/BluetoothRemoteGATTServer.json
@@ -84,7 +84,7 @@
             "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "56"
           }
         },
         "status": {
@@ -132,7 +132,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -181,7 +181,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -230,7 +230,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -279,7 +279,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -328,7 +328,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -377,7 +377,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {

--- a/api/BluetoothRemoteGATTServer.json
+++ b/api/BluetoothRemoteGATTServer.json
@@ -84,7 +84,7 @@
             "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": "56"
+            "version_added": false
           }
         },
         "status": {
@@ -132,7 +132,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -181,7 +181,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -230,7 +230,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -279,7 +279,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -328,7 +328,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -377,7 +377,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {

--- a/api/BluetoothRemoteGATTServer.json
+++ b/api/BluetoothRemoteGATTServer.json
@@ -8,11 +8,12 @@
           "chrome": [
             {
               "version_added": "56",
-              "notes": "macOS only."
+              "partial_implementation": true,
+              "notes": "Before Chrome 70, this feature was only supported in macOS.  In Chrome 70, support was added for Windows 10. Linux support is not enabled by default."
             },
             {
               "version_added": "56",
-              "notes": "Linux and versions of Windows earlier than 10.",
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
@@ -20,10 +21,6 @@
                   "value_to_set": "enabled"
                 }
               ]
-            },
-            {
-              "version_added": "70",
-              "notes": "Windows 10."
             }
           ],
           "chrome_android": {
@@ -32,11 +29,12 @@
           "edge": [
             {
               "version_added": "79",
-              "notes": "macOS only."
+              "partial_implementation": true,
+              "notes": "Supported by default only on macOS and Windows 10. Linux support is not enabled by default."
             },
             {
               "version_added": "79",
-              "notes": "Linux and versions of Windows earlier than 10.",
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
@@ -44,10 +42,6 @@
                   "value_to_set": "enabled"
                 }
               ]
-            },
-            {
-              "version_added": "79",
-              "notes": "Windows 10."
             }
           ],
           "firefox": {
@@ -62,11 +56,12 @@
           "opera": [
             {
               "version_added": "43",
-              "notes": "macOS only."
+              "partial_implementation": true,
+              "notes": "Before Opera 57, this feature was only supported in macOS.  In Opera 57, support was added for Windows 10. Linux support is not enabled by default."
             },
             {
               "version_added": "43",
-              "notes": "Linux and versions of Windows earlier than 10.",
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
@@ -74,10 +69,6 @@
                   "value_to_set": "enabled"
                 }
               ]
-            },
-            {
-              "version_added": "57",
-              "notes": "Windows 10."
             }
           ],
           "opera_android": {
@@ -107,51 +98,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTServer/connect",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattserver-connect",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -161,27 +116,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -210,51 +147,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTServer/connected",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattserver-connected",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -264,27 +165,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -313,51 +196,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTServer/device",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattserver-device",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -367,27 +214,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -416,51 +245,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTServer/disconnect",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattserver-disconnect",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -470,27 +263,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -519,51 +294,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTServer/getPrimaryService",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattserver-getprimaryservice",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -573,27 +312,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },
@@ -622,51 +343,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothRemoteGATTServer/getPrimaryServices",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattserver-getprimaryservices",
           "support": {
-            "chrome": [
-              {
-                "version_added": "56",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "56",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "70",
-                "notes": "Windows 10."
-              }
-            ],
+            "chrome": {
+              "version_added": "56"
+            },
             "chrome_android": {
               "version_added": "56"
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "79",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "79",
-                "notes": "Windows 10."
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -676,27 +361,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "macOS only."
-              },
-              {
-                "version_added": "43",
-                "notes": "Linux and versions of Windows earlier than 10.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "57",
-                "notes": "Windows 10."
-              }
-            ],
+            "opera": {
+              "version_added": "43"
+            },
             "opera_android": {
               "version_added": "43"
             },

--- a/api/BluetoothRemoteGATTService.json
+++ b/api/BluetoothRemoteGATTService.json
@@ -129,7 +129,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/BluetoothRemoteGATTService.json
+++ b/api/BluetoothRemoteGATTService.json
@@ -84,7 +84,7 @@
             "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "56"
           }
         },
         "status": {
@@ -132,7 +132,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -181,7 +181,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -230,7 +230,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -279,7 +279,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -328,7 +328,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {

--- a/api/BluetoothRemoteGATTService.json
+++ b/api/BluetoothRemoteGATTService.json
@@ -84,7 +84,7 @@
             "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": "56"
+            "version_added": false
           }
         },
         "status": {
@@ -132,7 +132,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -181,7 +181,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -230,7 +230,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -279,7 +279,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -328,7 +328,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {

--- a/api/BluetoothUUID.json
+++ b/api/BluetoothUUID.json
@@ -3,15 +3,45 @@
     "BluetoothUUID": {
       "__compat": {
         "support": {
-          "chrome": {
-            "version_added": "70"
-          },
+          "chrome": [
+            {
+              "version_added": "56",
+              "partial_implementation": true,
+              "notes": "Before Chrome 70, this feature was only supported in macOS.  In Chrome 70, support was added for Windows 10. Linux support is not enabled by default."
+            },
+            {
+              "version_added": "56",
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            }
+          ],
           "chrome_android": {
-            "version_added": "70"
+            "version_added": "56"
           },
-          "edge": {
-            "version_added": "79"
-          },
+          "edge": [
+            {
+              "version_added": "79",
+              "partial_implementation": true,
+              "notes": "Supported by default only on macOS and Windows 10. Linux support is not enabled by default."
+            },
+            {
+              "version_added": "79",
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            }
+          ],
           "firefox": {
             "version_added": false
           },
@@ -21,11 +51,26 @@
           "ie": {
             "version_added": false
           },
-          "opera": {
-            "version_added": false
-          },
+          "opera": [
+            {
+              "version_added": "43",
+              "partial_implementation": true,
+              "notes": "Before Opera 57, this feature was only supported in macOS.  In Opera 57, support was added for Windows 10. Linux support is not enabled by default."
+            },
+            {
+              "version_added": "43",
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            }
+          ],
           "opera_android": {
-            "version_added": "57"
+            "version_added": "43"
           },
           "safari": {
             "version_added": false
@@ -34,10 +79,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "10.0"
+            "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": "70"
+            "version_added": false
           }
         },
         "status": {
@@ -50,10 +95,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "70"
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": "70"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "79"
@@ -68,10 +113,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": "57"
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -83,7 +128,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": "56"
             }
           },
           "status": {
@@ -97,10 +142,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "70"
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": "70"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "79"
@@ -115,10 +160,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": "57"
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -130,7 +175,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": "56"
             }
           },
           "status": {
@@ -144,10 +189,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "70"
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": "70"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "79"
@@ -162,10 +207,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": "57"
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -177,7 +222,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": "56"
             }
           },
           "status": {
@@ -191,10 +236,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "70"
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": "70"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "79"
@@ -209,10 +254,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": "57"
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -224,7 +269,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": "56"
             }
           },
           "status": {

--- a/api/BluetoothUUID.json
+++ b/api/BluetoothUUID.json
@@ -82,7 +82,7 @@
             "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "56"
           }
         },
         "status": {

--- a/api/BluetoothUUID.json
+++ b/api/BluetoothUUID.json
@@ -82,7 +82,7 @@
             "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": "56"
+            "version_added": false
           }
         },
         "status": {
@@ -125,10 +125,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -172,10 +172,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -219,10 +219,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {
@@ -266,10 +266,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": false
             }
           },
           "status": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -376,15 +376,45 @@
       "bluetooth": {
         "__compat": {
           "support": {
-            "chrome": {
-              "version_added": "70"
-            },
+            "chrome": [
+              {
+                "version_added": "56",
+                "partial_implementation": true,
+                "notes": "Before Chrome 70, this feature was only supported in macOS.  In Chrome 70, support was added for Windows 10. Linux support is not enabled by default."
+              },
+              {
+                "version_added": "56",
+                "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": {
-              "version_added": "70"
+              "version_added": "56"
             },
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": [
+              {
+                "version_added": "79",
+                "partial_implementation": true,
+                "notes": "Supported by default only on macOS and Windows 10. Linux support is not enabled by default."
+              },
+              {
+                "version_added": "79",
+                "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": false
             },
@@ -394,11 +424,26 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "57"
-            },
+            "opera": [
+              {
+                "version_added": "43",
+                "partial_implementation": true,
+                "notes": "Before Opera 57, this feature was only supported in macOS.  In Opera 57, support was added for Windows 10. Linux support is not enabled by default."
+              },
+              {
+                "version_added": "43",
+                "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
-              "version_added": "49"
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -407,10 +452,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
This PR is a continuation off of #10197.  While I was updating some of the Bluetooth APIs, I realized that I hadn't made the other APIs' style consistent with our changes.  Additionally, I noticed a few errors in the data that we had.  This PR corrects the erroneous data and makes our styling consistent across all of the Bluetooth APIs when representing the OS-specific support.

Fixes #11532.