### PR TITLE
Firefox 92 ships size-adjust and font-size-adjust

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -810,7 +810,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -768,18 +768,24 @@
               "edge": {
                 "version_added": "92"
               },
-              "firefox": {
-                "version_added": "89",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.size-adjust.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "92"
+                },
+                {
+                  "version_added": "89",
+                  "version_removed": "92",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.size-adjust.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": {
-                "version_added": false
+                "version_added": "92"
               },
               "ie": {
                 "version_added": false

--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -109,24 +109,36 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "91",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-size-adjust.basis.enabled"
-                  }
-                ]
-              },
-              "firefox_android": {
-                "version_added": "91",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.font-size-adjust.basis.enabled"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "92"
+                },
+                {
+                  "version_added": "91",
+                  "version_removed": "92",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-size-adjust.basis.enabled"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "92"
+                },
+                {
+                  "version_added": "91",
+                  "version_removed": "92",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.font-size-adjust.basis.enabled"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/7754

Firefox 92 ships the `font-size-adjust` CSS property, and the `size-adjust` descriptor.