### PR TITLE
Add IE versions for api.WebGLRenderingContext.SharedArrayBuffer_as_param

### DIFF
--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -901,7 +901,7 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "47"
@@ -1742,7 +1742,7 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "47"
@@ -8595,7 +8595,7 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "47"
@@ -8741,7 +8741,7 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "47"
@@ -8887,7 +8887,7 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "47"
@@ -9033,7 +9033,7 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "47"


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `SharedArrayBuffer_as_param` member of the `WebGLRenderingContext` API.  Internet Explorer doesn't support `SharedArrayBuffer`, so it would be illogical for another API to support it as parameters.
