### PR TITLE
Updates opera to version 78

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -594,14 +594,21 @@
         "77": {
           "release_date": "2021-06-09",
           "release_notes": "https://blogs.opera.com/desktop/2021/06/opera-77-stable/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "91"
         },
         "78": {
-          "status": "beta",
+          "release_date": "2021-08-03",
+          "release_notes": "https://blogs.opera.com/desktop/2021/08/opera-78-stable/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "92"
+        },
+        "79": {
+          "status": "beta",
+          "engine": "Blink",
+          "engine_version": "93"
         }
       }
     }


### PR DESCRIPTION
According to Opera blog on [this link](https://blogs.opera.com/desktop/2021/08/opera-78-stable/), 78 is the current browser opera version.

Closes #11899.