### PR TITLE
Add Chrome/Safari versions for HashChangeEvent API

### DIFF
--- a/api/HashChangeEvent.json
+++ b/api/HashChangeEvent.json
@@ -103,10 +103,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#dom-hashchangeevent-newurl-dev",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -121,22 +121,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -152,10 +152,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#dom-hashchangeevent-oldurl-dev",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "8"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -170,22 +170,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/HashChangeEvent.json
+++ b/api/HashChangeEvent.json
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "≤15"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "≤14"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "5.1"
@@ -170,10 +170,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "≤15"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "≤14"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "5.1"

--- a/api/HashChangeEvent.json
+++ b/api/HashChangeEvent.json
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "5.1"
@@ -170,10 +170,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "5.1"


### PR DESCRIPTION
This PR adds real values for Chrome and Safari for the `HashChangeEvent` API, based upon manual testing.

Test Code Used:
```js
if (location.hash === '#foobar') {
	location.hash = '#foo';
} else {
	location.hash = '#foobar';
}

window.addEventListener('hashchange', function(event) {
	alert(event.oldURL);
	alert(event.newURL);
});
```
