### PR TITLE
Add Safari versions for api.URL.toString

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -1067,10 +1067,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "6.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `toString` member of the `URL` API, based upon manual testing.

Test Code Used: `new URL('https://localhost:8000').toString() === 'https://localhost:8000';`
