### PR TITLE
Update Safari versions for Window API

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -990,11 +990,11 @@
             },
             "safari": [
               {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               {
                 "version_added": "6",
-                "version_removed": "6.1",
+                "version_removed": "7",
                 "prefix": "webkit"
               }
             ],
@@ -1459,10 +1459,10 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -7202,7 +7202,7 @@
             ],
             "safari": [
               {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               {
                 "version_added": "6",
@@ -7214,7 +7214,7 @@
                 "version_added": "7"
               },
               {
-                "version_added": "6.1",
+                "version_added": "6",
                 "prefix": "webkit"
               }
             ],

--- a/api/Window.json
+++ b/api/Window.json
@@ -998,9 +998,16 @@
                 "prefix": "webkit"
               }
             ],
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": [
+              {
+                "version_added": "7"
+              },
+              {
+                "version_added": "6",
+                "version_removed": "7",
+                "prefix": "webkit"
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "1.5"
             },

--- a/api/Window.json
+++ b/api/Window.json
@@ -1459,10 +1459,10 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "3.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `Window` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.9).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Window
