### PR TITLE
Update Permissions policy spec URL for Display Capture

### DIFF
--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -348,7 +348,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/display-capture",
             "spec_url": [
               "https://w3c.github.io/mediacapture-screen-share/#permissions-policy-integration",
-              "https://w3c.github.io/permissions/#screen-capture"
+              "https://w3c.github.io/permissions/#display-capture"
             ],
             "support": {
               "chrome": {


### PR DESCRIPTION
https://github.com/w3c/permissions/commit/09af80b (https://github.com/w3c/permissions/pull/252) changed the heading and ID value for the display-capture policy-controlled feeature.