### PR TITLE
Make settings.json valid JSON

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,7 +19,7 @@
         "/mathml/*.json",
         "/svg/*.json",
         "/webdriver/*.json",
-        "/webextensions/*.json",
+        "/webextensions/*.json"
       ],
       "url": "/schemas/compat-data.schema.json"
     },


### PR DESCRIPTION
#### Summary
JSON does not permit trailing commas in array literals, so delete this one.

VSCode does not seem to care; in fact this file has had a trailing comma here since inception. However this file is more useful if tools which use strict JSON parsing can consume it too.

#### Test results and supporting details
- `python3 -m json.tool .vscode/settings.json` should print JSON, not an error message
- Open vscode, edit webextensions/api/captiveportal.json, add an invalid property, verify it is applying schema