### PR TITLE
Add Chrome/Safari versions for FocusEvent API

### DIFF
--- a/api/FocusEvent.json
+++ b/api/FocusEvent.json
@@ -6,10 +6,10 @@
         "spec_url": "https://w3c.github.io/uievents/#interface-focusevent",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "26"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "26"
           },
           "edge": {
             "version_added": "12"
@@ -24,22 +24,22 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
-            "version_added": true
+            "version_added": "7"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "7"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -55,10 +55,10 @@
           "description": "<code>FocusEvent()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "26"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "edge": {
               "version_added": "12"
@@ -73,22 +73,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chrome and Safari for the `FocusEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FocusEvent
