### PR TITLE
Bug 1614919 browser.identity.launchWebAuthFlow() exposes redirect_url

### DIFF
--- a/webextensions/api/identity.json
+++ b/webextensions/api/identity.json
@@ -12,9 +12,15 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": {
-                "version_added": "53"
-              },
+              "firefox": [
+                {
+                  "version_added": "53"
+                },
+                {
+                  "version_added": "86",
+                  "notes": "The loopback address http://127.0.0.1/mozoauth2/[subdomain of URL returned by identity.getRedirectURL()] can be used as the redirect URL to enable the use of Google OAuth flows."
+                }
+              ],
               "firefox_android": {
                 "version_added": false
               },
@@ -45,6 +51,10 @@
                   "version_added": "53",
                   "version_removed": "63",
                   "notes": "The <code>redirect_uri</code> URL parameter is required."
+                },
+                {
+                  "version_added": "75",
+                  "notes": "The <code>redirect_uri</code> URL parameter must be set to the URL returned by <code>identity.getRedirectURL()</code>."
                 }
               ],
               "firefox_android": {

--- a/webextensions/api/identity.json
+++ b/webextensions/api/identity.json
@@ -18,7 +18,7 @@
                 },
                 {
                   "version_added": "86",
-                  "notes": "The loopback address http://127.0.0.1/mozoauth2/[subdomain of URL returned by identity.getRedirectURL()] can be used as the redirect URL to enable the use of Google OAuth flows."
+                  "notes": "The <code>redirect_url</code> parameter now supports a loopback address, see <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/identity#getting_the_redirect_url'>Getting the redirect URL</a> for details."
                 }
               ],
               "firefox_android": {

--- a/webextensions/api/identity.json
+++ b/webextensions/api/identity.json
@@ -12,15 +12,9 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "53"
-                },
-                {
-                  "version_added": "86",
-                  "notes": "The <code>redirect_url</code> parameter now supports a loopback address, see <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/identity#getting_the_redirect_url'>Getting the redirect URL</a> for details."
-                }
-              ],
+              "firefox": {
+                "version_added": "53"
+              },
               "firefox_android": {
                 "version_added": false
               },
@@ -43,20 +37,9 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "53"
-                },
-                {
-                  "version_added": "53",
-                  "version_removed": "63",
-                  "notes": "The <code>redirect_uri</code> URL parameter is required."
-                },
-                {
-                  "version_added": "75",
-                  "notes": "The <code>redirect_uri</code> URL parameter must be set to the URL returned by <code>identity.getRedirectURL()</code>."
-                }
-              ],
+              "firefox": {
+                "version_added": "53"
+              },
               "firefox_android": {
                 "version_added": false
               },
@@ -65,6 +48,44 @@
               },
               "safari": {
                 "version_added": false
+              }
+            }
+          },
+          "redirect_uri": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": [
+                  {
+                    "version_added": "53"
+                  },
+                  {
+                    "version_added": "63",
+                    "notes": "The <code>redirect_uri</code> URL parameter is now optional."
+                  },
+                  {
+                    "version_added": "75",
+                    "notes": "The <code>redirect_uri</code> URL parameter must be set to the URL returned by <code>identity.getRedirectURL()</code>."
+                  },
+                  {
+                    "version_added": "86",
+                    "notes": "The <code>redirect_url</code> parameter now supports a loopback address, see <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/identity#getting_the_redirect_url'>Getting the redirect URL</a> for details."
+                  }
+                ],
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                }
               }
             }
           }


### PR DESCRIPTION
#### Summary
Added notes to:
* getRedirectURL regarding the use of a loopback address
* launchWebAuthFlow  noting the need for redirect_uri to be set to the URL returned by identity.getRedirectURL()

#### Test results and supporting details

Ran npm test, no issues found

#### Related issues
[Bug 1614919](https://bugzilla.mozilla.org/show_bug.cgi?id=1614919)
