### PR TITLE
Fix Firefox versions for Element.client{Left,Top}

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1831,7 +1831,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "3"
             },
             "firefox_android": {
               "version_added": "4"
@@ -1880,7 +1880,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "3"
             },
             "firefox_android": {
               "version_added": "4"


### PR DESCRIPTION
According to https://bugzilla.mozilla.org/show_bug.cgi?id=111207, these properties have been added in Firefox 3 and not Firefox 1.

This matches notes on MDN: [`Element.clientLeft`](https://developer.mozilla.org/en-US/docs/Web/API/Element/clientLeft) / [`Element.clientTop`](https://developer.mozilla.org/en-US/docs/Web/API/Element/clientTop):

> Gecko-based applications support clientLeft starting with Gecko 1.9 (Firefox 3, implemented in bug 111207). This property is not supported in Firefox 2 and earlier.