### PR TITLE
Add all browsers versions for WebSocket API

### DIFF
--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -89,10 +89,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "≤15"
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": "≤14"
+              "version_added": "12.1"
             },
             "safari": {
               "version_added": "5"
@@ -1009,10 +1009,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "≤15"
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": "≤14"
+              "version_added": "12.1"
             },
             "safari": {
               "version_added": "5"

--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -27,8 +27,7 @@
           ],
           "firefox_android": [
             {
-              "version_added": "14",
-              "notes": "See <a href='https://bugzil.la/695635'>bug 695635</a>."
+              "version_added": "14"
             },
             {
               "version_added": "7",

--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -23,11 +23,6 @@
               "version_removed": "11",
               "prefix": "Moz",
               "notes": "Message size limited to 16 MB (see <a href='https://bugzil.la/711205'>bug 711205</a>)."
-            },
-            {
-              "version_added": "4",
-              "version_removed": "6",
-              "notes": "Message size limited to 16 MB (see <a href='https://bugzil.la/711205'>bug 711205</a>)."
             }
           ],
           "firefox_android": [
@@ -39,11 +34,6 @@
               "version_added": "7",
               "version_removed": "14",
               "prefix": "Moz",
-              "notes": "Message size limited to 16 MB (see <a href='https://bugzil.la/711205'>bug 711205</a>)."
-            },
-            {
-              "version_added": "4",
-              "version_removed": "6",
               "notes": "Message size limited to 16 MB (see <a href='https://bugzil.la/711205'>bug 711205</a>)."
             }
           ],
@@ -82,24 +72,17 @@
           "description": "<code>WebSocket()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "7"
-              },
-              {
-                "version_added": "4",
-                "version_removed": "7",
-                "notes": "Parameter <code>protocols</code> not supported."
-              }
-            ],
+            "firefox": {
+              "version_added": "7"
+            },
             "firefox_android": {
               "version_added": "7"
             },
@@ -107,22 +90,22 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -138,40 +121,40 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket-binarytype-dev",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "15"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "11"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "ie": {
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -187,40 +170,40 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket-bufferedamount-dev",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "7"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "7"
             },
             "ie": {
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -244,26 +227,12 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "8"
-              },
-              {
-                "version_added": "4",
-                "version_removed": "8",
-                "notes": "Parameters not supported, see <a href='https://bugzil.la/674716'>bug 674716</a>."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "8"
-              },
-              {
-                "version_added": "4",
-                "version_removed": "8",
-                "notes": "Parameters not supported, see <a href='https://bugzil.la/674716'>bug 674716</a>."
-              }
-            ],
+            "firefox": {
+              "version_added": "7"
+            },
+            "firefox_android": {
+              "version_added": "7"
+            },
             "ie": {
               "version_added": "10"
             },
@@ -300,40 +269,40 @@
           "description": "<code>close</code> event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "7"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "7"
             },
             "ie": {
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": null
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -350,40 +319,40 @@
           "description": "<code>error</code> event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "5"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "7"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "7"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": null
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -399,10 +368,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket-extensions-dev",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "16"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -417,22 +386,22 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -449,40 +418,40 @@
           "description": "<code>message</code> event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "7"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "7"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": null
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -498,40 +467,40 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#handler-websocket-onclose",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "7"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "7"
             },
             "ie": {
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -547,40 +516,40 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#handler-websocket-onerror",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "5"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "7"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "7"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -596,40 +565,40 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#handler-websocket-onmessage",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "7"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "7"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -645,40 +614,40 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#handler-websocket-onopen",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "7"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "7"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -695,40 +664,40 @@
           "description": "<code>open</code> event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "7"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "7"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": null
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -744,40 +713,40 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket-protocol-dev",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "15"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "7"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "7"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -841,40 +810,40 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket-readystate-dev",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "4"
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "19"
+              "version_added": "7"
             },
             "firefox_android": {
-              "version_added": "19"
+              "version_added": "7"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
-              "version_added": "30"
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": "30"
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -914,7 +883,7 @@
                 "notes": "Only parameter of type <code>String</code> supported."
               },
               {
-                "version_added": "4",
+                "version_added": "7",
                 "version_removed": "8",
                 "notes": "Only parameter of type <code>String</code> supported. Returns <code>boolean</code>."
               }
@@ -935,13 +904,13 @@
                 "notes": "Only parameter of type <code>String</code> supported."
               },
               {
-                "version_added": "4",
+                "version_added": "7",
                 "version_removed": "8",
                 "notes": "Only parameter of type <code>String</code> supported. Returns <code>boolean</code>."
               }
             ],
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
               "version_added": "12.1"
@@ -975,40 +944,40 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket-url-dev",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "18"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "7"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "7"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1023,10 +992,10 @@
           "description": "Available in workers",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1041,10 +1010,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": "5"
@@ -1053,10 +1022,10 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -79,12 +79,26 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "7"
-            },
-            "firefox_android": {
-              "version_added": "7"
-            },
+            "firefox": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "7",
+                "version_removed": "11",
+                "prefix": "Moz"
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "14"
+              },
+              {
+                "version_added": "7",
+                "version_removed": "14",
+                "prefix": "Moz"
+              }
+            ],
             "ie": {
               "version_added": "10"
             },

--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -89,7 +89,7 @@
                 "prefix": "Moz"
               }
             ],
-            "firefox": [
+            "firefox_android": [
               {
                 "version_added": "14"
               },


### PR DESCRIPTION
This PR adds real values for all browsers for the `WebSocket` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WebSocket
