### PR TITLE
Update Chromium versions for api.MouseEvent.MouseEvent

### DIFF
--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -59,10 +59,10 @@
           "description": "<code>MouseEvent()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "47"
+              "version_added": "26"
             },
             "chrome_android": {
-              "version_added": "47"
+              "version_added": "26"
             },
             "edge": {
               "version_added": "12"
@@ -77,22 +77,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "47"
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `MouseEvent` member of the `MouseEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MouseEvent/MouseEvent
