### PR TITLE
Add insertFromComposition and deleteByComposition inputTypes

### DIFF
--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -322,6 +322,102 @@
             "deprecated": false
           }
         },
+        "deleteByComposition": {
+          "__compat": {
+            "description": "<code>deleteByComposition</code> input type",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "insertFromComposition": {
+          "__compat": {
+            "description": "<code>insertFromComposition</code> input type",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": {
+                "version_added": true
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "insertFromPasteAsQuotation": {
           "__compat": {
             "description": "<code>insertFromPasteAsQuotation</code> input type",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Add Input Events Level 2 `insertFromComposition` and `deleteByComposition` inputType events 

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

For each browser, on macOS pinyin IME input <kbd>a 1</kbd> (inserting 啊), then selecting the inserted text and input <kbd>b 1</kbd> (deleting 啊 and replacing it with 不). According to https://w3c.github.io/input-events/#event-order-during-ime-composition we should see 

- deleteByComposition beforeInput and input events for the second test since 啊 is being deleted 
- insertFromComposition beforeInput and input events for both cases 

Firefox: https://input-inspector.vercel.app/profiles/8n74DRvc3g5dhl6pMYQo - neither event fires  
Chrome: https://input-inspector.vercel.app/profiles/AXWWGKNTootDNMo6pXcY - neither event fires  
Safari: https://input-inspector.vercel.app/profiles/Hocw2xtbGkIbqgFwXzQP - insertFromComposition fires but deleteByComposition does not. I don't know when this was added, so this is just left as `true` 


<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Firefox - the original bug for supporting inputEvent notes both these level 2 events will not be implemented yet https://bugzilla.mozilla.org/show_bug.cgi?id=1447239

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
