### PR TITLE
Update SubtleCrypto compat for Deno 1.14

### DIFF
--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -393,7 +393,7 @@
             "deno": {
               "version_added": "1.14",
               "partial_implementation": true,
-              "notes": "Not supported: RSA-OAEP, ECDSA, ECDH, AES-CTR, AES-CBC, AES-GCM, AES-KW."
+              "notes": "Not supported: ECDSA, ECDH, AES-CTR, AES-CBC, AES-GCM, AES-KW."
             },
             "edge": {
               "version_added": "12",
@@ -538,7 +538,7 @@
             "deno": {
               "version_added": "1.14",
               "partial_implementation": true,
-              "notes": "Not supported: RSASSA-PKCS1-v1_5, RSA-PSS, RSA-OAEP, ECDSA, ECDH, AES-CTR, AES-CBC, AES-GCM, AES-KW."
+              "notes": "Not supported: ECDSA, ECDH, AES-CTR, AES-CBC, AES-GCM, AES-KW."
             },
             "edge": {
               "version_added": "12",
@@ -783,11 +783,17 @@
             "chrome_android": {
               "version_added": "37"
             },
-            "deno": {
-              "version_added": "1.12",
-              "partial_implementation": true,
-              "notes": "Not supported: ECDSA, HMAC."
-            },
+            "deno": [
+              {
+                "version_added": "1.14"
+              },
+              {
+                "version_removed": "1.14",
+                "version_added": "1.12",
+                "partial_implementation": true,
+                "notes": "Not supported: ECDSA, HMAC."
+              }
+            ],
             "edge": {
               "version_added": "12",
               "partial_implementation": true,

--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -143,7 +143,7 @@
             "deno": {
               "version_added": "1.14",
               "partial_implementation": true,
-              "notes": "Not supported: ECDH, HKDF."
+              "notes": "Not supported: ECDH."
             },
             "edge": {
               "version_added": "12",
@@ -393,7 +393,7 @@
             "deno": {
               "version_added": "1.14",
               "partial_implementation": true,
-              "notes": "Not supported: RSASSA-PKCS1-v1_5, RSA-PSS, RSA-OAEP, ECDSA, ECDH, AES-CTR, AES-CBC, AES-GCM, AES-KW."
+              "notes": "Not supported: RSA-OAEP, ECDSA, ECDH, AES-CTR, AES-CBC, AES-GCM, AES-KW."
             },
             "edge": {
               "version_added": "12",
@@ -463,7 +463,7 @@
               {
                 "version_added": "1.14",
                 "partial_implementation": true,
-                "notes": "Not supported: ECDSA P-521, ECDH, AES-CTR, AES-CBC, AES-GCM, AES-KW."
+                "notes": "Not supported: ECDSA P-521, ECDH P-521."
               },
               {
                 "version_added": "1.12",
@@ -538,7 +538,7 @@
             "deno": {
               "version_added": "1.14",
               "partial_implementation": true,
-              "notes": "Not supported: RSASSA-PKCS1-v1_5, RSA-PSS, RSA-OAEP, ECDSA, ECDH, AES-CTR, AES-CBC, AES-GCM, AES-KW, HKDF."
+              "notes": "Not supported: RSASSA-PKCS1-v1_5, RSA-PSS, RSA-OAEP, ECDSA, ECDH, AES-CTR, AES-CBC, AES-GCM, AES-KW."
             },
             "edge": {
               "version_added": "12",


### PR DESCRIPTION
#### Test results and supporting details

https://github.com/denoland/deno/issues/11690 <- progress tracked upstream here.
