### PR TITLE
Update spec URL for CSS scroll-behavior

### DIFF
--- a/css/properties/scroll-behavior.json
+++ b/css/properties/scroll-behavior.json
@@ -4,7 +4,7 @@
       "scroll-behavior": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-behavior",
-          "spec_url": "https://drafts.csswg.org/cssom-view/#smooth-scrolling",
+          "spec_url": "https://drafts.csswg.org/css-overflow/#smooth-scrolling",
           "support": {
             "chrome": {
               "version_added": "61"


### PR DESCRIPTION
https://github.com/w3c/csswg-drafts/commit/05b08f7 moved the `scroll-behavior` property out of the CSSOM View spec and into the CSS Overflow spec.