### PR TITLE
Bug 1612390 Sidebars inc in extension.getViews when windowId specified

### DIFF
--- a/webextensions/api/extension.json
+++ b/webextensions/api/extension.json
@@ -161,6 +161,38 @@
                 "version_added": "14"
               }
             }
+          },
+          "windowId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": [
+                  {
+                    "version_added": "45"
+                  },
+                  {
+                    "version_added": "93",
+                    "notes": "Sidebar views are now matched."
+                  }
+                ],
+                "firefox_android": {
+                  "version_added": "48",
+                  "notes": "The property is recognized, but the filter has no effect.",
+                  "partial_implementation": true
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": "14"
+                }
+              }
+            }
           }
         },
         "inIncognitoContext": {


### PR DESCRIPTION
Added line for `windowId` with a note on matching sidebars and Firefox for Android support 

Addresses  [Bug 1612390](https://bugzilla.mozilla.org/show_bug.cgi?id=1612390)

Tested and passed `npm test`