### PR TITLE
Add Safari iOS versions for api.Element.contextmenu_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2245,7 +2245,7 @@
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/Element.json
+++ b/api/Element.json
@@ -2245,7 +2245,8 @@
               "version_added": "3"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/213953'>bug 213953</a>."
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari iOS/iPadOS for the `contextmenu_event` member of the `Element` API.  This PR fixes #6376, which is where the data comes from.

Tracking Bug: https://webkit.org/b/213953