### PR TITLE
Update all browsers versions for MouseEvent API

### DIFF
--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -237,7 +237,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "43"
@@ -611,7 +611,7 @@
                 "version_added": "37"
               },
               {
-                "version_added": true,
+                "version_added": "25",
                 "version_removed": "37",
                 "prefix": "webkit"
               }
@@ -642,12 +642,26 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "24"
-            },
-            "opera_android": {
-              "version_added": "24"
-            },
+            "opera": [
+              {
+                "version_added": "24"
+              },
+              {
+                "version_added": "15",
+                "version_removed": "24",
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "24"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "24",
+                "prefix": "webkit"
+              }
+            ],
             "safari": [
               {
                 "version_added": "9"
@@ -673,7 +687,7 @@
                 "version_added": "3.0"
               },
               {
-                "version_added": true,
+                "version_added": "1.0",
                 "version_removed": "3.0",
                 "prefix": "webkit"
               }
@@ -716,7 +730,7 @@
                 "version_added": "37"
               },
               {
-                "version_added": true,
+                "version_added": "25",
                 "version_removed": "37",
                 "prefix": "webkit"
               }
@@ -747,12 +761,26 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "24"
-            },
-            "opera_android": {
-              "version_added": "24"
-            },
+            "opera": [
+              {
+                "version_added": "24"
+              },
+              {
+                "version_added": "15",
+                "version_removed": "24",
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "24"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "24",
+                "prefix": "webkit"
+              }
+            ],
             "safari": [
               {
                 "version_added": "9"
@@ -778,7 +806,7 @@
                 "version_added": "3.0"
               },
               {
-                "version_added": true,
+                "version_added": "1.0",
                 "version_removed": "3.0",
                 "prefix": "webkit"
               }

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -59,10 +59,10 @@
           "description": "<code>MouseEvent()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "47"
+              "version_added": "26"
             },
             "chrome_android": {
-              "version_added": "47"
+              "version_added": "26"
             },
             "edge": {
               "version_added": "12"
@@ -77,22 +77,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "47"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -108,40 +108,40 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-altkey",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -209,26 +209,26 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "15",
               "notes": "Resrictions apply depending on OS."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "15"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "30"
             },
             "safari": {
               "version_added": "11.1"
@@ -237,10 +237,10 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "43"
             }
           },
           "status": {
@@ -305,40 +305,40 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-clienty",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -354,40 +354,40 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-ctrlkey",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -412,19 +412,19 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "15"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "15"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "34"
             },
             "safari": {
               "version_added": "12.1"
@@ -499,40 +499,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/initMouseEvent",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -548,40 +548,40 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-metakey",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -643,10 +643,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "24"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "24"
             },
             "safari": [
               {
@@ -748,10 +748,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "24"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "24"
             },
             "safari": [
               {
@@ -807,10 +807,10 @@
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-mouseevent-offsetx",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -825,22 +825,22 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -856,10 +856,10 @@
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-mouseevent-offsety",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -874,22 +874,22 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -905,40 +905,40 @@
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-mouseevent-pagex",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -954,40 +954,40 @@
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-mouseevent-pagey",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1024,26 +1024,36 @@
                 }
               ]
             },
-            "firefox": {
-              "version_added": "30",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "canvas.hitregions.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": {
-              "version_added": "30",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "canvas.hitregions.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "32"
+              },
+              {
+                "version_added": "30",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "canvas.hitregions.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "32"
+              },
+              {
+                "version_added": "30",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "canvas.hitregions.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -1079,40 +1089,40 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-relatedtarget",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "48"
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1128,40 +1138,40 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-screenx",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1177,40 +1187,40 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-screeny",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1226,40 +1236,40 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-mouseevent-shiftkey",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1277,7 +1287,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1303,13 +1313,13 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1325,10 +1335,10 @@
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-mouseevent-x",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1343,22 +1353,22 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1374,10 +1384,10 @@
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-mouseevent-y",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1392,22 +1402,22 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -1024,36 +1024,26 @@
                 }
               ]
             },
-            "firefox": [
-              {
-                "version_added": "32"
-              },
-              {
-                "version_added": "30",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "canvas.hitregions.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "32"
-              },
-              {
-                "version_added": "30",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "canvas.hitregions.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "30",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "canvas.hitregions.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "30",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "canvas.hitregions.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "ie": {
               "version_added": false
             },

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -1313,7 +1313,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR updates and corrects the real values for all browsers for the `MouseEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MouseEvent
