### PR TITLE
Adds `color-contrast()` from Color Level 5

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -258,7 +258,7 @@
                 ]
               },
               "safari_ios": {
-                "version_added": "15"
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -248,7 +248,14 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "15"
+                "version_added": "15",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "CSS color-contrast()",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "safari_ios": {
                 "version_added": "15"

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -281,6 +281,56 @@
             }
           }
         },
+        "color-contrast": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-contrast()",
+            "spec_url": "https://www.w3.org/TR/css-color-5/#colorcontrast",
+            "description": "<code>color-contrast()</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "15"
+              },
+              "safari_ios": {
+                "version_added": "15"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "currentcolor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value#currentColor",

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -220,7 +220,7 @@
         "color-contrast": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/color-contrast()",
-            "spec_url": "https://www.w3.org/TR/css-color-5/#colorcontrast",
+            "spec_url": "https://drafts.csswg.org/css-color-5/#colorcontrast",
             "description": "<code>color-contrast()</code>",
             "support": {
               "chrome": {

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -217,6 +217,56 @@
             }
           }
         },
+        "color-contrast": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-contrast()",
+            "spec_url": "https://www.w3.org/TR/css-color-5/#colorcontrast",
+            "description": "<code>color-contrast()</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "15"
+              },
+              "safari_ios": {
+                "version_added": "15"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "color-mix": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/color-mix()",
@@ -266,56 +316,6 @@
               },
               "safari_ios": {
                 "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "color-contrast": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-contrast()",
-            "spec_url": "https://www.w3.org/TR/css-color-5/#colorcontrast",
-            "description": "<code>color-contrast()</code>",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": "15"
-              },
-              "safari_ios": {
-                "version_added": "15"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -219,7 +219,7 @@
         },
         "color-contrast": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-contrast()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/color-contrast()",
             "spec_url": "https://www.w3.org/TR/css-color-5/#colorcontrast",
             "description": "<code>color-contrast()</code>",
             "support": {


### PR DESCRIPTION
#### Summary
I noticed other color functions from color level 5 are available to query, but `color-contrast()` was missing. 

#### Test results and supporting details
Spec https://www.w3.org/TR/css-color-5/#colorcontrast
Webkit commit https://trac.webkit.org/changeset/273683/webkit/