### PR TITLE
Update Safari versions for api.Range.Range

### DIFF
--- a/api/Range.json
+++ b/api/Range.json
@@ -85,7 +85,7 @@
               "version_added": "16"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": "8"
@@ -581,7 +581,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "9"
+              "version_added": "≤4"
             },
             "safari_ios": {
               "version_added": true


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `Range` member of the `Range` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Range/Range
