### PR TITLE
TextTrack and WebVTT spec and MDN URLs

### DIFF
--- a/api/TextTrackCue.json
+++ b/api/TextTrackCue.json
@@ -51,6 +51,7 @@
       "endTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackCue/endTime",
+          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-texttrackcue-endtime",
           "support": {
             "chrome": {
               "version_added": "23"
@@ -197,6 +198,7 @@
       "id": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackCue/id",
+          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-texttrackcue-track/id",
           "support": {
             "chrome": {
               "version_added": "23"
@@ -244,6 +246,8 @@
       },
       "onenter": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackCue/onenter",
+          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#handler-texttrackcue-onenter",
           "support": {
             "chrome": {
               "version_added": "23"
@@ -291,6 +295,8 @@
       },
       "onexit": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackCue/onexit",
+          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#handler-texttrackcue-onexit",
           "support": {
             "chrome": {
               "version_added": "23"
@@ -339,6 +345,7 @@
       "pauseOnExit": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackCue/pauseOnExit",
+          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-texttrackcue-pauseonexit",
           "support": {
             "chrome": {
               "version_added": "23"
@@ -387,6 +394,7 @@
       "startTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackCue/startTime",
+          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-texttrackcue-starttime",
           "support": {
             "chrome": {
               "version_added": "23"
@@ -435,6 +443,7 @@
       "track": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackCue/track",
+          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-texttrackcue-track",
           "support": {
             "chrome": {
               "version_added": "23"

--- a/api/VTTCue.json
+++ b/api/VTTCue.json
@@ -101,6 +101,7 @@
       "align": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VTTCue/align",
+          "spec_url": "https://w3c.github.io/webvtt/#dom-vttcue-align",
           "support": {
             "chrome": {
               "version_added": "23"
@@ -149,6 +150,7 @@
       "getCueAsHTML": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VTTCue/getCueAsHTML",
+          "spec_url": "https://w3c.github.io/webvtt/#dom-vttcue-getcueashtml",
           "support": {
             "chrome": {
               "version_added": "23"
@@ -197,6 +199,7 @@
       "line": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VTTCue/line",
+          "spec_url": "https://w3c.github.io/webvtt/#dom-vttcue-line",
           "support": {
             "chrome": {
               "version_added": "23"
@@ -245,6 +248,7 @@
       "lineAlign": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VTTCue/lineAlign",
+          "spec_url": "https://w3c.github.io/webvtt/#dom-vttcue-linealign",
           "support": {
             "chrome": {
               "version_added": false
@@ -293,6 +297,7 @@
       "position": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VTTCue/position",
+          "spec_url": "https://w3c.github.io/webvtt/#dom-vttcue-position",
           "support": {
             "chrome": {
               "version_added": "23"
@@ -341,6 +346,7 @@
       "positionAlign": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VTTCue/positionAlign",
+          "spec_url": "https://w3c.github.io/webvtt/#dom-vttcue-positionalign",
           "support": {
             "chrome": {
               "version_added": false
@@ -389,6 +395,7 @@
       "region": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VTTCue/region",
+          "spec_url": "https://w3c.github.io/webvtt/#dom-vttcue-region",
           "support": {
             "chrome": {
               "version_added": false
@@ -437,6 +444,7 @@
       "size": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VTTCue/size",
+          "spec_url": "https://w3c.github.io/webvtt/#dom-vttcue-size",
           "support": {
             "chrome": {
               "version_added": "23"
@@ -485,6 +493,7 @@
       "snapToLines": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VTTCue/snapToLines",
+          "spec_url": "https://w3c.github.io/webvtt/#dom-vttcue-snaptolines",
           "support": {
             "chrome": {
               "version_added": "23"
@@ -533,6 +542,7 @@
       "text": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VTTCue/text",
+          "spec_url": "https://w3c.github.io/webvtt/#dom-vttcue-text",
           "support": {
             "chrome": {
               "version_added": "23"
@@ -581,6 +591,7 @@
       "vertical": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VTTCue/vertical",
+          "spec_url": "https://w3c.github.io/webvtt/#dom-vttcue-vertical",
           "support": {
             "chrome": {
               "version_added": "23"

--- a/api/VTTRegion.json
+++ b/api/VTTRegion.json
@@ -51,6 +51,7 @@
       "VTTRegion": {
         "__compat": {
           "description": "<code>VTTRegion()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/VTTRegion/VTTRegion",
           "spec_url": "https://w3c.github.io/webvtt/#dom-vttregion-vttregion",
           "support": {
             "chrome": {
@@ -100,6 +101,7 @@
       "id": {
         "__compat": {
           "spec_url": "https://w3c.github.io/webvtt/#dom-vttregion-id",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/VTTRegion/id",
           "support": {
             "chrome": {
               "version_added": false
@@ -148,6 +150,7 @@
       "lines": {
         "__compat": {
           "spec_url": "https://w3c.github.io/webvtt/#dom-vttregion-lines",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/VTTRegion/lines",
           "support": {
             "chrome": {
               "version_added": false
@@ -196,6 +199,7 @@
       "regionAnchorX": {
         "__compat": {
           "spec_url": "https://w3c.github.io/webvtt/#dom-vttregion-regionanchorx",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/VTTRegion/regionAnchorX",
           "support": {
             "chrome": {
               "version_added": false
@@ -244,6 +248,7 @@
       "regionAnchorY": {
         "__compat": {
           "spec_url": "https://w3c.github.io/webvtt/#dom-vttregion-regionanchory",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/VTTRegion/regionAnchorY",
           "support": {
             "chrome": {
               "version_added": false
@@ -292,6 +297,7 @@
       "scroll": {
         "__compat": {
           "spec_url": "https://w3c.github.io/webvtt/#dom-vttregion-scroll",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/VTTRegion/scroll",
           "support": {
             "chrome": {
               "version_added": false
@@ -340,6 +346,7 @@
       "viewportAnchorX": {
         "__compat": {
           "spec_url": "https://w3c.github.io/webvtt/#dom-vttregion-viewportanchorx",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/VTTRegion/viewportAnchorX",
           "support": {
             "chrome": {
               "version_added": false
@@ -388,6 +395,7 @@
       "viewportAnchorY": {
         "__compat": {
           "spec_url": "https://w3c.github.io/webvtt/#dom-vttregion-viewportanchory",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/VTTRegion/viewportAnchorY",
           "support": {
             "chrome": {
               "version_added": false
@@ -436,6 +444,7 @@
       "width": {
         "__compat": {
           "spec_url": "https://w3c.github.io/webvtt/#dom-vttregion-width",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/VTTRegion/width",
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
I've been working on some WebVTT and TextTrack pages, this PR adds missing spec and MDN URLs to related files.
