### PR TITLE
Un-deprecate FileSystemDirectoryReader

### DIFF
--- a/api/FileSystemDirectoryReader.json
+++ b/api/FileSystemDirectoryReader.json
@@ -50,8 +50,8 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": false,
-          "deprecated": true
+          "standard_track": true,
+          "deprecated": false
         }
       },
       "readEntries": {
@@ -98,8 +98,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
-            "deprecated": true
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
FileSystemDirectoryReader should never have been marked at deprecated.  See https://github.com/mdn/content/issues/8263 and see the spec at https://wicg.github.io/entries-api/#api-directoryreader. Related MDN PR: https://github.com/mdn/content/pull/8379