### PR TITLE
Add MediaDevices.selectAudioOutput

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -499,6 +499,69 @@
             "deprecated": false
           }
         }
+      },
+      "selectAudioOutput": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDevices/selectAudioOutput",
+          "spec_url": "https://w3c.github.io/mediacapture-output/#dom-mediadevices-selectaudiooutput",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "88",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.setsinkid.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "88",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "media.setsinkid.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -525,14 +525,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "88",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.setsinkid.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
`MediaDevices.selectAudioOutput()` landed in the spec 5 or 6 months ago. It was added to FF behind a preference. According to https://bugzilla.mozilla.org/show_bug.cgi?id=1699026 this was in FF88, but I have not tested that version.

I have searched webkit and crhome and can find no obvious evidence of support, so have marked as "false". 

The docs for this are going in as https://github.com/mdn/content/pull/7962 (which is part of delivering some features for FF92 that are being tracked in https://github.com/mdn/content/issues/7746).

FYI to test this I am calling the fragment below within an onclick handler function triggered by a button. That is important - the popup is protected by a feature called transient user activation - it won't launch unless the user has been interacting with the page in some way immediately before the popup is called.
```js
if (!navigator.mediaDevices.selectAudioOutput) {
  console.log("selectAudioOutput() not supported.");
  return;
}

//Display prompt and log selected device or error
navigator.mediaDevices.selectAudioOutput()
.then( (device) => {
    console.log(device.kind + ": " + device.label + " id = " + device.deviceId);
  })
.catch(function(err) {
  console.log(err.name + ": " + err.message);
});
```
