### PR TITLE
XRView.isFirstPersonObserver is always false in Chromiums

### DIFF
--- a/api/XRView.json
+++ b/api/XRView.json
@@ -104,15 +104,15 @@
           "support": {
             "chrome": {
               "version_added": "86",
-              "notes": "Always returns false since no headset with first-person view is supported."
+              "notes": "Always returns <code>false</code> since no headset with first-person view is supported."
             },
             "chrome_android": {
               "version_added": "86",
-              "notes": "Always returns false since no headset with first-person view is supported."
+              "notes": "Always returns <code>false</code> since no headset with first-person view is supported."
             },
             "edge": {
               "version_added": "86",
-              "notes": "Always returns false since no headset with first-person view is supported."
+              "notes": "Always returns <code>false</code> since no headset with first-person view is supported."
             },
             "firefox": {
               "version_added": false
@@ -137,7 +137,7 @@
             },
             "samsunginternet_android": {
               "version_added": "13.0",
-              "notes": "Always returns false since no headset with first-person view is supported."
+              "notes": "Always returns <code>false</code> since no headset with first-person view is supported."
             },
             "webview_android": {
               "version_added": false

--- a/api/XRView.json
+++ b/api/XRView.json
@@ -103,13 +103,16 @@
           "spec_url": "https://immersive-web.github.io/webxr-ar-module/#dom-xrview-isfirstpersonobserver",
           "support": {
             "chrome": {
-              "version_added": "86"
+              "version_added": "86",
+              "notes": "Always returns false since no headset with first-person view is supported."
             },
             "chrome_android": {
-              "version_added": "86"
+              "version_added": "86",
+              "notes": "Always returns false since no headset with first-person view is supported."
             },
             "edge": {
-              "version_added": "86"
+              "version_added": "86",
+              "notes": "Always returns false since no headset with first-person view is supported."
             },
             "firefox": {
               "version_added": false
@@ -133,7 +136,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "13.0"
+              "version_added": "13.0",
+              "notes": "Always returns false since no headset with first-person view is supported."
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
@dominiccooney mentioned this in https://github.com/mdn/content/issues/7276#issuecomment-888681981
See https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/xr/xr_view.h;l=47

I'm not sure if Samsung Internet implements this. Assuming no for now, but cc @AdaRoseCannon.

Also, I guess we can argue if we should set the partial implementation flag to true here (making the table cell rendered yellow).