### PR TITLE
alignment values for flexbox in Chrome 93 and a question

### DIFF
--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -209,16 +209,13 @@
               "description": "<code>left</code> and <code>right</code>",
               "support": {
                 "chrome": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "93"
                 },
                 "chrome_android": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "93"
                 },
                 "edge": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "93"
                 },
                 "firefox": {
                   "version_added": "52",
@@ -252,8 +249,7 @@
                   "notes": "This value is recognized, but has no effect."
                 },
                 "webview_android": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "93"
                 }
               },
               "status": {
@@ -373,16 +369,13 @@
               "description": "<code>start</code> and <code>end</code>",
               "support": {
                 "chrome": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "93"
                 },
                 "chrome_android": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "93"
                 },
                 "edge": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "93"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -412,8 +405,7 @@
                   "notes": "This value is recognized, but has no effect."
                 },
                 "webview_android": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "93"
                 }
               },
               "status": {

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -184,13 +184,13 @@
               "description": "<code>left</code> and <code>right</code>",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "93"
                 },
                 "chrome_android": {
-                  "version_added": false
+                  "version_added": "93"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "93"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -217,7 +217,7 @@
                   "version_added": false
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "93"
                 }
               },
               "status": {
@@ -289,13 +289,13 @@
               "description": "<code>start</code> and <code>end</code>",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "93"
                 },
                 "chrome_android": {
-                  "version_added": false
+                  "version_added": "93"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "93"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -322,7 +322,7 @@
                   "version_added": false
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "93"
                 }
               },
               "status": {

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -225,13 +225,13 @@
               "description": "<code>left</code> and <code>right</code>",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "93"
                 },
                 "chrome_android": {
-                  "version_added": false
+                  "version_added": "93"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "93"
                 },
                 "firefox": {
                   "version_added": "52"
@@ -258,7 +258,7 @@
                   "version_added": false
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "93"
                 }
               },
               "status": {
@@ -330,13 +330,13 @@
               "description": "<code>start</code> and <code>end</code>",
               "support": {
                 "chrome": {
-                  "version_added": "57"
+                  "version_added": "93"
                 },
                 "chrome_android": {
-                  "version_added": "57"
+                  "version_added": "93"
                 },
                 "edge": {
-                  "version_added": "79"
+                  "version_added": "93"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -363,7 +363,7 @@
                   "version_added": "7.0"
                 },
                 "webview_android": {
-                  "version_added": "57"
+                  "version_added": "93"
                 }
               },
               "status": {

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -239,16 +239,13 @@
               "description": "<code>left</code> and <code>right</code>",
               "support": {
                 "chrome": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "93"
                 },
                 "chrome_android": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "93"
                 },
                 "edge": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "93"
                 },
                 "firefox": {
                   "version_added": "52"
@@ -279,8 +276,7 @@
                   "notes": "This value is recognized, but has no effect."
                 },
                 "webview_android": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "93"
                 }
               },
               "status": {
@@ -400,16 +396,13 @@
               "description": "<code>start</code> and <code>end</code>",
               "support": {
                 "chrome": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "93"
                 },
                 "chrome_android": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "93"
                 },
                 "edge": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "93"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -439,8 +432,7 @@
                   "notes": "This value is recognized, but has no effect."
                 },
                 "webview_android": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "93"
                 }
               },
               "status": {


### PR DESCRIPTION
The alignment values of `start`, `end`, `left`, and `right` as they apply in flex layout, are in Chrome 93.

I believe that our values for `align-self` were incorrect previously for Chromium (stating support for the `-self` property and false for the `-items` property).

https://www.chromestatus.com/feature/5777880099323904

Before this is merged ...

I'm a bit dubious about the support data for Firefox, data says Firefox 45 for start/end and left/right. However, based on https://bugzilla.mozilla.org/show_bug.cgi?id=1472843 some of these didn't land until 63. Doing a test `justify-content: right` works in 61 and up. So much later than 45.

So I'm proposing to add to this a change to the values as listed in the above bug to correct the Firefox data.

Also, to add the line for `self-start/self-end` which is also shipping in Chromium 93, and is referenced in the above Firefox bug, so I think 63 or thereabouts, I'll test it.