### PR TITLE
Apple supports setLocalDescription without params

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -3787,10 +3787,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "14.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14.5"
               },
               "samsunginternet_android": {
                 "version_added": "13.0"


### PR DESCRIPTION
#### Summary

Adds Safari support for:

> RTCPeerConnection API: `setLocalDescription()`: `description` parameter is optional

#### Test results and supporting details

Apple added support for this feature to Webkit in [changeset 266468](https://trac.webkit.org/changeset/266468/webkit). This was first tagged in [Safari-611.1.1](https://trac.webkit.org/browser/webkit/tags/Safari-611.1.1). Webkit trac seems to no longer show official Safari release tags, but the GitHub mirror [for this changeset](https://github.com/WebKit/WebKit/commit/4aacc635928f533a77bf67c942dec730d1ed9569) shows that it is included in tags `releases/Apple/Safari-14.1-macOS-11.3` and `releases/Apple/Safari-14.1-iOS-14.5`.

I have verified (prompted by my own question [on StackOverflow](https://stackoverflow.com/a/68550987/829970)) that this actually does work in Safari 14.1 on macOS.

#### Related issues

Feature was initially added to this repository in #5814