### PR TITLE
Add Safari versions for URLSearchParams API

### DIFF
--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -357,12 +357,12 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": true,
+              "version_added": "10.1",
               "partial_implementation": true,
               "notes": "Removing a non-existent query parameter doesn't remove <code>?</code> from the URL. See <a href='https://webkit.org/b/193022'>bug 193022</a>."
             },
             "safari_ios": {
-              "version_added": true,
+              "version_added": "10.3",
               "partial_implementation": true,
               "notes": "Removing a non-existent query parameter doesn't remove <code>?</code> from the URL. See <a href='https://webkit.org/b/193022'>bug 193022</a>."
             },
@@ -412,10 +412,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -460,10 +460,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -512,10 +512,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -564,10 +564,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -616,10 +616,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -667,10 +667,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -719,10 +719,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -771,10 +771,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -823,10 +823,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -874,10 +874,10 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `URLSearchParams` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/URLSearchParams
