### PR TITLE
Add Firefox versions for FontFace API

### DIFF
--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -214,7 +214,7 @@
               "version_added": "58"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "58"
             },
             "ie": {
               "version_added": false
@@ -260,10 +260,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -309,10 +309,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -423,10 +423,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -504,10 +504,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -569,10 +569,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -618,10 +618,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -667,10 +667,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -716,10 +716,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -765,10 +765,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -863,10 +863,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `FontFace` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FontFace
