### PR TITLE
Remove irrelevant Chromium flag data for TextMetrics API

### DIFF
--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -53,36 +53,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/actualBoundingBoxAscent",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-actualboundingboxascent-dev",
           "support": {
-            "chrome": [
-              {
-                "version_added": "77"
-              },
-              {
-                "version_added": true,
-                "version_removed": "77",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "77"
-              },
-              {
-                "version_added": true,
-                "version_removed": "77",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "77"
+            },
             "edge": {
               "version_added": "79"
             },
@@ -126,36 +102,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/actualBoundingBoxDescent",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-actualboundingboxdescent-dev",
           "support": {
-            "chrome": [
-              {
-                "version_added": "77"
-              },
-              {
-                "version_added": true,
-                "version_removed": "77",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "77"
-              },
-              {
-                "version_added": true,
-                "version_removed": "77",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "77"
+            },
             "edge": {
               "version_added": "79"
             },
@@ -199,36 +151,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/actualBoundingBoxLeft",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-actualboundingboxleft-dev",
           "support": {
-            "chrome": [
-              {
-                "version_added": "77"
-              },
-              {
-                "version_added": true,
-                "version_removed": "77",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "77"
-              },
-              {
-                "version_added": true,
-                "version_removed": "77",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "77"
+            },
             "edge": {
               "version_added": "79"
             },
@@ -272,36 +200,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/actualBoundingBoxRight",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-actualboundingboxright-dev",
           "support": {
-            "chrome": [
-              {
-                "version_added": "77"
-              },
-              {
-                "version_added": true,
-                "version_removed": "77",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "77"
-              },
-              {
-                "version_added": true,
-                "version_removed": "77",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "77"
+            },
             "edge": {
               "version_added": "79"
             },
@@ -567,42 +471,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/fontBoundingBoxAscent",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-fontboundingboxascent-dev",
           "support": {
-            "chrome": [
-              {
-                "version_added": "87"
-              },
-              {
-                "version_added": true,
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "87"
-              },
-              {
-                "version_added": true,
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "87"
+            },
+            "chrome_android": {
+              "version_added": "87"
+            },
             "edge": {
-              "version_added": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
+              "version_added": "87"
             },
             "firefox": {
               "version_added": "74",
@@ -651,42 +527,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/fontBoundingBoxDescent",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-fontboundingboxdescent-dev",
           "support": {
-            "chrome": [
-              {
-                "version_added": "87"
-              },
-              {
-                "version_added": true,
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "87"
-              },
-              {
-                "version_added": true,
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental Web Platform Features"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "87"
+            },
+            "chrome_android": {
+              "version_added": "87"
+            },
             "edge": {
-              "version_added": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
+              "version_added": "87"
             },
             "firefox": {
               "version_added": "74",

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -471,14 +471,42 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/fontBoundingBoxAscent",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-fontboundingboxascent-dev",
           "support": {
-            "chrome": {
-              "version_added": "87"
-            },
-            "chrome_android": {
-              "version_added": "87"
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": true,
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": true,
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "edge": {
-              "version_added": "87"
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "firefox": {
               "version_added": "74",
@@ -527,14 +555,42 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextMetrics/fontBoundingBoxDescent",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-fontboundingboxdescent-dev",
           "support": {
-            "chrome": {
-              "version_added": "87"
-            },
-            "chrome_android": {
-              "version_added": "87"
-            },
+            "chrome": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": true,
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": true,
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "edge": {
-              "version_added": "87"
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features"
+                }
+              ]
             },
             "firefox": {
               "version_added": "74",


### PR DESCRIPTION
This PR removes irrelevant flag data for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `TextMetrics` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/vinyldarkscratch/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
