### PR TITLE
system-ui support in Firefox 92

### DIFF
--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -68,7 +68,7 @@
               },
               "firefox": [
                 {
-                  "version_added": false
+                  "version_added": "92"
                 },
                 {
                   "alternative_name": "-apple-system",
@@ -77,7 +77,7 @@
                 }
               ],
               "firefox_android": {
-                "version_added": false
+                "version_added": "92"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
Working on https://github.com/mdn/content/issues/7751

The `system-ui` value for `font-family` is shipping in Firefox 92.