### PR TITLE
RTCRtpEncodingParameters.active not supported in Firefox yet

### DIFF
--- a/api/RTCRtpEncodingParameters.json
+++ b/api/RTCRtpEncodingParameters.json
@@ -62,10 +62,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "46"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "46"
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
#### Summary
Fix claim that RTCRtpEncodingParameters.active is supported in Firefox (it is not)

#### Test results and supporting details
https://wpt.fyi/results/webrtc/RTCRtpParameters-encodings.html (though the tests are imprecise and fail on other stuff first).

https://bugzilla.mozilla.org/show_bug.cgi?id=1676855 - Implement RTCRtpEncodingParameters.active

#### Related issues
