### PR TITLE
Include api.Share compatibility on Opera 77

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3240,7 +3240,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "77"
+              "version_added": "75"
             },
             "opera_android": {
               "version_added": "48"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3240,7 +3240,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "77"
             },
             "opera_android": {
               "version_added": "48"


### PR DESCRIPTION
#### Summary

According to #11989, Opera has version 77 compatibility for `api.Navigator.share`.

In this PR, compatibility for the version has been included.

#### Related issues

Fixes #11989.
