### PR TITLE
Add Firefox versions for api.Document.documentURI.readonly

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -3395,10 +3395,10 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "10"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "10"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `documentURI.readonly` member of the `Document` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.12).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Document/documentURI.readonly
