### PR TITLE
Update Chrome/Safari versions for SVGStringList API

### DIFF
--- a/api/SVGStringList.json
+++ b/api/SVGStringList.json
@@ -6,7 +6,7 @@
         "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGStringList",
         "support": {
           "chrome": {
-            "version_added": "5"
+            "version_added": "1"
           },
           "chrome_android": {
             "version_added": "18"
@@ -32,10 +32,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "5"
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": "4"
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -54,7 +54,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -78,10 +78,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -101,7 +101,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -125,10 +125,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -148,7 +148,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -172,10 +172,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -195,7 +195,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -219,10 +219,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -242,7 +242,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -266,10 +266,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -289,16 +289,16 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "35"
             },
             "edge": {
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "13"
+              "version_added": "12"
             },
             "firefox_android": {
               "version_added": "14"
@@ -313,16 +313,16 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "13"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -336,7 +336,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -360,10 +360,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -383,7 +383,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -407,10 +407,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -430,7 +430,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -454,10 +454,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Chrome and Safari for the `SVGStringList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGStringList
