### PR TITLE
Add Firefox versions for api.Navigator.vibrate

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3691,7 +3691,7 @@
               },
               {
                 "version_added": "11",
-                "version_removed": true,
+                "version_removed": "16",
                 "prefix": "moz"
               }
             ],


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `vibrate` member of the `Navigator` API, based upon manual testing.

Test Code Used: `navigator.mozVibrate`
