### PR TITLE
Remove irrelevant api.HTMLSourceElement.keySystem feature

### DIFF
--- a/api/HTMLSourceElement.json
+++ b/api/HTMLSourceElement.json
@@ -96,65 +96,6 @@
           }
         }
       },
-      "keySystem": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSourceElement/keySystem",
-          "support": {
-            "chrome": {
-              "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": "≤18"
-            },
-            "firefox": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.eme.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": {
-              "version_added": true,
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.eme.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "media": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSourceElement/media",


### PR DESCRIPTION
This PR removes the irrelevant `keySystem` member of the `HTMLSourceElement` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features). The lack of current support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.3.0), even if the current BCD suggests support.
