### PR TITLE
Remove irrelevant api.TouchList.identifiedTouch feature

### DIFF
--- a/api/TouchList.json
+++ b/api/TouchList.json
@@ -54,54 +54,6 @@
           "deprecated": false
         }
       },
-      "identifiedTouch": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TouchList/identifiedTouch",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "item": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TouchList/item",


### PR DESCRIPTION
This PR removes the irrelevant `identifiedTouch` member of the `TouchList` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features). The lack of current support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2), even if the current BCD suggests support.
