### PR TITLE
Add Chromium versions for api.TimeRanges.length

### DIFF
--- a/api/TimeRanges.json
+++ b/api/TimeRanges.json
@@ -103,10 +103,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-timeranges-length-dev",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "6"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -121,10 +121,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "3.1"
@@ -133,10 +133,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `length` member of the `TimeRanges` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/f85a45d545671a8a59a97c18c5f313fce3b0c2f7
