### PR TITLE
Fix traverse script after yargs upgrade

### DIFF
--- a/scripts/traverse.js
+++ b/scripts/traverse.js
@@ -12,13 +12,13 @@ const { argv } = require('yargs').command(
       })
       .positional('folder', {
         describe: 'The folder(s) to test (set to "all" for all folders)',
-        type: 'array',
+        type: 'string',
         default: 'all',
       })
       .positional('value', {
         describe: 'The value(s) to test against',
-        type: 'array',
-        default: ['null', 'true'],
+        type: 'string',
+        default: 'null,true',
       })
       .option('depth', {
         alias: 'd',
@@ -79,9 +79,7 @@ const folders =
         'xslt',
       ]
     : argv.folder.split(',');
-const values = Array.isArray(argv.value)
-  ? argv.value
-  : argv.value.toString().split(',');
+const values = argv.value.split(',');
 
 for (const folder in folders)
   traverseFeatures(bcd[folders[folder]], argv.depth, `${folders[folder]}.`);


### PR DESCRIPTION
https://github.com/mdn/browser-compat-data/pull/11916 broke the traverse
script, probably due to https://github.com/yargs/yargs/pull/1992.

The problem now is that for `npm run chrome all 90`, `values`
will be ["null", "true", "90"], due to the combining of default and
given argument, where before `values` would have been ["90"].

We were using arrays for both folder and value, which doesn't really
make sense since only the last positional argument can be variadic:
https://github.com/yargs/yargs/blob/master/docs/advanced.md#variadic-positional-arguments

Since we use comma-separated values, just use strings instead to avoid
the problem.