### PR TITLE
Fix capitalization of MozNamedAttrMap

### DIFF
--- a/api/NamedNodeMap.json
+++ b/api/NamedNodeMap.json
@@ -21,7 +21,7 @@
             {
               "version_added": "22",
               "version_removed": "34",
-              "alternative_name": "mozNamedAttrMap"
+              "alternative_name": "MozNamedAttrMap"
             },
             {
               "version_added": "1",
@@ -35,7 +35,7 @@
             {
               "version_added": "22",
               "version_removed": "34",
-              "alternative_name": "mozNamedAttrMap"
+              "alternative_name": "MozNamedAttrMap"
             },
             {
               "version_added": "4",


### PR DESCRIPTION
Tested by inspecting `document.body.attributes` in Firefox 22 and 33.