### PR TITLE
Add all browsers versions for api.FocusEvent.relatedTarget

### DIFF
--- a/api/FocusEvent.json
+++ b/api/FocusEvent.json
@@ -104,40 +104,40 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-focusevent-relatedtarget",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "26"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "48"
+              "version_added": "24"
             },
             "firefox_android": {
-              "version_added": "48"
+              "version_added": "24"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for all browsers for the `relatedTarget` member of the `FocusEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FocusEvent/relatedTarget
