### PR TITLE
Deno does not implement `init*Event` methods

### DIFF
--- a/api/CloseEvent.json
+++ b/api/CloseEvent.json
@@ -170,7 +170,7 @@
               "version_added": false
             },
             "deno": {
-              "version_added": "1.4"
+              "version_added": false
             },
             "edge": {
               "version_added": "12",

--- a/api/CustomEvent.json
+++ b/api/CustomEvent.json
@@ -168,7 +168,7 @@
               "version_added": "18"
             },
             "deno": {
-              "version_added": "1.0"
+              "version_added": false
             },
             "edge": {
               "version_added": "12"

--- a/api/Event.json
+++ b/api/Event.json
@@ -698,7 +698,7 @@
               "version_added": "18"
             },
             "deno": {
-              "version_added": "1.0"
+              "version_added": false
             },
             "edge": {
               "version_added": "12"

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -173,7 +173,7 @@
               "version_added": true
             },
             "deno": {
-              "version_added": "1.4"
+              "version_added": false
             },
             "edge": {
               "version_added": "12"

--- a/api/ProgressEvent.json
+++ b/api/ProgressEvent.json
@@ -117,7 +117,7 @@
               "version_removed": "18"
             },
             "deno": {
-              "version_added": "1.3"
+              "version_added": false
             },
             "edge": {
               "version_added": "12",


### PR DESCRIPTION
#### Summary

Deno does not actually implement these, however they were marked as implemented.

