### PR TITLE
Add Safari versions for OverconstrainedErrorEvent API

### DIFF
--- a/api/OverconstrainedErrorEvent.json
+++ b/api/OverconstrainedErrorEvent.json
@@ -30,10 +30,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": true
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": false
@@ -78,10 +78,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `OverconstrainedErrorEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/OverconstrainedErrorEvent
