### PR TITLE
Add Chromium versions for api.CanvasRenderingContext2D.drawImage.Smoothing_downscaling

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1185,10 +1185,10 @@
             "description": "Smoothing when downscaling",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "54"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "54"
               },
               "edge": {
                 "version_added": "79"
@@ -1205,10 +1205,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "41"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "41"
               },
               "safari": {
                 "version_added": null
@@ -1217,10 +1217,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "6.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "54"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `drawImage.Smoothing_downscaling` member of the `CanvasRenderingContext2D` API, based upon information in a tracking bug.

Tracking Bug: https://crbug.com/269089
