### PR TITLE
Add Safari versions for api.RTCDTMFSender.tonechange_event

### DIFF
--- a/api/RTCDTMFSender.json
+++ b/api/RTCDTMFSender.json
@@ -274,10 +274,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "1.5"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `tonechange_event` member of the `RTCDTMFSender` API.  The data was copied from its event handler counterpart.
