### PR TITLE
Remove data for Window.onpaint

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -5128,54 +5128,6 @@
           }
         }
       },
-      "onpaint": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onpaint",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": false
-          }
-        }
-      },
       "onuserproximity": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onuserproximity",


### PR DESCRIPTION
To go with this change: https://github.com/mdn/content/pull/8244/commits/6866a76fd97dcb2e5f98e2ff3d2aa149d8c0253d which removed the MDN page itself.

Reason: hasn't been implemented anywhere (ever? for a long time?).