### PR TITLE
Add Safari preview support for BroadcastChannel behind flag

### DIFF
--- a/api/BroadcastChannel.json
+++ b/api/BroadcastChannel.json
@@ -43,8 +43,7 @@
             "flags": [
               {
                 "name": "BroadcastChannel API",
-                "type": "preference",
-                "value_to_set": "enabled"
+                "type": "preference"
               }
             ]
           },
@@ -102,8 +101,7 @@
               "flags": [
                 {
                   "name": "BroadcastChannel API",
-                  "type": "preference",
-                  "value_to_set": "enabled"
+                  "type": "preference"
                 }
               ]
             },
@@ -161,8 +159,7 @@
               "flags": [
                 {
                   "name": "BroadcastChannel API",
-                  "type": "preference",
-                  "value_to_set": "enabled"
+                  "type": "preference"
                 }
               ]
             },
@@ -221,8 +218,7 @@
               "flags": [
                 {
                   "name": "BroadcastChannel API",
-                  "type": "preference",
-                  "value_to_set": "enabled"
+                  "type": "preference"
                 }
               ]
             },
@@ -281,8 +277,7 @@
               "flags": [
                 {
                   "name": "BroadcastChannel API",
-                  "type": "preference",
-                  "value_to_set": "enabled"
+                  "type": "preference"
                 }
               ]
             },
@@ -341,8 +336,7 @@
               "flags": [
                 {
                   "name": "BroadcastChannel API",
-                  "type": "preference",
-                  "value_to_set": "enabled"
+                  "type": "preference"
                 }
               ]
             },
@@ -400,8 +394,7 @@
               "flags": [
                 {
                   "name": "BroadcastChannel API",
-                  "type": "preference",
-                  "value_to_set": "enabled"
+                  "type": "preference"
                 }
               ]
             },
@@ -459,8 +452,7 @@
               "flags": [
                 {
                   "name": "BroadcastChannel API",
-                  "type": "preference",
-                  "value_to_set": "enabled"
+                  "type": "preference"
                 }
               ]
             },
@@ -519,8 +511,7 @@
               "flags": [
                 {
                   "name": "BroadcastChannel API",
-                  "type": "preference",
-                  "value_to_set": "enabled"
+                  "type": "preference"
                 }
               ]
             },

--- a/api/BroadcastChannel.json
+++ b/api/BroadcastChannel.json
@@ -39,7 +39,14 @@
             "version_added": "41"
           },
           "safari": {
-            "version_added": false
+            "version_added": "preview",
+            "flags": [
+              {
+                "name": "BroadcastChannel API",
+                "type": "preference",
+                "value_to_set": "enabled"
+              }
+            ]
           },
           "safari_ios": {
             "version_added": false
@@ -91,7 +98,14 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview",
+              "flags": [
+                {
+                  "name": "BroadcastChannel API",
+                  "type": "preference",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari_ios": {
               "version_added": false
@@ -143,7 +157,14 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview",
+              "flags": [
+                {
+                  "name": "BroadcastChannel API",
+                  "type": "preference",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari_ios": {
               "version_added": false
@@ -196,7 +217,14 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview",
+              "flags": [
+                {
+                  "name": "BroadcastChannel API",
+                  "type": "preference",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari_ios": {
               "version_added": false
@@ -249,8 +277,14 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/171216'>bug 171216</a>."
+              "version_added": "preview",
+              "flags": [
+                {
+                  "name": "BroadcastChannel API",
+                  "type": "preference",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari_ios": {
               "version_added": false,
@@ -303,7 +337,14 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview",
+              "flags": [
+                {
+                  "name": "BroadcastChannel API",
+                  "type": "preference",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari_ios": {
               "version_added": false
@@ -355,7 +396,14 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview",
+              "flags": [
+                {
+                  "name": "BroadcastChannel API",
+                  "type": "preference",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari_ios": {
               "version_added": false
@@ -407,8 +455,14 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/171216'>bug 171216</a>."
+              "version_added": "preview",
+              "flags": [
+                {
+                  "name": "BroadcastChannel API",
+                  "type": "preference",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari_ios": {
               "version_added": false,
@@ -461,7 +515,14 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview",
+              "flags": [
+                {
+                  "name": "BroadcastChannel API",
+                  "type": "preference",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Safari Tech Preview now supports Broadcast Channel behind an experimental feature flag.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

![image](https://user-images.githubusercontent.com/32498324/129976129-5f2d8106-2a35-4345-acfc-be4ff52d96a8.png)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
