### PR TITLE
Add Firefox versions for api.Navigator.connection

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -694,7 +694,7 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "31",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `connection` member of the `Navigator` API.  The data was collected by looking for the mentioned flag in various Firefox versions in BrowserStack, looking for the first version it was added in, and checking to see if `connection` is present in that version (which it was).
