### PR TITLE
Add safari version for css color-mix()

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -257,7 +257,13 @@
                 ]
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "CSS color-contrast()"
+                  }
+                ]
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -327,7 +333,13 @@
                 ]
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "CSS color-mix()"
+                  }
+                ]
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -319,7 +319,14 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "CSS color-mix()",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "safari_ios": {
                 "version_added": false

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -252,8 +252,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "CSS color-contrast()",
-                    "value_to_set": "true"
+                    "name": "CSS color-contrast()"
                   }
                 ]
               },
@@ -323,8 +322,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "CSS color-mix()",
-                    "value_to_set": "true"
+                    "name": "CSS color-mix()"
                   }
                 ]
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

`color-mix()` is behind a flag in Safari 15.

#### Test results and supporting details

 * https://trac.webkit.org/changeset/273244/webkit/
 * https://webkit.org/blog/11577/release-notes-for-safari-technology-preview-122/#post-11577:~:text=CSS%20Color,-Added

I also installed Safari 15 (beta) on my device, and verified the flag is there and works as expected.

<img width="1058" alt="image" src="https://user-images.githubusercontent.com/2166114/132999871-f84698d7-a65a-4413-b611-173684ad8c1e.png">

#### Related issues

N/A
