### PR TITLE
Set Firefox 92 as stable

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -659,27 +659,28 @@
         "91": {
           "release_date": "2021-08-10",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/91",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "91"
         },
         "92": {
           "release_date": "2021-09-07",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/92",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "92"
         },
         "93": {
           "release_date": "2021-10-05",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/93",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "93"
         },
         "94": {
           "release_date": "2021-11-02",
-          "status": "planned",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/94",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "94"
         },

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -525,27 +525,28 @@
         "91": {
           "release_date": "2021-08-10",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/91",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "91"
         },
         "92": {
           "release_date": "2021-09-07",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/92",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "92"
         },
         "93": {
           "release_date": "2021-10-05",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/93",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "93"
         },
         "94": {
           "release_date": "2021-11-02",
-          "status": "planned",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/94",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "94"
         },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Set Firefox 92 as stable

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://www.mozilla.org/en-US/firefox/92.0/releasenotes/

