### PR TITLE
Add spec and MDN URLs for BarProp

### DIFF
--- a/api/BarProp.json
+++ b/api/BarProp.json
@@ -2,6 +2,8 @@
   "api": {
     "BarProp": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/BarProp",
+        "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#barprop",
         "support": {
           "chrome": {
             "version_added": "29"
@@ -48,6 +50,8 @@
       },
       "visible": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BarProp/visible",
+          "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-barprop-visible",
           "support": {
             "chrome": {
               "version_added": "43"


### PR DESCRIPTION
I've been working on BarProp in https://github.com/mdn/content/pull/7854

This PR adds the spec and MDN URLs.