### PR TITLE
Remove wrong mdn_url from HTMLBaseFontElement

### DIFF
--- a/api/HTMLBaseFontElement.json
+++ b/api/HTMLBaseFontElement.json
@@ -53,7 +53,6 @@
       },
       "color": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLBaseFontElement/color",
           "support": {
             "chrome": {
               "version_added": false
@@ -105,7 +104,6 @@
       },
       "face": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLBaseFontElement/face",
           "support": {
             "chrome": {
               "version_added": false
@@ -157,7 +155,6 @@
       },
       "size": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLBaseFontElement/size",
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
These mdn urls don't exist.

They will never exist as this feature is in the progress of being completely removed; only waiting for IE11 to be retired.

(They lead to MDN flaws, hiding real flaws)