### PR TITLE
Bug-1669566-Add-cookieStoreId-to-browser.downloads

### DIFF
--- a/webextensions/api/downloads.json
+++ b/webextensions/api/downloads.json
@@ -715,7 +715,8 @@
                 },
                 "firefox": {
                   "version_added": "47",
-                  "partial_implementation": true
+                  "partial_implementation": true,
+                  "notes": "The parameter is ignored."
                 },
                 "firefox_android": {
                   "version_added": "48",
@@ -741,7 +742,8 @@
                 },
                 "firefox": {
                   "version_added": "47",
-                  "partial_implementation": true
+                  "partial_implementation": true,
+                  "notes": "The parameter is ignored."
                 },
                 "firefox_android": {
                   "version_added": "48",

--- a/webextensions/api/downloads.json
+++ b/webextensions/api/downloads.json
@@ -219,7 +219,6 @@
                   "version_added": false
                 },
                 "firefox_android": {
-                  "notes": "Always given as 'safe'.",
                   "version_added": false
                 },
                 "opera": {
@@ -715,7 +714,8 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": "47"
+                  "version_added": "47",
+                  "partial_implementation": true
                 },
                 "firefox_android": {
                   "version_added": "48",
@@ -740,7 +740,8 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": "47"
+                  "version_added": "47",
+                  "partial_implementation": true
                 },
                 "firefox_android": {
                   "version_added": "48",
@@ -765,11 +766,10 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": "47"
+                  "version_added": false
                 },
                 "firefox_android": {
-                  "version_added": "48",
-                  "version_removed": "79"
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": true

--- a/webextensions/api/downloads.json
+++ b/webextensions/api/downloads.json
@@ -181,6 +181,30 @@
               }
             }
           },
+          "cookieStoreId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "92"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
           "danger": {
             "__compat": {
               "support": {
@@ -606,6 +630,655 @@
                 "version_added": false
               }
             }
+          },
+          "bytesReceived": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "cookieStoreId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "92"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "danger": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "endedAfter": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "endedBefore": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "endTime": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "error": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "exists": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "filename": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "filenameRegex": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "fileSize": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "id": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "limit": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "mime": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "orderBy": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "paused": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "query": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "startedAfter": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "startedBefore": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "startTime": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "state": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "totalBytes": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "totalBytesGreater": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "totalBytesLess": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "url": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "urlRegex": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "47"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "version_removed": "79"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
           }
         },
         "DownloadTime": {
@@ -905,6 +1578,30 @@
                 },
                 "opera": {
                   "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "cookieStoreId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "92"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
                 },
                 "safari": {
                   "version_added": false


### PR DESCRIPTION
Adds details of support for cookieStoreId to download.download, downloads.DownloadQuery, and downloads.DownloadItem. In addition, adds the missing properties for downloads.DownloadQuery. This provides compatibility data for [Bug 1669566](https://bugzilla.mozilla.org/show_bug.cgi?id=1669566).

npm test run and passed

Corresponding changes to MDN documentation are in [Bug 1669566 add cookie store id to browser.downloads #8106](https://github.com/mdn/content/pull/8106)
