### PR TITLE
Firefox 93 supports datetime-local

### DIFF
--- a/html/elements/input/datetime-local.json
+++ b/html/elements/input/datetime-local.json
@@ -18,8 +18,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/888320'>bug 888320</a> and <a href='https://wiki.mozilla.org/TPE_DOM/Date_time_input_types'>TPE DOM/Date time input types</a>."
+                "version_added": "93"
               },
               "firefox_android": {
                 "version_added": true


### PR DESCRIPTION
#### Summary
Firefox 93 supports datetime-local, updates version to reflect this.

#### Test results and supporting details
Downloaded nightly build, checked if it worked on https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local

See https://bugzilla.mozilla.org/show_bug.cgi?id=1283388

#### Related issues
Fixes #12248
