### PR TITLE
Fix notes in APIs using structured clone for Deno

### DIFF
--- a/api/DedicatedWorkerGlobalScope.json
+++ b/api/DedicatedWorkerGlobalScope.json
@@ -433,16 +433,16 @@
                 "version_added": "1.12",
                 "partial_implementation": true,
                 "notes": [
-                  "The <code>message</code> parameter does not support cloning <code>SharedArrayBuffer</code> or <code>Blob</code> values.",
+                  "The <code>message</code> parameter does not support cloning <code>Blob</code> values.",
                   "The <code>transfer</code> parameter does not accept <code>ArrayBuffer</code> items. Passing an <code>ArrayBuffer</code> results in an error being thrown."
                 ]
               },
               {
                 "version_added": "1.10",
-                "version_removed": "1.11",
+                "version_removed": "1.12",
                 "partial_implementation": true,
                 "notes": [
-                  "The <code>message</code> parameter does not support <code>SharedArrayBuffer</code>.",
+                  "The <code>message</code> parameter does not support cloning <code>SharedArrayBuffer</code> or <code>Blob</code> values.",
                   "The <code>transfer</code> parameter is ignored."
                 ]
               },

--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -355,7 +355,7 @@
               "version_added": "1.12",
               "partial_implementation": true,
               "notes": [
-                "The <code>message</code> parameter does not support cloning <code>SharedArrayBuffer</code> or <code>Blob</code> values.",
+                "The <code>message</code> parameter does not support cloning <code>Blob</code> values.",
                 "The <code>transfer</code> parameter does not accept <code>ArrayBuffer</code> items. Passing an <code>ArrayBuffer</code> results in an error being thrown."
               ]
             },

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -663,13 +663,13 @@
                 "version_added": "1.12",
                 "partial_implementation": true,
                 "notes": [
-                  "The <code>message</code> parameter does not support cloning <code>SharedArrayBuffer</code> or <code>Blob</code> values.",
+                  "The <code>message</code> parameter does not support cloning <code>Blob</code> values.",
                   "The <code>transfer</code> parameter does not accept <code>ArrayBuffer</code> items. Passing an <code>ArrayBuffer</code> results in an error being thrown."
                 ]
               },
               {
                 "version_added": "1.10",
-                "version_removed": "1.11",
+                "version_removed": "1.12",
                 "partial_implementation": true,
                 "notes": [
                   "The <code>message</code> parameter does not support <code>SharedArrayBuffer</code>.",


### PR DESCRIPTION
#### Summary

SharedArrayBuffer support actually landed in Deno 1.12. Also fixed version_removed to be inclusive of 1.11.

#### Supporting Data

https://github.com/denoland/deno/commit/bdfad23dd012d0c3226b466544e86109da18d09c
