### PR TITLE
Add Chromium versions for SVGAnimatedString API

### DIFF
--- a/api/SVGAnimatedString.json
+++ b/api/SVGAnimatedString.json
@@ -21,7 +21,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": false
+            "version_added": "9"
           },
           "opera": {
             "version_added": "15"
@@ -54,10 +54,10 @@
           "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedString__animVal",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "15"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -69,25 +69,25 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -103,10 +103,10 @@
           "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedString__baseVal",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "15"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -118,25 +118,25 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "4"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `SVGAnimatedString` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.2.12).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGAnimatedString
