### PR TITLE
Add Firefox versions for FontFaceSet API

### DIFF
--- a/api/FontFaceSet.json
+++ b/api/FontFaceSet.json
@@ -110,10 +110,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -207,10 +207,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -255,10 +255,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -540,10 +540,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -588,10 +588,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -636,10 +636,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -780,10 +780,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `FontFaceSet` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FontFaceSet
