### PR TITLE
Add Safari iOS versions for RelativeOrientationSensor API

### DIFF
--- a/api/RelativeOrientationSensor.json
+++ b/api/RelativeOrientationSensor.json
@@ -29,6 +29,9 @@
           "safari": {
             "version_added": false
           },
+          "safari_ios": {
+            "version_added": false
+          },
           "samsunginternet_android": {
             "version_added": "9.0"
           },
@@ -70,6 +73,9 @@
               "version_added": "48"
             },
             "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": {


### PR DESCRIPTION
This PR adds real values for Safari iOS/iPadOS for the `RelativeOrientationSensor` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RelativeOrientationSensor
