### PR TITLE
Updates edge to version 92

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -133,20 +133,26 @@
         "91": {
           "release_date": "2021-05-27",
           "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-91086437-may-27",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "91"
         },
         "92": {
-          "status": "beta",
+          "release_date": "2021-07-22",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-92090255-july-22",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "92"
         },
         "93": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "93"
-        }
+        },
+        "94": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "94"
       }
     }
   }

--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -153,6 +153,7 @@
           "status": "nightly",
           "engine": "Blink",
           "engine_version": "94"
+        }
       }
     }
   }


### PR DESCRIPTION
According to the [release notes](https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-92090255-july-22), Edge has been updated to version 92.

This PR keeps the `browsers/edge.json` file up to date.

Closes #11726.