### PR TITLE
Add Safari versions for TextTrackList API

### DIFF
--- a/api/TextTrackList.json
+++ b/api/TextTrackList.json
@@ -79,10 +79,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -129,10 +129,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -436,10 +436,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `TextTrackList` API.  The data was copied from their event handler counterparts.
