### PR TITLE
Deprecate BasicCardRequest/BasicCardResponse

### DIFF
--- a/api/BasicCardRequest.json
+++ b/api/BasicCardRequest.json
@@ -3,7 +3,6 @@
     "BasicCardRequest": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/BasicCardRequest",
-        "spec_url": "https://w3c.github.io/payment-method-basic-card/#basiccardrequest-dictionary",
         "support": {
           "chrome": {
             "version_added": false
@@ -71,14 +70,13 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
-          "deprecated": false
+          "standard_track": false,
+          "deprecated": true
         }
       },
       "supportedNetworks": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BasicCardRequest/supportedNetworks",
-          "spec_url": "https://w3c.github.io/payment-method-basic-card/#dom-basiccardrequest-supportednetworks",
           "support": {
             "chrome": {
               "version_added": false
@@ -136,8 +134,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -203,7 +201,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/BasicCardResponse.json
+++ b/api/BasicCardResponse.json
@@ -3,7 +3,6 @@
     "BasicCardResponse": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/BasicCardResponse",
-        "spec_url": "https://w3c.github.io/payment-method-basic-card/#basiccardresponse-dictionary",
         "support": {
           "chrome": {
             "version_added": false
@@ -71,14 +70,13 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
-          "deprecated": false
+          "standard_track": false,
+          "deprecated": true
         }
       },
       "billingAddress": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BasicCardResponse/billingAddress",
-          "spec_url": "https://w3c.github.io/payment-method-basic-card/#dom-basiccardresponse-billingaddress",
           "support": {
             "chrome": {
               "version_added": false
@@ -136,15 +134,14 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
       "cardholderName": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BasicCardResponse/cardholderName",
-          "spec_url": "https://w3c.github.io/payment-method-basic-card/#dom-basiccardresponse-cardholdername",
           "support": {
             "chrome": {
               "version_added": false
@@ -202,15 +199,14 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
       "cardNumber": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BasicCardResponse/cardNumber",
-          "spec_url": "https://w3c.github.io/payment-method-basic-card/#dom-basiccardresponse-cardnumber",
           "support": {
             "chrome": {
               "version_added": false
@@ -268,15 +264,14 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
       "cardSecurityCode": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BasicCardResponse/cardSecurityCode",
-          "spec_url": "https://w3c.github.io/payment-method-basic-card/#dom-basiccardresponse-cardsecuritycode",
           "support": {
             "chrome": {
               "version_added": false
@@ -334,15 +329,14 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
       "expiryMonth": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BasicCardResponse/expiryMonth",
-          "spec_url": "https://w3c.github.io/payment-method-basic-card/#dom-basiccardresponse-expirymonth",
           "support": {
             "chrome": {
               "version_added": false
@@ -400,15 +394,14 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
       "expiryYear": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BasicCardResponse/expiryYear",
-          "spec_url": "https://w3c.github.io/payment-method-basic-card/#dom-basiccardresponse-expiryyear",
           "support": {
             "chrome": {
               "version_added": false
@@ -466,8 +459,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
See https://w3c.github.io/payment-method-basic-card/#sotd:

> The Web Payments Working Group has discontinued work on this document.

...and see https://github.com/w3c/payment-method-basic-card#deprecated---basic-card

> ⚠️ The W3C Web Payments Working Group has discontinued work on the Basic Card Payment Method.⚠️

So this change drops all the spec URLs for the BasicCardRequest and BasicCardResponse features and all their subfeatures, while also marking them all as deprecated and non-standard.

Related MDN change: https://github.com/mdn/content/pull/8496