### PR TITLE
Add Chrome/Safari versions for api.HTMLInputElement.search_event

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1819,10 +1819,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLInputElement/search_event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -1837,22 +1837,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1843,7 +1843,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "2"
             },
             "safari_ios": {
               "version_added": "1"


### PR DESCRIPTION
This PR adds real values for Chrome and Safari for the `search_event` member of the `HTMLInputElement` API.  The data was copied from its event handler counterparts.
