### PR TITLE
FF supports navigator.share behind pref

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3355,8 +3355,7 @@
             },
             "firefox_android": {
               "version_added": "79",
-              "partial_implementation": true,
-              "notes": "Firefox for Android does not support sharing text or files."
+              "partial_implementation": true
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
`Navigator.share()` was marked false for FireFox desktop. However testing shows that it does work for desktop Windows (at least). I think it was added in FF71 in this [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1312422) behind the preference `dom.webshare.enabled`.
Note that FF android is not blocked by this preference.

I also did some testing and verified that `Navigator.share()` and `Navigator.canShare()` work on Windows Opera and Edge, and also Opera Android. I have *guessed* the versions for desktop match Chrome (but without the partial implementation warning due, I think, to MacOS issues). 

Upshot, those changes might perhaps revert to `true` if you think this is not a safe assumption.

FYI these methods are protected by web-share permission. I have not added subfeatures for that, because I don't know if it is a compatibility issue (at all). 