### PR TITLE
Added Safari 15 support for hasIndices

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -460,10 +460,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "15"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15"
               },
               "samsunginternet_android": {
                 "version_added": "15.0"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Update Safari support for `RegExp.hasIndices`.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
See WebKit Bugzilla: https://bugs.webkit.org/show_bug.cgi?id=202475
Change landed in https://commits.webkit.org/r273086

