### PR TITLE
Added Samsung Internet 16.0 Beta

### DIFF
--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -162,7 +162,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "16.0"
             },
             "webview_android": {
               "version_added": "92"

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -209,7 +209,6 @@
           "engine_version": "90"
         },
         "16.0": {
-          "release_date": "2021-09-01",
           "status": "beta",
           "engine": "Blink",
           "engine_version": "92"

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -198,15 +198,21 @@
         },
         "14.2": {
           "release_date": "2021-05-05",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "87"
         },
         "15.0": {
           "release_date": "2021-07-15",
-          "status": "beta",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "90"
+        },
+        "16.0": {
+          "release_date": "2021-09-01",
+          "status": "beta",
+          "engine": "Blink",
+          "engine_version": "92"
         }
       }
     }

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -803,7 +803,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "16.0"
               },
               "webview_android": {
                 "version_added": "92"

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -153,7 +153,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "16.0"
               },
               "webview_android": {
                 "version_added": "92"

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -209,7 +209,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "16.0"
               },
               "webview_android": {
                 "version_added": "92"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -152,7 +152,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "16.0"
               },
               "webview_android": {
                 "version_added": "92"

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -328,7 +328,7 @@
                       "version_added": "14.5"
                     },
                     "samsunginternet_android": {
-                      "version_added": false
+                      "version_added": "16.0"
                     },
                     "webview_android": {
                       "version_added": "92"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Added Samsung Internet 16.0 as a beta release and marked 15.0 as stable.

Also copied across blink 92 support data to Samsung Internet 16.0

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

![image](https://user-images.githubusercontent.com/32498324/132095340-bc96371b-d11c-466f-b3fa-8496c2a597ac.png)

https://play.google.com/store/apps/details?id=com.sec.android.app.sbrowser.beta
