### PR TITLE
Add Safari versions for MediaKeyMessageEvent API

### DIFF
--- a/api/MediaKeyMessageEvent.json
+++ b/api/MediaKeyMessageEvent.json
@@ -30,10 +30,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": true
+            "version_added": "12.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "12.2"
           },
           "samsunginternet_android": {
             "version_added": "4.0"
@@ -79,10 +79,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -128,10 +128,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -177,10 +177,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "12.2"
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `MediaKeyMessageEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaKeyMessageEvent
