### PR TITLE
Add all browsers versions for SecurityPolicyViolationEvent API

### DIFF
--- a/api/SecurityPolicyViolationEvent.json
+++ b/api/SecurityPolicyViolationEvent.json
@@ -6,13 +6,13 @@
         "spec_url": "https://w3c.github.io/webappsec-csp/#report-violation",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "41"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "41"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "15"
           },
           "firefox": {
             "version_added": "63"
@@ -24,22 +24,22 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "28"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "28"
           },
           "safari": {
-            "version_added": true
+            "version_added": "10"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "10"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "4.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "41"
           }
         },
         "status": {
@@ -55,13 +55,13 @@
           "description": "<code>SecurityPolicyViolationEvent()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "41"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "15"
             },
             "firefox": {
               "version_added": "63"
@@ -73,22 +73,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "28"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "41"
             }
           },
           "status": {
@@ -104,10 +104,10 @@
           "spec_url": "https://w3c.github.io/webappsec-csp/#dom-securitypolicyviolationevent-blockeduri",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "41"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "edge": {
               "version_added": "15"
@@ -122,22 +122,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "28"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "41"
             }
           },
           "status": {
@@ -153,10 +153,10 @@
           "spec_url": "https://w3c.github.io/webappsec-csp/#dom-securitypolicyviolationevent-columnnumber",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "41"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "edge": {
               "version_added": "15"
@@ -171,22 +171,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "28"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "41"
             }
           },
           "status": {
@@ -202,13 +202,13 @@
           "spec_url": "https://w3c.github.io/webappsec-csp/#dom-securitypolicyviolationevent-disposition",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "56"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "63"
@@ -220,22 +220,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "56"
             }
           },
           "status": {
@@ -251,10 +251,10 @@
           "spec_url": "https://w3c.github.io/webappsec-csp/#dom-securitypolicyviolationevent-documenturi",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "41"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "edge": {
               "version_added": "15"
@@ -269,22 +269,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "28"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "41"
             }
           },
           "status": {
@@ -300,10 +300,10 @@
           "spec_url": "https://w3c.github.io/webappsec-csp/#dom-securitypolicyviolationevent-effectivedirective",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "41"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "edge": {
               "version_added": "15"
@@ -318,22 +318,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "28"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "41"
             }
           },
           "status": {
@@ -349,10 +349,10 @@
           "spec_url": "https://w3c.github.io/webappsec-csp/#dom-securitypolicyviolationevent-linenumber",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "41"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "edge": {
               "version_added": "15"
@@ -367,22 +367,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "28"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "41"
             }
           },
           "status": {
@@ -398,10 +398,10 @@
           "spec_url": "https://w3c.github.io/webappsec-csp/#dom-securitypolicyviolationevent-originalpolicy",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "41"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "edge": {
               "version_added": "15"
@@ -416,22 +416,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "28"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "41"
             }
           },
           "status": {
@@ -447,10 +447,10 @@
           "spec_url": "https://w3c.github.io/webappsec-csp/#dom-securitypolicyviolationevent-referrer",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "41"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "edge": {
               "version_added": "15"
@@ -465,22 +465,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "28"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "41"
             }
           },
           "status": {
@@ -502,7 +502,7 @@
               "version_added": "59"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "63"
@@ -520,10 +520,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -545,10 +545,10 @@
           "spec_url": "https://w3c.github.io/webappsec-csp/#dom-securitypolicyviolationevent-sourcefile",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "41"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "edge": {
               "version_added": "15"
@@ -563,22 +563,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "28"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "41"
             }
           },
           "status": {
@@ -594,10 +594,10 @@
           "spec_url": "https://w3c.github.io/webappsec-csp/#dom-securitypolicyviolationevent-statuscode",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "41"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "edge": {
               "version_added": "15"
@@ -612,22 +612,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "28"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "41"
             }
           },
           "status": {
@@ -643,10 +643,10 @@
           "spec_url": "https://w3c.github.io/webappsec-csp/#dom-securitypolicyviolationevent-violateddirective",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "41"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "edge": {
               "version_added": "15"
@@ -661,22 +661,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "28"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "41"
             }
           },
           "status": {
@@ -697,7 +697,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "15"
             },
             "firefox": {
               "version_added": "63"


### PR DESCRIPTION
This PR adds real values for all browsers for the `SecurityPolicyViolationEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SecurityPolicyViolationEvent
