### PR TITLE
HTMLElement.attachInternals is in Firefox 93

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -391,10 +391,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "93"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "93"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Missed in #12283, probably should also be covered in https://github.com/mdn/content/issues/8616. @rachelandrew 

https://bugzilla.mozilla.org/show_bug.cgi?id=1723521