### PR TITLE
Correct Samsung Internet Release Dates

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -197,13 +197,13 @@
           "engine_version": "87"
         },
         "14.2": {
-          "release_date": "2021-05-05",
+          "release_date": "2021-06-25",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "87"
         },
         "15.0": {
-          "release_date": "2021-07-15",
+          "release_date": "2021-08-13",
           "status": "current",
           "engine": "Blink",
           "engine_version": "90"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Correct the release dates for Samsung Internet 15 and 14.2

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

These are best guesses based on APK Mirror upload dates.

https://www.apkmirror.com/apk/samsung-electronics-co-ltd/samsung-internet-for-android/samsung-internet-for-android-14-2-1-69-release/#:~:text=1142169500-,June%2025%2C%202021,-armeabi-v7a

https://www.apkmirror.com/apk/samsung-electronics-co-ltd/samsung-internet-for-android/samsung-internet-for-android-15-0-1-43-release/#:~:text=1150143502-,August%2013%2C%202021,-arm64-v8a%20%2B%20armeabi

Also https://www.androidpolice.com/2021/08/14/samsung-internet-15-beta-adds-anti-tracking-technology-and-a-new-search-widget/#1 was updated on the 14th August to say it was released.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Fixes #12263 
