### PR TITLE
Add Safari iOS versions for Screen API

### DIFF
--- a/api/Screen.json
+++ b/api/Screen.json
@@ -379,7 +379,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -778,7 +778,7 @@
               "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari iOS/iPadOS for the `Screen` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Screen
