### PR TITLE
ElementInternals.shadowRoot is in Firefox 93

### DIFF
--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -15,10 +15,10 @@
             "version_added": "79"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "93"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "93"
           },
           "ie": {
             "version_added": false

--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -357,10 +357,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "93"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "93"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Working on https://github.com/mdn/content/issues/8616

Adds support in Firefox 93 for `ElementInternals.shadowRoot`.