### PR TITLE
Represent support for webkitRTCPeerConnection

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -5,15 +5,33 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection",
         "spec_url": "https://w3c.github.io/webrtc-pc/#interface-definition",
         "support": {
-          "chrome": {
-            "version_added": "23"
-          },
-          "chrome_android": {
-            "version_added": "25"
-          },
-          "edge": {
-            "version_added": "15"
-          },
+          "chrome": [
+            {
+              "version_added": "55"
+            },
+            {
+              "prefix": "webkit",
+              "version_added": "23"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "55"
+            },
+            {
+              "prefix": "webkit",
+              "version_added": "25"
+            }
+          ],
+          "edge": [
+            {
+              "version_added": "15"
+            },
+            {
+              "prefix": "webkit",
+              "version_added": "15"
+            }
+          ],
           "firefox": [
             {
               "version_added": "44"
@@ -37,22 +55,20 @@
           },
           "opera": [
             {
-              "version_added": "43",
-              "notes": "Promise-based version."
+              "version_added": "42"
             },
             {
-              "version_added": "37",
-              "version_removed": "43"
+              "prefix": "webkit",
+              "version_added": "15"
             }
           ],
           "opera_android": [
             {
-              "version_added": "43",
-              "notes": "Promise-based version."
+              "version_added": "42"
             },
             {
-              "version_added": "37",
-              "version_removed": "43"
+              "prefix": "webkit",
+              "version_added": "14"
             }
           ],
           "safari": {
@@ -67,13 +83,18 @@
             },
             {
               "prefix": "webkit",
-              "version_removed": "6.0",
-              "version_added": "5.0"
+              "version_added": "1.5"
             }
           ],
-          "webview_android": {
-            "version_added": "≤37"
-          }
+          "webview_android": [
+            {
+              "version_added": "55"
+            },
+            {
+              "prefix": "webkit",
+              "version_added": "≤37"
+            }
+          ]
         },
         "status": {
           "experimental": false,
@@ -87,17 +108,35 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/RTCPeerConnection",
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-peerconnection",
           "support": {
-            "chrome": {
-              "version_added": "23",
-              "notes": "Before Chrome 63 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
-            },
-            "chrome_android": {
-              "version_added": true,
-              "notes": "Before Chrome 63 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
-            },
-            "edge": {
-              "version_added": "15"
-            },
+            "chrome": [
+              {
+                "version_added": "55",
+                "notes": "Before Chrome 63 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "23"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "55",
+                "notes": "Before Chrome 63 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "25"
+              }
+            ],
+            "edge": [
+              {
+                "version_added": "15"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "15"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "44"
@@ -121,22 +160,22 @@
             },
             "opera": [
               {
-                "version_added": "43",
-                "notes": "Promise-based version."
+                "version_added": "42",
+                "notes": "Before Opera 50 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
               },
               {
-                "version_added": "37",
-                "version_removed": "43"
+                "prefix": "webkit",
+                "version_added": "15"
               }
             ],
             "opera_android": [
               {
-                "version_added": "43",
-                "notes": "Promise-based version."
+                "version_added": "42",
+                "notes": "Before Opera Android 46 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
               },
               {
-                "version_added": "37",
-                "version_removed": "43"
+                "prefix": "webkit",
+                "version_added": "14"
               }
             ],
             "safari": {
@@ -145,12 +184,19 @@
             "safari_ios": {
               "version_added": "11"
             },
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "6.0",
+                "notes": "Before Samsung Internet 8.0 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5"
+              }
+            ],
             "webview_android": {
               "version_added": "≤37",
-              "notes": "Before Chrome 63 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
+              "notes": "Before WebView 63 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
             }
           },
           "status": {


### PR DESCRIPTION
Tests for the prefixed and unprefixed variants:
http://mdn-bcd-collector.appspot.com/tests/api/RTCPeerConnection/RTCPeerConnection
http://mdn-bcd-collector.appspot.com/tests/api/webkitRTCPeerConnection/webkitRTCPeerConnection

The Chrome data matches https://caniuse.com/rtcpeerconnection and was
confirmed with the above tests.

Support for both were confirmed in Edge 15 on BrowserStack.

The other changes were mirrored.