### PR TITLE
Add Safari iOS versions for MouseWheelEvent API

### DIFF
--- a/api/MouseWheelEvent.json
+++ b/api/MouseWheelEvent.json
@@ -32,7 +32,7 @@
             "version_added": true
           },
           "safari_ios": {
-            "version_added": null
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": true
@@ -128,7 +128,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true
@@ -176,7 +176,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari iOS/iPadOS for the `MouseWheelEvent` API.  iOS and iPadOS don't have mouse support, so there's no way they can get mouse wheel events.  (The iPad Pro's trackpad isn't considered a "mouse" by Safari.)
