### PR TITLE
Add Chromium versions for api.FileList.length

### DIFF
--- a/api/FileList.json
+++ b/api/FileList.json
@@ -110,10 +110,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileList/length",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "44"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "deno": {
               "version_added": false
@@ -131,10 +131,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "31"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "safari": {
               "version_added": "10"
@@ -143,10 +143,10 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "44"
             }
           },
           "status": {

--- a/api/FileList.json
+++ b/api/FileList.json
@@ -110,10 +110,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileList/length",
           "support": {
             "chrome": {
-              "version_added": "44"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "44"
+              "version_added": "18"
             },
             "deno": {
               "version_added": false
@@ -131,22 +131,22 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "31"
+              "version_added": "11.1"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "11.1"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "44"
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `length` member of the `FileList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FileList/length
