### PR TITLE
Add api.URLPattern API

### DIFF
--- a/api/URLPattern.json
+++ b/api/URLPattern.json
@@ -1,0 +1,644 @@
+{
+  "api": {
+    "URLPattern": {
+      "__compat": {
+        "spec_url": "https://wicg.github.io/urlpattern/#urlpattern",
+        "support": {
+          "chrome": {
+            "version_added": "93",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#enable-experimental-web-platform-features",
+                "value_to_set": "Enabled"
+              }
+            ]
+          },
+          "chrome_android": {
+            "version_added": "93",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#enable-experimental-web-platform-features",
+                "value_to_set": "Enabled"
+              }
+            ]
+          },
+          "deno": {
+            "version_added": "1.14",
+            "flags": [
+              {
+                "type": "runtime_flag",
+                "name": "--unstable"
+              }
+            ]
+          },
+          "edge": {
+            "version_added": "93",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#enable-experimental-web-platform-features",
+                "value_to_set": "Enabled"
+              }
+            ]
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "URLPattern": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/urlpattern/#dom-urlpattern-urlpattern",
+          "description": "<code>URLPattern()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": "93"
+            },
+            "chrome_android": {
+              "version_added": "93"
+            },
+            "deno": {
+              "version_added": "1.14"
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "exec": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/urlpattern/#dom-urlpattern-exec",
+          "support": {
+            "chrome": {
+              "version_added": "93"
+            },
+            "chrome_android": {
+              "version_added": "93"
+            },
+            "deno": {
+              "version_added": "1.14"
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "hash": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/urlpattern/#dom-urlpattern-hash",
+          "support": {
+            "chrome": {
+              "version_added": "93"
+            },
+            "chrome_android": {
+              "version_added": "93"
+            },
+            "deno": {
+              "version_added": "1.14"
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "hostname": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/urlpattern/#dom-urlpattern-hostname",
+          "support": {
+            "chrome": {
+              "version_added": "93"
+            },
+            "chrome_android": {
+              "version_added": "93"
+            },
+            "deno": {
+              "version_added": "1.14"
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "password": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/urlpattern/#dom-urlpattern-password",
+          "support": {
+            "chrome": {
+              "version_added": "93"
+            },
+            "chrome_android": {
+              "version_added": "93"
+            },
+            "deno": {
+              "version_added": "1.14"
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pathname": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/urlpattern/#dom-urlpattern-pathname",
+          "support": {
+            "chrome": {
+              "version_added": "93"
+            },
+            "chrome_android": {
+              "version_added": "93"
+            },
+            "deno": {
+              "version_added": "1.14"
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "port": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/urlpattern/#dom-urlpattern-port",
+          "support": {
+            "chrome": {
+              "version_added": "93"
+            },
+            "chrome_android": {
+              "version_added": "93"
+            },
+            "deno": {
+              "version_added": "1.14"
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "protocol": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/urlpattern/#dom-urlpattern-protocol",
+          "support": {
+            "chrome": {
+              "version_added": "93"
+            },
+            "chrome_android": {
+              "version_added": "93"
+            },
+            "deno": {
+              "version_added": "1.14"
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "search": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/urlpattern/#dom-urlpattern-search",
+          "support": {
+            "chrome": {
+              "version_added": "93"
+            },
+            "chrome_android": {
+              "version_added": "93"
+            },
+            "deno": {
+              "version_added": "1.14"
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "test": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/urlpattern/#dom-urlpattern-test",
+          "support": {
+            "chrome": {
+              "version_added": "93"
+            },
+            "chrome_android": {
+              "version_added": "93"
+            },
+            "deno": {
+              "version_added": "1.14"
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "username": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/urlpattern/#dom-urlpattern-username",
+          "support": {
+            "chrome": {
+              "version_added": "93"
+            },
+            "chrome_android": {
+              "version_added": "93"
+            },
+            "deno": {
+              "version_added": "1.14"
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Landing in Deno (--unstable) in 1.14. Already shipped in Chrome 93 with
experimental web platform features flag. Will ship in 95 unflagged (all
3 required API OWNERS LGTM have been acquired).

https://wicg.github.io/urlpattern
https://github.com/denoland/deno/pull/11941
https://www.chromestatus.com/feature/5731920199548928

