### PR TITLE
Add Chromium versions for WEBGL_lose_context API

### DIFF
--- a/api/WEBGL_lose_context.json
+++ b/api/WEBGL_lose_context.json
@@ -10,7 +10,7 @@
               "version_added": "26"
             },
             {
-              "version_added": true,
+              "version_added": "18",
               "prefix": "WEBKIT_"
             }
           ],
@@ -19,7 +19,7 @@
               "version_added": "26"
             },
             {
-              "version_added": true,
+              "version_added": "18",
               "prefix": "WEBKIT_"
             }
           ],
@@ -47,7 +47,7 @@
               "version_added": "15"
             },
             {
-              "version_added": true,
+              "version_added": "15",
               "prefix": "WEBKIT_"
             }
           ],
@@ -56,7 +56,7 @@
               "version_added": "14"
             },
             {
-              "version_added": true,
+              "version_added": "14",
               "prefix": "WEBKIT_"
             }
           ],
@@ -71,7 +71,7 @@
               "version_added": "1.5"
             },
             {
-              "version_added": true,
+              "version_added": "1.0",
               "prefix": "WEBKIT_"
             }
           ],
@@ -80,7 +80,7 @@
               "version_added": "≤37"
             },
             {
-              "version_added": true,
+              "version_added": "≤37",
               "prefix": "WEBKIT_"
             }
           ]


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `WEBGL_lose_context` API, based upon manual testing.

Test Code Used:
```js
var canvas = document.createElement('canvas');
var ctx = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
ctx.getExtension('WEBKIT_WEBGL_lose_context');
```