### PR TITLE
Update Deno 1.14 release status

### DIFF
--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -103,9 +103,16 @@
         },
         "1.14": {
           "release_date": "2021-09-14",
-          "status": "nightly",
+          "release_notes": "https://github.com/denoland/deno/releases/tag/v1.14.0",
+          "status": "current",
           "engine": "V8",
           "engine_version": "9.4"
+        },
+        "1.15": {
+          "release_date": "2021-10-12",
+          "status": "nightly",
+          "engine": "V8",
+          "engine_version": "9.5"
         }
       }
     }


### PR DESCRIPTION
Release is happening tomorrow (so release_notes link will only start working tomorrow).
