### PR TITLE
FF93 onslotchange to globalevents and shadowroot

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -4325,6 +4325,55 @@
           }
         }
       },
+      "onslotchange": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onslotchange",
+          "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onslotchange",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "93"
+            },
+            "firefox_android": {
+              "version_added": "93"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "preview"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "onstalled": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onstalled",

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -307,10 +307,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "93"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "93"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
FF93 added the event handler `onslotchange`  to  ShadowRoot and also the GlobalEventHandler. This PR adds the version to FF for ShadowRoot and creates new entry for the GlobalEvent Handler. 

Note, I have set this as experimental, as only one implementation

- FF bug https://bugzilla.mozilla.org/show_bug.cgi?id=1501983. I have also tested this and verified in FF93 (and not present in FF92)
- Tested Chrome and it is not present - intent to ship is recent and here: https://groups.google.com/a/mozilla.org/g/dev-platform/c/tHIn-Ce1DSE
- Safari is in preview apparently https://bugs.webkit.org/show_bug.cgi?id=191310 though I have not tested this.
- Other docs work can be tracked in https://github.com/mdn/content/issues/8624