### PR TITLE
Update Chrome/Safari versions for ErrorEvent API

### DIFF
--- a/api/ErrorEvent.json
+++ b/api/ErrorEvent.json
@@ -6,7 +6,7 @@
         "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#the-errorevent-interface",
         "support": {
           "chrome": {
-            "version_added": "10"
+            "version_added": "15"
           },
           "chrome_android": {
             "version_added": "18"
@@ -30,10 +30,10 @@
             "version_added": "11"
           },
           "safari": {
-            "version_added": true
+            "version_added": "6"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "6"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -54,10 +54,10 @@
           "description": "<code>ErrorEvent()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "16"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "14"
@@ -72,22 +72,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -198,7 +198,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ErrorEvent/filename",
           "support": {
             "chrome": {
-              "version_added": "10"
+              "version_added": "15"
             },
             "chrome_android": {
               "version_added": "18"
@@ -246,7 +246,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ErrorEvent/lineno",
           "support": {
             "chrome": {
-              "version_added": "10"
+              "version_added": "15"
             },
             "chrome_android": {
               "version_added": "18"
@@ -294,7 +294,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ErrorEvent/message",
           "support": {
             "chrome": {
-              "version_added": "10"
+              "version_added": "15"
             },
             "chrome_android": {
               "version_added": "18"


### PR DESCRIPTION
This PR updates and corrects the real values for Chrome and Safari for the `ErrorEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ErrorEvent
