### PR TITLE
Update PermissionStatus spec URL

### DIFF
--- a/api/PermissionStatus.json
+++ b/api/PermissionStatus.json
@@ -3,7 +3,7 @@
     "PermissionStatus": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PermissionStatus",
-        "spec_url": "https://w3c.github.io/permissions/#status-of-a-permission",
+        "spec_url": "https://w3c.github.io/permissions/#permissionstatus-interface",
         "support": {
           "chrome": {
             "version_added": "43"


### PR DESCRIPTION
The Permissions spec has recently been updated, and one of the changes included reorganizing the content such that what had been in the section at https://www.w3.org/TR/2021/WD-permissions-20210720/#status-of-a-permission is now in https://w3c.github.io/permissions/#permissionstatus-interface.