### PR TITLE
Add all browsers versions for TransitionEvent API

### DIFF
--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -38,17 +38,29 @@
             "version_added": "10"
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
-          "safari": {
-            "version_added": true
-          },
-          "safari_ios": {
-            "version_added": true
-          },
+          "safari": [
+            {
+              "version_added": "7"
+            },
+            {
+              "prefix": "WebKit",
+              "version_added": "≤4"
+            }
+          ],
+          "safari_ios": [
+            {
+              "version_added": "7"
+            },
+            {
+              "prefix": "WebKit",
+              "version_added": "≤3"
+            }
+          ],
           "samsunginternet_android": [
             {
               "version_added": "2.0"
@@ -101,10 +113,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -150,16 +162,16 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -180,12 +192,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TransitionEvent/initTransitionEvent",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "Removal version unknown."
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": false,
-              "notes": "Removal version unknown."
+              "version_added": false
             },
             "edge": {
               "version_added": "12",
@@ -203,26 +213,24 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": false,
-              "notes": "Removal version unknown."
+              "version_added": "≤12.1",
+              "version_removed": "15"
             },
             "opera_android": {
-              "version_added": false,
-              "notes": "Removal version unknown."
+              "version_added": "≤12.1",
+              "version_removed": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false,
-              "notes": "Removal version unknown."
+              "version_added": false
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "Removal version unknown."
+              "version_added": false
             }
           },
           "status": {
@@ -247,25 +255,25 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -305,16 +313,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -192,7 +192,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TransitionEvent/initTransitionEvent",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "2",
+              "version_removed": "18",
+              "alternative_name": "initWebKitTransitionEvent"
             },
             "chrome_android": {
               "version_added": false
@@ -221,10 +223,14 @@
               "version_removed": "14"
             },
             "safari": {
-              "version_added": false
+              "version_added": "≤4",
+              "version_removed": "6",
+              "alternative_name": "initWebKitTransitionEvent"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3",
+              "version_removed": "6",
+              "alternative_name": "initWebKitTransitionEvent"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for all browsers for the `TransitionEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TransitionEvent
