### PR TITLE
Remove irrelevant flag data for ESM support

### DIFF
--- a/javascript/operators/destructuring.json
+++ b/javascript/operators/destructuring.json
@@ -125,20 +125,9 @@
               "deno": {
                 "version_added": "1.0"
               },
-              "edge": [
-                {
-                  "version_added": "16"
-                },
-                {
-                  "version_added": "14",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "Enable experimental Javascript features"
-                    }
-                  ]
-                }
-              ],
+              "edge": {
+                "version_added": "16"
+              },
               "firefox": {
                 "version_added": "41"
               },

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -685,50 +685,15 @@
             "deno": {
               "version_added": "1.0"
             },
-            "edge": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "15",
-                "flags": [
-                  {
-                    "name": "Experimental JavaScript Features",
-                    "type": "preference"
-                  }
-                ]
-              }
-            ],
-            "firefox": [
-              {
-                "version_added": "60"
-              },
-              {
-                "version_added": "54",
-                "version_removed": "60",
-                "flags": [
-                  {
-                    "name": "dom.moduleScripts.enabled",
-                    "type": "preference"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "60"
-              },
-              {
-                "version_added": "54",
-                "version_removed": "60",
-                "flags": [
-                  {
-                    "name": "dom.moduleScripts.enabled",
-                    "type": "preference"
-                  }
-                ]
-              }
-            ],
+            "edge": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "60"
+            },
+            "firefox_android": {
+              "version_added": "60"
+            },
             "ie": {
               "version_added": false
             },
@@ -798,50 +763,15 @@
               "deno": {
                 "version_added": "1.0"
               },
-              "edge": [
-                {
-                  "version_added": "16"
-                },
-                {
-                  "version_added": "15",
-                  "flags": [
-                    {
-                      "name": "Experimental JavaScript Features",
-                      "type": "preference"
-                    }
-                  ]
-                }
-              ],
-              "firefox": [
-                {
-                  "version_added": "60"
-                },
-                {
-                  "version_added": "54",
-                  "version_removed": "60",
-                  "flags": [
-                    {
-                      "name": "dom.moduleScripts.enabled",
-                      "type": "preference"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "60"
-                },
-                {
-                  "version_added": "54",
-                  "version_removed": "60",
-                  "flags": [
-                    {
-                      "name": "dom.moduleScripts.enabled",
-                      "type": "preference"
-                    }
-                  ]
-                }
-              ],
+              "edge": {
+                "version_added": "16"
+              },
+              "firefox": {
+                "version_added": "60"
+              },
+              "firefox_android": {
+                "version_added": "60"
+              },
               "ie": {
                 "version_added": false
               },
@@ -1708,50 +1638,15 @@
             "deno": {
               "version_added": "1.0"
             },
-            "edge": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "15",
-                "flags": [
-                  {
-                    "name": "Experimental JavaScript Features",
-                    "type": "preference"
-                  }
-                ]
-              }
-            ],
-            "firefox": [
-              {
-                "version_added": "60"
-              },
-              {
-                "version_added": "54",
-                "version_removed": "60",
-                "flags": [
-                  {
-                    "name": "dom.moduleScripts.enabled",
-                    "type": "preference"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "60"
-              },
-              {
-                "version_added": "54",
-                "version_removed": "60",
-                "flags": [
-                  {
-                    "name": "dom.moduleScripts.enabled",
-                    "type": "preference"
-                  }
-                ]
-              }
-            ],
+            "edge": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "60"
+            },
+            "firefox_android": {
+              "version_added": "60"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
These are old enough for removal per the guideline:
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data

The "rest_in_arrays" change is not ESM, but rather a similar drive-by
change.
