### PR TITLE
Update spec URL for gamepad permission policy

### DIFF
--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -602,7 +602,7 @@
         "gamepad": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/gamepad",
-            "spec_url": "https://www.w3.org/TR/gamepad/#dfn-gamepad",
+            "spec_url": "https://w3c.github.io/gamepad/#permission-policy",
             "support": {
               "chrome": {
                 "version_added": "86",


### PR DESCRIPTION
* In general, should link to w3c.github.io spec versions rather than www.w3.org/TR — because many of the www.w3.org/TR are out of date, while the w3c.github.io versions always reflect the latest changes.

* In general, should link to the closest heading ID, when it makes sense, not necessarily to the most-specific dfn ID — because linking to the heading immediately orients the reader/developer, with more context,  in a way that linking deeper in doesn’t.

  For example, a developer following a link to the specific anchor https://w3c.github.io/gamepad/#dfn-gamepad won’t even see the “Integration with Permissions Policy” heading, because they get scrolled past it. But a developer following a link to https://w3c.github.io/gamepad/#permission-policy will immediately see the heading and the entire content of the section — so it provides more context and clarity for them as a reader.