### PR TITLE
Allow release notes scripts to run from any branch

### DIFF
--- a/scripts/release-utils.js
+++ b/scripts/release-utils.js
@@ -7,7 +7,6 @@ function exec(command) {
 
 function getLatestTag() {
   const currentBranch = exec('git rev-parse --abbrev-ref HEAD');
-  assert.equal('main', currentBranch, 'Run this script on `main` branch only');
   return exec('git describe --abbrev=0 --tags');
 }
 
@@ -28,7 +27,7 @@ function releaseYargsBuilder(yargs) {
   });
   yargs.positional('end-version-tag', {
     type: 'string',
-    default: 'HEAD',
+    default: 'main',
   });
 }
 


### PR DESCRIPTION
By explicitly choosing `main` as the default subject of the release notes scripts, they can be run safely from any branch. This should remove a little bit of friction while preparing release notes.