### PR TITLE
Update all browsers versions for KeyboardEvent API

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -55,10 +55,10 @@
           "description": "<code>KeyboardEvent()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "26"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "edge": {
               "version_added": "12"
@@ -73,22 +73,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -104,40 +104,40 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-keyboardevent-altkey",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -153,19 +153,19 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-keyboardevent-charcode",
           "support": {
             "chrome": {
-              "version_added": "26"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -174,16 +174,16 @@
               "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -226,10 +226,10 @@
               "version_added": "35"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -251,40 +251,40 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-keyboardevent-ctrlkey",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -300,10 +300,10 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-keyboardevent-getmodifierstate",
           "support": {
             "chrome": {
-              "version_added": "31"
+              "version_added": "30"
             },
             "chrome_android": {
-              "version_added": "31"
+              "version_added": "30"
             },
             "edge": {
               "version_added": "12"
@@ -333,7 +333,7 @@
               "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -1243,10 +1243,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -1414,16 +1414,16 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-keyboardevent-keycode",
           "support": {
             "chrome": {
-              "version_added": "26"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "26"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "1.5"
             },
             "firefox_android": {
               "version_added": "4"
@@ -1438,13 +1438,13 @@
               "version_added": "12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4.2"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": "1.5"
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -1490,10 +1490,10 @@
               "version_removed": "41"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.5",
@@ -1517,10 +1517,10 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-keyboardevent-location",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "30"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "30"
             },
             "edge": {
               "version_added": "12"
@@ -1535,22 +1535,22 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "17"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -1566,40 +1566,40 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-keyboardevent-metakey",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1615,10 +1615,10 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-keyboardevent-repeat",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "32"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "edge": {
               "version_added": "12"
@@ -1633,10 +1633,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "19"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "19"
             },
             "safari": {
               "version_added": "10.1"
@@ -1645,10 +1645,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1664,40 +1664,40 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-keyboardevent-shiftkey",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1713,20 +1713,20 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-uievent-which",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "2",
+              "version_added": "1.5",
               "notes": "Firefox also implements this property on the <code>UIEvent</code> interface."
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "4",
               "notes": "Firefox also implements this property on the <code>UIEvent</code> interface."
             },
             "ie": {
@@ -1739,13 +1739,13 @@
               "version_added": "12.1"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"


### PR DESCRIPTION
This PR updates and corrects the real values for all browsers for the `KeyboardEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/KeyboardEvent
