### PR TITLE
Update Safari versions for HTMLImageElement API

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -76,7 +76,7 @@
               "version_added": "8"
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": "≤4"
             },
             "safari_ios": {
               "version_added": "1"
@@ -1202,10 +1202,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": "2.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `HTMLImageElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLImageElement
