### PR TITLE
Object.hasOwn() is supported in Deno 1.13

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -987,7 +987,7 @@
                 "version_added": false
               },
               "deno": {
-                "version_added": false
+                "version_added": "1.13"
               },
               "edge": {
                 "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Deno 1.13 is running v8 9.3 which supports `Object.hasOwn`

```sh
$ deno
Deno 1.13.0
exit using ctrl+d or close()
> Object.hasOwn
[Function: hasOwn]
```

Also, the upcoming version of Chrome 93 supports `Object.hasOwn` as well

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
