### PR TITLE
adds missing property and method, plus URLs to NavigatorUAData

### DIFF
--- a/api/NavigatorUAData.json
+++ b/api/NavigatorUAData.json
@@ -3,6 +3,7 @@
     "NavigatorUAData": {
       "__compat": {
         "spec_url": "https://wicg.github.io/ua-client-hints/#navigatoruadata",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorUAData",
         "support": {
           "chrome": {
             "version_added": "90"
@@ -51,6 +52,7 @@
       "brands": {
         "__compat": {
           "spec_url": "https://wicg.github.io/ua-client-hints/#dom-navigatoruadata-brands",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorUAData/brands",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -99,6 +101,7 @@
       "getHighEntropyValues": {
         "__compat": {
           "spec_url": "https://wicg.github.io/ua-client-hints/#dom-navigatoruadata-gethighentropyvalues",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorUAData/getHighEntropyValues",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -147,6 +150,7 @@
       "mobile": {
         "__compat": {
           "spec_url": "https://wicg.github.io/ua-client-hints/#dom-navigatoruadata-mobile",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorUAData/mobile",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -183,6 +187,110 @@
             },
             "webview_android": {
               "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "platform": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/ua-client-hints/#dom-uadatavalues-platform",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorUAData/platform",
+          "support": {
+            "chrome": {
+              "version_added": false,
+              "notes": "See <a href='https://www.chromestatus.com/feature/5733498725859328'>Chrome Platform Status</a>."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "See <a href='https://www.chromestatus.com/feature/5733498725859328'>Chrome Platform Status</a>."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false,
+              "notes": "See <a href='https://www.chromestatus.com/feature/5733498725859328'>Chrome Platform Status</a>."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "toJSON": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/ua-client-hints/#dom-uadatavalues-tojson",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorUAData/toJSON",
+          "support": {
+            "chrome": {
+              "version_added": false,
+              "notes": "See <a href='https://www.chromestatus.com/feature/5733498725859328'>Chrome Platform Status</a>."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "See <a href='https://www.chromestatus.com/feature/5733498725859328'>Chrome Platform Status</a>."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false,
+              "notes": "See <a href='https://www.chromestatus.com/feature/5733498725859328'>Chrome Platform Status</a>."
             }
           },
           "status": {


### PR DESCRIPTION
Working on NavigatorUAData for the User-Agent Client Hints API in https://github.com/mdn/content/pull/7280

There has been an additional property `platform` added to the spec, and in development in Chromium, also a toJSON() method. This PR adds those, plus the spec and MDN URLs.