### PR TITLE
Update Safari versions for Document API

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -86,10 +86,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -2953,7 +2953,7 @@
               "version_added": "16"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": "8"
@@ -8097,11 +8097,11 @@
               "version_removed": "50"
             },
             "safari": {
-              "version_added": "6.1",
+              "version_added": "7",
               "version_removed": "14"
             },
             "safari_ios": {
-              "version_added": "6.1",
+              "version_added": "7",
               "version_removed": "14"
             },
             "samsunginternet_android": {
@@ -11618,7 +11618,7 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `Document` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Document
