### PR TITLE
Add IE/Edge versions for api.IDBDatabase.onclose

### DIFF
--- a/api/IDBDatabase.json
+++ b/api/IDBDatabase.json
@@ -198,7 +198,7 @@
               "version_added": "31"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "50"
@@ -207,7 +207,7 @@
               "version_added": "50"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -549,7 +549,7 @@
               "version_added": "31"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "50"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `onclose` member of the `IDBDatabase` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/IDBDatabase/onclose
