### PR TITLE
Remove notes that duplicate standard_track status

### DIFF
--- a/api/RTCRtpEncodingParameters.json
+++ b/api/RTCRtpEncodingParameters.json
@@ -205,12 +205,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "46",
-              "notes": "This non-standard property should not be used in production code."
+              "version_added": "46"
             },
             "firefox_android": {
-              "version_added": "46",
-              "notes": "This non-standard property should not be used in production code."
+              "version_added": "46"
             },
             "ie": {
               "version_added": false
@@ -502,12 +500,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "46",
-              "notes": "This non-standard property should not be used in production code."
+              "version_added": "46"
             },
             "firefox_android": {
-              "version_added": "46",
-              "notes": "This non-standard property should not be used in production code."
+              "version_added": "46"
             },
             "ie": {
               "version_added": false
@@ -600,12 +596,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "46",
-              "notes": "This non-standard property should not be used in production code."
+              "version_added": "46"
             },
             "firefox_android": {
-              "version_added": "46",
-              "notes": "This non-standard property should not be used in production code."
+              "version_added": "46"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
#### Summary

These notes duplicate the status for their respective features. Not sure how they got in, but I'm not going to go trolling blame to find out.

(I know the actual clean up needed here is dedictionarying this data, but this was a quick fix.)

#### Related issues

Discovered in the course of reviewing https://github.com/mdn/browser-compat-data/pull/11807.
