### PR TITLE
Fix release dates for Deno versions

### DIFF
--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -60,49 +60,49 @@
           "engine_version": "8.9"
         },
         "1.8": {
-          "release_date": "2020-03-02",
+          "release_date": "2021-03-02",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.8.0",
           "status": "retired",
           "engine": "V8",
           "engine_version": "9.0"
         },
         "1.9": {
-          "release_date": "2020-04-13",
+          "release_date": "2021-04-13",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.9.0",
           "status": "retired",
           "engine": "V8",
           "engine_version": "9.1"
         },
         "1.10": {
-          "release_date": "2020-05-11",
+          "release_date": "2021-05-11",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.10.1",
           "status": "retired",
           "engine": "V8",
           "engine_version": "9.1"
         },
         "1.11": {
-          "release_date": "2020-06-08",
+          "release_date": "2021-06-08",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.11.0",
           "status": "retired",
           "engine": "V8",
           "engine_version": "9.1"
         },
         "1.12": {
-          "release_date": "2020-07-13",
+          "release_date": "2021-07-13",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.12.0",
           "status": "current",
           "engine": "V8",
           "engine_version": "9.2"
         },
         "1.13": {
-          "release_date": "2020-08-10",
+          "release_date": "2021-08-10",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.13.0",
           "status": "current",
           "engine": "V8",
           "engine_version": "9.3"
         },
         "1.14": {
-          "release_date": "2020-09-14",
+          "release_date": "2021-09-14",
           "status": "nightly",
           "engine": "V8",
           "engine_version": "9.4"


### PR DESCRIPTION
#### Summary

The release dates from this year (2021) all had their year specified as 2020.
This fixes that.

#### Test results and supporting details

See release notes at https://deno.com/blog
