### PR TITLE
Remove irrelevant api.XMLSerializer.serializeToStream feature

### DIFF
--- a/api/XMLSerializer.json
+++ b/api/XMLSerializer.json
@@ -97,55 +97,6 @@
           }
         }
       },
-      "serializeToStream": {
-        "__compat": {
-          "support": {
-            "chrome": {
-              "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": true,
-              "version_removed": "20"
-            },
-            "firefox_android": {
-              "version_added": true,
-              "version_removed": "20"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "serializeToString": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLSerializer/serializeToString",


### PR DESCRIPTION
This PR removes the irrelevant `serializeToStream` member of the `XMLSerializer` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features). The lack of current support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.3.0), even if the current BCD suggests support.
