### PR TITLE
Remove KeyboardEvent.which and MouseEvent.which

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -1706,57 +1706,6 @@
             "deprecated": false
           }
         }
-      },
-      "which": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyboardEvent/which",
-          "spec_url": "https://w3c.github.io/uievents/#dom-uievent-which",
-          "support": {
-            "chrome": {
-              "version_added": "1"
-            },
-            "chrome_android": {
-              "version_added": "18"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "1.5",
-              "notes": "Firefox also implements this property on the <code>UIEvent</code> interface."
-            },
-            "firefox_android": {
-              "version_added": "4",
-              "notes": "Firefox also implements this property on the <code>UIEvent</code> interface."
-            },
-            "ie": {
-              "version_added": "9"
-            },
-            "opera": {
-              "version_added": "12.1"
-            },
-            "opera_android": {
-              "version_added": "12.1"
-            },
-            "safari": {
-              "version_added": "≤4"
-            },
-            "safari_ios": {
-              "version_added": "≤3"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.0"
-            },
-            "webview_android": {
-              "version_added": "≤37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
       }
     }
   }

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -1297,56 +1297,6 @@
           }
         }
       },
-      "which": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/which",
-          "support": {
-            "chrome": {
-              "version_added": "1"
-            },
-            "chrome_android": {
-              "version_added": "18"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "1",
-              "notes": "On <code>mousemove</code> events, the <code>which</code> property is incorrectly always set to <code>1</code>."
-            },
-            "firefox_android": {
-              "version_added": "4",
-              "notes": "On <code>mousemove</code> events, the <code>which</code> property is incorrectly always set to <code>1</code>."
-            },
-            "ie": {
-              "version_added": "9"
-            },
-            "opera": {
-              "version_added": "10.6"
-            },
-            "opera_android": {
-              "version_added": "11"
-            },
-            "safari": {
-              "version_added": "3.1"
-            },
-            "safari_ios": {
-              "version_added": "2"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.0"
-            },
-            "webview_android": {
-              "version_added": "≤37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": false
-          }
-        }
-      },
       "x": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/x",

--- a/api/UIEvent.json
+++ b/api/UIEvent.json
@@ -579,6 +579,7 @@
       "which": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/UIEvent/which",
+          "spec_url": "https://w3c.github.io/uievents/#dom-uievent-which",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -586,24 +587,52 @@
             "chrome_android": {
               "version_added": "18"
             },
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/KeyboardEvent'><code>KeyboardEvent</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/MouseEvent'><code>MouseEvent</code></a>, not all <code>UIEvent</code> objects."
+              }
+            ],
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "On <code>mousemove</code> events, the <code>which</code> property is incorrectly always set to <code>1</code>."
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "On <code>mousemove</code> events, the <code>which</code> property is incorrectly always set to <code>1</code>."
             },
             "ie": {
-              "version_added": false
+              "version_added": "9",
+              "partial_implementation": true,
+              "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/KeyboardEvent'><code>KeyboardEvent</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/MouseEvent'><code>MouseEvent</code></a>, not all <code>UIEvent</code> objects."
             },
-            "opera": {
-              "version_added": "15"
-            },
-            "opera_android": {
-              "version_added": "14"
-            },
+            "opera": [
+              {
+                "version_added": "15"
+              },
+              {
+                "version_added": "≤12.1",
+                "version_removed": "15",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/KeyboardEvent'><code>KeyboardEvent</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/MouseEvent'><code>MouseEvent</code></a>, not all <code>UIEvent</code> objects."
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "14"
+              },
+              {
+                "version_added": "≤12.1",
+                "version_removed": "14",
+                "partial_implementation": true,
+                "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/KeyboardEvent'><code>KeyboardEvent</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/MouseEvent'><code>MouseEvent</code></a>, not all <code>UIEvent</code> objects."
+              }
+            ],
             "safari": {
               "version_added": "≤4"
             },


### PR DESCRIPTION
UIEvent.which is already in the data, so update that to reflect the
partial support from when `which` was on KeyboardEvent and MouseEvent.

The existing data from MouseEvent is not perfectly preserved, in
particular the early Opera and Safari versions have not been verified,
so instead ranges are used in the merged data.