### PR TITLE
Deno supports CryptoKey + CryptoKeyPair

### DIFF
--- a/api/CryptoKey.json
+++ b/api/CryptoKey.json
@@ -12,7 +12,7 @@
             "version_added": "37"
           },
           "deno": {
-            "version_added": false
+            "version_added": "1.12"
           },
           "edge": {
             "version_added": "12"
@@ -66,7 +66,7 @@
               "version_added": "37"
             },
             "deno": {
-              "version_added": false
+              "version_added": "1.12"
             },
             "edge": {
               "version_added": "12"
@@ -120,9 +120,16 @@
             "chrome_android": {
               "version_added": "37"
             },
-            "deno": {
-              "version_added": false
-            },
+            "deno": [
+              {
+                "version_added": "1.13"
+              },
+              {
+                "version_added": "1.12",
+                "partial_implementation": true,
+                "notes": "The only supported value for this property is <code>true</code>."
+              }
+            ],
             "edge": {
               "version_added": "12"
             },
@@ -230,7 +237,7 @@
               "version_added": "37"
             },
             "deno": {
-              "version_added": false
+              "version_added": "1.12"
             },
             "edge": {
               "version_added": "12"
@@ -285,7 +292,7 @@
               "version_added": "37"
             },
             "deno": {
-              "version_added": false
+              "version_added": "1.12"
             },
             "edge": {
               "version_added": "12"

--- a/api/CryptoKeyPair.json
+++ b/api/CryptoKeyPair.json
@@ -12,7 +12,7 @@
             "version_added": "37"
           },
           "deno": {
-            "version_added": false
+            "version_added": "1.12"
           },
           "edge": {
             "version_added": "≤18"


### PR DESCRIPTION
#### Summary

Forgot to add these when adding support for `SubtleCrypto#generateKey`.

#### Test results and supporting details

![image](https://user-images.githubusercontent.com/7829205/130436380-cb2bd1ff-7411-40c0-a97d-5851429d2918.png)


