### PR TITLE
Update Safari versions for DOMTokenList API

### DIFF
--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -33,7 +33,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": "5"
+            "version_added": "6"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -81,7 +81,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -178,7 +178,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -323,7 +323,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -420,7 +420,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -469,7 +469,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -761,7 +761,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -30,7 +30,7 @@
             "version_added": "11.5"
           },
           "safari": {
-            "version_added": "5"
+            "version_added": "6"
           },
           "safari_ios": {
             "version_added": "5"
@@ -78,7 +78,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": "5"
@@ -175,7 +175,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": "5"
@@ -320,7 +320,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": "5"
@@ -417,7 +417,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": "5"
@@ -466,7 +466,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": "5"
@@ -758,7 +758,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": "5"

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -30,7 +30,7 @@
             "version_added": "11.5"
           },
           "safari": {
-            "version_added": "5.1"
+            "version_added": "5"
           },
           "safari_ios": {
             "version_added": "5"
@@ -78,7 +78,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "safari_ios": {
               "version_added": "5"
@@ -175,7 +175,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "safari_ios": {
               "version_added": "5"
@@ -320,7 +320,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "safari_ios": {
               "version_added": "5"
@@ -466,7 +466,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "safari_ios": {
               "version_added": "5"
@@ -758,7 +758,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "safari_ios": {
               "version_added": "5"

--- a/api/Element.json
+++ b/api/Element.json
@@ -1543,7 +1543,7 @@
                 "version_added": "7"
               },
               {
-                "version_added": "5",
+                "version_added": "6",
                 "version_removed": "7",
                 "notes": "Not supported for SVG elements.",
                 "partial_implementation": true


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `DOMTokenList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DOMTokenList
