### PR TITLE
Add all browsers versions for Document API

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -623,10 +623,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "51"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "51"
             },
             "ie": {
               "version_added": "10"
@@ -1751,10 +1751,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": false
@@ -2988,10 +2988,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": false
@@ -8188,10 +8188,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": "11"
@@ -9756,40 +9756,40 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-readystatechange",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "9"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -10466,10 +10466,10 @@
           "description": "<code>selectionchange</code> event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "11"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -10481,25 +10481,25 @@
               "version_added": "52"
             },
             "ie": {
-              "version_added": true
+              "version_added": "5.5"
             },
             "opera": {
-              "version_added": null
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -10516,10 +10516,10 @@
           "description": "<code>selectstart</code> event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -10531,13 +10531,13 @@
               "version_added": "52"
             },
             "ie": {
-              "version_added": true
+              "version_added": "4"
             },
             "opera": {
-              "version_added": null
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14"
             },
             "safari": {
               "version_added": "1.3"
@@ -10546,10 +10546,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -11030,10 +11030,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -11655,10 +11655,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "17"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "17"
             },
             "ie": {
               "version_added": true
@@ -11670,7 +11670,7 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": false

--- a/api/Document.json
+++ b/api/Document.json
@@ -9756,7 +9756,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-readystatechange",
           "support": {
             "chrome": {
-              "version_added": "9"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -9780,10 +9780,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/Document.json
+++ b/api/Document.json
@@ -1751,10 +1751,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": "9"
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": "9"
+              "version_added": "6"
             },
             "ie": {
               "version_added": false
@@ -2988,10 +2988,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": "9"
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": "9"
+              "version_added": "6"
             },
             "ie": {
               "version_added": false
@@ -7297,10 +7297,10 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "9"
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": "9"
+              "version_added": "6"
             },
             "ie": {
               "version_added": false
@@ -7345,10 +7345,10 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "9"
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": "9"
+              "version_added": "6"
             },
             "ie": {
               "version_added": false
@@ -7681,10 +7681,10 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "9"
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": "9"
+              "version_added": "6"
             },
             "ie": {
               "version_added": false
@@ -8188,10 +8188,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "9"
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": "9"
+              "version_added": "6"
             },
             "ie": {
               "version_added": "11"

--- a/api/Document.json
+++ b/api/Document.json
@@ -623,10 +623,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "51"
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": "51"
+              "version_added": "6"
             },
             "ie": {
               "version_added": "10"
@@ -673,10 +673,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "51"
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": "51"
+              "version_added": "6"
             },
             "ie": {
               "version_added": "10"
@@ -723,10 +723,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "51"
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": "51"
+              "version_added": "6"
             },
             "ie": {
               "version_added": "10"

--- a/api/Document.json
+++ b/api/Document.json
@@ -9765,10 +9765,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "9"
+              "version_added": "4"
             },
             "firefox_android": {
-              "version_added": "9"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4"


### PR DESCRIPTION
This PR adds real values for all browsers for the `Document` API.  The data was copied from their matching event handlers (such as in `GlobalEventHandlers`), as well as manual testing.

Test Code Used:

animation events: https://github.com/mdn/browser-compat-data/pull/11861#discussion_r717507599

copy/cut/paste:
```html
<div id="test">
	<input value="The quick brown fox jumps over the lazy dog." />
</div>

<script>
	document.addEventListener('copy', function() {
		alert('Foo One!');
	});
	document.oncopy = function() {
		alert('Foo Two!');
	};
	document.addEventListener('cut', function() {
		alert('Bar One!');
	});
	document.oncut = function() {
		alert('Bar Two!');
	};
	document.addEventListener('paste', function() {
		alert('Baz One!');
	});
	document.onpaste = function() {
		alert('Baz Two!');
	};
</script>
```

readystatechange: http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=9673

selectionchange:
```html
<div id="test">
	<p>The quick brown fox jumps over the lazy dog.</p>
</div>

<script>
	document.addEventListener('selectionchange', function() {
		alert('Foo!');
	});
</script>
```