### PR TITLE
Add Chromium versions for DeviceMotionEvent API

### DIFF
--- a/api/DeviceMotionEvent.json
+++ b/api/DeviceMotionEvent.json
@@ -104,10 +104,10 @@
           "spec_url": "https://w3c.github.io/deviceorientation/#ref-for-dom-devicemotionevent-acceleration③",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "11"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -122,10 +122,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -134,10 +134,10 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -153,10 +153,10 @@
           "spec_url": "https://w3c.github.io/deviceorientation/#ref-for-dom-devicemotionevent-accelerationincludinggravity④",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "11"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -171,10 +171,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -183,10 +183,10 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -202,10 +202,10 @@
           "spec_url": "https://w3c.github.io/deviceorientation/#ref-for-dom-devicemotionevent-interval①",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "11"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -220,10 +220,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -232,10 +232,10 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -251,10 +251,10 @@
           "spec_url": "https://w3c.github.io/deviceorientation/#ref-for-dom-devicemotionevent-rotationrate②",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "11"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -269,10 +269,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -281,10 +281,10 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `DeviceMotionEvent` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/8136adc9f9f8e570d8a39a1fb4c19dd6cb67b548
