### PR TITLE
Add missing Deno data for javascript.classes

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -550,6 +550,9 @@
             "chrome_android": {
               "version_added": "91"
             },
+            "deno": {
+              "version_added": "1.9"
+            },
             "edge": {
               "version_added": "91"
             },
@@ -602,6 +605,9 @@
             },
             "chrome_android": {
               "version_added": "84"
+            },
+            "deno": {
+              "version_added": "1.0"
             },
             "edge": {
               "version_added": "84"


### PR DESCRIPTION
#### Test results and supporting details

Features were added in V8 9.1 and V8 8.4, so Deno 1.9 and Deno 1.0 respectively.
