### PR TITLE
Add Firefox versions for External API

### DIFF
--- a/api/External.json
+++ b/api/External.json
@@ -14,10 +14,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "2"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": false
@@ -61,11 +61,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "notes": "From Firefox 78 this function does nothing, as the specification requires.",
-              "version_added": true
+              "version_added": "2",
+              "notes": "From Firefox 78 this function does nothing, as the specification requires."
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -110,10 +110,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "2"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `External` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/External
