### PR TITLE
Remove api.MediaDevices.stereo_audio_capture

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -499,54 +499,6 @@
             "deprecated": false
           }
         }
-      },
-      "stereo_audio_capture": {
-        "__compat": {
-          "description": "Stereo audio capture",
-          "support": {
-            "chrome": {
-              "version_added": null
-            },
-            "chrome_android": {
-              "version_added": null
-            },
-            "edge": {
-              "version_added": null
-            },
-            "firefox": {
-              "version_added": "55"
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": null
-            },
-            "webview_android": {
-              "version_added": null
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
This PR removes the "stereo audio capture" feature of the MediaDevices API.  As far as I can tell, this is a Firefox-only change, and I haven't been able to find any code in other browsers that suggests the same functionality.  Additionally, there are hardly any consumer-level microphones that contain more than one audio channel.
