### PR TITLE
HTMLSlotElement is not experimental

### DIFF
--- a/api/HTMLSlotElement.json
+++ b/api/HTMLSlotElement.json
@@ -43,13 +43,14 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
       },
       "assign": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSlotElement/assign",
           "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#dom-slot-assign",
           "support": {
             "chrome": {
@@ -62,10 +63,10 @@
               "version_added": "86"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "92"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "92"
             },
             "ie": {
               "version_added": false
@@ -90,7 +91,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -139,7 +140,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -188,7 +189,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -237,7 +238,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -287,7 +288,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/7756

The `assign()` method is in Firefox 92. I also changed the API to not be experimental as there seems to be wide implementation. 
