### PR TITLE
Add all browsers versions for MediaStreamEvent API

### DIFF
--- a/api/MediaStreamEvent.json
+++ b/api/MediaStreamEvent.json
@@ -5,11 +5,11 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamEvent",
         "support": {
           "chrome": {
-            "version_added": "15",
+            "version_added": "26",
             "notes": "See <a href='https://crbug.com/697059'>bug 697059</a>."
           },
           "chrome_android": {
-            "version_added": "18",
+            "version_added": "26",
             "notes": "See <a href='https://crbug.com/697059'>bug 697059</a>."
           },
           "edge": {
@@ -39,7 +39,7 @@
             "version_removed": "12"
           },
           "samsunginternet_android": {
-            "version_added": "1.0"
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": "≤37"

--- a/api/MediaStreamEvent.json
+++ b/api/MediaStreamEvent.json
@@ -5,30 +5,30 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamEvent",
         "support": {
           "chrome": {
-            "version_added": true,
+            "version_added": "15",
             "notes": "See <a href='https://crbug.com/697059'>bug 697059</a>."
           },
           "chrome_android": {
-            "version_added": true,
+            "version_added": "18",
             "notes": "See <a href='https://crbug.com/697059'>bug 697059</a>."
           },
           "edge": {
             "version_added": "15"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "24"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "24"
           },
           "ie": {
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": "11",
@@ -39,10 +39,10 @@
             "version_removed": "12"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -57,28 +57,28 @@
           "description": "<code>MediaStreamEvent()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "26"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "edge": {
               "version_added": "15"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "24"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "24"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11",
@@ -89,10 +89,10 @@
               "version_removed": "12"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for all browsers for the `MediaStreamEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaStreamEvent
