### PR TITLE
Add Chromium versions for api.MouseEvent.region

### DIFF
--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -1030,7 +1030,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/region",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "51",
               "flags": [
                 {
                   "type": "preference",
@@ -1040,10 +1040,17 @@
               ]
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "51",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "edge": {
-              "version_added": "≤79",
+              "version_added": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -1076,10 +1083,24 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "38",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "41",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Experimental Web Platform Features",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `region` member of the `MouseEvent` API, based upon commit history and date.

Commit: https://storage.googleapis.com/chromium-find-releases-static/f18.html#f18571e9097d0533f6fc18d62b3ab006e1d6c6d4
