### PR TITLE
Add IE/Edge versions for api.WorkerLocation.toString

### DIFF
--- a/api/WorkerLocation.json
+++ b/api/WorkerLocation.json
@@ -534,7 +534,7 @@
               "version_added": "1.7"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5"
@@ -543,7 +543,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤15"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `toString` member of the `WorkerLocation` API, based upon manual testing.

Test Code Used: `self.location // Inside of a web worker`
