### PR TITLE
Add IE/Edge versions for TextTrackList API

### DIFF
--- a/api/TextTrackList.json
+++ b/api/TextTrackList.json
@@ -61,7 +61,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "31"
@@ -70,7 +70,7 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": null
@@ -111,7 +111,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "18"
             },
             "firefox": {
               "version_added": "31"
@@ -120,7 +120,7 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -418,7 +418,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "18"
             },
             "firefox": {
               "version_added": "31"
@@ -427,7 +427,7 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `TextTrackList` API.  The data was copied from their event handler counterparts.
