### PR TITLE
Update support data for scroll-snap

### DIFF
--- a/css/properties/scroll-snap-stop.json
+++ b/css/properties/scroll-snap-stop.json
@@ -16,10 +16,12 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1312165'>bug 1312165</a>."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1312165'>bug 1312165</a>."
             },
             "ie": {
               "version_added": false
@@ -28,7 +30,7 @@
               "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": "15"

--- a/css/properties/scroll-snap-type.json
+++ b/css/properties/scroll-snap-type.json
@@ -12,11 +12,17 @@
             "chrome_android": {
               "version_added": "69"
             },
-            "edge": {
-              "version_added": "12",
-              "prefix": "-ms-",
-              "notes": "Edge supports an earlier draft of CSS Scroll Snap without axis values."
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79",
+                "prefix": "-ms-",
+                "notes": "Edge supports an earlier draft of CSS Scroll Snap without axis values."
+              }
+            ],
             "firefox": [
               {
                 "version_added": "68"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Add Opera Android support for scroll-snap-stop. Also linked to Firefox tracking bug.

Fixed Edge support for scroll-snap-type

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Edge was outdated based on EdgeHTML support.

Opera Android is just copying blink support data.
