### PR TITLE
Update Chrome/Safari versions for SVGPoint API

### DIFF
--- a/api/SVGPoint.json
+++ b/api/SVGPoint.json
@@ -6,7 +6,7 @@
         "spec_url": "https://www.w3.org/TR/SVG11/coords.html#InterfaceSVGPoint",
         "support": {
           "chrome": {
-            "version_added": "5"
+            "version_added": "1"
           },
           "chrome_android": {
             "version_added": "18"
@@ -30,10 +30,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "5"
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": "4"
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -54,7 +54,7 @@
           "spec_url": "https://www.w3.org/TR/SVG11/coords.html#__svg__SVGPoint__matrixTransform",
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -78,10 +78,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -103,10 +103,10 @@
           "spec_url": "https://www.w3.org/TR/SVG11/coords.html#__svg__SVGPoint__x",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -127,16 +127,16 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -152,10 +152,10 @@
           "spec_url": "https://www.w3.org/TR/SVG11/coords.html#__svg__SVGPoint__y",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -176,16 +176,16 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chrome and Safari for the `SVGPoint` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGPoint
