### PR TITLE
Add Safari versions for Window API

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1650,7 +1650,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
               "version_added": "4.2"
@@ -1714,7 +1714,7 @@
               "version_added": "12"
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
               "version_added": "4.2"
@@ -4511,7 +4511,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -4560,7 +4560,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `Window` API.  The event handler data was obtained using the mdn-bcd-collector project, while the events themselves were copied from their event handler counterparts.
