### PR TITLE
Update Firefox versions for SourceBuffer API

### DIFF
--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -32,7 +32,7 @@
             "version_added": "42"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "42"
           },
           "ie": {
             "version_added": "11",
@@ -104,7 +104,7 @@
               "version_added": "42"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "42"
             },
             "ie": {
               "version_added": "11",
@@ -156,7 +156,7 @@
               "version_added": "42"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "42"
             },
             "ie": {
               "version_added": "11",
@@ -313,7 +313,7 @@
               "version_added": "42"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "42"
             },
             "ie": {
               "version_added": "11",
@@ -365,7 +365,7 @@
               "version_added": "42"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "42"
             },
             "ie": {
               "version_added": "11",
@@ -510,7 +510,7 @@
               "version_added": "42"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "42"
             },
             "ie": {
               "version_added": "11",
@@ -561,7 +561,7 @@
               "version_added": "63"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "ie": {
               "version_added": false
@@ -612,7 +612,7 @@
               "version_added": "42"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "42"
             },
             "ie": {
               "version_added": "11",
@@ -663,7 +663,7 @@
               "version_added": "42"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "42"
             },
             "ie": {
               "version_added": "11",
@@ -714,7 +714,7 @@
               "version_added": "42"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "42"
             },
             "ie": {
               "version_added": "11",
@@ -765,7 +765,7 @@
               "version_added": "42"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "42"
             },
             "ie": {
               "version_added": "11",
@@ -816,7 +816,7 @@
               "version_added": "42"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "42"
             },
             "ie": {
               "version_added": "11",
@@ -867,7 +867,7 @@
               "version_added": "42"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "42"
             },
             "ie": {
               "version_added": "11",
@@ -919,7 +919,7 @@
               "version_added": "42"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "42"
             },
             "ie": {
               "version_added": "11",
@@ -1077,7 +1077,7 @@
               "version_added": "42"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "42"
             },
             "ie": {
               "version_added": "11",
@@ -1177,7 +1177,7 @@
               "version_added": "42"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "42"
             },
             "ie": {
               "version_added": "11",


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `SourceBuffer` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SourceBuffer
