### PR TITLE
Firefox Android 91 is released

### DIFF
--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -518,27 +518,28 @@
         "90": {
           "release_date": "2021-07-13",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/90",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "90"
         },
         "91": {
           "release_date": "2021-08-10",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/91",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "91"
         },
         "92": {
           "release_date": "2021-09-07",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/92",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "92"
         },
         "93": {
           "release_date": "2021-10-05",
-          "status": "planned",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/93",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "93"
         },


### PR DESCRIPTION
Firefox Android 91 has been released.  This PR updates our data accordingly.
