### PR TITLE
Add api.WindowWorkerGlobalScope.structuredClone

### DIFF
--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -1357,6 +1357,66 @@
             }
           }
         }
+      },
+      "structuredClone": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/structuredClone",
+          "spec_url": "https://html.spec.whatwg.org/multipage/structured-data.html#dom-structuredclone",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": "1.13",
+              "partial_implementation": true,
+              "notes": [
+                "The <code>message</code> parameter does not support cloning <code>Blob</code> values.",
+                "The <code>transfer</code> parameter does not accept <code>ArrayBuffer</code> items. Passing an <code>ArrayBuffer</code> results in an error being thrown."
+              ]
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/WindowOrWorkerGlobalScope.json
+++ b/api/WindowOrWorkerGlobalScope.json
@@ -1412,7 +1412,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
#### Summary

Adds data entry for `self.structuredClone()`. See spec change:
https://github.com/whatwg/html/commit/1b5099fcf55cc6332fb9af5d36ac4db47749438b

#### Test results and supporting details

No browser support, except for in Deno.
https://wpt.fyi/results/html/webappapis/structured-clone?label=master&label=experimental&product=chrome&product=edge&product=firefox&product=safari&product=deno&aligned
