### PR TITLE
Add Chrome/Safari versions for ErrorEvent API

### DIFF
--- a/api/ErrorEvent.json
+++ b/api/ErrorEvent.json
@@ -30,10 +30,10 @@
             "version_added": "11"
           },
           "safari": {
-            "version_added": true
+            "version_added": "6"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "6"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -54,10 +54,10 @@
           "description": "<code>ErrorEvent()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "16"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "14"
@@ -72,22 +72,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -102,10 +102,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ErrorEvent/colno",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "30"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "30"
             },
             "edge": {
               "version_added": "12"
@@ -120,22 +120,22 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "17"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "safari": {
-              "version_added": true
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -150,10 +150,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ErrorEvent/error",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "30"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "30"
             },
             "edge": {
               "version_added": "12"
@@ -168,22 +168,22 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": true
+              "version_added": "17"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -222,10 +222,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -270,10 +270,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -318,10 +318,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Chrome and Safari for the `ErrorEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ErrorEvent
