### PR TITLE
Update Chrome/Safari versions for SVGTransformList API

### DIFF
--- a/api/SVGTransformList.json
+++ b/api/SVGTransformList.json
@@ -6,7 +6,7 @@
         "spec_url": "https://svgwg.org/svg2-draft/coords.html#InterfaceSVGTransformList",
         "support": {
           "chrome": {
-            "version_added": "5"
+            "version_added": "1"
           },
           "chrome_android": {
             "version_added": "18"
@@ -30,10 +30,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "5"
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": "4"
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -53,7 +53,7 @@
           "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__appendItem",
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -77,10 +77,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -101,7 +101,7 @@
           "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__clear",
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -125,10 +125,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -149,7 +149,7 @@
           "spec_url": "https://svgwg.org/svg2-draft/coords.html#__svg__SVGTransformList__consolidate",
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -173,10 +173,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -197,7 +197,7 @@
           "spec_url": "https://svgwg.org/svg2-draft/coords.html#__svg__SVGTransformList__createSVGTransformFromMatrix",
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -221,10 +221,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -245,7 +245,7 @@
           "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__getItem",
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -269,10 +269,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -293,7 +293,7 @@
           "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__initialize",
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -317,10 +317,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -341,7 +341,7 @@
           "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__insertItemBefore",
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -365,10 +365,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -388,10 +388,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "35"
             },
             "edge": {
               "version_added": "79"
@@ -412,16 +412,16 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "13"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {
@@ -436,7 +436,7 @@
           "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__numberOfItems",
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -460,10 +460,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -484,7 +484,7 @@
           "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__removeItem",
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -508,10 +508,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -532,7 +532,7 @@
           "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__replaceItem",
           "support": {
             "chrome": {
-              "version_added": "5"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -556,10 +556,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Chrome and Safari for the `SVGTransformList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGTransformList
