### PR TITLE
Set WebAuthn APIs as supported in Opera Desktop

### DIFF
--- a/api/AuthenticatorAssertionResponse.json
+++ b/api/AuthenticatorAssertionResponse.json
@@ -26,7 +26,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "54"
           },
           "opera_android": {
             "version_added": false
@@ -76,7 +76,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": false
@@ -127,7 +127,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": false
@@ -178,7 +178,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": false

--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -26,7 +26,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "54"
           },
           "opera_android": {
             "version_added": false
@@ -76,7 +76,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": false
@@ -123,7 +123,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "71"
             },
             "opera_android": {
               "version_added": false
@@ -170,7 +170,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "71"
             },
             "opera_android": {
               "version_added": false
@@ -217,7 +217,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "71"
             },
             "opera_android": {
               "version_added": false
@@ -266,7 +266,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
               "version_added": false

--- a/api/AuthenticatorResponse.json
+++ b/api/AuthenticatorResponse.json
@@ -26,7 +26,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "54"
           },
           "opera_android": {
             "version_added": false
@@ -76,7 +76,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": false

--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -26,7 +26,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "54"
           },
           "opera_android": {
             "version_added": false
@@ -76,7 +76,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": false
@@ -127,7 +127,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": false
@@ -178,7 +178,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": false
@@ -229,7 +229,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "54"
             },
             "opera_android": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Set WebAuthn APIs as supported in Opera Desktop

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

This copies across Chrome desktop support to Opera in the places it was missing.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
