### PR TITLE
Add Chromium versions for api.Window.showModalDialog

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -8843,7 +8843,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/showModalDialog",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "6",
               "version_removed": "43"
             },
             "chrome_android": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `showModalDialog` member of the `Window` API by mirroring the data.
