### PR TITLE
Add flag to Chrome Canary for HTML Sanitizer API

### DIFF
--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -6,7 +6,15 @@
         "spec_url": "https://wicg.github.io/sanitizer-api/#sanitizer-api",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": false,
+            "notes": "Currently Chrome Canary only",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "enable-experimental-web-platform-features",
+                "value_to_set": "enabled"
+              }
+            ]
           },
           "chrome_android": {
             "version_added": false
@@ -69,7 +77,15 @@
           "description": "<code>Sanitizer()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "Currently Chrome Canary only",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": false
@@ -132,7 +148,15 @@
           "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-sanitize",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "Currently Chrome Canary only",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": {
               "version_added": false

--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -6,8 +6,7 @@
         "spec_url": "https://wicg.github.io/sanitizer-api/#sanitizer-api",
         "support": {
           "chrome": {
-            "version_added": false,
-            "notes": "Currently Chrome Canary only",
+            "version_added": "preview",
             "flags": [
               {
                 "type": "preference",
@@ -77,8 +76,7 @@
           "description": "<code>Sanitizer()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "Currently Chrome Canary only",
+              "version_added": "preview",
               "flags": [
                 {
                   "type": "preference",
@@ -148,8 +146,7 @@
           "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-sanitize",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "Currently Chrome Canary only",
+              "version_added": "preview",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
#### Test results and supporting details
1. Visit https://sanitizer-api.dev/ on Chrome Canary
![image](https://user-images.githubusercontent.com/14011954/129463536-28027c23-b7c4-496d-abb2-33762c447536.png)
2. Set Experimental Web Platform features on chrome://flags to Enabled
3. Revisit https://sanitizer-api.dev/ after restarting Chrome Canary

Other supporting links:
- https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/sanitizer_api/sanitizer.cc
- https://www.chromestatus.com/feature/5786893650231296#details