### PR TITLE
Add Safari versions for Document API

### DIFF
--- a/api/_mixins/DocumentOrShadowRoot__Document.json
+++ b/api/_mixins/DocumentOrShadowRoot__Document.json
@@ -302,7 +302,7 @@
               }
             ],
             "safari": {
-              "version_added": true,
+              "version_added": "6",
               "prefix": "webkit"
             },
             "safari_ios": {


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `Document` API, based upon manual testing.

Test Code Used: `document.webkitFullscreenElement`
