### PR TITLE
Update Chromium versions for RTCDataChannel API

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -6,10 +6,10 @@
         "spec_url": "https://w3c.github.io/webrtc-pc/#rtcdatachannel",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "24"
           },
           "chrome_android": {
-            "version_added": "29"
+            "version_added": "25"
           },
           "edge": {
             "version_added": "79"
@@ -38,10 +38,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": "11"
@@ -50,10 +50,10 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": "2.0"
+            "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": "4.4"
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -68,10 +68,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-datachannel-binarytype",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "29"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "79"
@@ -86,10 +86,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -98,10 +98,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -117,10 +117,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-datachannel-bufferedamount",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "79"
@@ -135,10 +135,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -147,10 +147,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -223,10 +223,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel-bufferedamountlowthreshold",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "46"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "46"
             },
             "edge": {
               "version_added": "79"
@@ -241,10 +241,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "33"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "33"
             },
             "safari": {
               "version_added": "11"
@@ -253,10 +253,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "46"
             }
           },
           "status": {
@@ -272,10 +272,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel-close",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "79"
@@ -290,10 +290,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -302,10 +302,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -322,10 +322,10 @@
           "description": "<code>close</code> event",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤79"
@@ -340,10 +340,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -352,10 +352,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -372,10 +372,10 @@
           "description": "<code>error</code> event",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤79"
@@ -390,10 +390,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -402,10 +402,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -421,10 +421,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel-id",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "30"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "30"
             },
             "edge": {
               "version_added": "79"
@@ -439,10 +439,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "17"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "18"
             },
             "safari": {
               "version_added": "11"
@@ -451,10 +451,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -470,10 +470,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-datachannel-label",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "79"
@@ -488,10 +488,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -500,10 +500,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -568,10 +568,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-datachannel-maxretransmits",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "30"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "30"
             },
             "edge": {
               "version_added": "79"
@@ -586,10 +586,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "17"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "18"
             },
             "safari": {
               "version_added": "11"
@@ -598,10 +598,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -618,10 +618,10 @@
           "description": "<code>message</code> event",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤79"
@@ -636,10 +636,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": true
@@ -648,10 +648,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -667,10 +667,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-datachannel-negotiated",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "30"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "30"
             },
             "edge": {
               "version_added": "79"
@@ -685,10 +685,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "17"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "18"
             },
             "safari": {
               "version_added": "11"
@@ -697,10 +697,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -716,11 +716,11 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel-onbufferedamountlow",
           "support": {
             "chrome": {
-              "version_added": "57",
+              "version_added": "46",
               "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
             },
             "chrome_android": {
-              "version_added": "57",
+              "version_added": "46",
               "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
             },
             "edge": {
@@ -737,11 +737,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "44",
+              "version_added": "33",
               "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
             },
             "opera_android": {
-              "version_added": "43",
+              "version_added": "33",
               "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
             },
             "safari": {
@@ -751,11 +751,11 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "7.0",
+              "version_added": "5.0",
               "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
             },
             "webview_android": {
-              "version_added": "57",
+              "version_added": "46",
               "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
             }
           },
@@ -772,10 +772,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel-onclose",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "79"
@@ -790,10 +790,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -802,10 +802,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -842,7 +842,7 @@
               "version_added": "68"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "58"
             },
             "safari": {
               "version_added": false
@@ -870,10 +870,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel-onerror",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "79"
@@ -888,10 +888,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -900,10 +900,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -919,10 +919,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel-onmessage",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "79"
@@ -937,10 +937,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -949,10 +949,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -968,10 +968,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel-onopen",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "79"
@@ -986,10 +986,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -998,10 +998,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1018,10 +1018,10 @@
           "description": "<code>open</code> event",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤79"
@@ -1036,10 +1036,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": true
@@ -1048,10 +1048,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1067,10 +1067,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-datachannel-ordered",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "30"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "30"
             },
             "edge": {
               "version_added": "79"
@@ -1085,10 +1085,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "17"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "18"
             },
             "safari": {
               "version_added": "11"
@@ -1097,10 +1097,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -1133,10 +1133,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "15"
@@ -1164,10 +1164,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-datachannel-protocol",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "30"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "30"
             },
             "edge": {
               "version_added": "79"
@@ -1182,10 +1182,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "17"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "18"
             },
             "safari": {
               "version_added": "11"
@@ -1194,10 +1194,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -1213,10 +1213,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-datachannel-readystate",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "79"
@@ -1231,10 +1231,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -1243,10 +1243,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1261,10 +1261,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel/reliable",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "79"
@@ -1279,10 +1279,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -1291,10 +1291,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1358,10 +1358,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel-send",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "79"
@@ -1376,10 +1376,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -1388,10 +1388,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `RTCDataChannel` API, based upon both commit history and results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.12).

Commit-based data:
https://source.chromium.org/chromium/chromium/src/+/ce4f330106a77d5f5c2a5b4d7b7abbb1bf7a299e (Chrome 25 (mirrored from RTCPeerConnection.createDataChannel): RTCDataChannel, label, reliable, readyState, bufferedAmount, binaryType, send, close, onopen, onerror, onclose, onmessage, open_event, error_event, close_event, message_event)
https://source.chromium.org/chromium/chromium/src/+/138b48a5d343fa8688ecf5ee120edd2e8a8841b9 (Chrome 30 (based upon feature freeze date of Jul 26, 2013): ordered, maxRetransmits, protocol, negotiated, id)
All other changes: https://mdn-bcd-collector.appspot.com/tests/api/RTCDataChannel
