### PR TITLE
Add Firefox versions for api.Screen.[lock/unlock]orientation

### DIFF
--- a/api/Screen.json
+++ b/api/Screen.json
@@ -410,11 +410,11 @@
               "prefix": "ms"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "14",
               "prefix": "moz"
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "14",
               "prefix": "moz"
             },
             "ie": {
@@ -648,7 +648,7 @@
                 "version_added": "43"
               },
               {
-                "version_added": true,
+                "version_added": "14",
                 "prefix": "moz"
               }
             ],
@@ -657,7 +657,7 @@
                 "version_added": "43"
               },
               {
-                "version_added": true,
+                "version_added": "14",
                 "prefix": "moz"
               }
             ],
@@ -809,11 +809,11 @@
               "prefix": "ms"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "14",
               "prefix": "moz"
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "14",
               "prefix": "moz"
             },
             "ie": {


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `orientation`-based members of the `Screen` API, based upon manual testing.

Test Code Used: `window.screen.mozOrientation;`
