### PR TITLE
Add Firefox versions for api.Event.initEvent

### DIFF
--- a/api/Event.json
+++ b/api/Event.json
@@ -708,7 +708,7 @@
                 "version_added": "17"
               },
               {
-                "version_added": true,
+                "version_added": "1",
                 "version_removed": "17",
                 "partial_implementation": true,
                 "notes": "Before Firefox 17, a call to this method after the dispatching of the event raised an exception instead of doing nothing."
@@ -719,7 +719,7 @@
                 "version_added": "17"
               },
               {
-                "version_added": true,
+                "version_added": "4",
                 "version_removed": "17",
                 "partial_implementation": true,
                 "notes": "Before Firefox 17, a call to this method after the dispatching of the event raised an exception instead of doing nothing."


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `initEvent` member of the `Event` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Event/initEvent
