### PR TITLE
Remove irrelevant documentURI.readonly feature

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -3380,54 +3380,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "readonly": {
-          "__compat": {
-            "description": "Read-only behavior",
-            "support": {
-              "chrome": {
-                "version_added": "43"
-              },
-              "chrome_android": {
-                "version_added": "43"
-              },
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": {
-                "version_added": "10"
-              },
-              "firefox_android": {
-                "version_added": "10"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "30"
-              },
-              "opera_android": {
-                "version_added": "30"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": "4.0"
-              },
-              "webview_android": {
-                "version_added": "43"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "domain": {


### PR DESCRIPTION
The original behavior, being able to set document.documentURI, is a
superset of the current behavior, and there isn't anything worth noting
to users of the API today. The mutable behavior, if seen as its own
feature, has been removed for long enough that it's irrelevant.

https://mdn-bcd-collector.appspot.com/tests/api/Document/documentURI/readonly
was used to determine that documentURI was made readonly in Edge 17,
the only part of the data that could make this change <2 years.