### PR TITLE
Remove `Headers.getAll()` as irrelevant

### DIFF
--- a/api/Headers.json
+++ b/api/Headers.json
@@ -315,10 +315,12 @@
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-headers-get①",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "42",
+              "notes": "Before version 57, <code>get()</code> returns only the first value for the specified header."
             },
             "chrome_android": {
-              "version_added": "42"
+              "version_added": "42",
+              "notes": "Before version 57, <code>get()</code> returns only the first value for the specified header."
             },
             "deno": {
               "version_added": "1.0"
@@ -326,26 +328,24 @@
             "edge": {
               "version_added": "14"
             },
-            "firefox": [
-              {
-                "version_added": "52",
-                "notes": "Prior to Firefox 52, <code>get()</code> only returned the first value in the specified header, with <code>getAll()</code> returning all values. From 52 onwards, <code>get()</code> now returns all values and <code>getAll()</code> has been deleted."
-              },
-              {
-                "version_added": "39"
-              }
-            ],
+            "firefox": {
+              "version_added": "39",
+              "notes": "Before version 52, <code>get()</code> returns only the first value for the specified header."
+            },
             "firefox_android": {
-              "version_added": false
+              "version_added": "44",
+              "notes": "Before version 52, <code>get()</code> returns only the first value for the specified header."
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "29"
+              "version_added": "29",
+              "notes": "Before version 44, <code>get()</code> returns only the first value for the specified header."
             },
             "opera_android": {
-              "version_added": "29"
+              "version_added": "29",
+              "notes": "Before version 43, <code>get()</code> returns only the first value for the specified header."
             },
             "safari": {
               "version_added": "10.1"
@@ -354,10 +354,12 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "4.0",
+              "notes": "Before version 7.0, <code>get()</code> returns only the first value for the specified header."
             },
             "webview_android": {
-              "version_added": "42"
+              "version_added": "42",
+              "notes": "Before version 57, <code>get()</code> returns only the first value for the specified header."
             }
           },
           "status": {

--- a/api/Headers.json
+++ b/api/Headers.json
@@ -369,64 +369,6 @@
           }
         }
       },
-      "getAll": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/getAll",
-          "support": {
-            "chrome": {
-              "version_added": "42",
-              "version_removed": "60"
-            },
-            "chrome_android": {
-              "version_added": "42",
-              "version_removed": "60"
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": "39",
-              "version_removed": "52"
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "29",
-              "version_removed": "47"
-            },
-            "opera_android": {
-              "version_added": "29",
-              "version_removed": "44"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "4.0",
-              "version_removed": "8.0"
-            },
-            "webview_android": {
-              "version_added": "42",
-              "version_removed": "60"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "has": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/has",

--- a/api/Headers.json
+++ b/api/Headers.json
@@ -385,8 +385,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "≤18",
-              "version_removed": "79"
+              "version_added": false
             },
             "firefox": {
               "version_added": "39",
@@ -413,7 +412,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "4.0",
+              "version_removed": "8.0"
             },
             "webview_android": {
               "version_added": "42",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR:

- Removes `api.Headers.getAll` as irrelevant
- Scrubs mentions of `getAll` from notes on `get`
- Improves consistency of `get` data

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

With manual testing, I found that Edge never supported `getAll`, clearing it for removal as irrelevant (removed from all other browsers over two years ago). In the course of investigation, I also confirmed the historic behavior of `get` and updated the notes accordingly.

Finally, to support content removals on MDN, I scrubbed mentions of `getAll` from the notes for `get`.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

I was inspired to investigate this by https://github.com/mdn/browser-compat-data/pull/12157.

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
