### PR TITLE
Add Firefox versions for PerformanceEntry API

### DIFF
--- a/api/PerformanceEntry.json
+++ b/api/PerformanceEntry.json
@@ -27,10 +27,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "38"
+            "version_added": "35"
           },
           "firefox_android": {
-            "version_added": "38"
+            "version_added": "35"
           },
           "ie": {
             "version_added": "10"
@@ -103,10 +103,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "38"
+              "version_added": "35"
             },
             "firefox_android": {
-              "version_added": "38"
+              "version_added": "35"
             },
             "ie": {
               "version_added": "10"
@@ -155,10 +155,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "38"
+              "version_added": "35"
             },
             "firefox_android": {
-              "version_added": "38"
+              "version_added": "35"
             },
             "ie": {
               "version_added": "10"
@@ -207,10 +207,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "38"
+              "version_added": "35"
             },
             "firefox_android": {
-              "version_added": "38"
+              "version_added": "35"
             },
             "ie": {
               "version_added": "10"
@@ -259,10 +259,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "38"
+              "version_added": "35"
             },
             "firefox_android": {
-              "version_added": "38"
+              "version_added": "35"
             },
             "ie": {
               "version_added": "10"
@@ -311,10 +311,10 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "38"
+              "version_added": "35"
             },
             "firefox_android": {
-              "version_added": "38"
+              "version_added": "35"
             },
             "ie": {
               "version_added": false

--- a/api/PerformanceEntry.json
+++ b/api/PerformanceEntry.json
@@ -27,10 +27,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "38"
           },
           "firefox_android": {
-            "version_added": "25"
+            "version_added": "38"
           },
           "ie": {
             "version_added": "10"
@@ -103,10 +103,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "38"
             },
             "firefox_android": {
-              "version_added": "25"
+              "version_added": "38"
             },
             "ie": {
               "version_added": "10"
@@ -155,10 +155,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "38"
             },
             "firefox_android": {
-              "version_added": "25"
+              "version_added": "38"
             },
             "ie": {
               "version_added": "10"
@@ -207,10 +207,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "38"
             },
             "firefox_android": {
-              "version_added": "25"
+              "version_added": "38"
             },
             "ie": {
               "version_added": "10"
@@ -259,10 +259,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "38"
             },
             "firefox_android": {
-              "version_added": "25"
+              "version_added": "38"
             },
             "ie": {
               "version_added": "10"
@@ -311,10 +311,10 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "38"
             },
             "firefox_android": {
-              "version_added": "25"
+              "version_added": "38"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `PerformanceEntry` API, based upon browser bug history.

Bugs:
https://bugzil.la/822480
https://bugzil.la/1047848
