### PR TITLE
Add XRPose.{angular,linear}Velocity

### DIFF
--- a/api/XRPose.json
+++ b/api/XRPose.json
@@ -48,6 +48,55 @@
           "deprecated": false
         }
       },
+      "angularVelocity": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRPose/angularVelocity",
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrpose-angularvelocity",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "emulatedPosition": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRPose/emulatedPosition",
@@ -85,6 +134,55 @@
             },
             "samsunginternet_android": {
               "version_added": "11.2"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "linearVelocity": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRPose/linearVelocity",
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrpose-linearvelocity",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/XRPose.json
+++ b/api/XRPose.json
@@ -54,10 +54,12 @@
           "spec_url": "https://immersive-web.github.io/webxr/#dom-xrpose-angularvelocity",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/1202213'>bug 1202213</a>"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/1202213'>bug 1202213</a>"
             },
             "edge": {
               "version_added": false
@@ -87,7 +89,8 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/1202213'>bug 1202213</a>"
             }
           },
           "status": {
@@ -152,10 +155,12 @@
           "spec_url": "https://immersive-web.github.io/webxr/#dom-xrpose-linearvelocity",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/1202213'>bug 1202213</a>"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/1202213'>bug 1202213</a>"
             },
             "edge": {
               "version_added": false
@@ -185,7 +190,8 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/1202213'>bug 1202213</a>"
             }
           },
           "status": {


### PR DESCRIPTION
These are all-false features (https://github.com/mdn/browser-compat-data/issues/10619)

but

- They are shipping in XR-specific browsers, [such as Oculus](https://developer.oculus.com/documentation/oculus-browser/browser-release-notes/#oculus-browser-150)
- They are part of the WebXR core spec
- There is a bug to implement these in Chromium, https://bugs.chromium.org/p/chromium/issues/detail?id=1202213

Are these valid enough points to add the features anyways?