### PR TITLE
Add Safari versions for api.Worker.Worker.options_name_parameter

### DIFF
--- a/api/Worker.json
+++ b/api/Worker.json
@@ -277,12 +277,10 @@
                 "version_added": "49"
               },
               "safari": {
-                "version_added": false,
-                "notes": "Supported in <a href='https://webkit.org/blog/8406/release-notes-for-safari-technology-preview-64/'>Safari Technology Preview 64</a>"
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false,
-                "notes": "Supported in <a href='https://webkit.org/blog/8406/release-notes-for-safari-technology-preview-64/'>Safari Technology Preview 64</a>"
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": "10.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `Worker.options_name_parameter` member of the `Worker` API.  By using the mapping in https://github.com/mdn/browser-compat-data/issues/2991, I've set the appropriate version numbers based upon their matching TP edition.  Fixes #6455.
