### PR TITLE
Add Firefox versions for RTCRtpReceiver API; correct related API features

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1515,10 +1515,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "34"
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "34"
             },
             "ie": {
               "version_added": false

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1400,10 +1400,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "34"
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "34"
             },
             "ie": {
               "version_added": false

--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -15,10 +15,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "34"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "34"
           },
           "ie": {
             "version_added": false
@@ -637,10 +637,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "34"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "34"
             },
             "ie": {
               "version_added": false
@@ -686,10 +686,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "82"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "82"
             },
             "ie": {
               "version_added": false

--- a/api/RTCTrackEvent.json
+++ b/api/RTCTrackEvent.json
@@ -112,7 +112,7 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "34"
             },
             "firefox_android": {
               "version_added": "44"


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `RTCRtpReceiver` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCRtpReceiver
