### PR TITLE
Update Safari versions for HTMLMediaElement API

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -255,10 +255,10 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1411,10 +1411,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "8"
             },
             "webview_android": {
               "version_added": false
@@ -4100,10 +4100,10 @@
               ]
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `HTMLMediaElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLMediaElement
