### PR TITLE
Add partial implementation notes for Safari `InputEvent()` constructor

### DIFF
--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -84,12 +84,12 @@
             "safari": {
               "version_added": "10.1",
               "partial_implementation": true,
-              "notes": [
-                "Does not support inputEventInit parameter, see <a href='https://bugs.webkit.org/show_bug.cgi?id=170416'>bug 170416</a>"
-              ]
+              "notes": "The <code>inputEventInit</code> parameter is not supported. See <a href='https://webkit.org/b/170416'>bug 170416</a>."
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": "10.3",
+              "partial_implementation": true,
+              "notes": "The <code>inputEventInit</code> parameter is not supported. See <a href='https://webkit.org/b/170416'>bug 170416</a>."
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -82,7 +82,11 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10.1",
+              "partial_implementation": true,
+              "notes": [
+                "Does not support inputEventInit parameter, see <a href='https://bugs.webkit.org/show_bug.cgi?id=170416'>bug 170416</a>"
+              ]
             },
             "safari_ios": {
               "version_added": "10.3"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Add partial implementation notes for Safari `InputEvent()` constructor 

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->


In Safari's console - 

```
> e = new InputEvent('beforeinput', { inputType: 'insertText' }) 
< InputEvent {isTrusted: false, inputType: "", data: null, dataTransfer: null, getTargetRanges: function, …}
> e.inputType
< ""
```

Compared to in Firefox 

``` 
> e = new InputEvent('beforeinput', { inputType: 'insertText' })
< beforeinput { target: null, isTrusted: false, isComposing: false, inputType: "insertText", detail: 0, layerX: 0, layerY: 0, which: 0, rangeOffset: 0, SCROLL_PAGE_UP: -32768, … }
> e.inputType
< "insertText"
``` 


<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://bugs.webkit.org/show_bug.cgi?id=170416

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fixes https://github.com/mdn/browser-compat-data/issues/11994

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
