### PR TITLE
No MediaStream support in createObjectURL in Deno

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -246,7 +246,7 @@
                 "version_removed": "71"
               },
               "deno": {
-                "version_added": "1.9"
+                "version_added": false
               },
               "edge": {
                 "version_added": "12",


### PR DESCRIPTION
We don't support this.
