### PR TITLE
Update Firefox versions for MediaStream API

### DIFF
--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -27,10 +27,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "15"
+            "version_added": "36"
           },
           "firefox_android": {
-            "version_added": "15"
+            "version_added": "36"
           },
           "ie": {
             "version_added": false
@@ -103,7 +103,7 @@
               "version_added": "44"
             },
             "firefox_android": {
-              "version_added": "42"
+              "version_added": "44"
             },
             "ie": {
               "version_added": false
@@ -198,10 +198,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -453,11 +453,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "22",
+              "version_added": "36",
               "notes": "Prior to Firefox 64, this method returned an array of <code>AudioStreamTrack</code> objects. However, <code>MediaStreamTrack</code> has now subsumed that interface's functionality."
             },
             "firefox_android": {
-              "version_added": "22",
+              "version_added": "36",
               "notes": "Prior to Firefox 64, this method returned an array of <code>AudioStreamTrack</code> objects. However, <code>MediaStreamTrack</code> has now subsumed that interface's functionality."
             },
             "ie": {
@@ -553,10 +553,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "36"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "36"
             },
             "ie": {
               "version_added": false
@@ -602,11 +602,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "22",
+              "version_added": "36",
               "notes": "Prior to Firefox 64, this method returned an array of <code>VideoStreamTrack</code> objects. However, <code>MediaStreamTrack</code> has now subsumed that interface's functionality."
             },
             "firefox_android": {
-              "version_added": "22",
+              "version_added": "36",
               "notes": "Prior to Firefox 64, this method returned an array of <code>VideoStreamTrack</code> objects. However, <code>MediaStreamTrack</code> has now subsumed that interface's functionality."
             },
             "ie": {
@@ -656,10 +656,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "41"
+              "version_added": "38"
             },
             "firefox_android": {
-              "version_added": "41"
+              "version_added": "38"
             },
             "ie": {
               "version_added": false
@@ -709,10 +709,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -760,10 +760,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -812,10 +812,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -909,10 +909,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -958,10 +958,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "59"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "59"
             },
             "ie": {
               "version_added": false
@@ -1006,10 +1006,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "44"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "ie": {
               "version_added": false
@@ -1106,10 +1106,12 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "36",
+              "version_removed": "64"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "36",
+              "version_removed": "64"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `MediaStream` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaStream
