### PR TITLE
Mark AbortSignal.abort() as shipped in Chromium 93

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -60,16 +60,16 @@
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-abortsignal-abort①",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "93"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "93"
             },
             "deno": {
               "version_added": "1.9"
             },
             "edge": {
-              "version_added": false
+              "version_added": "93"
             },
             "firefox": {
               "version_added": "88"
@@ -99,7 +99,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "93"
             }
           },
           "status": {


### PR DESCRIPTION
https://www.chromestatus.com/feature/5642501387976704

Also confirmed manually in Chrome 93.