### PR TITLE
Update compat-table for `Array.prototype.at()`

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -117,7 +117,7 @@
                 "version_added": "92"
               },
               "edge": {
-                "version_added": false
+                "version_added": "92"
               },
               "firefox": {
                 "version_added": "90"


### PR DESCRIPTION
#### Summary
 - `Array.prototype.at()` is supported by Microsoft Edge v92.

#### Test results and supporting details
 - Verified using Microsoft Edge v92.0.902.55.

![Array prototype at()_EdgeV92](https://user-images.githubusercontent.com/23277581/127318190-54e51e9a-8c70-4071-821a-48fe32091248.png)

