### PR TITLE
Set WebAuthn APIs as supported in Firefox Android 92

### DIFF
--- a/api/AuthenticatorAssertionResponse.json
+++ b/api/AuthenticatorAssertionResponse.json
@@ -18,10 +18,17 @@
             "version_added": "60",
             "notes": "Only supports USB U2F tokens."
           },
-          "firefox_android": {
-            "version_added": "60",
-            "notes": "Only supports USB U2F tokens."
-          },
+          "firefox_android": [
+            {
+              "version_added": "92"
+            },
+            {
+              "version_added": "60",
+              "version_removed": "92",
+              "partial_implementation": true,
+              "notes": "Only supports USB U2F tokens."
+            }
+          ],
           "ie": {
             "version_added": false
           },
@@ -68,10 +75,17 @@
               "version_added": "60",
               "notes": "Only supports USB U2F tokens."
             },
-            "firefox_android": {
-              "version_added": "60",
-              "notes": "Only supports USB U2F tokens."
-            },
+            "firefox_android": [
+              {
+                "version_added": "92"
+              },
+              {
+                "version_added": "60",
+                "version_removed": "92",
+                "partial_implementation": true,
+                "notes": "Only supports USB U2F tokens."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -119,10 +133,17 @@
               "version_added": "60",
               "notes": "Only supports USB U2F tokens."
             },
-            "firefox_android": {
-              "version_added": "60",
-              "notes": "Only supports USB U2F tokens."
-            },
+            "firefox_android": [
+              {
+                "version_added": "92"
+              },
+              {
+                "version_added": "60",
+                "version_removed": "92",
+                "partial_implementation": true,
+                "notes": "Only supports USB U2F tokens."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -170,10 +191,17 @@
               "version_added": "60",
               "notes": "Only supports USB U2F tokens."
             },
-            "firefox_android": {
-              "version_added": "60",
-              "notes": "Only supports USB U2F tokens."
-            },
+            "firefox_android": [
+              {
+                "version_added": "92"
+              },
+              {
+                "version_added": "60",
+                "version_removed": "92",
+                "partial_implementation": true,
+                "notes": "Only supports USB U2F tokens."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -18,10 +18,17 @@
             "version_added": "60",
             "notes": "Only supports USB U2F tokens."
           },
-          "firefox_android": {
-            "version_added": "60",
-            "notes": "Only supports USB U2F tokens."
-          },
+          "firefox_android": [
+            {
+              "version_added": "92"
+            },
+            {
+              "version_added": "60",
+              "version_removed": "92",
+              "partial_implementation": true,
+              "notes": "Only supports USB U2F tokens."
+            }
+          ],
           "ie": {
             "version_added": false
           },
@@ -68,10 +75,17 @@
               "version_added": "60",
               "notes": "Only supports USB U2F tokens."
             },
-            "firefox_android": {
-              "version_added": "60",
-              "notes": "Only supports USB U2F tokens."
-            },
+            "firefox_android": [
+              {
+                "version_added": "92"
+              },
+              {
+                "version_added": "60",
+                "version_removed": "92",
+                "partial_implementation": true,
+                "notes": "Only supports USB U2F tokens."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/AuthenticatorResponse.json
+++ b/api/AuthenticatorResponse.json
@@ -18,10 +18,17 @@
             "version_added": "60",
             "notes": "Only supports USB U2F tokens."
           },
-          "firefox_android": {
-            "version_added": "60",
-            "notes": "Only supports USB U2F tokens."
-          },
+          "firefox_android": [
+            {
+              "version_added": "92"
+            },
+            {
+              "version_added": "60",
+              "version_removed": "92",
+              "partial_implementation": true,
+              "notes": "Only supports USB U2F tokens."
+            }
+          ],
           "ie": {
             "version_added": false
           },
@@ -68,10 +75,17 @@
               "version_added": "60",
               "notes": "Only supports USB U2F tokens."
             },
-            "firefox_android": {
-              "version_added": "60",
-              "notes": "Only supports USB U2F tokens."
-            },
+            "firefox_android": [
+              {
+                "version_added": "92"
+              },
+              {
+                "version_added": "60",
+                "version_removed": "92",
+                "partial_implementation": true,
+                "notes": "Only supports USB U2F tokens."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -18,10 +18,17 @@
             "version_added": "60",
             "notes": "Only supports USB U2F tokens."
           },
-          "firefox_android": {
-            "version_added": "60",
-            "notes": "Only supports USB U2F tokens."
-          },
+          "firefox_android": [
+            {
+              "version_added": "92"
+            },
+            {
+              "version_added": "60",
+              "version_removed": "92",
+              "partial_implementation": true,
+              "notes": "Only supports USB U2F tokens."
+            }
+          ],
           "ie": {
             "version_added": false
           },
@@ -68,10 +75,17 @@
               "version_added": "60",
               "notes": "Only supports USB U2F tokens."
             },
-            "firefox_android": {
-              "version_added": "60",
-              "notes": "Only supports USB U2F tokens."
-            },
+            "firefox_android": [
+              {
+                "version_added": "92"
+              },
+              {
+                "version_added": "60",
+                "version_removed": "92",
+                "partial_implementation": true,
+                "notes": "Only supports USB U2F tokens."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -119,10 +133,17 @@
               "version_added": "60",
               "notes": "Only supports USB U2F tokens."
             },
-            "firefox_android": {
-              "version_added": "60",
-              "notes": "Only supports USB U2F tokens."
-            },
+            "firefox_android": [
+              {
+                "version_added": "92"
+              },
+              {
+                "version_added": "60",
+                "version_removed": "92",
+                "partial_implementation": true,
+                "notes": "Only supports USB U2F tokens."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -170,10 +191,17 @@
               "version_added": "60",
               "notes": "Only supports USB U2F tokens."
             },
-            "firefox_android": {
-              "version_added": "60",
-              "notes": "Only supports USB U2F tokens."
-            },
+            "firefox_android": [
+              {
+                "version_added": "92"
+              },
+              {
+                "version_added": "60",
+                "version_removed": "92",
+                "partial_implementation": true,
+                "notes": "Only supports USB U2F tokens."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -221,10 +249,17 @@
               "version_added": "60",
               "notes": "Only supports USB U2F tokens."
             },
-            "firefox_android": {
-              "version_added": "60",
-              "notes": "Only supports USB U2F tokens."
-            },
+            "firefox_android": [
+              {
+                "version_added": "92"
+              },
+              {
+                "version_added": "60",
+                "version_removed": "92",
+                "partial_implementation": true,
+                "notes": "Only supports USB U2F tokens."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/PublicKeyCredentialCreationOptions.json
+++ b/api/PublicKeyCredentialCreationOptions.json
@@ -18,7 +18,7 @@
             "version_added": "60"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "92"
           },
           "ie": {
             "version_added": false
@@ -66,7 +66,7 @@
               "version_added": "60"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "92"
             },
             "ie": {
               "version_added": false
@@ -115,7 +115,7 @@
               "version_added": "60"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "92"
             },
             "ie": {
               "version_added": false
@@ -164,7 +164,7 @@
               "version_added": "60"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "92"
             },
             "ie": {
               "version_added": false
@@ -213,7 +213,7 @@
               "version_added": "60"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "92"
             },
             "ie": {
               "version_added": false
@@ -262,7 +262,7 @@
               "version_added": "60"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "92"
             },
             "ie": {
               "version_added": false
@@ -311,7 +311,7 @@
               "version_added": "60"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "92"
             },
             "ie": {
               "version_added": false
@@ -360,7 +360,7 @@
               "version_added": "60"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "92"
             },
             "ie": {
               "version_added": false
@@ -409,7 +409,7 @@
               "version_added": "60"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "92"
             },
             "ie": {
               "version_added": false
@@ -458,7 +458,7 @@
               "version_added": "60"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "92"
             },
             "ie": {
               "version_added": false

--- a/api/PublicKeyCredentialRequestOptions.json
+++ b/api/PublicKeyCredentialRequestOptions.json
@@ -18,7 +18,7 @@
             "version_added": "60"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "92"
           },
           "ie": {
             "version_added": false
@@ -66,7 +66,7 @@
               "version_added": "60"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "92"
             },
             "ie": {
               "version_added": false
@@ -115,7 +115,7 @@
               "version_added": "60"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "92"
             },
             "ie": {
               "version_added": false
@@ -164,7 +164,7 @@
               "version_added": "60"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "92"
             },
             "ie": {
               "version_added": false
@@ -213,7 +213,7 @@
               "version_added": "60"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "92"
             },
             "ie": {
               "version_added": false
@@ -262,7 +262,7 @@
               "version_added": "60"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "92"
             },
             "ie": {
               "version_added": false
@@ -311,7 +311,7 @@
               "version_added": "60"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "92"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

This updates Firefox Android support for WebAuthn related APIs.

I've set them all as fully supported in Firefox 92. And left the preview entries as partial implementations.

I will file off an issue to investigate the extent of the implementation pre-92. I know that it was partially implemented as it passes basic feature detection but fails weirdly on https://webauthn.io

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Tested on https://webauthn.io

And https://www.mozilla.org/en-US/firefox/android/92.0/releasenotes/#:~:text=Added%20support%20for%20Web%20Authentication%20API

