### PR TITLE
Bug-1630415-Make-nativeMessaging-an-optional-permission

### DIFF
--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -475,6 +475,31 @@
             }
           }
         },
+        "nativeMessaging": {
+          "__compat": {
+            "description": "<code>nativeMessaging</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "87"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "notifications": {
           "__compat": {
             "description": "<code>notifications</code>",


### PR DESCRIPTION
Adds nativeMessaging to the list of supported optional permission as per [Bug 1630415 ](https://bugzilla.mozilla.org/show_bug.cgi?id=1630415).

npm test run with no errors