### PR TITLE
Add data for api.Crypto.randomUUID

### DIFF
--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -119,6 +119,62 @@
           }
         }
       },
+      "randomUUID": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Crypto/randomUUID",
+          "spec_url": "https://w3c.github.io/webcrypto/#Crypto-method-randomUUID",
+          "description": "<code>randomUUID()</code>",
+          "support": {
+            "chrome": {
+              "version_added": "92"
+            },
+            "chrome_android": {
+              "version_added": "92"
+            },
+            "deno": {
+              "version_added": "1.11"
+            },
+            "edge": {
+              "version_added": "92"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": "16.7.0"
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "92"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "subtle": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Crypto/subtle",

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -279,6 +279,13 @@
         "16.6.0": {
           "release_date": "2021-07-29",
           "release_notes": "https://nodejs.org/en/blog/release/v16.6.0/",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "9.2"
+        },
+        "16.7.0": {
+          "release_date": "2021-08-17",
+          "release_notes": "https://nodejs.org/en/blog/release/v16.7.0/",
           "status": "current",
           "engine": "V8",
           "engine_version": "9.2"


### PR DESCRIPTION
Unflagged in Chromium 92, Deno 1.12 and Node 16.7.0.


Chrome & Deno: https://wpt.fyi/results/WebCryptoAPI/randomUUID.https.any.html?label=experimental&label=master&product=chrome&product=deno&product=firefox&product=safari&aligned&q=uuid

Node: https://nodejs.org/api/webcrypto.html#webcrypto_crypto_randomuuid
