### PR TITLE
`Object.hasOwn()` to ship in Firefox 92 and Chrome 93

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -981,16 +981,16 @@
             "spec_url": "https://tc39.es/proposal-accessible-object-hasownproperty/#sec-object.hasown",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "93"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "93"
               },
               "deno": {
                 "version_added": "1.13"
               },
               "edge": {
-                "version_added": false
+                "version_added": "93"
               },
               "firefox": {
                 "version_added": "92"
@@ -1005,7 +1005,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "79"
               },
               "opera_android": {
                 "version_added": false
@@ -1020,7 +1020,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "93"
               }
             },
             "status": {

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -993,12 +993,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "91",
-                "notes": "Available only in nightly builds."
+                "version_added": "92"
               },
               "firefox_android": {
-                "version_added": "91",
-                "notes": "Available only in nightly builds."
+                "version_added": "92"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
#### Summary

Update status of `Object.hasOwn()` for Firefox 92 and Chromium 93.

#### Test results and supporting details

* Firefox 92 ships `Object.hasOwn()` according to [bug 1721149](https://bugzilla.mozilla.org/show_bug.cgi?id=1721149)
* Chrome 93 (and friends) ships `Object.hasOwn()` according to [this status entry](https://chromestatus.com/feature/5662263404920832) (and a little manual testing)

#### Related issues

A follow up to https://github.com/mdn/browser-compat-data/pull/11548 (cc: @hamishwillee) and inspired by https://github.com/mdn/browser-compat-data/pull/12160.