### PR TITLE
Update Safari versions for HTMLTemplateElement API

### DIFF
--- a/api/HTMLTemplateElement.json
+++ b/api/HTMLTemplateElement.json
@@ -30,10 +30,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": "6.1"
+            "version_added": "8"
           },
           "safari_ios": {
-            "version_added": "6.1"
+            "version_added": "8"
           },
           "samsunginternet_android": {
             "version_added": "1.5"
@@ -78,10 +78,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": "1.5"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `HTMLTemplateElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLTemplateElement
