### PR TITLE
Add IE versions for api.TextTrackCue.enter-exit_event

### DIFF
--- a/api/TextTrackCue.json
+++ b/api/TextTrackCue.json
@@ -108,7 +108,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "31"
@@ -117,7 +117,7 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": null
@@ -157,7 +157,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "31"
@@ -166,7 +166,7 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `enter-exit_event` member of the `TextTrackCue` API.  The data was copied from their event handler counterparts (`onenter` and `onexit`).
