### PR TITLE
Update accent-color CSS property

### DIFF
--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -19,16 +19,16 @@
               "version_added": "92"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "92"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "93"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "93"
             },
             "safari": {
               "version_added": false
@@ -37,10 +37,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "93"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "93"
             }
           },
           "status": {

--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -7,45 +7,16 @@
           "spec_url": "https://drafts.csswg.org/css-ui/#widget-accent",
           "support": {
             "chrome": {
-              "version_added": "91",
-              "flags": [
-                {
-                  "name": "#enable-experimental-web-platform-features",
-                  "type": "preference",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "93"
             },
             "chrome_android": {
-              "version_added": "91",
-              "flags": [
-                {
-                  "name": "#enable-experimental-web-platform-features",
-                  "type": "preference",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "93"
             },
             "edge": {
-              "version_added": "91",
-              "flags": [
-                {
-                  "name": "#enable-experimental-web-platform-features",
-                  "type": "preference",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "93"
             },
             "firefox": {
-              "version_added": "90",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.accent-color.enabled",
-                  "value_to_set": "enabled"
-                }
-              ],
-              "notes": "Enabled by default in Firefox Nightly."
+              "version_added": "92"
             },
             "firefox_android": {
               "version_added": false
@@ -73,7 +44,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
accent-color has been enabled by default in chrome and firefox and will reach stable channels soon.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Here is the patch I made to enable it in chrome 93: https://chromium-review.googlesource.com/c/chromium/src/+/3065268