### PR TITLE
Put css.types.basic-shape.ellipse at the right level

### DIFF
--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -149,6 +149,56 @@
             }
           }
         },
+        "ellipse": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape/ellipse()",
+            "spec_url": "https://drafts.csswg.org/css-shapes/#funcdef-polygon",
+            "description": "<code>ellipse()</code>",
+            "support": {
+              "chrome": {
+                "version_added": "37"
+              },
+              "chrome_android": {
+                "version_added": "37"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": {
+                "version_added": "54"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "24"
+              },
+              "opera_android": {
+                "version_added": "24"
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              },
+              "samsunginternet_android": {
+                "version_added": "3.0"
+              },
+              "webview_android": {
+                "version_added": "37"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "inset": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape/inset()",
@@ -329,56 +379,6 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        }
-      },
-      "ellipse": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape/ellipse()",
-          "spec_url": "https://drafts.csswg.org/css-shapes/#funcdef-polygon",
-          "description": "<code>ellipse()</code>",
-          "support": {
-            "chrome": {
-              "version_added": "37"
-            },
-            "chrome_android": {
-              "version_added": "37"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "54"
-            },
-            "firefox_android": {
-              "version_added": "54"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "24"
-            },
-            "opera_android": {
-              "version_added": "24"
-            },
-            "safari": {
-              "version_added": "10.1"
-            },
-            "safari_ios": {
-              "version_added": "10.3"
-            },
-            "samsunginternet_android": {
-              "version_added": "3.0"
-            },
-            "webview_android": {
-              "version_added": "37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
ellipse() was one level too high (css.types.ellipse instead of css.types.basic-shape.ellipse)