### PR TITLE
Add Safari versions for PopStateEvent API

### DIFF
--- a/api/PopStateEvent.json
+++ b/api/PopStateEvent.json
@@ -30,10 +30,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": true
+            "version_added": "6"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "6"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -126,10 +126,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `PopStateEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PopStateEvent
