### PR TITLE
Add Firefox versions for WEBGL_depth_texture API

### DIFF
--- a/api/WEBGL_depth_texture.json
+++ b/api/WEBGL_depth_texture.json
@@ -32,13 +32,20 @@
             },
             {
               "prefix": "MOZ_",
-              "version_added": true,
+              "version_added": "17",
               "version_removed": "58"
             }
           ],
-          "firefox_android": {
-            "version_added": null
-          },
+          "firefox_android": [
+            {
+              "version_added": "22"
+            },
+            {
+              "prefix": "MOZ_",
+              "version_added": "17",
+              "version_removed": "58"
+            }
+          ],
           "ie": {
             "version_added": false
           },


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `WEBGL_depth_texture` API, based upon information in a tracking bug.

Tracking Bug: https://bugzil.la/738866

The removal version was confirmed via manual testing:

![Screenshot from 2021-09-16 12-46-24](https://user-images.githubusercontent.com/5179191/133676282-9ae9cea3-6bd4-4721-85c0-866ff6f2e244.png)
