### PR TITLE
Remove irrelevant api.Document.documentURIObject feature

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -3430,58 +3430,6 @@
           }
         }
       },
-      "documentURIObject": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/documentURIObject",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": true,
-              "version_removed": "57",
-              "notes": "Available only to <a href='https://developer.mozilla.org/docs/Archive/Add-ons'>legacy extensions</a>."
-            },
-            "firefox_android": {
-              "version_added": true,
-              "version_removed": "57",
-              "notes": "Available only to <a href='https://developer.mozilla.org/docs/Archive/Add-ons'>legacy extensions</a>."
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": false
-          }
-        }
-      },
       "domain": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/domain",


### PR DESCRIPTION
This PR removes the irrelevant `documentURIObject` member of the `Document` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features). The lack of current support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2), even if the current BCD suggests support.
