### PR TITLE
Add Firefox versions for api.FileSystemDirectoryReader.readEntries

### DIFF
--- a/api/FileSystemDirectoryReader.json
+++ b/api/FileSystemDirectoryReader.json
@@ -69,10 +69,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "51"
+              "version_added": "50"
             },
             "firefox_android": {
-              "version_added": "51"
+              "version_added": "50"
             },
             "ie": {
               "version_added": false

--- a/api/FileSystemDirectoryReader.json
+++ b/api/FileSystemDirectoryReader.json
@@ -69,10 +69,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "51"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "51"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `readEntries` member of the `FileSystemDirectoryReader` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FileSystemDirectoryReader/readEntries
