### PR TITLE
Add Firefox versions for api.Window.message_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3639,10 +3639,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "9"
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `message_event` member of the `Window` API.  The data was copied from its event handler counterpart (`api.WindowEventHandlers.message_event`).
