### PR TITLE
Gamepad API - secure_context_required

### DIFF
--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -817,6 +817,89 @@
           }
         }
       },
+      "secure_context_required": {
+        "__compat": {
+          "description": "Secure context required",
+          "support": {
+            "chrome": {
+              "version_added": "86",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#restrict-gamepad-access",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": "86",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#restrict-gamepad-access",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "edge": {
+              "version_added": "86",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#restrict-gamepad-access",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "firefox": {
+              "version_added": "91"
+            },
+            "firefox_android": {
+              "version_added": "91"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "72",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#restrict-gamepad-access",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "opera_android": {
+              "version_added": "61",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#restrict-gamepad-access",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "timestamp": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Gamepad/timestamp",

--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -139,6 +139,89 @@
           }
         }
       },
+      "secure_context_required": {
+        "__compat": {
+          "description": "Secure context required",
+          "support": {
+            "chrome": {
+              "version_added": "86",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#restrict-gamepad-access",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": "86",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#restrict-gamepad-access",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "edge": {
+              "version_added": "86",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#restrict-gamepad-access",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "firefox": {
+              "version_added": "91"
+            },
+            "firefox_android": {
+              "version_added": "91"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "72",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#restrict-gamepad-access",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "opera_android": {
+              "version_added": "61",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#restrict-gamepad-access",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "touched": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GamepadButton/touched",

--- a/api/GamepadEvent.json
+++ b/api/GamepadEvent.json
@@ -202,6 +202,89 @@
             "deprecated": false
           }
         }
+      },
+      "secure_context_required": {
+        "__compat": {
+          "description": "Secure context required",
+          "support": {
+            "chrome": {
+              "version_added": "86",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#restrict-gamepad-access",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": "86",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#restrict-gamepad-access",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "edge": {
+              "version_added": "86",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#restrict-gamepad-access",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "firefox": {
+              "version_added": "91"
+            },
+            "firefox_android": {
+              "version_added": "91"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "72",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#restrict-gamepad-access",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "opera_android": {
+              "version_added": "61",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#restrict-gamepad-access",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/GamepadHapticActuator.json
+++ b/api/GamepadHapticActuator.json
@@ -192,6 +192,89 @@
           }
         }
       },
+      "secure_context_required": {
+        "__compat": {
+          "description": "Secure context required",
+          "support": {
+            "chrome": {
+              "version_added": "86",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#restrict-gamepad-access",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": "86",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#restrict-gamepad-access",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "edge": {
+              "version_added": "86",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#restrict-gamepad-access",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "firefox": {
+              "version_added": "91"
+            },
+            "firefox_android": {
+              "version_added": "91"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "72",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#restrict-gamepad-access",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "opera_android": {
+              "version_added": "61",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#restrict-gamepad-access",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "type": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GamepadHapticActuator/type",

--- a/api/GamepadPose.json
+++ b/api/GamepadPose.json
@@ -448,6 +448,54 @@
             "deprecated": false
           }
         }
+      },
+      "secure_context_required": {
+        "__compat": {
+          "description": "Secure context required",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "91"
+            },
+            "firefox_android": {
+              "version_added": "91"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1174,6 +1174,89 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "secure_context_required": {
+          "__compat": {
+            "description": "Secure context required",
+            "support": {
+              "chrome": {
+                "version_added": "86",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#restrict-gamepad-access",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": {
+                "version_added": "86",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#restrict-gamepad-access",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "edge": {
+                "version_added": "86",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#restrict-gamepad-access",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "firefox": {
+                "version_added": "91"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#restrict-gamepad-access",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "opera_android": {
+                "version_added": "61",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#restrict-gamepad-access",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "getInstalledRelatedApps": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -4782,6 +4782,89 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "secure_context_required": {
+          "__compat": {
+            "description": "Secure context required",
+            "support": {
+              "chrome": {
+                "version_added": "86",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#restrict-gamepad-access",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": {
+                "version_added": "86",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#restrict-gamepad-access",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "edge": {
+                "version_added": "86",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#restrict-gamepad-access",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "firefox": {
+                "version_added": "91"
+              },
+              "firefox_android": {
+                "version_added": "91"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#restrict-gamepad-access",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "opera_android": {
+                "version_added": "61",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#restrict-gamepad-access",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "ongamepaddisconnected": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -4866,6 +4866,89 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "secure_context_required": {
+          "__compat": {
+            "description": "Secure context required",
+            "support": {
+              "chrome": {
+                "version_added": "86",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#restrict-gamepad-access",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": {
+                "version_added": "86",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#restrict-gamepad-access",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "edge": {
+                "version_added": "86",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#restrict-gamepad-access",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "firefox": {
+                "version_added": "91"
+              },
+              "firefox_android": {
+                "version_added": "91"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#restrict-gamepad-access",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "opera_android": {
+                "version_added": "61",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#restrict-gamepad-access",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "online_event": {


### PR DESCRIPTION
FF91 requires `gamepad` has secure context: https://bugzilla.mozilla.org/show_bug.cgi?id=1704005. Further,  Chrome also puts gamepad in secure context from v86, though I read this as being behind a flag: https://bugs.chromium.org/p/chromium/issues/detail?id=1099544

This updates theMDN listed [GamePad APIs](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad_API): 
`Gamepad`, `GamepadButton`, `GamepadEvent`, `GamepadHapticActuator`, `GamepadPose`. 

I did a check on `Navigator.getGamepads()` and that also requires a secure context. Since not everything in Navigator does, do I need to do add secure_context_required as a _subfeature_ of the method??
I can't tell if  `Window.ongamepadconnected` event and disconnected would require secure context - I get null on both secure and insecure contexts.

Related docs work can be tracked in https://github.com/mdn/content/issues/6723. This is associated with the change in https://github.com/mdn/browser-compat-data/pull/11770

