### PR TITLE
Remove irrelevant api.Document.tooltipNode feature

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -10830,55 +10830,6 @@
           }
         }
       },
-      "tooltipNode": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/tooltipNode",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": true,
-              "notes": "Available only to <a href='https://developer.mozilla.org/docs/Mozilla/Tech/XUL'>XUL documents</a>."
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": false
-          }
-        }
-      },
       "touchcancel_event": {
         "__compat": {
           "description": "<code>touchcancel</code> event",


### PR DESCRIPTION
This PR removes the irrelevant `tooltipNode` member of the `Document` API.  The documentation for XUL documents has been removed from MDN, creating a broken link, and many other XUL features have been removed back in Firefox 64.