### PR TITLE
Adds font-synthesis: small-caps

### DIFF
--- a/css/properties/font-synthesis.json
+++ b/css/properties/font-synthesis.json
@@ -93,7 +93,7 @@
             "status": {
               "experimental": true,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         }

--- a/css/properties/font-synthesis.json
+++ b/css/properties/font-synthesis.json
@@ -48,6 +48,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "small-caps": {
+          "__compat": {
+            "description": "<code>small-caps</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "93"
+              },
+              "firefox_android": {
+                "version_added": "93"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
         }
       }
     }

--- a/css/properties/font-synthesis.json
+++ b/css/properties/font-synthesis.json
@@ -91,7 +91,7 @@
               }
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": true
             }


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/8611

Firefox 93 adds support for `font-synthesis: small-caps`.
