### PR TITLE
Remove partial_implementation from Crypto.subtle and SubtleCrypto

### DIFF
--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -199,8 +199,7 @@
               "version_added": "34"
             },
             "ie": {
-              "version_added": "11",
-              "partial_implementation": true
+              "version_added": "11"
             },
             "nodejs": {
               "version_added": "15.0.0"

--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -15,8 +15,7 @@
             "version_added": "1.11"
           },
           "edge": {
-            "version_added": "12",
-            "partial_implementation": true
+            "version_added": "12"
           },
           "firefox": {
             "version_added": "34"
@@ -25,8 +24,7 @@
             "version_added": "34"
           },
           "ie": {
-            "version_added": "11",
-            "partial_implementation": true
+            "version_added": "11"
           },
           "nodejs": {
             "version_added": "15.0.0"


### PR DESCRIPTION
There are no notes here, but partial_implementation with notes are
already used for most of the SubtleCrypto methods. There's no need for
the parent feature to summarize the state of subfeatures, in particular
when crypto.subtle is just an object full of methods, and not something
that does anything on its own.
