### PR TITLE
Adding note about disabledFeatures static property

### DIFF
--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -105,6 +105,10 @@
           "support": {
             "chrome": [
               {
+                "version_added": "77",
+                "notes": "Support for disabledFeatures static property."
+              },
+              {
                 "version_added": "67",
                 "notes": "Support for 'Customized built-in elements' as well."
               },
@@ -114,6 +118,10 @@
               }
             ],
             "chrome_android": [
+              {
+                "version_added": "77",
+                "notes": "Support for disabledFeatures static property."
+              },
               {
                 "version_added": "67",
                 "notes": "Support for 'Customized built-in elements' as well."
@@ -126,6 +134,10 @@
             "edge": [
               {
                 "version_added": "79",
+                "notes": "Support for disabledFeatures static property."
+              },
+              {
+                "version_added": "79",
                 "notes": "Support for 'Customized built-in elements' as well."
               },
               {
@@ -133,16 +145,32 @@
                 "notes": "Support for 'Autonomous custom elements' only."
               }
             ],
-            "firefox": {
-              "version_added": "63"
-            },
-            "firefox_android": {
-              "version_added": "63"
-            },
+            "firefox": [
+              {
+                "version_added": "92",
+                "notes": "Support for disabledFeatures static property."
+              },
+              {
+                "version_added": "63"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "92",
+                "notes": "Support for disabledFeatures static property."
+              },
+              {
+                "version_added": "63"
+              }
+            ],
             "ie": {
               "version_added": false
             },
             "opera": [
+              {
+                "version_added": "64",
+                "notes": "Support for disabledFeatures static property."
+              },
               {
                 "version_added": "54",
                 "notes": "Support for 'Customized built-in elements' as well."
@@ -153,6 +181,10 @@
               }
             ],
             "opera_android": [
+              {
+                "version_added": "55",
+                "notes": "Support for disabledFeatures static property."
+              },
               {
                 "version_added": "48",
                 "notes": "Support for 'Customized built-in elements' as well."
@@ -172,6 +204,10 @@
             },
             "samsunginternet_android": [
               {
+                "version_added": "12.0",
+                "notes": "Support for disabledFeatures static property."
+              },
+              {
                 "version_added": "9.0",
                 "notes": "Support for 'Customized built-in elements' as well."
               },
@@ -181,6 +217,10 @@
               }
             ],
             "webview_android": [
+              {
+                "version_added": "77",
+                "notes": "Support for disabledFeatures static property."
+              },
               {
                 "version_added": "67",
                 "notes": "Support for 'Customized built-in elements' as well."


### PR DESCRIPTION
Working on https://github.com/mdn/content/issues/7745

I wasn't altogether sure where to note this. So tell me if you think it should be elsewhere and I'll re-do it.

The spec is here: https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-define-dev (step 6 mentions it). So that's why I've added it to define.

I found the Chromium information here https://bugs.chromium.org/p/chromium/issues/detail?id=972951&q=disabledFeatures&can=1 and tested that it is in 77. I also checked Safari where it does not appear to be implemented. 