### PR TITLE
Add spec+mdn urls for XMLHttpRequest()

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -57,6 +57,8 @@
       "XMLHttpRequest": {
         "__compat": {
           "description": "<code>XMLHttpRequest()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/XMLHttpRequest",
+          "spec_url": "https://xhr.spec.whatwg.org/#dom-xmlhttprequest",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -57,7 +57,7 @@
       "XMLHttpRequest": {
         "__compat": {
           "description": "<code>XMLHttpRequest()</code> constructor",
-          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/XMLHttpRequest",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/XMLHttpRequest",
           "spec_url": "https://xhr.spec.whatwg.org/#dom-xmlhttprequest",
           "support": {
             "chrome": {


### PR DESCRIPTION
Both mdn and spec urls were missing for the `XMLHttpRequest` ctor (and I just added both tables on the mdn page)