### PR TITLE
Safari TP 132, 133, 134 and 135 additions

### DIFF
--- a/api/BroadcastChannel.json
+++ b/api/BroadcastChannel.json
@@ -39,13 +39,7 @@
             "version_added": "41"
           },
           "safari": {
-            "version_added": "preview",
-            "flags": [
-              {
-                "name": "BroadcastChannel API",
-                "type": "preference"
-              }
-            ]
+            "version_added": "preview"
           },
           "safari_ios": {
             "version_added": false
@@ -97,13 +91,7 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "name": "BroadcastChannel API",
-                  "type": "preference"
-                }
-              ]
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -155,13 +143,7 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "name": "BroadcastChannel API",
-                  "type": "preference"
-                }
-              ]
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -214,13 +196,7 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "name": "BroadcastChannel API",
-                  "type": "preference"
-                }
-              ]
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -273,13 +249,7 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "name": "BroadcastChannel API",
-                  "type": "preference"
-                }
-              ]
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false,
@@ -332,13 +302,7 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "name": "BroadcastChannel API",
-                  "type": "preference"
-                }
-              ]
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -390,13 +354,7 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "name": "BroadcastChannel API",
-                  "type": "preference"
-                }
-              ]
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -448,13 +406,7 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "name": "BroadcastChannel API",
-                  "type": "preference"
-                }
-              ]
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false,
@@ -507,13 +459,7 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "name": "BroadcastChannel API",
-                  "type": "preference"
-                }
-              ]
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false

--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -159,7 +159,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false

--- a/api/FileSystemDirectoryHandle.json
+++ b/api/FileSystemDirectoryHandle.json
@@ -43,7 +43,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": false,
           "deprecated": false
         }
@@ -90,7 +90,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }
@@ -139,7 +139,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }
@@ -188,7 +188,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }
@@ -236,7 +236,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }
@@ -285,7 +285,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }
@@ -334,7 +334,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }
@@ -382,7 +382,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }

--- a/api/FileSystemFileHandle.json
+++ b/api/FileSystemFileHandle.json
@@ -43,7 +43,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": false,
           "deprecated": false
         }
@@ -78,7 +78,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -91,7 +91,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }
@@ -140,7 +140,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }

--- a/api/FileSystemHandle.json
+++ b/api/FileSystemHandle.json
@@ -43,7 +43,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": false,
           "deprecated": false
         }
@@ -91,7 +91,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }
@@ -140,7 +140,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }
@@ -189,7 +189,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }
@@ -225,7 +225,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -238,7 +238,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }
@@ -274,7 +274,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -287,7 +287,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }

--- a/api/FileSystemHandle.json
+++ b/api/FileSystemHandle.json
@@ -238,7 +238,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": false,
             "deprecated": false
           }
@@ -287,7 +287,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": false,
             "deprecated": false
           }

--- a/api/FileSystemWritableFileStream.json
+++ b/api/FileSystemWritableFileStream.json
@@ -43,7 +43,7 @@
           }
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": false,
           "deprecated": false
         }
@@ -91,7 +91,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": false,
             "deprecated": false
           }
@@ -140,7 +140,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": false,
             "deprecated": false
           }
@@ -189,7 +189,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": false,
             "deprecated": false
           }

--- a/api/FileSystemWritableFileStream.json
+++ b/api/FileSystemWritableFileStream.json
@@ -30,7 +30,7 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "preview"
           },
           "safari_ios": {
             "version_added": false
@@ -43,7 +43,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": false,
           "deprecated": false
         }
@@ -78,7 +78,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -91,7 +91,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }
@@ -127,7 +127,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -140,7 +140,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }
@@ -176,7 +176,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -189,7 +189,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1398,7 +1398,13 @@
               ]
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview",
+              "flags": [
+                {
+                  "name": "inert attribute",
+                  "type": "preference"
+                }
+              ]
             },
             "safari_ios": {
               "version_added": false

--- a/api/PerformanceNavigationTiming.json
+++ b/api/PerformanceNavigationTiming.json
@@ -45,7 +45,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -93,7 +93,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -142,7 +142,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -191,7 +191,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -240,7 +240,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -289,7 +289,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -338,7 +338,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -387,7 +387,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -436,7 +436,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -485,7 +485,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -534,7 +534,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -583,7 +583,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -831,7 +831,7 @@
               "version_added": "58"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false

--- a/api/RTCDtlsTransport.json
+++ b/api/RTCDtlsTransport.json
@@ -32,7 +32,7 @@
             "version_added": "50"
           },
           "safari": {
-            "version_added": false
+            "version_added": "preview"
           },
           "safari_ios": {
             "version_added": false
@@ -81,7 +81,7 @@
               "version_added": "50"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -133,7 +133,7 @@
               "version_added": "50"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -183,7 +183,7 @@
               "version_added": "50"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -234,7 +234,7 @@
               "version_added": "50"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -285,7 +285,7 @@
               "version_added": "50"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -337,7 +337,7 @@
               "version_added": "50"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false

--- a/api/RTCError.json
+++ b/api/RTCError.json
@@ -30,7 +30,7 @@
             "version_added": "53"
           },
           "safari": {
-            "version_added": false
+            "version_added": "preview"
           },
           "safari_ios": {
             "version_added": false
@@ -78,7 +78,7 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -127,7 +127,7 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -174,7 +174,7 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -223,7 +223,7 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -272,7 +272,7 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -321,7 +321,7 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -370,7 +370,7 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false

--- a/api/RTCErrorEvent.json
+++ b/api/RTCErrorEvent.json
@@ -30,7 +30,7 @@
             "version_added": "53"
           },
           "safari": {
-            "version_added": false
+            "version_added": "preview"
           },
           "safari_ios": {
             "version_added": false
@@ -78,7 +78,7 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -127,7 +127,7 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -689,7 +689,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false

--- a/api/RTCSctpTransport.json
+++ b/api/RTCSctpTransport.json
@@ -32,7 +32,7 @@
             "version_added": "54"
           },
           "safari": {
-            "version_added": false
+            "version_added": "preview"
           },
           "safari_ios": {
             "version_added": false
@@ -81,7 +81,7 @@
               "version_added": "54"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -131,7 +131,7 @@
               "version_added": "54"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -181,7 +181,7 @@
               "version_added": "54"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -232,7 +232,7 @@
               "version_added": "54"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -282,7 +282,7 @@
               "version_added": "54"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false

--- a/api/ResizeObserverEntry.json
+++ b/api/ResizeObserverEntry.json
@@ -30,10 +30,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": false
+            "version_added": true
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": true
           },
           "samsunginternet_android": {
             "version_added": "9.0"
@@ -78,7 +78,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -135,7 +135,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -184,10 +184,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -280,10 +280,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": "9.0"

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -1567,7 +1567,7 @@
               "version_added": "57"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false

--- a/api/StorageManager.json
+++ b/api/StorageManager.json
@@ -78,7 +78,7 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -138,7 +138,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }

--- a/api/_globals/structuredClone.json
+++ b/api/_globals/structuredClone.json
@@ -48,7 +48,7 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "preview"
           },
           "safari_ios": {
             "version_added": false

--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -84,7 +84,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -89,11 +89,16 @@
                 "prefix": "-webkit-"
               }
             ],
-            "safari": {
-              "version_added": "3",
-              "partial_implementation": true,
-              "prefix": "-webkit-"
-            },
+            "safari": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "3",
+                "partial_implementation": true,
+                "prefix": "-webkit-"
+              }
+            ],
             "safari_ios": {
               "version_added": "1",
               "partial_implementation": true,

--- a/css/properties/backface-visibility.json
+++ b/css/properties/backface-visibility.json
@@ -80,10 +80,15 @@
                 "version_added": "14"
               }
             ],
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": "5.1"
-            },
+            "safari": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "5.1"
+              }
+            ],
             "safari_ios": {
               "prefix": "-webkit-",
               "version_added": "5"

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -208,7 +208,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": {
                 "version_added": false

--- a/css/properties/scroll-behavior.json
+++ b/css/properties/scroll-behavior.json
@@ -30,15 +30,21 @@
             "opera_android": {
               "version_added": "45"
             },
-            "safari": {
-              "version_added": "14",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "CSSOM View Smooth Scrolling"
-                }
-              ]
-            },
+            "safari": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "preview",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "CSSOM View Smooth Scrolling"
+                  }
+                ]
+              }
+            ],
             "safari_ios": {
               "version_added": "14",
               "flags": [

--- a/css/properties/text-decoration-skip-ink.json
+++ b/css/properties/text-decoration-skip-ink.json
@@ -31,7 +31,7 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false

--- a/css/selectors/backdrop.json
+++ b/css/selectors/backdrop.json
@@ -69,7 +69,7 @@
               }
             ],
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -128,7 +128,7 @@
                 "version_added": "19"
               },
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": {
                 "version_added": false

--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -66,12 +66,12 @@
             },
             "safari": [
               {
-                "version_added": "preview"
-              },
-              {
                 "version_added": "11.1",
                 "partial_implementation": true,
                 "notes": "Safari support is limited to <code>color</code> and <code>font-size</code>. See <a href='https://webkit.org/b/204163'>bug 204163</a>."
+              },
+              {
+                "version_added": "preview"
               }
             ],
             "safari_ios": {

--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -64,11 +64,16 @@
             "opera_android": {
               "version_added": "61"
             },
-            "safari": {
-              "version_added": "11.1",
-              "partial_implementation": true,
-              "notes": "Safari support is limited to <code>color</code> and <code>font-size</code>. See <a href='https://webkit.org/b/204163'>bug 204163</a>."
-            },
+            "safari": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "11.1",
+                "partial_implementation": true,
+                "notes": "Safari support is limited to <code>color</code> and <code>font-size</code>. See <a href='https://webkit.org/b/204163'>bug 204163</a>."
+              }
+            ],
             "safari_ios": {
               "version_added": "11.3",
               "partial_implementation": true,

--- a/html/elements/dialog.json
+++ b/html/elements/dialog.json
@@ -47,7 +47,7 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -109,7 +109,7 @@
                 "version_added": "24"
               },
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": {
                 "version_added": false

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -596,8 +596,7 @@
                 "version_added": "55"
               },
               "safari": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/196698'>bug 196698</a>."
+                "version_added": "preview"
               },
               "safari_ios": {
                 "version_added": false,

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1415,7 +1415,7 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "preview"
                 },
                 "safari_ios": {
                   "version_added": false
@@ -1466,7 +1466,7 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "preview"
                 },
                 "safari_ios": {
                   "version_added": false
@@ -1614,7 +1614,7 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "preview"
                 },
                 "safari_ios": {
                   "version_added": false
@@ -1665,7 +1665,7 @@
                   "version_added": null
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "preview"
                 },
                 "safari_ios": {
                   "version_added": false

--- a/http/headers/cross-origin-embedder-policy.json
+++ b/http/headers/cross-origin-embedder-policy.json
@@ -31,13 +31,7 @@
               "version_added": "59"
             },
             "safari": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "name": "Cross-Origin-Embedder-Policy (COEP) header",
-                  "type": "preference"
-                }
-              ]
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false

--- a/http/headers/cross-origin-opener-policy.json
+++ b/http/headers/cross-origin-opener-policy.json
@@ -55,13 +55,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "name": "Cross-Origin-Opener-Policy (COOP) header",
-                  "type": "preference"
-                }
-              ]
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -147,7 +147,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": {
                 "version_added": false

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -1014,7 +1014,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": {
                 "version_added": false

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -114,10 +114,16 @@
             "opera_android": {
               "version_added": false
             },
-            "safari": {
-              "version_added": "10.1",
-              "version_removed": "11"
-            },
+            "safari": [
+              {
+                "version_added": "preview",
+                "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+              },
+              {
+                "version_added": "10.1",
+                "version_removed": "11"
+              }
+            ],
             "safari_ios": {
               "version_added": "10.3",
               "version_removed": "11"
@@ -252,10 +258,16 @@
               "opera_android": {
                 "version_added": false
               },
-              "safari": {
-                "version_added": "10.1",
-                "version_removed": "11"
-              },
+              "safari": [
+                {
+                  "version_added": "preview",
+                  "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.1",
+                  "version_removed": "11"
+                }
+              ],
               "safari_ios": {
                 "version_added": "10.3",
                 "version_removed": "11"
@@ -390,10 +402,16 @@
               "opera_android": {
                 "version_added": false
               },
-              "safari": {
-                "version_added": "10.1",
-                "version_removed": "11"
-              },
+              "safari": [
+                {
+                  "version_added": "preview",
+                  "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.1",
+                  "version_removed": "11"
+                }
+              ],
               "safari_ios": {
                 "version_added": "10.3",
                 "version_removed": "11"
@@ -528,10 +546,16 @@
               "opera_android": {
                 "version_added": false
               },
-              "safari": {
-                "version_added": "10.1",
-                "version_removed": "11"
-              },
+              "safari": [
+                {
+                  "version_added": "preview",
+                  "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.1",
+                  "version_removed": "11"
+                }
+              ],
               "safari_ios": {
                 "version_added": "10.3",
                 "version_removed": "11"

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -203,7 +203,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": {
                 "version_added": false

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -146,7 +146,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": {
                 "version_added": false

--- a/webextensions/manifest/externally_connectable.json
+++ b/webextensions/manifest/externally_connectable.json
@@ -22,7 +22,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             }
           }
         }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Set Safari preview support for additions in TP13, TP133, TP134 and TP135

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://webkit.org/blog/11971/release-notes-for-safari-technology-preview-132/

https://webkit.org/blog/11975/release-notes-for-safari-technology-preview-133/

https://webkit.org/blog/12033/release-notes-for-safari-technology-preview-134/

https://webkit.org/blog/12040/release-notes-for-safari-technology-preview-135/

https://webkit.org/blog/11975/release-notes-for-safari-technology-preview-133/#:~:text=Added%20support%20for%20self-start%2C%20self-end%2C%20start%2C%20end%2C%20left%2C%20and%20right%20values%20in%20positional%20alignment%20(r282267%2C%20r282078%2C%20r281840) - I've ignored this for now as the existing support data seems to be rather dubious and needs more investigating.


Closes https://github.com/mdn/browser-compat-data/issues/13301
