### PR TITLE
Add all browsers versions for CDATASection API

### DIFF
--- a/api/CDATASection.json
+++ b/api/CDATASection.json
@@ -15,7 +15,7 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "1"
           },
           "firefox_android": {
             "version_added": "4"
@@ -24,10 +24,10 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": "3"


### PR DESCRIPTION
This PR adds real values for all browsers for the `CDATASection` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CDATASection
