### PR TITLE
Add Chromium versions for api.GlobalEventHandlers.onanimation/transition*

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -172,6 +172,12 @@
               {
                 "version_added": "81",
                 "alternative_name": "onwebkitanimationend"
+              },
+              {
+                "version_added": "43",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Before Chrome 79, this event handler was only supported on the <code>Window</code> interface."
               }
             ],
             "chrome_android": [
@@ -181,6 +187,12 @@
               {
                 "version_added": "81",
                 "alternative_name": "onwebkitanimationend"
+              },
+              {
+                "version_added": "43",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Before Chrome 79, this event handler was only supported on the <code>Window</code> interface."
               }
             ],
             "edge": [
@@ -201,12 +213,36 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "66"
-            },
-            "opera_android": {
-              "version_added": "57"
-            },
+            "opera": [
+              {
+                "version_added": "66"
+              },
+              {
+                "version_added": "68",
+                "alternative_name": "onwebkitanimationend"
+              },
+              {
+                "version_added": "30",
+                "version_removed": "66",
+                "partial_implementation": true,
+                "notes": "Before Opera 66, this event handler was only supported on the <code>Window</code> interface."
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "59",
+                "alternative_name": "onwebkitanimationend"
+              },
+              {
+                "version_added": "30",
+                "version_removed": "57",
+                "partial_implementation": true,
+                "notes": "Before Opera Android 57, this event handler was only supported on the <code>Window</code> interface."
+              }
+            ],
             "safari": {
               "version_added": "9"
             },
@@ -220,6 +256,12 @@
               {
                 "version_added": "13.0",
                 "alternative_name": "onwebkitanimationend"
+              },
+              {
+                "version_added": "4.0",
+                "version_removed": "12.0",
+                "partial_implementation": true,
+                "notes": "Before Samsung Internet 12.0, this event handler was only supported on the <code>Window</code> interface."
               }
             ],
             "webview_android": [
@@ -229,6 +271,12 @@
               {
                 "version_added": "81",
                 "alternative_name": "onwebkitanimationend"
+              },
+              {
+                "version_added": "43",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Before WebView 79, this event handler was only supported on the <code>Window</code> interface."
               }
             ]
           },
@@ -251,6 +299,12 @@
               {
                 "version_added": "81",
                 "alternative_name": "onwebkitanimationiteration"
+              },
+              {
+                "version_added": "43",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Before Chrome 79, this event handler was only supported on the <code>Window</code> interface."
               }
             ],
             "chrome_android": [
@@ -260,6 +314,12 @@
               {
                 "version_added": "81",
                 "alternative_name": "onwebkitanimationiteration"
+              },
+              {
+                "version_added": "43",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Before Chrome 79, this event handler was only supported on the <code>Window</code> interface."
               }
             ],
             "edge": [
@@ -280,12 +340,36 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "66"
-            },
-            "opera_android": {
-              "version_added": "57"
-            },
+            "opera": [
+              {
+                "version_added": "66"
+              },
+              {
+                "version_added": "68",
+                "alternative_name": "onwebkitanimationend"
+              },
+              {
+                "version_added": "30",
+                "version_removed": "66",
+                "partial_implementation": true,
+                "notes": "Before Opera 66, this event handler was only supported on the <code>Window</code> interface."
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "59",
+                "alternative_name": "onwebkitanimationend"
+              },
+              {
+                "version_added": "30",
+                "version_removed": "57",
+                "partial_implementation": true,
+                "notes": "Before Opera Android 57, this event handler was only supported on the <code>Window</code> interface."
+              }
+            ],
             "safari": {
               "version_added": "9"
             },
@@ -299,6 +383,12 @@
               {
                 "version_added": "13.0",
                 "alternative_name": "onwebkitanimationiteration"
+              },
+              {
+                "version_added": "4.0",
+                "version_removed": "12.0",
+                "partial_implementation": true,
+                "notes": "Before Samsung Internet 12.0, this event handler was only supported on the <code>Window</code> interface."
               }
             ],
             "webview_android": [
@@ -308,6 +398,12 @@
               {
                 "version_added": "81",
                 "alternative_name": "onwebkitanimationiteration"
+              },
+              {
+                "version_added": "43",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Before WebView 79, this event handler was only supported on the <code>Window</code> interface."
               }
             ]
           },
@@ -330,6 +426,12 @@
               {
                 "version_added": "81",
                 "alternative_name": "onwebkitanimationstart"
+              },
+              {
+                "version_added": "43",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Before Chrome 79, this event handler was only supported on the <code>Window</code> interface."
               }
             ],
             "chrome_android": [
@@ -339,6 +441,12 @@
               {
                 "version_added": "81",
                 "alternative_name": "onwebkitanimationstart"
+              },
+              {
+                "version_added": "43",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Before Chrome 79, this event handler was only supported on the <code>Window</code> interface."
               }
             ],
             "edge": [
@@ -359,12 +467,36 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "66"
-            },
-            "opera_android": {
-              "version_added": "57"
-            },
+            "opera": [
+              {
+                "version_added": "66"
+              },
+              {
+                "version_added": "68",
+                "alternative_name": "onwebkitanimationend"
+              },
+              {
+                "version_added": "30",
+                "version_removed": "66",
+                "partial_implementation": true,
+                "notes": "Before Opera 66, this event handler was only supported on the <code>Window</code> interface."
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "59",
+                "alternative_name": "onwebkitanimationend"
+              },
+              {
+                "version_added": "30",
+                "version_removed": "57",
+                "partial_implementation": true,
+                "notes": "Before Opera Android 57, this event handler was only supported on the <code>Window</code> interface."
+              }
+            ],
             "safari": {
               "version_added": "9"
             },
@@ -378,6 +510,12 @@
               {
                 "version_added": "13.0",
                 "alternative_name": "onwebkitanimationstart"
+              },
+              {
+                "version_added": "4.0",
+                "version_removed": "12.0",
+                "partial_implementation": true,
+                "notes": "Before Samsung Internet 12.0, this event handler was only supported on the <code>Window</code> interface."
               }
             ],
             "webview_android": [
@@ -387,6 +525,12 @@
               {
                 "version_added": "81",
                 "alternative_name": "onwebkitanimationstart"
+              },
+              {
+                "version_added": "43",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Before WebView 79, this event handler was only supported on the <code>Window</code> interface."
               }
             ]
           },
@@ -4779,6 +4923,12 @@
               {
                 "version_added": "81",
                 "alternative_name": "onwebkittransitionend"
+              },
+              {
+                "version_added": "26",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Before Chrome 79, this event handler was only supported on the <code>Window</code> interface."
               }
             ],
             "chrome_android": [
@@ -4788,6 +4938,12 @@
               {
                 "version_added": "81",
                 "alternative_name": "onwebkittransitionend"
+              },
+              {
+                "version_added": "26",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Before Chrome 79, this event handler was only supported on the <code>Window</code> interface."
               }
             ],
             "edge": [
@@ -4809,12 +4965,36 @@
               "version_added": false,
               "notes": "The <code>ontransitionend</code> attribute is not supported in IE. To listen to this event, use <code>document.addEventListener('transitionend', function() {});</code>."
             },
-            "opera": {
-              "version_added": "66"
-            },
-            "opera_android": {
-              "version_added": "57"
-            },
+            "opera": [
+              {
+                "version_added": "66"
+              },
+              {
+                "version_added": "68",
+                "alternative_name": "onwebkittransitionend"
+              },
+              {
+                "version_added": "15",
+                "version_removed": "66",
+                "partial_implementation": true,
+                "notes": "Before Opera 66, this event handler was only supported on the <code>Window</code> interface."
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "59",
+                "alternative_name": "onwebkittransitionend"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "57",
+                "partial_implementation": true,
+                "notes": "Before Opera Android 57, this event handler was only supported on the <code>Window</code> interface."
+              }
+            ],
             "safari": {
               "version_added": "11"
             },
@@ -4828,6 +5008,12 @@
               {
                 "version_added": "13.0",
                 "alternative_name": "onwebkittransitionend"
+              },
+              {
+                "version_added": "1.5",
+                "version_removed": "11.0",
+                "partial_implementation": true,
+                "notes": "Before Samsung Internet 11.0, this event handler was only supported on the <code>Window</code> interface."
               }
             ],
             "webview_android": [
@@ -4837,6 +5023,12 @@
               {
                 "version_added": "81",
                 "alternative_name": "onwebkittransitionend"
+              },
+              {
+                "version_added": "≤37",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Before Chrome 79, this event handler was only supported on the <code>Window</code> interface."
               }
             ]
           },

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -261,7 +261,7 @@
                 "version_added": "4.0",
                 "version_removed": "12.0",
                 "partial_implementation": true,
-                "notes": "Before Samsung Internet 12.0, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ],
             "webview_android": [
@@ -276,7 +276,7 @@
                 "version_added": "43",
                 "version_removed": "79",
                 "partial_implementation": true,
-                "notes": "Before WebView 79, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ]
           },
@@ -388,7 +388,7 @@
                 "version_added": "4.0",
                 "version_removed": "12.0",
                 "partial_implementation": true,
-                "notes": "Before Samsung Internet 12.0, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ],
             "webview_android": [
@@ -403,7 +403,7 @@
                 "version_added": "43",
                 "version_removed": "79",
                 "partial_implementation": true,
-                "notes": "Before WebView 79, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ]
           },

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -177,7 +177,7 @@
                 "version_added": "43",
                 "version_removed": "79",
                 "partial_implementation": true,
-                "notes": "Before Chrome 79, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ],
             "chrome_android": [
@@ -192,7 +192,7 @@
                 "version_added": "43",
                 "version_removed": "79",
                 "partial_implementation": true,
-                "notes": "Before Chrome 79, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ],
             "edge": [
@@ -225,7 +225,7 @@
                 "version_added": "30",
                 "version_removed": "66",
                 "partial_implementation": true,
-                "notes": "Before Opera 66, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ],
             "opera_android": [
@@ -240,7 +240,7 @@
                 "version_added": "30",
                 "version_removed": "57",
                 "partial_implementation": true,
-                "notes": "Before Opera Android 57, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ],
             "safari": {
@@ -304,7 +304,7 @@
                 "version_added": "43",
                 "version_removed": "79",
                 "partial_implementation": true,
-                "notes": "Before Chrome 79, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ],
             "chrome_android": [
@@ -319,7 +319,7 @@
                 "version_added": "43",
                 "version_removed": "79",
                 "partial_implementation": true,
-                "notes": "Before Chrome 79, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ],
             "edge": [
@@ -352,7 +352,7 @@
                 "version_added": "30",
                 "version_removed": "66",
                 "partial_implementation": true,
-                "notes": "Before Opera 66, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ],
             "opera_android": [
@@ -367,7 +367,7 @@
                 "version_added": "30",
                 "version_removed": "57",
                 "partial_implementation": true,
-                "notes": "Before Opera Android 57, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ],
             "safari": {
@@ -431,7 +431,7 @@
                 "version_added": "43",
                 "version_removed": "79",
                 "partial_implementation": true,
-                "notes": "Before Chrome 79, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ],
             "chrome_android": [
@@ -446,7 +446,7 @@
                 "version_added": "43",
                 "version_removed": "79",
                 "partial_implementation": true,
-                "notes": "Before Chrome 79, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ],
             "edge": [
@@ -479,7 +479,7 @@
                 "version_added": "30",
                 "version_removed": "66",
                 "partial_implementation": true,
-                "notes": "Before Opera 66, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ],
             "opera_android": [
@@ -494,7 +494,7 @@
                 "version_added": "30",
                 "version_removed": "57",
                 "partial_implementation": true,
-                "notes": "Before Opera Android 57, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ],
             "safari": {
@@ -515,7 +515,7 @@
                 "version_added": "4.0",
                 "version_removed": "12.0",
                 "partial_implementation": true,
-                "notes": "Before Samsung Internet 12.0, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ],
             "webview_android": [
@@ -530,7 +530,7 @@
                 "version_added": "43",
                 "version_removed": "79",
                 "partial_implementation": true,
-                "notes": "Before WebView 79, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ]
           },
@@ -4928,7 +4928,7 @@
                 "version_added": "26",
                 "version_removed": "79",
                 "partial_implementation": true,
-                "notes": "Before Chrome 79, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ],
             "chrome_android": [
@@ -4943,7 +4943,7 @@
                 "version_added": "26",
                 "version_removed": "79",
                 "partial_implementation": true,
-                "notes": "Before Chrome 79, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ],
             "edge": [
@@ -4977,7 +4977,7 @@
                 "version_added": "15",
                 "version_removed": "66",
                 "partial_implementation": true,
-                "notes": "Before Opera 66, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ],
             "opera_android": [
@@ -4992,7 +4992,7 @@
                 "version_added": "14",
                 "version_removed": "57",
                 "partial_implementation": true,
-                "notes": "Before Opera Android 57, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ],
             "safari": {
@@ -5013,7 +5013,7 @@
                 "version_added": "1.5",
                 "version_removed": "11.0",
                 "partial_implementation": true,
-                "notes": "Before Samsung Internet 11.0, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ],
             "webview_android": [
@@ -5028,7 +5028,7 @@
                 "version_added": "≤37",
                 "version_removed": "79",
                 "partial_implementation": true,
-                "notes": "Before Chrome 79, this event handler was only supported on the <code>Window</code> interface."
+                "notes": "Only supported on the <code>Window</code> interface."
               }
             ]
           },

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -170,7 +170,7 @@
                 "version_added": "79"
               },
               {
-                "version_added": true,
+                "version_added": "81",
                 "alternative_name": "onwebkitanimationend"
               }
             ],
@@ -179,7 +179,7 @@
                 "version_added": "79"
               },
               {
-                "version_added": true,
+                "version_added": "81",
                 "alternative_name": "onwebkitanimationend"
               }
             ],
@@ -188,7 +188,7 @@
                 "version_added": "18"
               },
               {
-                "version_added": "≤79",
+                "version_added": "81",
                 "alternative_name": "onwebkitanimationend"
               }
             ],
@@ -218,7 +218,7 @@
                 "version_added": "12.0"
               },
               {
-                "version_added": true,
+                "version_added": "13.0",
                 "alternative_name": "onwebkitanimationend"
               }
             ],
@@ -227,7 +227,7 @@
                 "version_added": "79"
               },
               {
-                "version_added": true,
+                "version_added": "81",
                 "alternative_name": "onwebkitanimationend"
               }
             ]
@@ -249,7 +249,7 @@
                 "version_added": "79"
               },
               {
-                "version_added": true,
+                "version_added": "81",
                 "alternative_name": "onwebkitanimationiteration"
               }
             ],
@@ -258,7 +258,7 @@
                 "version_added": "79"
               },
               {
-                "version_added": true,
+                "version_added": "81",
                 "alternative_name": "onwebkitanimationiteration"
               }
             ],
@@ -267,7 +267,7 @@
                 "version_added": "18"
               },
               {
-                "version_added": "≤79",
+                "version_added": "81",
                 "alternative_name": "onwebkitanimationiteration"
               }
             ],
@@ -297,7 +297,7 @@
                 "version_added": "12.0"
               },
               {
-                "version_added": true,
+                "version_added": "13.0",
                 "alternative_name": "onwebkitanimationiteration"
               }
             ],
@@ -306,7 +306,7 @@
                 "version_added": "79"
               },
               {
-                "version_added": true,
+                "version_added": "81",
                 "alternative_name": "onwebkitanimationiteration"
               }
             ]
@@ -328,7 +328,7 @@
                 "version_added": "79"
               },
               {
-                "version_added": true,
+                "version_added": "81",
                 "alternative_name": "onwebkitanimationstart"
               }
             ],
@@ -337,7 +337,7 @@
                 "version_added": "79"
               },
               {
-                "version_added": true,
+                "version_added": "81",
                 "alternative_name": "onwebkitanimationstart"
               }
             ],
@@ -346,7 +346,7 @@
                 "version_added": "18"
               },
               {
-                "version_added": "≤79",
+                "version_added": "81",
                 "alternative_name": "onwebkitanimationstart"
               }
             ],
@@ -376,7 +376,7 @@
                 "version_added": "12.0"
               },
               {
-                "version_added": true,
+                "version_added": "13.0",
                 "alternative_name": "onwebkitanimationstart"
               }
             ],
@@ -385,7 +385,7 @@
                 "version_added": "79"
               },
               {
-                "version_added": true,
+                "version_added": "81",
                 "alternative_name": "onwebkitanimationstart"
               }
             ]
@@ -4777,7 +4777,7 @@
                 "version_added": "79"
               },
               {
-                "version_added": true,
+                "version_added": "81",
                 "alternative_name": "onwebkittransitionend"
               }
             ],
@@ -4786,7 +4786,7 @@
                 "version_added": "79"
               },
               {
-                "version_added": true,
+                "version_added": "81",
                 "alternative_name": "onwebkittransitionend"
               }
             ],
@@ -4795,7 +4795,7 @@
                 "version_added": "18"
               },
               {
-                "version_added": "≤79",
+                "version_added": "81",
                 "alternative_name": "onwebkittransitionend"
               }
             ],
@@ -4826,7 +4826,7 @@
                 "version_added": "11.0"
               },
               {
-                "version_added": true,
+                "version_added": "13.0",
                 "alternative_name": "onwebkittransitionend"
               }
             ],
@@ -4835,7 +4835,7 @@
                 "version_added": "79"
               },
               {
-                "version_added": true,
+                "version_added": "81",
                 "alternative_name": "onwebkittransitionend"
               }
             ]


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the prefixed versions of the `onanimation*` and `ontransition*` members of the `GlobalEventHandlers` API, based upon manual testing.

Test Code Used: `document.onwebkit* === null;`
