### PR TITLE
Add IE/Edge versions for api.HTMLElement.pointercapture_events

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1096,7 +1096,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "59"
@@ -1105,7 +1105,7 @@
               "version_added": "79"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "44"
@@ -1884,7 +1884,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "59"
@@ -1893,7 +1893,7 @@
               "version_added": "79"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "44"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `pointercapture_events` member of the `HTMLElement` API.  The data was copied from their event handler counterparts (`api.GlobalEventHandlers.on[got/lost]pointercapture`).
