### PR TITLE
Add Safari 10.1+ support for color(srgb) in addition to display-p3

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -189,7 +189,7 @@
                   "version_added": "10.1",
                   "version_removed": "15",
                   "partial_implementation": true,
-                  "notes": "Only supports <code>display-p3</code> predefined color profile."
+                  "notes": "Only supports <code>display-p3</code> and <code>srgb</code> predefined color profiles."
                 }
               ],
               "safari_ios": [
@@ -200,7 +200,7 @@
                   "version_added": "10.3",
                   "version_removed": "15",
                   "partial_implementation": true,
-                  "notes": "Only supports <code>display-p3</code> predefined color profile."
+                  "notes": "Only supports <code>display-p3</code> and <code>srgb</code> predefined color profiles."
                 }
               ],
               "samsunginternet_android": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

As per [my comment](https://github.com/mdn/browser-compat-data/pull/10898#issuecomment-898860628), `color(srgb ...)` syntax seems to have been available since Safari 10.x. 

#### Test results and supporting details

Tested in BrowserStack with:

```html
<!DOCTYPE html>
<html lang='en'>
<head>
	<meta charset="utf-8">
	<title></title>
</head>
<body style='background: color(srgb 0.9 0.25 0.3)'>
</body>
</html>
```

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
