### PR TITLE
Add mdn/spec_url for XRLayer

### DIFF
--- a/api/XRLayer.json
+++ b/api/XRLayer.json
@@ -2,6 +2,8 @@
   "api": {
     "XRLayer": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRLayer",
+        "spec_url": "https://immersive-web.github.io/webxr/#xrlayer-interface",
         "support": {
           "chrome": {
             "version_added": "84"


### PR DESCRIPTION
Spec: https://immersive-web.github.io/webxr/#xrlayer-interface
I'm creating this page on MDN.