### PR TITLE
Add Chromium versions for api.FetchEvent.request

### DIFF
--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -356,10 +356,10 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#fetch-event-request",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "40"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "40"
             },
             "edge": {
               "version_added": "17"
@@ -374,10 +374,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "27"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "27"
             },
             "safari": {
               "version_added": "11.1"
@@ -386,10 +386,10 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "40"
             }
           },
           "status": {

--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -6,10 +6,10 @@
         "spec_url": "https://w3c.github.io/ServiceWorker/#fetchevent-interface",
         "support": {
           "chrome": {
-            "version_added": "42"
+            "version_added": "40"
           },
           "chrome_android": {
-            "version_added": "42"
+            "version_added": "40"
           },
           "edge": {
             "version_added": "17"
@@ -25,10 +25,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "29"
+            "version_added": "27"
           },
           "opera_android": {
-            "version_added": "29"
+            "version_added": "27"
           },
           "safari": {
             "version_added": "11.1"
@@ -40,7 +40,7 @@
             "version_added": "4.0"
           },
           "webview_android": {
-            "version_added": "42"
+            "version_added": "40"
           }
         },
         "status": {
@@ -56,10 +56,10 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#dom-fetchevent-fetchevent",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "chrome_android": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "edge": {
               "version_added": "17"
@@ -75,10 +75,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "29"
+              "version_added": "27"
             },
             "opera_android": {
-              "version_added": "29"
+              "version_added": "27"
             },
             "safari": {
               "version_added": "11.1"
@@ -90,7 +90,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "42"
+              "version_added": "40"
             }
           },
           "status": {
@@ -356,10 +356,10 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#fetch-event-request",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "chrome_android": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "edge": {
               "version_added": "17"
@@ -374,10 +374,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "29"
+              "version_added": "27"
             },
             "opera_android": {
-              "version_added": "29"
+              "version_added": "27"
             },
             "safari": {
               "version_added": "11.1"
@@ -389,7 +389,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "42"
+              "version_added": "40"
             }
           },
           "status": {

--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -6,10 +6,10 @@
         "spec_url": "https://w3c.github.io/ServiceWorker/#fetchevent-interface",
         "support": {
           "chrome": {
-            "version_added": "40"
+            "version_added": "42"
           },
           "chrome_android": {
-            "version_added": "40"
+            "version_added": "42"
           },
           "edge": {
             "version_added": "17"
@@ -25,10 +25,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "27"
+            "version_added": "29"
           },
           "opera_android": {
-            "version_added": "27"
+            "version_added": "29"
           },
           "safari": {
             "version_added": "11.1"
@@ -40,7 +40,7 @@
             "version_added": "4.0"
           },
           "webview_android": {
-            "version_added": "40"
+            "version_added": "42"
           }
         },
         "status": {
@@ -56,10 +56,10 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#dom-fetchevent-fetchevent",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "chrome_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "edge": {
               "version_added": "17"
@@ -75,10 +75,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "27"
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": "27"
+              "version_added": "29"
             },
             "safari": {
               "version_added": "11.1"
@@ -90,7 +90,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "40"
+              "version_added": "42"
             }
           },
           "status": {
@@ -356,10 +356,10 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#fetch-event-request",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "chrome_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "edge": {
               "version_added": "17"
@@ -374,10 +374,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "27"
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": "27"
+              "version_added": "29"
             },
             "safari": {
               "version_added": "11.1"
@@ -389,7 +389,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "40"
+              "version_added": "42"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `request` member of the `FetchEvent` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/451a831fc3cb3c0b845298abbdde172219444d9f
