### PR TITLE
Add Element securitypolicyviolation_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -7648,6 +7648,55 @@
           }
         }
       },
+      "securitypolicyviolation_event": {
+        "__compat": {
+          "description": "<code>securitypolicyviolation</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/securitypolicyviolation_event",
+          "support": {
+            "chrome": {
+              "version_added": "41"
+            },
+            "chrome_android": {
+              "version_added": "41"
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "firefox": {
+              "version_added": "63"
+            },
+            "firefox_android": {
+              "version_added": "63"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "28"
+            },
+            "opera_android": {
+              "version_added": "28"
+            },
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": {
+              "version_added": "10"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "41"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
       "select_event": {
         "__compat": {
           "description": "<code>select</code> event",


### PR DESCRIPTION
This adds `securitypolicyviolation_event` to the `Element` API as a follow on from #12289.

This appears to have been a long term omission. 
- I have added it to Element because that is what the [spec says here](https://html.spec.whatwg.org/#event-securitypolicyviolation)
- I have matched the versions of the associated event object [SecurityPolicyViolationEvent](https://developer.mozilla.org/en-US/docs/Web/API/SecurityPolicyViolationEvent) which I would have expected to have been added at the same time.
- I did not add the spec URL because it causes an assertion error: "spec_url": "https://html.spec.whatwg.org/#event-securitypolicyviolation",