### PR TITLE
Deno 1.14 supports ArrayBuffer in structured clone

### DIFF
--- a/api/DedicatedWorkerGlobalScope.json
+++ b/api/DedicatedWorkerGlobalScope.json
@@ -430,7 +430,12 @@
             },
             "deno": [
               {
+                "version_added": "1.14",
+                "notes": "The <code>message</code> parameter does not support cloning <code>Blob</code> values."
+              },
+              {
                 "version_added": "1.12",
+                "version_removed": "1.14",
                 "partial_implementation": true,
                 "notes": [
                   "The <code>message</code> parameter does not support cloning <code>Blob</code> values.",

--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -351,14 +351,21 @@
             "chrome_android": {
               "version_added": "18"
             },
-            "deno": {
-              "version_added": "1.12",
-              "partial_implementation": true,
-              "notes": [
-                "The <code>message</code> parameter does not support cloning <code>Blob</code> values.",
-                "The <code>transfer</code> parameter does not accept <code>ArrayBuffer</code> items. Passing an <code>ArrayBuffer</code> results in an error being thrown."
-              ]
-            },
+            "deno": [
+              {
+                "version_added": "1.14",
+                "notes": "The <code>message</code> parameter does not support cloning <code>Blob</code> values."
+              },
+              {
+                "version_added": "1.12",
+                "version_removed": "1.14",
+                "partial_implementation": true,
+                "notes": [
+                  "The <code>message</code> parameter does not support cloning <code>Blob</code> values.",
+                  "The <code>transfer</code> parameter does not accept <code>ArrayBuffer</code> items. Passing an <code>ArrayBuffer</code> results in an error being thrown."
+                ]
+              }
+            ],
             "edge": {
               "version_added": "12"
             },

--- a/api/Transferable.json
+++ b/api/Transferable.json
@@ -12,7 +12,7 @@
             "version_added": true
           },
           "deno": {
-            "version_added": false
+            "version_added": "1.12"
           },
           "edge": {
             "version_added": "12"

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -660,7 +660,12 @@
             },
             "deno": [
               {
+                "version_added": "1.14",
+                "notes": "The <code>message</code> parameter does not support cloning <code>Blob</code> values."
+              },
+              {
                 "version_added": "1.12",
+                "version_removed": "1.14",
                 "partial_implementation": true,
                 "notes": [
                   "The <code>message</code> parameter does not support cloning <code>Blob</code> values.",

--- a/api/_globals/structuredClone.json
+++ b/api/_globals/structuredClone.json
@@ -11,14 +11,21 @@
           "chrome_android": {
             "version_added": false
           },
-          "deno": {
-            "version_added": "1.13",
-            "partial_implementation": true,
-            "notes": [
-              "The <code>message</code> parameter does not support cloning <code>Blob</code> values.",
-              "The <code>transfer</code> parameter does not accept <code>ArrayBuffer</code> items. Passing an <code>ArrayBuffer</code> results in an error being thrown."
-            ]
-          },
+          "deno": [
+            {
+              "version_added": "1.14",
+              "notes": "The <code>message</code> parameter does not support cloning <code>Blob</code> values."
+            },
+            {
+              "version_added": "1.13",
+              "version_removed": "1.14",
+              "partial_implementation": true,
+              "notes": [
+                "The <code>message</code> parameter does not support cloning <code>Blob</code> values.",
+                "The <code>transfer</code> parameter does not accept <code>ArrayBuffer</code> items. Passing an <code>ArrayBuffer</code> results in an error being thrown."
+              ]
+            }
+          ],
           "edge": {
             "version_added": false
           },


### PR DESCRIPTION
#### Test results and supporting details

https://github.com/denoland/deno/commit/5d814a4c244d489b4ae51002a0cf1d3c2fe16058
