### PR TITLE
Update Safari versions for VTTCue API

### DIFF
--- a/api/VTTCue.json
+++ b/api/VTTCue.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "6.1"
+            "version_added": "6"
           },
           "safari_ios": {
             "version_added": "8"
@@ -79,7 +79,7 @@
               "version_added": "20"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": "8"
@@ -128,7 +128,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": "8"
@@ -177,7 +177,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": "8"
@@ -226,7 +226,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": "8"
@@ -324,7 +324,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": "8"
@@ -471,7 +471,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": "8"
@@ -520,7 +520,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": "8"
@@ -569,7 +569,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": "8"
@@ -618,7 +618,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": "8"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `VTTCue` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/VTTCue
