### PR TITLE
`Object.hasOwn()` added in Node 16.9

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -286,9 +286,16 @@
         "16.7.0": {
           "release_date": "2021-08-17",
           "release_notes": "https://nodejs.org/en/blog/release/v16.7.0/",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "9.2"
+        },
+        "16.9.0": {
+          "release_date": "2021-09-07",
+          "release_notes": "https://nodejs.org/en/blog/release/v16.9.0/",
+          "status": "current",
+          "engine": "V8",
+          "engine_version": "9.3"
         }
       }
     }

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -1002,7 +1002,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "16.9.0"
               },
               "opera": {
                 "version_added": "79"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Node v16.9.0 adds `Object.hasOwn`.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
- [Node 16.9 release notes](https://github.com/nodejs/node/releases/tag/v16.9.0)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
n/a

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
