### PR TITLE
Remove api.AnimationEvent.initAnimationEvent

### DIFF
--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -280,65 +280,6 @@
           }
         }
       },
-      "initAnimationEvent": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationEvent/initAnimationEvent",
-          "support": {
-            "chrome": {
-              "alternative_name": "initWebKitAnimationEvent",
-              "version_added": "1",
-              "version_removed": "18"
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": "12",
-              "version_removed": "16"
-            },
-            "firefox": {
-              "version_added": "6",
-              "version_removed": "23"
-            },
-            "firefox_android": {
-              "version_added": "6",
-              "version_removed": "23"
-            },
-            "ie": {
-              "version_added": "10"
-            },
-            "opera": {
-              "version_added": "12.1",
-              "version_removed": "15"
-            },
-            "opera_android": {
-              "version_added": "12.1",
-              "version_removed": "14"
-            },
-            "safari": {
-              "alternative_name": "initWebKitAnimationEvent",
-              "version_added": "4",
-              "version_removed": "6"
-            },
-            "safari_ios": {
-              "alternative_name": "initWebKitAnimationEvent",
-              "version_added": "3.2",
-              "version_removed": "6"
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "pseudoElement": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationEvent/pseudoElement",


### PR DESCRIPTION
This qualifies as an irrelevant feature removed 2+ years ago:
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features

MDN removal: https://github.com/mdn/content/pull/8095