### PR TITLE
Remove irrelevant api.Window.beforeunload_event.custom_text_support feature

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -686,63 +686,6 @@
             "deprecated": false
           }
         },
-        "custom_text_support": {
-          "__compat": {
-            "description": "Custom text support",
-            "support": {
-              "chrome": {
-                "version_added": true,
-                "version_removed": "51"
-              },
-              "chrome_android": {
-                "version_added": true,
-                "version_removed": "51"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": true,
-                "version_removed": "44"
-              },
-              "firefox_android": {
-                "version_added": true,
-                "version_removed": "44"
-              },
-              "ie": {
-                "version_added": true
-              },
-              "opera": {
-                "version_added": true,
-                "version_removed": "38"
-              },
-              "opera_android": {
-                "version_added": true,
-                "version_removed": "41"
-              },
-              "safari": {
-                "version_added": true,
-                "version_removed": "9"
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true,
-                "version_removed": "5.0"
-              },
-              "webview_android": {
-                "version_added": true,
-                "version_removed": "51"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
-          }
-        },
         "event_returnvalue_activation": {
           "__compat": {
             "description": "Activation using <code>event.returnValue = \"string\";</code>",


### PR DESCRIPTION
This PR removes the irrelevant `beforeunload_event.custom_text_support` member of the `Window` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features). The lack of current support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2), even if the current BCD suggests support.
