### PR TITLE
Add mdn/spec urls for WebXR anchors

### DIFF
--- a/api/XRAnchor.json
+++ b/api/XRAnchor.json
@@ -2,6 +2,8 @@
   "api": {
     "XRAnchor": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRAnchor",
+        "spec_url": "https://immersive-web.github.io/anchors/#xr-anchor",
         "support": {
           "chrome": {
             "version_added": "85"
@@ -48,6 +50,8 @@
       },
       "anchorSpace": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRAnchor/anchorSpace",
+          "spec_url": "https://immersive-web.github.io/anchors/#dom-xranchor-anchorspace",
           "support": {
             "chrome": {
               "version_added": "85"
@@ -95,6 +99,8 @@
       },
       "delete": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRAnchor/delete",
+          "spec_url": "https://immersive-web.github.io/anchors/#dom-xranchor-delete",
           "support": {
             "chrome": {
               "version_added": "85"

--- a/api/XRAnchorSet.json
+++ b/api/XRAnchorSet.json
@@ -2,6 +2,8 @@
   "api": {
     "XRAnchorSet": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRAnchorSet",
+        "spec_url": "https://immersive-web.github.io/anchors/#xranchorset",
         "support": {
           "chrome": {
             "version_added": "85"

--- a/api/XRFrame.json
+++ b/api/XRFrame.json
@@ -50,6 +50,8 @@
       },
       "createAnchor": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRFrame/createAnchor",
+          "spec_url": "https://immersive-web.github.io/anchors/#dom-xrframe-createanchor",
           "support": {
             "chrome": {
               "version_added": "85"
@@ -436,6 +438,8 @@
       },
       "trackedAnchors": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRFrame/trackedAnchors",
+          "spec_url": "https://immersive-web.github.io/anchors/#dom-xrframe-trackedanchors",
           "support": {
             "chrome": {
               "version_added": "85"


### PR DESCRIPTION
Content work is getting done in https://github.com/mdn/content/pull/7662

XRAnchorSet is a Set-like object and it makes no sense to me to create those sub-pages on MDN. (Also, I don't want to fall into into this trap now. It is filed in https://github.com/mdn/browser-compat-data/issues/6367)