### PR TITLE
Include safari support for AudioWorklet data

### DIFF
--- a/api/AudioWorkletGlobalScope.json
+++ b/api/AudioWorkletGlobalScope.json
@@ -30,7 +30,7 @@
             "version_added": "47"
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
             "version_added": false

--- a/api/AudioWorkletGlobalScope.json
+++ b/api/AudioWorkletGlobalScope.json
@@ -33,7 +33,7 @@
             "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": "9.0"

--- a/api/AudioWorkletProcessor.json
+++ b/api/AudioWorkletProcessor.json
@@ -33,7 +33,7 @@
             "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": "9.0"

--- a/api/AudioWorkletProcessor.json
+++ b/api/AudioWorkletProcessor.json
@@ -30,7 +30,7 @@
             "version_added": null
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
             "version_added": false


### PR DESCRIPTION
Hi everyone! 

This PR includes Safari 14.1 compatibility for `AudioWorkletGlobalScope` and `AudioWorkletProcessor`.

Closes #11648.