### PR TITLE
Add Firefox versions for SVGAnimationElement API

### DIFF
--- a/api/SVGAnimationElement.json
+++ b/api/SVGAnimationElement.json
@@ -492,10 +492,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "93"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "93"
             },
             "ie": {
               "version_added": false
@@ -541,10 +541,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "93"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "93"
             },
             "ie": {
               "version_added": false
@@ -590,10 +590,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "93"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "93"
             },
             "ie": {
               "version_added": false

--- a/api/SVGAnimationElement.json
+++ b/api/SVGAnimationElement.json
@@ -158,10 +158,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "6"
             },
             "ie": {
               "version_added": false
@@ -302,10 +302,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "6"
             },
             "ie": {
               "version_added": false
@@ -640,10 +640,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "6"
             },
             "ie": {
               "version_added": false

--- a/api/SVGAnimationElement.json
+++ b/api/SVGAnimationElement.json
@@ -158,10 +158,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -302,10 +302,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -492,10 +492,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -541,10 +541,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -590,10 +590,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -640,10 +640,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `SVGAnimationElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0) and manual testing.

Tests Used (event handlers): https://mdn-bcd-collector.appspot.com/tests/api/SVGAnimationElement

Test Used (events):
```html
<div id="test">
	<svg xmlns="http://www.w3.org/2000/svg">
	  <title>'onbegin' event handler content attribute</title>
	  <rect width="0" height="100" fill="green">
	    <animate id="anim" attributeName="visibility" to="visible" begin="0s" end="2s" fill="freeze" onbegin="document.getElementById('anim2').beginElement()"/>
	    <set id="anim2" attributeName="width" to="100" begin="indefinite"/>
	  </rect>
	  </svg>
</div>

<script>
	var set = document.getElementById('anim2');
	set.addEventListener('beginEvent', function() {
		alert('begin');
	});
</script>
```
