### PR TITLE
Adds avoid-page and avoid-column support for break-inside for Firefox

### DIFF
--- a/css/properties/break-inside.json
+++ b/css/properties/break-inside.json
@@ -67,9 +67,9 @@
               "deprecated": false
             }
           },
-          "column": {
+          "avoid-column": {
             "__compat": {
-              "description": "<code>column</code> and <code>avoid-column</code>",
+              "description": "<code>avoid-column</code>",
               "support": {
                 "chrome": {
                   "version_added": "50"
@@ -181,9 +181,9 @@
               "deprecated": false
             }
           },
-          "page": {
+          "avoid-page": {
             "__compat": {
-              "description": "<code>page</code> and <code>avoid-page</code>",
+              "description": "<code>avoid-page</code>",
               "support": {
                 "chrome": {
                   "version_added": "51"

--- a/css/properties/break-inside.json
+++ b/css/properties/break-inside.json
@@ -81,10 +81,10 @@
                   "version_added": "12"
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "92"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "92"
                 },
                 "ie": {
                   "version_added": "10"
@@ -195,10 +195,10 @@
                   "version_added": "12"
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "92"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "92"
                 },
                 "ie": {
                   "version_added": false


### PR DESCRIPTION
#### Summary
Firefox 92 added support for the keywords `avoid-page` and `avoid-column` of the `break-inside` property. See [bug 1722945](https://bugzilla.mozilla.org/show_bug.cgi?id=1722945).

While I was on that I realized that the descriptions were wrong. They included the keywords `column` and `page` which are only available for `break-before` and `break-after` (see https://www.w3.org/TR/css-break-3/#break-between and https://www.w3.org/TR/css-break-3/#break-within). So I removed them.

#### Test results and supporting details
https://jsfiddle.net/SebastianZ/qukjxtyh/

Sebastian