### PR TITLE
Add Safari versions for TextMetrics API

### DIFF
--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -33,7 +33,7 @@
             "version_added": "3.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "3"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -102,10 +102,10 @@
               "version_added": "55"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "12.0"
@@ -175,10 +175,10 @@
               "version_added": "55"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "12.0"
@@ -248,10 +248,10 @@
               "version_added": "55"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "12.0"
@@ -321,10 +321,10 @@
               "version_added": "55"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "12.0"
@@ -395,10 +395,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -469,10 +469,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -543,10 +543,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -627,10 +627,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "14.0"
@@ -711,10 +711,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "14.0"
@@ -785,10 +785,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -859,10 +859,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -30,10 +30,10 @@
             "version_added": "10.1"
           },
           "safari": {
-            "version_added": "3.1"
+            "version_added": "4"
           },
           "safari_ios": {
-            "version_added": "3"
+            "version_added": "3.2"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -908,7 +908,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "4"
             },
             "safari_ios": {
               "version_added": "3.2"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `TextMetrics` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.12).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TextMetrics
