### PR TITLE
Update Safari versions for TextTrackCue API

### DIFF
--- a/api/TextTrackCue.json
+++ b/api/TextTrackCue.json
@@ -78,10 +78,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "8"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -225,10 +225,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "8"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -372,10 +372,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "8"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -421,10 +421,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "8"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -470,10 +470,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "8"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "1.5"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `TextTrackCue` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TextTrackCue
