### PR TITLE
Firefox 91 gamepad permission policy

### DIFF
--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -656,14 +656,7 @@
                 ]
               },
               "opera_android": {
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#restrict-gamepad-access",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "safari": {
                 "version_added": false

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -602,7 +602,7 @@
         "gamepad": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/gamepad",
-            "spec_url": "https://w3c.github.io/permissions/#gamepad",
+            "spec_url": "https://www.w3.org/TR/gamepad/#dfn-gamepad",
             "support": {
               "chrome": {
                 "version_added": "86",

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -636,11 +636,11 @@
               },
               "firefox": {
                 "version_added": "91",
-                "notes": "The default allowlist is <code>all</code> instead of <code>self</code> (as required by the specification)."
+                "notes": "The default allowlist is <code>*</code> instead of <code>self</code> (as required by the specification)."
               },
               "firefox_android": {
                 "version_added": "91",
-                "notes": "The default allowlist is <code>all</code> instead of <code>self</code> (as required by the specification)."
+                "notes": "The default allowlist is <code>*</code> instead of <code>self</code> (as required by the specification)."
               },
               "ie": {
                 "version_added": false

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -599,6 +599,92 @@
             }
           }
         },
+        "gamepad": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/gamepad",
+            "spec_url": "https://w3c.github.io/permissions/#gamepad",
+            "support": {
+              "chrome": {
+                "version_added": "86",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#restrict-gamepad-access",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": {
+                "version_added": "86",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#restrict-gamepad-access",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "edge": {
+                "version_added": "86",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#restrict-gamepad-access",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "firefox": {
+                "version_added": "91",
+                "notes": "The default allowlist is <code>all</code> instead of <code>self</code> (as required by the specification)."
+              },
+              "firefox_android": {
+                "version_added": "91",
+                "notes": "The default allowlist is <code>all</code> instead of <code>self</code> (as required by the specification)."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#restrict-gamepad-access",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "opera_android": {
+                "version_added": "61",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#restrict-gamepad-access",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "geolocation": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/geolocation",


### PR DESCRIPTION
FF91 adds `gamepad` feature policy (permission policy) directive. This is spec non-compliant in that the default policy is * (all) rather than `self` (is a temporary bug fix):
- FF bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1704005
- FF bug where permission is modified to EAll: https://bugzilla.mozilla.org/show_bug.cgi?id=1718221
- Docs work for this being tracked in: https://github.com/mdn/content/issues/6723

This was added to Chromium based things in v86 behind a preference: https://bugs.chromium.org/p/chromium/issues/detail?id=1011006. This is supposed to be removed soon. There is no evidence this is in Safari - see Moz bug above.