### PR TITLE
Update notes regarding default value of an RTCPeerConnection option

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -111,7 +111,7 @@
             "chrome": [
               {
                 "version_added": "55",
-                "notes": "In Chrome 63, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
+                "notes": "Before Chrome 63, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter is <code>&quot;negotiate&quot;</code> instead of <code>&quot;required&quot;</code>."
               },
               {
                 "prefix": "webkit",
@@ -121,7 +121,7 @@
             "chrome_android": [
               {
                 "version_added": "55",
-                "notes": "In Chrome 63, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
+                "notes": "Before Chrome 63, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter is <code>&quot;negotiate&quot;</code> instead of <code>&quot;required&quot;</code>."
               },
               {
                 "prefix": "webkit",
@@ -161,7 +161,7 @@
             "opera": [
               {
                 "version_added": "42",
-                "notes": "In Opera 50, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
+                "notes": "Before Opera 50, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter is <code>&quot;negotiate&quot;</code> instead of <code>&quot;required&quot;</code>."
               },
               {
                 "prefix": "webkit",
@@ -171,7 +171,7 @@
             "opera_android": [
               {
                 "version_added": "42",
-                "notes": "In Opera Android 46, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
+                "notes": "Before Opera Android 46, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter is <code>&quot;negotiate&quot;</code> instead of <code>&quot;required&quot;</code>."
               },
               {
                 "prefix": "webkit",
@@ -187,7 +187,7 @@
             "samsunginternet_android": [
               {
                 "version_added": "6.0",
-                "notes": "In Samsung Internet 8.0, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
+                "notes": "Before Samsung Internet 8.0, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter is <code>&quot;negotiate&quot;</code> instead of <code>&quot;required&quot;</code>."
               },
               {
                 "prefix": "webkit",
@@ -196,7 +196,7 @@
             ],
             "webview_android": {
               "version_added": "≤37",
-              "notes": "In WebView 63, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
+              "notes": "Before WebView 63, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter is <code>&quot;negotiate&quot;</code> instead of <code>&quot;required&quot;</code>."
             }
           },
           "status": {

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -111,7 +111,7 @@
             "chrome": [
               {
                 "version_added": "55",
-                "notes": "Before Chrome 63 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
+                "notes": "In Chrome 63, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
               },
               {
                 "prefix": "webkit",
@@ -121,7 +121,7 @@
             "chrome_android": [
               {
                 "version_added": "55",
-                "notes": "Before Chrome 63 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
+                "notes": "In Chrome 63, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
               },
               {
                 "prefix": "webkit",
@@ -161,7 +161,7 @@
             "opera": [
               {
                 "version_added": "42",
-                "notes": "Before Opera 50 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
+                "notes": "In Opera 50, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
               },
               {
                 "prefix": "webkit",
@@ -171,7 +171,7 @@
             "opera_android": [
               {
                 "version_added": "42",
-                "notes": "Before Opera Android 46 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
+                "notes": "In Opera Android 46, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
               },
               {
                 "prefix": "webkit",
@@ -187,7 +187,7 @@
             "samsunginternet_android": [
               {
                 "version_added": "6.0",
-                "notes": "Before Samsung Internet 8.0 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
+                "notes": "In Samsung Internet 8.0, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
               },
               {
                 "prefix": "webkit",
@@ -196,7 +196,7 @@
             ],
             "webview_android": {
               "version_added": "≤37",
-              "notes": "Before WebView 63 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
+              "notes": "In WebView 63, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
             }
           },
           "status": {


### PR DESCRIPTION
Cherry-picked from #12300.  This PR updates the notes regarding the default value of `rtcpMuxPolicy` for Chrome when creating a new instance and indicates what the new default value is.  Currently, the notes don't mention what the new default value is, which is slightly unhelpful.  (There's only two values available, but this note update removes the need to scroll up on the page and find that out.)
