### PR TITLE
Add Firefox versions for VTTCue API

### DIFF
--- a/api/VTTCue.json
+++ b/api/VTTCue.json
@@ -15,10 +15,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "26"
+            "version_added": "31"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "31"
           },
           "ie": {
             "version_added": false
@@ -64,10 +64,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "ie": {
               "version_added": false
@@ -112,10 +112,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "ie": {
               "version_added": false
@@ -160,10 +160,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "ie": {
               "version_added": false
@@ -208,10 +208,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "ie": {
               "version_added": false
@@ -256,10 +256,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "ie": {
               "version_added": false
@@ -304,10 +304,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "ie": {
               "version_added": false
@@ -352,10 +352,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "ie": {
               "version_added": false
@@ -400,10 +400,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "59"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "ie": {
               "version_added": false
@@ -448,10 +448,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "ie": {
               "version_added": false
@@ -496,10 +496,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "ie": {
               "version_added": false
@@ -544,10 +544,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "ie": {
               "version_added": false
@@ -592,10 +592,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `VTTCue` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/VTTCue
