### PR TITLE
Add all browsers versions for UIEvent API

### DIFF
--- a/api/UIEvent.json
+++ b/api/UIEvent.json
@@ -6,10 +6,10 @@
         "spec_url": "https://w3c.github.io/uievents/#idl-uievent",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -24,22 +24,22 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": true
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -55,13 +55,13 @@
           "description": "<code>UIEvent()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "26"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "11"
@@ -73,22 +73,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -104,10 +104,10 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-uievent-detail",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -124,22 +124,22 @@
               "notes": "Always <code>0</code> on <code>click</code> and <code>dblclick</code> events. On <code>mousedown</code> and <code>mouseup</code> events, the count is not unique to the element, but is rather the global click count for the current document -- even across refreshes."
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -155,10 +155,10 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-uievent-inituievent",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -173,22 +173,22 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -255,13 +255,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/UIEvent/layerX",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1",
+              "version_removed": "45"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18",
+              "version_removed": "45"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -270,25 +272,29 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15",
+              "version_removed": "32"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14",
+              "version_removed": "32"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0",
+              "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37",
+              "version_removed": "45"
             }
           },
           "status": {
@@ -303,13 +309,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/UIEvent/layerY",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1",
+              "version_removed": "45"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18",
+              "version_removed": "45"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -318,25 +326,29 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15",
+              "version_removed": "32"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14",
+              "version_removed": "32"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0",
+              "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37",
+              "version_removed": "45"
             }
           },
           "status": {
@@ -351,17 +363,17 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/UIEvent/pageX",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "44",
               "notes": "Replaced by <code>MouseEvent.pageX</code> in version 45."
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "44",
               "notes": "Replaced by <code>MouseEvent.pageX</code> in version 45."
             },
             "edge": {
-              "version_added": "12"
+              "version_added": false
             },
             "firefox": {
               "version_added": "1",
@@ -372,27 +384,29 @@
               "version_removed": "79"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "15",
+              "version_removed": "31"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14",
+              "version_removed": "32"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "4.0",
               "notes": "Replaced by <code>MouseEvent.pageX</code> in Samsung Internet 5.0."
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "≤37",
               "version_removed": "44",
               "notes": "Replaced by <code>MouseEvent.pageX</code> in version 45."
             }
@@ -409,17 +423,17 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/UIEvent/pageY",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "44",
               "notes": "Replaced by <code>MouseEvent.pageY</code> in version 45."
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "44",
               "notes": "Replaced by <code>MouseEvent.pageY</code> in version 45."
             },
             "edge": {
-              "version_added": "12"
+              "version_added": false
             },
             "firefox": {
               "version_added": "1",
@@ -430,27 +444,29 @@
               "version_removed": "79"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "15",
+              "version_removed": "31"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14",
+              "version_removed": "32"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "4.0",
               "notes": "Replaced by <code>MouseEvent.pageY</code> in Samsung Internet 5.0."
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "≤37",
               "version_removed": "44",
               "notes": "Replaced by <code>MouseEvent.pageY</code> in version 45."
             }
@@ -474,7 +490,7 @@
               "version_added": "47"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -486,10 +502,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "34"
             },
             "safari": {
               "version_added": false
@@ -517,10 +533,10 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-uievent-view",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -535,22 +551,22 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -565,13 +581,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/UIEvent/which",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "1"
@@ -583,22 +599,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for all browsers for the `UIEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/UIEvent
