### PR TITLE
Add Chromium/Firefox versions for SVGViewElement API

### DIFF
--- a/api/SVGViewElement.json
+++ b/api/SVGViewElement.json
@@ -148,11 +148,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "56"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "56"
             },
             "edge": {
@@ -160,22 +160,22 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "15",
               "version_removed": "61"
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "15",
               "version_removed": "61"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "15",
               "version_removed": "43"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "14",
               "version_removed": "43"
             },
             "safari": {
@@ -187,11 +187,11 @@
               "version_removed": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "6.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "≤37",
               "version_removed": "56"
             }
           },


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `SVGViewElement` API, based upon commit history and date, and for Firefox using the mdn-bcd-collector project (v3.3.0).

Commit: https://source.chromium.org/chromium/chromium/src/+/e05eff9340f3b0fbe454210ce9513057f851e8ec
