### PR TITLE
Remove notes about Opera Mini for HTMLCanvasElement

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -24,12 +24,10 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": "9",
-            "notes": "Opera Mini 5.0 and later has partial support."
+            "version_added": "9"
           },
           "opera_android": {
-            "version_added": "10.1",
-            "notes": "Opera Mini 5.0 and later has partial support."
+            "version_added": "10.1"
           },
           "safari": {
             "version_added": "3"


### PR DESCRIPTION
BCD doesn't have Opera Mini as a browser, and these are the only
references to "Opera Mini" in any notes.
