### PR TITLE
Add Chromium versions for RTCPeerConnectionIceEvent API

### DIFF
--- a/api/RTCPeerConnectionIceEvent.json
+++ b/api/RTCPeerConnectionIceEvent.json
@@ -8,7 +8,7 @@
           "chrome": [
             {
               "alternative_name": "RTCIceCandidateEvent",
-              "version_added": true,
+              "version_added": "24",
               "version_removed": "56"
             },
             {
@@ -18,7 +18,7 @@
           "chrome_android": [
             {
               "alternative_name": "RTCIceCandidateEvent",
-              "version_added": true,
+              "version_added": "25",
               "version_removed": "56"
             },
             {
@@ -52,7 +52,7 @@
           "samsunginternet_android": [
             {
               "alternative_name": "RTCIceCandidateEvent",
-              "version_added": true,
+              "version_added": "1.5",
               "version_removed": "6.0"
             },
             {
@@ -62,7 +62,7 @@
           "webview_android": [
             {
               "alternative_name": "RTCIceCandidateEvent",
-              "version_added": true,
+              "version_added": "≤37",
               "version_removed": "56"
             },
             {

--- a/api/RTCPeerConnectionIceEvent.json
+++ b/api/RTCPeerConnectionIceEvent.json
@@ -132,10 +132,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnectioniceevent-candidate",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "15"
@@ -162,10 +162,10 @@
               "version_added": "12"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "56"
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `RTCPeerConnectionIceEvent` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/17f2e5e5850823844c8d6127b1b8ec068a7cc736
