### PR TITLE
Add Firefox versions for XSLTProcessor API

### DIFF
--- a/api/XSLTProcessor.json
+++ b/api/XSLTProcessor.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": false
@@ -110,10 +110,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -161,10 +161,10 @@
               "notes": "Edge only supports string values."
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -215,10 +215,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -263,10 +263,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -311,10 +311,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -362,10 +362,10 @@
               "notes": "Edge only supports string values."
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -419,11 +419,11 @@
               "notes": "Edge returns <code>null</code> if an error occurs."
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Firefox throws an exception if an error occurs."
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "4",
               "notes": "Firefox throws an exception if an error occurs."
             },
             "ie": {
@@ -484,11 +484,11 @@
               "notes": "Edge returns <code>null</code> if an error occurs."
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Firefox throws an exception if an error occurs."
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "4",
               "notes": "Firefox throws an exception if an error occurs."
             },
             "ie": {


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `XSLTProcessor` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/XSLTProcessor
