### PR TITLE
Drop the “type” attribute from ImageDecoder

### DIFF
--- a/api/ImageDecoder.json
+++ b/api/ImageDecoder.json
@@ -441,8 +441,6 @@
       },
       "type": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageDecoder/type",
-          "spec_url": "https://w3c.github.io/webcodecs/#dom-imagedecoder-type",
           "support": {
             "chrome": {
               "version_added": "94"
@@ -482,8 +480,8 @@
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
+            "experimental": false,
+            "standard_track": false,
             "deprecated": false
           }
         }


### PR DESCRIPTION
https://w3c.github.io/webcodecs/#imagedecoder-interface doesn’t show any `type` attribute for the `ImageDecoder` interface/object.

---

Maybe this was supposed to be for `isTypeSupported`?