### PR TITLE
Add mdn_urls for WebXR LE; add XRLightProbe.reflectionchange_event

### DIFF
--- a/api/XRFrame.json
+++ b/api/XRFrame.json
@@ -241,6 +241,7 @@
       "getLightEstimate": {
         "__compat": {
           "spec_url": "https://immersive-web.github.io/lighting-estimation/#dom-xrframe-getlightestimate",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRFrame/getLightEstimate",
           "support": {
             "chrome": {
               "version_added": "90"

--- a/api/XRLightEstimate.json
+++ b/api/XRLightEstimate.json
@@ -3,6 +3,7 @@
     "XRLightEstimate": {
       "__compat": {
         "spec_url": "https://immersive-web.github.io/lighting-estimation/#xrlightestimate-interface",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRLightEstimate",
         "support": {
           "chrome": {
             "version_added": "90"
@@ -50,6 +51,7 @@
       "primaryLightDirection": {
         "__compat": {
           "spec_url": "https://immersive-web.github.io/lighting-estimation/#dom-xrlightestimate-primarylightdirection",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRLightEstimate/primaryLightDirection",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -98,6 +100,7 @@
       "primaryLightIntensity": {
         "__compat": {
           "spec_url": "https://immersive-web.github.io/lighting-estimation/#dom-xrlightestimate-primarylightintensity",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRLightEstimate/primaryLightIntensity",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -146,6 +149,7 @@
       "sphericalHarmonicsCoefficients": {
         "__compat": {
           "spec_url": "https://immersive-web.github.io/lighting-estimation/#dom-xrlightestimate-sphericalharmonicscoefficients",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRLightEstimate/sphericalHarmonicsCoefficients",
           "support": {
             "chrome": {
               "version_added": "90"

--- a/api/XRLightProbe.json
+++ b/api/XRLightProbe.json
@@ -3,6 +3,7 @@
     "XRLightProbe": {
       "__compat": {
         "spec_url": "https://immersive-web.github.io/lighting-estimation/#xrlightprobe-interface",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRLightProbe",
         "support": {
           "chrome": {
             "version_added": "90"
@@ -50,6 +51,7 @@
       "onreflectionchange": {
         "__compat": {
           "spec_url": "https://immersive-web.github.io/lighting-estimation/#dom-xrlightprobe-onreflectionchange",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRLightProbe/onreflectionchange",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -98,6 +100,57 @@
       "probeSpace": {
         "__compat": {
           "spec_url": "https://immersive-web.github.io/lighting-estimation/#dom-xrlightprobe-probespace",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRLightProbe/probeSpace",
+          "support": {
+            "chrome": {
+              "version_added": "90"
+            },
+            "chrome_android": {
+              "version_added": "90"
+            },
+            "edge": {
+              "version_added": "90"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "76"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "reflectionchange_event": {
+        "__compat": {
+          "description": "<code>reflectionchange</code> event",
+          "spec_url": "https://immersive-web.github.io/lighting-estimation/#eventdef-xrlightprobe-reflectionchange",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRLightProbe/reflectionchange_event",
           "support": {
             "chrome": {
               "version_added": "90"

--- a/api/XRSession.json
+++ b/api/XRSession.json
@@ -986,6 +986,7 @@
       "preferredReflectionFormat": {
         "__compat": {
           "spec_url": "https://immersive-web.github.io/lighting-estimation/#dom-xrsession-preferredreflectionformat",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSession/preferredReflectionFormat",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -1228,6 +1229,7 @@
       "requestLightProbe": {
         "__compat": {
           "spec_url": "https://immersive-web.github.io/lighting-estimation/#dom-xrsession-requestlightprobe",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSession/requestLightProbe",
           "support": {
             "chrome": {
               "version_added": "90"

--- a/api/XRWebGLBinding.json
+++ b/api/XRWebGLBinding.json
@@ -150,6 +150,7 @@
       "getReflectionCubeMap": {
         "__compat": {
           "spec_url": "https://immersive-web.github.io/lighting-estimation/#dom-xrwebglbinding-getreflectioncubemap",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRWebGLBinding/getReflectionCubeMap",
           "support": {
             "chrome": {
               "version_added": "90"


### PR DESCRIPTION
I wrote docs :)

Spec: https://immersive-web.github.io/lighting-estimation/

MDN PRs:
- https://github.com/mdn/content/pull/7965
- https://github.com/mdn/content/pull/7972
- https://github.com/mdn/content/pull/8013

Also added the reflectionchange_event feature, which wasn't added originally. The compat data is assumed the same as onreflectionchange.