### PR TITLE
Add Chrome/Safari versions for api.MediaError.code

### DIFF
--- a/api/MediaError.json
+++ b/api/MediaError.json
@@ -61,10 +61,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-mediaerror-code-dev",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -79,22 +79,22 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chrome and Safari for the `code` member of the `MediaError` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/f85a45d545671a8a59a97c18c5f313fce3b0c2f7
