### PR TITLE
Remove incorrect note for element.getAnimations() in Safari

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -3465,9 +3465,7 @@
             ],
             "safari": [
               {
-                "version_added": "13.1",
-                "partial_implementation": true,
-                "notes": "Does not support the <code>subtree</code> option."
+                "version_added": "13.1"
               },
               {
                 "version_added": "11.1",
@@ -3483,9 +3481,7 @@
             ],
             "safari_ios": [
               {
-                "version_added": "13.4",
-                "partial_implementation": true,
-                "notes": "Does not support the <code>subtree</code> option."
+                "version_added": "13.4"
               },
               {
                 "version_added": "11.3",


### PR DESCRIPTION
This was implemented in https://trac.webkit.org/changeset/255149/webkit
which using WebKit version mapping would be Safari 14, but it must have
been backported.

https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=9607 was
used to confirm support for the subtree parameter in Safari 13.1 on
Sauce Labs.