### PR TITLE
Remove irrelevant api.Text.isElementContentWhitespace feature

### DIFF
--- a/api/Text.json
+++ b/api/Text.json
@@ -147,56 +147,6 @@
           }
         }
       },
-      "isElementContentWhitespace": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Text/isElementContentWhitespace",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": true,
-              "version_removed": "10"
-            },
-            "firefox_android": {
-              "version_added": true,
-              "version_removed": "10"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
-      },
       "replaceWholeText": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Text/replaceWholeText",


### PR DESCRIPTION
This PR removes the irrelevant `isElementContentWhitespace` member of the `Text` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features). The lack of current support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2), even if the current BCD suggests support.
