### PR TITLE
Add Chromium versions for HTMLMediaElement API

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2209,7 +2209,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -2236,10 +2236,10 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -2258,7 +2258,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -2286,10 +2286,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -2354,10 +2354,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onerror",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2372,10 +2372,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "1.3"
@@ -2384,10 +2384,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -2546,10 +2546,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-media-pause-dev",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2576,10 +2576,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -2648,7 +2648,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -2675,10 +2675,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -2844,7 +2844,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -2871,10 +2871,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -2892,7 +2892,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -2919,10 +2919,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -3060,7 +3060,7 @@
               "version_added": "72"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "61"
             },
             "safari": {
               "prefix": "webkit",
@@ -3295,7 +3295,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -3322,10 +3322,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -3393,7 +3393,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -3420,10 +3420,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -3506,7 +3506,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -3695,7 +3695,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -3722,10 +3722,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -4128,7 +4128,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -4155,10 +4155,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `HTMLMediaElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLMediaElement
