### PR TITLE
Update IE versions for External API

### DIFF
--- a/api/External.json
+++ b/api/External.json
@@ -20,7 +20,7 @@
             "version_added": true
           },
           "ie": {
-            "version_added": false
+            "version_added": "≤6"
           },
           "opera": {
             "version_added": "15"
@@ -68,7 +68,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": false
+              "version_added": "7"
             },
             "opera": {
               "version_added": "15"
@@ -116,7 +116,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": false
+              "version_added": "7"
             },
             "opera": {
               "version_added": "15"


### PR DESCRIPTION
This PR updates and corrects the real values for Internet Explorer for the `External` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/External
