### PR TITLE
accent-color shipping in Firefox 92 and Chrome 93

### DIFF
--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -6,49 +6,73 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/accent-color",
           "spec_url": "https://drafts.csswg.org/css-ui/#widget-accent",
           "support": {
-            "chrome": {
-              "version_added": "91",
-              "flags": [
-                {
-                  "name": "#enable-experimental-web-platform-features",
-                  "type": "preference",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": "91",
-              "flags": [
-                {
-                  "name": "#enable-experimental-web-platform-features",
-                  "type": "preference",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
-            "edge": {
-              "version_added": "91",
-              "flags": [
-                {
-                  "name": "#enable-experimental-web-platform-features",
-                  "type": "preference",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
-            "firefox": {
-              "version_added": "90",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.accent-color.enabled",
-                  "value_to_set": "enabled"
-                }
-              ],
-              "notes": "Enabled by default in Firefox Nightly."
-            },
+            "chrome": [
+              {
+                "version_added": "93"
+              },
+              {
+                "version_added": "91",
+                "version_removed": "93",
+                "flags": [
+                  {
+                    "name": "#enable-experimental-web-platform-features",
+                    "type": "preference",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "93"
+              },
+              {
+                "version_added": "91",
+                "version_removed": "93",
+                "flags": [
+                  {
+                    "name": "#enable-experimental-web-platform-features",
+                    "type": "preference",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "edge": [
+              {
+                "version_added": "93"
+              },
+              {
+                "version_added": "91",
+                "version_removed": "93",
+                "flags": [
+                  {
+                    "name": "#enable-experimental-web-platform-features",
+                    "type": "preference",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "92"
+              },
+              {
+                "version_added": "90",
+                "version_removed": "92",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.accent-color.enabled",
+                    "value_to_set": "enabled"
+                  }
+                ],
+                "notes": "Enabled by default in Firefox Nightly."
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "92"
             },
             "ie": {
               "version_added": false
@@ -69,7 +93,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "93"
             }
           },
           "status": {

--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -97,7 +97,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
Working on https://github.com/mdn/content/issues/7752

The `accent-color` property is shipping in Firefox 92.
It is also shipping in Chrome 93: https://chromestatus.com/feature/4752739957473280 