### PR TITLE
Add Safari versions for api.CanvasRenderingContext2D.drawImage.Smoothing_downscaling

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1211,10 +1211,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `drawImage.Smoothing_downscaling` member of the `CanvasRenderingContext2D` API.  Comparing code in the Firefox and Chrome tracking bugs (https://bugzil.la/1360415 and https://crbug.com/269089), I'm not seeing any similar code in Safari's source code (https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp), nor any bugs in WebKit Bugzilla.
