### PR TITLE
Update Safari versions for FileReaderSync API

### DIFF
--- a/api/FileReaderSync.json
+++ b/api/FileReaderSync.json
@@ -30,12 +30,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "6",
-            "version_removed": "7"
+            "version_added": "6"
           },
           "safari_ios": {
-            "version_added": "6",
-            "version_removed": "7"
+            "version_added": "6"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -79,12 +77,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6",
-              "version_removed": "7"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "version_removed": "7"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -130,12 +126,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6",
-              "version_removed": "7"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "version_removed": "7"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -181,12 +175,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6",
-              "version_removed": "7"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "version_removed": "7"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -232,12 +224,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6",
-              "version_removed": "7"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "version_removed": "7"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -283,12 +273,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6",
-              "version_removed": "7"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6",
-              "version_removed": "7"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -309,11 +297,11 @@
           "description": "Available in workers",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "7",
               "notes": "From Chrome 59, not supported in service workers."
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "notes": "From Chrome 59, not supported in service workers."
             },
             "edge": {
@@ -329,32 +317,30 @@
               "notes": "From Firefox 61, not supported in service workers."
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤15",
               "notes": "From Opera 46, not supported in service workers."
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤14",
               "notes": "From Opera 43, not supported in service workers."
             },
             "safari": {
-              "version_added": true,
-              "version_removed": "7",
+              "version_added": "6",
               "notes": "Not supported in service workers."
             },
             "safari_ios": {
-              "version_added": true,
-              "version_removed": "7",
+              "version_added": "6",
               "notes": "Not supported in service workers."
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "notes": "From version 7.0, not supported in service workers."
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "≤37",
               "notes": "From version 59, not supported in service workers."
             }
           },


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `FileReaderSync` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FileReaderSync
