### PR TITLE
Update Safari versions for FileReader API

### DIFF
--- a/api/FileReader.json
+++ b/api/FileReader.json
@@ -253,11 +253,11 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6.1",
+              "version_added": "6",
               "notes": "The <code>error</code> property returns a <code>DOMError</code> object."
             },
             "safari_ios": {
-              "version_added": "6.1",
+              "version_added": "6",
               "notes": "The <code>error</code> property returns a <code>DOMError</code> object."
             },
             "samsunginternet_android": {
@@ -535,10 +535,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -587,10 +587,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -639,10 +639,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -690,10 +690,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -741,10 +741,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -792,10 +792,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1106,10 +1106,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -1158,10 +1158,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `FileReader` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FileReader
