### PR TITLE
Add Safari versions for api.WebGLRenderingContext.SharedArrayBuffer_as_param

### DIFF
--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -910,10 +910,10 @@
                 "version_added": "44"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "8.0"
@@ -1751,10 +1751,10 @@
                 "version_added": "44"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "8.0"
@@ -8604,10 +8604,10 @@
                 "version_added": "44"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "8.0"
@@ -8750,10 +8750,10 @@
                 "version_added": "44"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "8.0"
@@ -8896,10 +8896,10 @@
                 "version_added": "44"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "8.0"
@@ -9042,10 +9042,10 @@
                 "version_added": "44"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "8.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `SharedArrayBuffer_as_param` member of the `WebGLRenderingContext` API, based upon commit history and date.

Commit: https://trac.webkit.org/browser/webkit/releases/Apple/Safari%2010.1.2/WebCore/html/canvas/WebGLRenderingContextBase.idl
