### PR TITLE
Add Safari versions for api.DOMTokenList.toggle.force_parameter

### DIFF
--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -805,10 +805,10 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": "1.5"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `toggle.force_parameter` member of the `DOMTokenList` API, based upon manual testing.

Test Code Used: 
```js
var elm = document.createElement('b');
elm.className = 'foo bar';
elm.classList.toggle('foo', true);
return elm.className === 'foo bar';
```
