### PR TITLE
Add all browsers versions for FileReader API

### DIFF
--- a/api/FileReader.json
+++ b/api/FileReader.json
@@ -108,7 +108,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -135,7 +135,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -155,40 +155,40 @@
           "spec_url": "https://w3c.github.io/FileAPI/#dfn-abort-event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3.6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "11"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -207,7 +207,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -238,11 +238,11 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6.1",
+              "version_added": "7",
               "notes": "The <code>error</code> property returns a <code>DOMError</code> object."
             },
             "safari_ios": {
-              "version_added": "6.1",
+              "version_added": "7",
               "notes": "The <code>error</code> property returns a <code>DOMError</code> object."
             },
             "samsunginternet_android": {
@@ -266,225 +266,10 @@
           "spec_url": "https://w3c.github.io/FileAPI/#dfn-error-event",
           "support": {
             "chrome": {
-              "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": true
-            },
-            "firefox_android": {
-              "version_added": true
-            },
-            "ie": {
-              "version_added": true
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": true
-            },
-            "safari_ios": {
-              "version_added": true
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "load_event": {
-        "__compat": {
-          "description": "<code>load</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileReader/load_event",
-          "spec_url": "https://w3c.github.io/FileAPI/#dfn-load-event",
-          "support": {
-            "chrome": {
-              "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": true
-            },
-            "firefox_android": {
-              "version_added": true
-            },
-            "ie": {
-              "version_added": true
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": true
-            },
-            "safari_ios": {
-              "version_added": true
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "loadend_event": {
-        "__compat": {
-          "description": "<code>loadend</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileReader/loadend_event",
-          "spec_url": "https://w3c.github.io/FileAPI/#dfn-loadend-event",
-          "support": {
-            "chrome": {
-              "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": true
-            },
-            "firefox_android": {
-              "version_added": true
-            },
-            "ie": {
-              "version_added": true
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": true
-            },
-            "safari_ios": {
-              "version_added": true
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "loadstart_event": {
-        "__compat": {
-          "description": "<code>loadstart</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileReader/loadstart_event",
-          "spec_url": "https://w3c.github.io/FileAPI/#dfn-loadstart-event",
-          "support": {
-            "chrome": {
-              "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": [
-              {
-                "version_added": "79"
-              },
-              {
-                "version_added": true,
-                "version_removed": "79",
-                "partial_implementation": true,
-                "notes": "<code>loadstart</code> event dispatches synchronously (should be asynchronously as per spec)."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "79"
-              },
-              {
-                "version_added": true,
-                "version_removed": "79",
-                "partial_implementation": true,
-                "notes": "<code>loadstart</code> event dispatches synchronously (should be asynchronously as per spec)."
-              }
-            ],
-            "ie": {
-              "version_added": true
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": true
-            },
-            "safari_ios": {
-              "version_added": true
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onabort": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileReader/onabort",
-          "spec_url": "https://w3c.github.io/FileAPI/#dfn-onabort",
-          "support": {
-            "chrome": {
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -505,13 +290,228 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "load_event": {
+        "__compat": {
+          "description": "<code>load</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileReader/load_event",
+          "spec_url": "https://w3c.github.io/FileAPI/#dfn-load-event",
+          "support": {
+            "chrome": {
+              "version_added": "7"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "3.6"
+            },
+            "firefox_android": {
+              "version_added": "32"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "11"
+            },
+            "opera_android": {
+              "version_added": "11"
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadend_event": {
+        "__compat": {
+          "description": "<code>loadend</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileReader/loadend_event",
+          "spec_url": "https://w3c.github.io/FileAPI/#dfn-loadend-event",
+          "support": {
+            "chrome": {
+              "version_added": "7"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "3.6"
+            },
+            "firefox_android": {
+              "version_added": "32"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "11"
+            },
+            "opera_android": {
+              "version_added": "11"
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadstart_event": {
+        "__compat": {
+          "description": "<code>loadstart</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileReader/loadstart_event",
+          "spec_url": "https://w3c.github.io/FileAPI/#dfn-loadstart-event",
+          "support": {
+            "chrome": {
+              "version_added": "7"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "3.6",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "<code>loadstart</code> event dispatches synchronously (should be asynchronously as per spec)."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "32",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "<code>loadstart</code> event dispatches synchronously (should be asynchronously as per spec)."
+              }
+            ],
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "11"
+            },
+            "opera_android": {
+              "version_added": "11"
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onabort": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileReader/onabort",
+          "spec_url": "https://w3c.github.io/FileAPI/#dfn-onabort",
+          "support": {
+            "chrome": {
+              "version_added": "7"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "3.6"
+            },
+            "firefox_android": {
+              "version_added": "32"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "11"
+            },
+            "opera_android": {
+              "version_added": "11"
+            },
+            "safari": {
+              "version_added": "7"
+            },
+            "safari_ios": {
+              "version_added": "7"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -533,7 +533,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -554,13 +554,13 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -603,10 +603,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -630,7 +630,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -651,13 +651,13 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -726,7 +726,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -747,13 +747,13 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -773,40 +773,40 @@
           "spec_url": "https://w3c.github.io/FileAPI/#dfn-progress-event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3.6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "ie": {
-              "version_added": true
+              "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "11"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1022,7 +1022,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1043,13 +1043,13 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -1071,7 +1071,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -1095,10 +1095,10 @@
               "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"

--- a/api/FileReader.json
+++ b/api/FileReader.json
@@ -179,10 +179,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -238,11 +238,11 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "7",
+              "version_added": "6",
               "notes": "The <code>error</code> property returns a <code>DOMError</code> object."
             },
             "safari_ios": {
-              "version_added": "7",
+              "version_added": "6",
               "notes": "The <code>error</code> property returns a <code>DOMError</code> object."
             },
             "samsunginternet_android": {
@@ -290,10 +290,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -340,10 +340,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -390,10 +390,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -456,10 +456,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -505,10 +505,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -554,10 +554,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -603,10 +603,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -651,10 +651,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -699,10 +699,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -747,10 +747,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -797,10 +797,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1043,10 +1043,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1092,10 +1092,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for all browsers for the `FileReader` API.  The data for the events was copied from their event handler counterparts.  Data for the other features was mirrored from Chrome to Chrome Android and Samsung Internet.  Finally, this corrects the Safari data.