### PR TITLE
Add Safari versions for api.CloseEvent.CloseEvent

### DIFF
--- a/api/CloseEvent.json
+++ b/api/CloseEvent.json
@@ -83,10 +83,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `CloseEvent` member of the `CloseEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CloseEvent/CloseEvent
