### PR TITLE
Firefox 91 - api.window.visualViewport now supported for desktop

### DIFF
--- a/api/VisualViewport.json
+++ b/api/VisualViewport.json
@@ -14,16 +14,21 @@
           "edge": {
             "version_added": "79"
           },
-          "firefox": {
-            "version_added": "63",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.visualviewport.enabled",
-                "value_to_set": "true"
-              }
-            ]
-          },
+          "firefox": [
+            {
+              "version_added": "91"
+            },
+            {
+              "version_added": "63",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.visualviewport.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": [
             {
               "version_added": "68"
@@ -81,16 +86,21 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.visualviewport.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "91"
+              },
+              {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.visualviewport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": [
               {
                 "version_added": "68"
@@ -149,16 +159,21 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.visualviewport.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "91"
+              },
+              {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.visualviewport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": [
               {
                 "version_added": "68"
@@ -217,16 +232,21 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.visualviewport.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "91"
+              },
+              {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.visualviewport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": [
               {
                 "version_added": "68"
@@ -297,16 +317,21 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "66",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.visualviewport.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "91"
+              },
+              {
+                "version_added": "66",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.visualviewport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": [
               {
                 "version_added": "68"
@@ -401,16 +426,21 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "66",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.visualviewport.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "91"
+              },
+              {
+                "version_added": "66",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.visualviewport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": [
               {
                 "version_added": "68"
@@ -493,16 +523,21 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.visualviewport.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "91"
+              },
+              {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.visualviewport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": [
               {
                 "version_added": "68"
@@ -561,16 +596,21 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.visualviewport.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "91"
+              },
+              {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.visualviewport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": [
               {
                 "version_added": "68"
@@ -642,16 +682,21 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "66",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.visualviewport.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "91"
+              },
+              {
+                "version_added": "66",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.visualviewport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": [
               {
                 "version_added": "68"
@@ -734,16 +779,21 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.visualviewport.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "91"
+              },
+              {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.visualviewport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": [
               {
                 "version_added": "68"
@@ -815,16 +865,21 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "66",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.visualviewport.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "91"
+              },
+              {
+                "version_added": "66",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.visualviewport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": [
               {
                 "version_added": "68"
@@ -907,16 +962,21 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.visualviewport.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "91"
+              },
+              {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.visualviewport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": [
               {
                 "version_added": "68"

--- a/api/Window.json
+++ b/api/Window.json
@@ -10224,7 +10224,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Window.json
+++ b/api/Window.json
@@ -10171,26 +10171,36 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.visualviewport.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.visualviewport.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "91"
+              },
+              {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.visualviewport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "68"
+              },
+              {
+                "version_added": "63",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.visualviewport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
Visual Viewport API now supported on FF91 desktop. This just mirrors the pattern used for FF android, which enabled the preference in FF68. 

- Moz bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1551302
- Docs tracking: https://github.com/mdn/content/issues/6713