### PR TITLE
Fix crypto.randomUUID() spec URL

### DIFF
--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -122,7 +122,7 @@
       "randomUUID": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Crypto/randomUUID",
-          "spec_url": "https://w3c.github.io/webcrypto/#Crypto-method-randomUUID",
+          "spec_url": "https://wicg.github.io/uuid/#extensions-to-the-crypto-interface",
           "description": "<code>randomUUID()</code>",
           "support": {
             "chrome": {


### PR DESCRIPTION
The `crypto.randomUUID()` method isn’t in the Web Crypto spec but instead in a separate spec.

The spec URL chosen here is intentionally the anchor for the closest heading rather than the specific anchor for the definition of method.

The rationale for that choice is that this is a case where landing developers at a section heading gives them a lot more context — because the section has a note explaining the method in developer-friendly language, and if we instead landed developers at the formal normative definition, the only way they’d see the more developer-friendly explanation would be if they knew to scroll back up vertically to find it.

cc @lucacasonato