### PR TITLE
Add IE versions for CompositionEvent API

### DIFF
--- a/api/CompositionEvent.json
+++ b/api/CompositionEvent.json
@@ -21,7 +21,7 @@
             "version_added": "9"
           },
           "ie": {
-            "version_added": true
+            "version_added": "9"
           },
           "opera": {
             "version_added": false
@@ -70,7 +70,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": false
@@ -119,7 +119,7 @@
               "version_added": "9"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": false
@@ -167,7 +167,7 @@
               "version_added": "9"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": false
@@ -215,7 +215,7 @@
               "version_added": "9"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `CompositionEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CompositionEvent
