### PR TITLE
Add Chrome/Safari versions for HTMLMediaElement API

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -1371,7 +1371,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "1"
             }
           },
           "status": {
@@ -1663,7 +1663,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -1362,10 +1362,10 @@
               "version_added": "12"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1630,10 +1630,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/media.html#event-media-loadstart",
           "support": {
             "chrome": {
-              "version_added": "32"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "32"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1647,35 +1647,23 @@
             "ie": {
               "version_added": "9"
             },
-            "opera": [
-              {
-                "version_added": "19"
-              },
-              {
-                "version_added": "≤12.1",
-                "version_removed": "15"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "19"
-              },
-              {
-                "version_added": "≤12.1",
-                "version_removed": "14"
-              }
-            ],
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
             "safari": {
-              "version_added": "9"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "9"
+              "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -3105,10 +3093,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/media.html#event-media-progress",
           "support": {
             "chrome": {
-              "version_added": "32"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "32"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -3122,35 +3110,23 @@
             "ie": {
               "version_added": "9"
             },
-            "opera": [
-              {
-                "version_added": "19"
-              },
-              {
-                "version_added": "≤12.1",
-                "version_removed": "15"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "19"
-              },
-              {
-                "version_added": "≤12.1",
-                "version_removed": "14"
-              }
-            ],
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
             "safari": {
-              "version_added": "9"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": "9"
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -3126,7 +3126,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -55,10 +55,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/media.html#event-media-abort",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -73,22 +73,22 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": null
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -1338,10 +1338,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/media.html#event-media-error",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "10"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1356,22 +1356,22 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1630,10 +1630,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/media.html#event-media-loadstart",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "32"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "edge": {
               "version_added": "12"
@@ -1647,23 +1647,35 @@
             "ie": {
               "version_added": "9"
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "19"
+              },
+              {
+                "version_added": "≤12.1",
+                "version_removed": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "19"
+              },
+              {
+                "version_added": "≤12.1",
+                "version_removed": "14"
+              }
+            ],
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -3093,10 +3105,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/media.html#event-media-progress",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "32"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "edge": {
               "version_added": "12"
@@ -3110,23 +3122,35 @@
             "ie": {
               "version_added": "9"
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "19"
+              },
+              {
+                "version_added": "≤12.1",
+                "version_removed": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "19"
+              },
+              {
+                "version_added": "≤12.1",
+                "version_removed": "14"
+              }
+            ],
             "safari": {
-              "version_added": null
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "9"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -1338,7 +1338,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/media.html#event-media-error",
           "support": {
             "chrome": {
-              "version_added": "10"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -1362,10 +1362,10 @@
               "version_added": "12"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Chrome and Safari for the `HTMLMediaElement` API.  The data was copied from their event handler counterparts in `GlobalEventHandlers`.
