### PR TITLE
Add all browsers versions for PageTransitionEvent API

### DIFF
--- a/api/PageTransitionEvent.json
+++ b/api/PageTransitionEvent.json
@@ -6,40 +6,40 @@
         "spec_url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-pagetransitionevent-interface",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "4"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "11"
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
-            "version_added": true
+            "version_added": "5"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "4"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {


### PR DESCRIPTION
This PR adds real values for all browsers for the `PageTransitionEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PageTransitionEvent
