### PR TITLE
Add Safari versions for Element API

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -5082,10 +5082,10 @@
               "version_added": "18"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -5132,10 +5132,10 @@
               "version_added": "18"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "2.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `Element` API.  The data was copied from their event handler counterparts (in `GlobalEventHandlers`).
