### PR TITLE
Add IE/Edge versions for Window API

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -309,7 +309,7 @@
             ],
             "edge": [
               {
-                "version_added": "≤79"
+                "version_added": "18"
               },
               {
                 "version_added": "≤79",
@@ -323,7 +323,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -389,7 +389,7 @@
             ],
             "edge": [
               {
-                "version_added": "≤79"
+                "version_added": "18"
               },
               {
                 "version_added": "≤79",
@@ -403,7 +403,7 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -469,7 +469,7 @@
             ],
             "edge": [
               {
-                "version_added": "≤79"
+                "version_added": "18"
               },
               {
                 "version_added": "≤79",
@@ -483,7 +483,7 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -1632,7 +1632,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "6"
@@ -1641,7 +1641,7 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": true
@@ -1682,7 +1682,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": [
               {
@@ -1705,7 +1705,7 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": "11"
             },
             "opera": {
               "version_added": "12"
@@ -1892,7 +1892,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -1901,7 +1901,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null
@@ -3636,7 +3636,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "9"
@@ -3645,7 +3645,7 @@
               "version_added": "9"
             },
             "ie": {
-              "version_added": null
+              "version_added": "8"
             },
             "opera": {
               "version_added": "47"
@@ -3686,7 +3686,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "18"
             },
             "firefox": {
               "version_added": "57"
@@ -3695,7 +3695,7 @@
               "version_added": "57"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "47"
@@ -9566,7 +9566,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -9646,7 +9646,7 @@
               "version_added": "51"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -9696,7 +9696,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -9776,7 +9776,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `Window` API.  The data was copied from their event handler counterparts in `api.Window`, `api.WindowEventHandlers`, and `api.GlobalEventHandlers`.
