### PR TITLE
Update Firefox versions for NamedNodeMap API

### DIFF
--- a/api/NamedNodeMap.json
+++ b/api/NamedNodeMap.json
@@ -24,7 +24,7 @@
               "alternative_name": "mozNamedAttrMap"
             },
             {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "22"
             }
           ],
@@ -38,7 +38,7 @@
               "alternative_name": "mozNamedAttrMap"
             },
             {
-              "version_added": true,
+              "version_added": "4",
               "version_removed": "22"
             }
           ],
@@ -85,10 +85,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "34"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "34"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "6"
@@ -133,10 +133,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "34"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "34"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -181,10 +181,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "34"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "34"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "5"
@@ -229,10 +229,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "34"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "34"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "5"
@@ -277,10 +277,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "34"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "34"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "6"
@@ -325,10 +325,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "34"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "34"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -373,10 +373,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "34"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "34"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "6"
@@ -421,10 +421,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "34"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "34"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `NamedNodeMap` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/NamedNodeMap
