### PR TITLE
Correct versions for WEBGL_compressed_texture_pvrtc API

### DIFF
--- a/api/WEBGL_compressed_texture_pvrtc.json
+++ b/api/WEBGL_compressed_texture_pvrtc.json
@@ -14,7 +14,10 @@
           "edge": {
             "version_added": false
           },
-          "firefox": [
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": [
             {
               "version_added": "18"
             },
@@ -24,9 +27,6 @@
               "version_removed": "58"
             }
           ],
-          "firefox_android": {
-            "version_added": null
-          },
           "ie": {
             "version_added": false
           },

--- a/api/WEBGL_compressed_texture_pvrtc.json
+++ b/api/WEBGL_compressed_texture_pvrtc.json
@@ -6,10 +6,10 @@
         "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_pvrtc/",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "28"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "28"
           },
           "edge": {
             "version_added": "79"
@@ -31,10 +31,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "15"
           },
           "safari": {
             "version_added": false
@@ -43,10 +43,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/WEBGL_compressed_texture_pvrtc.json
+++ b/api/WEBGL_compressed_texture_pvrtc.json
@@ -6,13 +6,13 @@
         "spec_url": "https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_pvrtc/",
         "support": {
           "chrome": {
-            "version_added": "28"
+            "version_added": false
           },
           "chrome_android": {
             "version_added": "28"
           },
           "edge": {
-            "version_added": "79"
+            "version_added": false
           },
           "firefox": [
             {
@@ -31,7 +31,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "15"
+            "version_added": false
           },
           "opera_android": {
             "version_added": "15"


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `WEBGL_compressed_texture_pvrtc` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/4cb6a26d8b06a60da0e7460eedb5034d5d25ae30

Additionally, this PR corrects the data for Firefox in the process.  Since this is an API designed solely for specific mobile devices, desktop support wouldn't be a thing.