### PR TITLE
HTMLInputElement/HTMLTextAreaElement selectionchanged_event feature

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1863,6 +1863,56 @@
           }
         }
       },
+      "selectionchange_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLInputElement/selectionchange_event",
+          "spec_url": "https://w3c.github.io/selection-api/#selectionchange-event",
+          "description": "<code>selectionchange</code> event",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "92"
+            },
+            "firefox_android": {
+              "version_added": "92"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "selectionDirection": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLInputElement/selectionDirection",

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1907,7 +1907,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1870,13 +1870,13 @@
           "description": "<code>selectionchange</code> event",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "92"
@@ -1888,22 +1888,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -906,13 +906,13 @@
           "description": "<code>selectionchange</code> event",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": null
+              "version_added": false
             },
             "edge": {
-              "version_added": null
+              "version_added": false
             },
             "firefox": {
               "version_added": "92"
@@ -924,22 +924,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": null
+              "version_added": false
             },
             "webview_android": {
-              "version_added": null
+              "version_added": false
             }
           },
           "status": {

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -943,7 +943,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -899,6 +899,56 @@
           }
         }
       },
+      "selectionchange_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/selectionchange_event",
+          "spec_url": "https://w3c.github.io/selection-api/#selectionchange-event",
+          "description": "<code>selectionchange</code> event",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "92"
+            },
+            "firefox_android": {
+              "version_added": "92"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "selectionDirection": {
         "__compat": {
           "support": {


### PR DESCRIPTION
FF92 adds support for  [this spec change](https://github.com/w3c/selection-api/pull/141) to `selectionchange` events in https://bugzilla.mozilla.org/show_bug.cgi?id=1648944

In summary, 
- originally [`selectionchange_event`](https://developer.mozilla.org/en-US/docs/Web/API/Document/selectionchange_event) (no cancel, no bubble) was fired on `Document` to indicate that the selection (essentially a "breaking point" node and optionally a range of nodes from that) had changed. 
- The spec change lets you get events for a text selection. An event of the same name is fired on  `HTMLInputElement` and `HTMLInputElement`. (i.e. `<textarea>` or `<input>`). This is not cancellable (as well) but can bubble. All these events are handled in [GlobalEventHandlers.onselectionchange](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onselectionchange)

What this does is add the event to `HTMLInputElement` and `HTMLInputElement`. 
- I have put `null` for the other browsers. The spec change does not provide any indication either way and this thing seems to be out of date: https://docs.w3cub.com/dom_events/selectionchange
- I am using this as a test case: https://bugzilla.mozilla.org/show_bug.cgi?id=1648944#c0 - To me it looks like this is NOT implemented in chrome - essentially you get the old event if you select in on of the text elements (not bubblable). 

Questions:
1. Does that make sense? Can you help me confirm that I can put `false` for webkit and chromium
1.  Do I also need to add a subfeature in [GlobalEventHandlers.onselectionchange](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onselectionchange) to indicate the version in which the modified events changed? 
2. Should [Selection](https://developer.mozilla.org/en-US/docs/Web/API/Selection) still be considered experimental?


Docs tracking: https://github.com/mdn/content/issues/7755
