### PR TITLE
Remove notes about adapter.js for getUserMedia()

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1286,13 +1286,11 @@
             ],
             "firefox": {
               "version_added": "17",
-              "prefix": "moz",
-              "notes": "The constraint syntax described here is available as of Firefox 38. Earlier versions (32-37) used an outdated constraint syntax, but the syntax described here is available there through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+              "prefix": "moz"
             },
             "firefox_android": {
               "version_added": "24",
-              "prefix": "moz",
-              "notes": "The constraint syntax described here is available as of Firefox 38. Earlier versions (32-37) used an outdated constraint syntax, but the syntax described here is available there through the <a href='https://github.com/webrtc/adapter'>adapter.js</a> polyfill."
+              "prefix": "moz"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
See also earlier cleanup:
https://github.com/mdn/browser-compat-data/pull/7002
https://github.com/mdn/browser-compat-data/pull/7005