### PR TITLE
Add IE versions for WebSocket API

### DIFF
--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -315,7 +315,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -365,7 +365,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -464,7 +464,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true
@@ -710,7 +710,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `WebSocket` API.  The data was copied from their event handler counterparts (AKA `onclose`).
