### PR TITLE
Add Safari versions for SVGRenderingIntent API

### DIFF
--- a/api/SVGRenderingIntent.json
+++ b/api/SVGRenderingIntent.json
@@ -34,10 +34,10 @@
             "version_removed": "32"
           },
           "safari": {
-            "version_added": true
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
             "version_added": "1.0",


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `SVGRenderingIntent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGRenderingIntent
