### PR TITLE
Update Safari versions for CustomEvent API

### DIFF
--- a/api/CustomEvent.json
+++ b/api/CustomEvent.json
@@ -33,10 +33,10 @@
             "version_added": "11"
           },
           "safari": {
-            "version_added": "5.1"
+            "version_added": "5"
           },
           "safari_ios": {
-            "version_added": "6"
+            "version_added": "5"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -85,10 +85,10 @@
               "version_added": "12"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -137,10 +137,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -189,10 +189,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "7.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `CustomEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CustomEvent
