### PR TITLE
Add Chromium versions for WEBGL_compressed_texture_s3tc API

### DIFF
--- a/api/WEBGL_compressed_texture_s3tc.json
+++ b/api/WEBGL_compressed_texture_s3tc.json
@@ -10,7 +10,8 @@
               "version_added": "26"
             },
             {
-              "version_added": true,
+              "version_added": "26",
+              "version_removed": "56",
               "prefix": "WEBKIT_"
             }
           ],
@@ -41,7 +42,8 @@
               "version_added": "15"
             },
             {
-              "version_added": true,
+              "version_added": "15",
+              "version_removed": "43",
               "prefix": "WEBKIT_"
             }
           ],


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `WEBGL_compressed_texture_s3tc` API, based upon manual testing.

Test Code Used:
```js
var canvas = document.createElement('canvas');
var webGL = canvas.getContext('webgl2') || canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
webGL.getExtension('WEBKIT_WEBGL_compressed_texture_s3tc');
```
