### PR TITLE
Add Chromium versions for api.Text.replaceWholeText

### DIFF
--- a/api/Text.json
+++ b/api/Text.json
@@ -152,11 +152,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Text/replaceWholeText",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "45"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "45"
             },
             "edge": {
@@ -175,11 +175,11 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "15",
               "version_removed": "32"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "14",
               "version_removed": "32"
             },
             "safari": {
@@ -191,11 +191,11 @@
               "version_removed": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "≤37",
               "version_removed": "45"
             }
           },


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `replaceWholeText` member of the `Text` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/d900ec14819533e256774b97aefa3cdf0817d32f
