### PR TITLE
onsecuritypolicyviolation global event handler and friends

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -3931,6 +3931,55 @@
           }
         }
       },
+      "onsecuritypolicyviolation": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onsecuritypolicyviolation",
+          "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onsecuritypolicyviolation",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "93"
+            },
+            "firefox_android": {
+              "version_added": "93"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "onseeked": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onseeked",

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -3964,7 +3964,7 @@
               "version_added": "preview"
             },
             "safari_ios": {
-              "version_added": "preview"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -3961,10 +3961,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": null
+              "version_added": "preview"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "preview"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/SecurityPolicyViolationEvent.json
+++ b/api/SecurityPolicyViolationEvent.json
@@ -43,7 +43,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }


### PR DESCRIPTION
The HTML spec added a global event handler `onsecuritypolicyviolation` in https://github.com/whatwg/html/pull/2651.
- Firefox adding in FF93 : https://bugzilla.mozilla.org/show_bug.cgi?id=1727302
- Webkit adding/added in https://bugs.webkit.org/show_bug.cgi?id=229381 
- Chromium not yet added https://bugs.chromium.org/p/chromium/issues/detail?id=1242893

I need help to work out whether this is in Safari yet. I also updated the `SecurityPolicyViolationEvent` to indicate it is not experimental - based on broad rollout. 

Note that the event fired by element is not in BCD - I added that in a separate PR: #12333