### PR TITLE
Add Safari versions for api.PaymentResponse.onpayerdetailchange

### DIFF
--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -238,7 +238,7 @@
               "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -286,10 +286,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `onpayerdetailchange` member of the `PaymentResponse` API.  The data for the event handler was obtained from the mdn-bcd-collector project, while the event itself was copied from the event handler.
