### PR TITLE
Add back ClientRect alias for DOMRectReadOnly

### DIFF
--- a/api/DOMRectReadOnly.json
+++ b/api/DOMRectReadOnly.json
@@ -5,42 +5,130 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly",
         "spec_url": "https://drafts.fxtf.org/geometry/#DOMRect",
         "support": {
-          "chrome": {
-            "version_added": "61"
-          },
-          "chrome_android": {
-            "version_added": "61"
-          },
-          "edge": {
-            "version_added": "79"
-          },
-          "firefox": {
-            "version_added": "31"
-          },
-          "firefox_android": {
-            "version_added": "31"
-          },
+          "chrome": [
+            {
+              "version_added": "61"
+            },
+            {
+              "alternative_name": "ClientRect",
+              "version_added": "2",
+              "version_removed": "61"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "61"
+            },
+            {
+              "alternative_name": "ClientRect",
+              "version_added": "18",
+              "version_removed": "61"
+            }
+          ],
+          "edge": [
+            {
+              "version_added": "79"
+            },
+            {
+              "alternative_name": "ClientRect",
+              "version_added": "12",
+              "version_removed": "79"
+            }
+          ],
+          "firefox": [
+            {
+              "version_added": "31"
+            },
+            {
+              "alternative_name": "DOMRect",
+              "version_added": "27",
+              "version_removed": "31"
+            },
+            {
+              "alternative_name": "ClientRect",
+              "version_added": "3",
+              "version_removed": "27"
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "31"
+            },
+            {
+              "alternative_name": "DOMRect",
+              "version_added": "27",
+              "version_removed": "31"
+            },
+            {
+              "alternative_name": "ClientRect",
+              "version_added": "4",
+              "version_removed": "27"
+            }
+          ],
           "ie": {
-            "version_added": false
+            "alternative_name": "ClientRect",
+            "version_added": "4"
           },
-          "opera": {
-            "version_added": "48"
-          },
-          "opera_android": {
-            "version_added": "45"
-          },
-          "safari": {
-            "version_added": "10.1"
-          },
-          "safari_ios": {
-            "version_added": "10.3"
-          },
-          "samsunginternet_android": {
-            "version_added": "8.0"
-          },
-          "webview_android": {
-            "version_added": "61"
-          }
+          "opera": [
+            {
+              "version_added": "48"
+            },
+            {
+              "alternative_name": "ClientRect",
+              "version_added": "9.5",
+              "version_removed": "48"
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "45"
+            },
+            {
+              "alternative_name": "ClientRect",
+              "version_added": "10.1",
+              "version_removed": "45"
+            }
+          ],
+          "safari": [
+            {
+              "version_added": "10.1"
+            },
+            {
+              "alternative_name": "ClientRect",
+              "version_added": "4",
+              "version_removed": "11"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "10.3"
+            },
+            {
+              "alternative_name": "ClientRect",
+              "version_added": "3.2",
+              "version_removed": "11"
+            }
+          ],
+          "samsunginternet_android": [
+            {
+              "version_added": "8.0"
+            },
+            {
+              "alternative_name": "ClientRect",
+              "version_added": "1.0",
+              "version_removed": "8.0"
+            }
+          ],
+          "webview_android": [
+            {
+              "version_added": "61"
+            },
+            {
+              "alternative_name": "ClientRect",
+              "version_added": "2",
+              "version_removed": "61"
+            }
+          ]
         },
         "status": {
           "experimental": false,
@@ -104,40 +192,40 @@
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrectreadonly-bottom",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "2"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "18"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": "31"
+              "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "4"
             },
             "opera": {
-              "version_added": "48"
+              "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": "45"
-            },
-            "safari": {
               "version_added": "10.1"
             },
+            "safari": {
+              "version_added": "4"
+            },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": "8.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": "2"
             }
           },
           "status": {
@@ -203,40 +291,40 @@
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrectreadonly-height",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "2"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "18"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": "31"
+              "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "4"
             },
             "opera": {
-              "version_added": "48"
+              "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": "45"
-            },
-            "safari": {
               "version_added": "10.1"
             },
+            "safari": {
+              "version_added": "4"
+            },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": "8.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": "2"
             }
           },
           "status": {
@@ -252,40 +340,40 @@
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrectreadonly-left",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "2"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "18"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": "31"
+              "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "4"
             },
             "opera": {
-              "version_added": "48"
+              "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": "45"
-            },
-            "safari": {
               "version_added": "10.1"
             },
+            "safari": {
+              "version_added": "4"
+            },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": "8.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": "2"
             }
           },
           "status": {
@@ -301,40 +389,40 @@
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrectreadonly-right",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "2"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "18"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": "31"
+              "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "4"
             },
             "opera": {
-              "version_added": "48"
+              "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": "45"
-            },
-            "safari": {
               "version_added": "10.1"
             },
+            "safari": {
+              "version_added": "4"
+            },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": "8.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": "2"
             }
           },
           "status": {
@@ -397,40 +485,40 @@
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrectreadonly-top",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "2"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "18"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": "31"
+              "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "4"
             },
             "opera": {
-              "version_added": "48"
+              "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": "45"
-            },
-            "safari": {
               "version_added": "10.1"
             },
+            "safari": {
+              "version_added": "4"
+            },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": "8.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": "2"
             }
           },
           "status": {
@@ -446,40 +534,40 @@
           "spec_url": "https://drafts.fxtf.org/geometry/#dom-domrectreadonly-width",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "2"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "18"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": "31"
+              "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "4"
             },
             "opera": {
-              "version_added": "48"
+              "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": "45"
-            },
-            "safari": {
               "version_added": "10.1"
             },
+            "safari": {
+              "version_added": "4"
+            },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": "8.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": "2"
             }
           },
           "status": {


### PR DESCRIPTION
Since the properties top, right, bottom and left are on DOMRectReadOnly,
it's necessary to treat ClientRect as an alias of both DOMRect and
DOMRectReadOnly. See discussion starting here:
https://github.com/mdn/browser-compat-data/pull/11679#issuecomment-885951832

This reverts https://github.com/mdn/browser-compat-data/pull/11694 but
goes much further in representing the ClientRect support than before.