### PR TITLE
Set WebAuthn APIs as unsupported in Samsung Internet

### DIFF
--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -38,7 +38,7 @@
             "version_added": "13"
           },
           "samsunginternet_android": {
-            "version_added": "10.0"
+            "version_added": false
           },
           "webview_android": {
             "version_added": false
@@ -88,7 +88,7 @@
               "version_added": "13"
             },
             "samsunginternet_android": {
-              "version_added": "10.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -278,7 +278,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "11.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Remove erroneous samsung internet webauthn support

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

WebAuthn isn't implemented in Samsung Internet, the current support data seems to have been incorrectly copied over from Chrome support data. webauthn.io shows an unsupported error and none of the interfaces are exposed.

(The support data for the Credential and CredentialsContainer interface is correct however)
