### PR TITLE
Add permission and feature policy speaker-selection

### DIFF
--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -1185,7 +1185,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -1140,6 +1140,56 @@
             "deprecated": true
           }
         }
+      },
+      "speaker-selection_permission": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Permissions/speaker-selection",
+          "spec_url": "https://w3c.github.io/permissions/#dom-permissionname-speaker-selection",
+          "description": "<code>speaker-selection</code> permission",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "92"
+            },
+            "firefox_android": {
+              "version_added": "92"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -1355,10 +1355,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": "14.0"
+                "version_added": false
               },
               "webview_android": {
-                "version_added": "84"
+                "version_added": false
               }
             },
             "status": {

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -1319,6 +1319,55 @@
             }
           }
         },
+        "speaker-selection": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/speaker-selection",
+            "spec_url": "https://w3c.github.io/mediacapture-output/#permissions-policy-integration",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "92"
+              },
+              "firefox_android": {
+                "version_added": "92"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "14.0"
+              },
+              "webview_android": {
+                "version_added": "84"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "sync-xhr": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/sync-xhr",


### PR DESCRIPTION
FF92 adds support for the `speaker-selection` permission and associated Permission-Policy (Feature-Policy on FF) - see https://bugzilla.mozilla.org/show_bug.cgi?id=1577199

I tried this on my phone with the first (enumerateDevices) test here: https://wpt.live/audio-output/. Test is not all that helpful. But anyway, if you look at https://bugzilla.mozilla.org/show_bug.cgi?id=1577199#c21 you will see that the evidence is that this feature is not supported on Safari or Chrome.

Tracking other docs work for this in https://github.com/mdn/content/issues/7746#issuecomment-898177902