### PR TITLE
Add Safari versions for api.Element.animate/getAnimations

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -695,9 +695,20 @@
                 ]
               }
             ],
-            "safari_ios": {
-              "version_added": "13.4"
-            },
+            "safari_ios": [
+              {
+                "version_added": "13.4"
+              },
+              {
+                "version_added": "11.3",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  }
+                ]
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "3.0"
             },

--- a/api/Element.json
+++ b/api/Element.json
@@ -3463,28 +3463,42 @@
                 ]
               }
             ],
-            "safari": {
-              "version_added": "11.1",
-              "partial_implementation": true,
-              "notes": "Does not support the <code>subtree</code> option.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Web Animations"
-                }
-              ]
-            },
-            "safari_ios": {
-              "version_added": "11.3",
-              "partial_implementation": true,
-              "notes": "Does not support the <code>subtree</code> option.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Web Animations"
-                }
-              ]
-            },
+            "safari": [
+              {
+                "version_added": "13.1",
+                "partial_implementation": true,
+                "notes": "Does not support the <code>subtree</code> option."
+              },
+              {
+                "version_added": "11.1",
+                "partial_implementation": true,
+                "notes": "Does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  }
+                ]
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "13.4",
+                "partial_implementation": true,
+                "notes": "Does not support the <code>subtree</code> option."
+              },
+              {
+                "version_added": "11.3",
+                "partial_implementation": true,
+                "notes": "Does not support the <code>subtree</code> option.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  }
+                ]
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "14.0"
             },

--- a/api/Element.json
+++ b/api/Element.json
@@ -686,15 +686,11 @@
                 "version_added": "13.1"
               },
               {
-                "version_added": true,
+                "version_added": "11.1",
                 "flags": [
                   {
                     "type": "preference",
                     "name": "Web Animations"
-                  },
-                  {
-                    "type": "preference",
-                    "name": "CSS Animations via Web Animations"
                   }
                 ]
               }
@@ -3457,32 +3453,24 @@
               }
             ],
             "safari": {
-              "version_added": true,
+              "version_added": "11.1",
               "partial_implementation": true,
               "notes": "Does not support the <code>subtree</code> option.",
               "flags": [
                 {
                   "type": "preference",
                   "name": "Web Animations"
-                },
-                {
-                  "type": "preference",
-                  "name": "CSS Animations via Web Animations"
                 }
               ]
             },
             "safari_ios": {
-              "version_added": true,
+              "version_added": "11.3",
               "partial_implementation": true,
               "notes": "Does not support the <code>subtree</code> option.",
               "flags": [
                 {
                   "type": "preference",
                   "name": "Web Animations"
-                },
-                {
-                  "type": "preference",
-                  "name": "CSS Animations via Web Animations"
                 }
               ]
             },


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `animate` and `getAnimations` members of the `Element` API.  It turns out the "CSS Animations via Web Animations" flag had no effect upon these properties.  The data was obtained by going through SauceLabs, checking each individual version, turning on the flag (if it was available), and seeing what the first version that supported the property was.
