### PR TITLE
Add Chromium versions for api.CustomEvent.initCustomEvent

### DIFF
--- a/api/CustomEvent.json
+++ b/api/CustomEvent.json
@@ -152,24 +152,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomEvent/initCustomEvent",
           "spec_url": "https://dom.spec.whatwg.org/#dom-customevent-initcustomevent",
           "support": {
-            "chrome": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": "59",
-                "notes": "<code>canBubble</code>, <code>cancelable</code>, and <code>detail</code> are optional parameters defaulting to <code>false</code>, <code>false</code>, and <code>null</code> respectively."
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": "59",
-                "notes": "<code>canBubble</code>, <code>cancelable</code>, and <code>detail</code> are optional parameters defaulting to <code>false</code>, <code>false</code>, and <code>null</code> respectively."
-              }
-            ],
+            "chrome": {
+              "version_added": "15",
+              "notes": "Since Chrome 59, <code>canBubble</code>, <code>cancelable</code>, and <code>detail</code> are optional parameters defaulting to <code>false</code>, <code>false</code>, and <code>null</code> respectively."
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "notes": "Since Chrome 59, <code>canBubble</code>, <code>cancelable</code>, and <code>detail</code> are optional parameters defaulting to <code>false</code>, <code>false</code>, and <code>null</code> respectively."
+            },
             "edge": {
               "version_added": "12"
             },
@@ -183,10 +173,12 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": "11"
+              "version_added": "11",
+              "notes": "Since Opera 46, <code>canBubble</code>, <code>cancelable</code>, and <code>detail</code> are optional parameters defaulting to <code>false</code>, <code>false</code>, and <code>null</code> respectively."
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11",
+              "notes": "Since Opera Android 43, <code>canBubble</code>, <code>cancelable</code>, and <code>detail</code> are optional parameters defaulting to <code>false</code>, <code>false</code>, and <code>null</code> respectively."
             },
             "safari": {
               "version_added": "5.1"
@@ -194,24 +186,14 @@
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": "7.0",
-                "notes": "<code>canBubble</code>, <code>cancelable</code>, and <code>detail</code> are optional parameters defaulting to <code>false</code>, <code>false</code>, and <code>null</code> respectively."
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": true
-              },
-              {
-                "version_added": "59",
-                "notes": "<code>canBubble</code>, <code>cancelable</code>, and <code>detail</code> are optional parameters defaulting to <code>false</code>, <code>false</code>, and <code>null</code> respectively."
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "7.0",
+              "notes": "Since Samsung Internet 7.0, <code>canBubble</code>, <code>cancelable</code>, and <code>detail</code> are optional parameters defaulting to <code>false</code>, <code>false</code>, and <code>null</code> respectively."
+            },
+            "webview_android": {
+              "version_added": "≤37",
+              "notes": "Since Chrome 59, <code>canBubble</code>, <code>cancelable</code>, and <code>detail</code> are optional parameters defaulting to <code>false</code>, <code>false</code>, and <code>null</code> respectively."
+            }
           },
           "status": {
             "experimental": false,

--- a/api/CustomEvent.json
+++ b/api/CustomEvent.json
@@ -153,12 +153,10 @@
           "spec_url": "https://dom.spec.whatwg.org/#dom-customevent-initcustomevent",
           "support": {
             "chrome": {
-              "version_added": "15",
-              "notes": "Since Chrome 59, <code>canBubble</code>, <code>cancelable</code>, and <code>detail</code> are optional parameters defaulting to <code>false</code>, <code>false</code>, and <code>null</code> respectively."
+              "version_added": "15"
             },
             "chrome_android": {
-              "version_added": "18",
-              "notes": "Since Chrome 59, <code>canBubble</code>, <code>cancelable</code>, and <code>detail</code> are optional parameters defaulting to <code>false</code>, <code>false</code>, and <code>null</code> respectively."
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -173,12 +171,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": "11",
-              "notes": "Since Opera 46, <code>canBubble</code>, <code>cancelable</code>, and <code>detail</code> are optional parameters defaulting to <code>false</code>, <code>false</code>, and <code>null</code> respectively."
+              "version_added": "11"
             },
             "opera_android": {
-              "version_added": "11",
-              "notes": "Since Opera Android 43, <code>canBubble</code>, <code>cancelable</code>, and <code>detail</code> are optional parameters defaulting to <code>false</code>, <code>false</code>, and <code>null</code> respectively."
+              "version_added": "11"
             },
             "safari": {
               "version_added": "5.1"
@@ -187,12 +183,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "7.0",
-              "notes": "Since Samsung Internet 7.0, <code>canBubble</code>, <code>cancelable</code>, and <code>detail</code> are optional parameters defaulting to <code>false</code>, <code>false</code>, and <code>null</code> respectively."
+              "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": "≤37",
-              "notes": "Since Chrome 59, <code>canBubble</code>, <code>cancelable</code>, and <code>detail</code> are optional parameters defaulting to <code>false</code>, <code>false</code>, and <code>null</code> respectively."
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `initCustomEvent` member of the `CustomEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CustomEvent/initCustomEvent
