### PR TITLE
Update Safari versions for HTMLInputElement API

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -693,7 +693,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "safari_ios": {
               "version_added": "5"
@@ -741,7 +741,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "safari_ios": {
               "version_added": "5"
@@ -789,7 +789,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "safari_ios": {
               "version_added": "5"
@@ -885,7 +885,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "safari_ios": {
               "version_added": "5"
@@ -933,10 +933,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -980,7 +980,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "safari_ios": {
               "version_added": "5"
@@ -1127,7 +1127,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
             "safari_ios": {
               "version_added": "5"
@@ -2875,10 +2875,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "1.5"

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -696,7 +696,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -744,7 +744,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -792,7 +792,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -888,7 +888,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -983,7 +983,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1130,7 +1130,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `HTMLInputElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLInputElement
