### PR TITLE
Add Safari versions for MediaEncryptedEvent API

### DIFF
--- a/api/MediaEncryptedEvent.json
+++ b/api/MediaEncryptedEvent.json
@@ -29,10 +29,10 @@
             "version_added": "29"
           },
           "safari": {
-            "version_added": true
+            "version_added": "12.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "12.2"
           },
           "samsunginternet_android": {
             "version_added": "4.0"
@@ -77,10 +77,10 @@
               "version_added": "29"
             },
             "safari": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -125,10 +125,10 @@
               "version_added": "29"
             },
             "safari": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -173,10 +173,10 @@
               "version_added": "29"
             },
             "safari": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `MediaEncryptedEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaEncryptedEvent
