### PR TITLE
api/DataTransfer/webkit

### DIFF
--- a/api/DataTransfer.json
+++ b/api/DataTransfer.json
@@ -154,10 +154,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-cleardata-dev",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "3"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -172,22 +172,22 @@
               "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -203,10 +203,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-dropeffect-dev",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "3"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -221,22 +221,22 @@
               "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -252,10 +252,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-effectallowed-dev",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "3"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -270,22 +270,22 @@
               "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -301,10 +301,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-files-dev",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "3"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -319,22 +319,22 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -350,10 +350,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-getdata-dev",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "3"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -368,22 +368,22 @@
               "version_added": "8"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -891,10 +891,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-setdragimage-dev",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "3"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "18"
@@ -909,22 +909,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -940,10 +940,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-types-dev",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "3"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -962,23 +962,23 @@
               ]
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "notes": "As of Opera 12, <code>Text</code> is returned instead of <code>text/plain</code>"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -260,7 +260,7 @@
               "notes": "See <a href='https://crbug.com/697059'>bug 697059</a>."
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "25",
               "notes": "See <a href='https://crbug.com/697059'>bug 697059</a>."
             },
             "edge": {
@@ -290,7 +290,7 @@
               "version_removed": "12"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -329,10 +329,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -341,7 +341,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -390,7 +390,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "9.0"
             },
             "webview_android": {
               "version_added": "64"
@@ -489,7 +489,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -511,7 +511,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "15"
@@ -526,10 +526,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -538,7 +538,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -575,10 +575,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "59"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "51"
             },
             "safari": {
               "version_added": "11"
@@ -625,10 +625,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "59"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "51"
             },
             "safari": {
               "version_added": "11"
@@ -735,7 +735,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -783,7 +783,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -881,7 +881,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "70"
@@ -918,10 +918,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "safari": {
               "version_added": "11"
@@ -968,10 +968,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -980,10 +980,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1078,7 +1078,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "70"
@@ -1128,7 +1128,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -1180,7 +1180,7 @@
               "version_removed": "12"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -1281,7 +1281,7 @@
               "version_removed": "12"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -2681,7 +2681,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "70"
@@ -2730,7 +2730,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "70"

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -197,7 +197,7 @@
             "webview_android": [
               {
                 "version_added": "56",
-                "notes": "In Chrome 63, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
+                "notes": "In WebView 63, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
               },
               {
                 "version_added": "≤37",

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -5,12 +5,24 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection",
         "spec_url": "https://w3c.github.io/webrtc-pc/#interface-definition",
         "support": {
-          "chrome": {
-            "version_added": "23"
-          },
-          "chrome_android": {
-            "version_added": "25"
-          },
+          "chrome": [
+            {
+              "version_added": "56"
+            },
+            {
+              "version_added": "23",
+              "prefix": "webkit"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "56"
+            },
+            {
+              "version_added": "25",
+              "prefix": "webkit"
+            }
+          ],
           "edge": {
             "version_added": "15"
           },
@@ -37,22 +49,20 @@
           },
           "opera": [
             {
-              "version_added": "43",
-              "notes": "Promise-based version."
+              "version_added": "43"
             },
             {
-              "version_added": "37",
-              "version_removed": "43"
+              "version_added": "15",
+              "prefix": "webkit"
             }
           ],
           "opera_android": [
             {
-              "version_added": "43",
-              "notes": "Promise-based version."
+              "version_added": "43"
             },
             {
-              "version_added": "37",
-              "version_removed": "43"
+              "version_added": "14",
+              "prefix": "webkit"
             }
           ],
           "safari": {
@@ -66,14 +76,19 @@
               "version_added": "6.0"
             },
             {
-              "prefix": "webkit",
-              "version_removed": "6.0",
-              "version_added": "5.0"
+              "version_added": "1.5",
+              "prefix": "webkit"
             }
           ],
-          "webview_android": {
-            "version_added": "≤37"
-          }
+          "webview_android": [
+            {
+              "version_added": "56"
+            },
+            {
+              "version_added": "≤37",
+              "prefix": "webkit"
+            }
+          ]
         },
         "status": {
           "experimental": false,
@@ -87,14 +102,26 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/RTCPeerConnection",
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-peerconnection",
           "support": {
-            "chrome": {
-              "version_added": "23",
-              "notes": "Before Chrome 63 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
-            },
-            "chrome_android": {
-              "version_added": true,
-              "notes": "Before Chrome 63 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
-            },
+            "chrome": [
+              {
+                "version_added": "56",
+                "notes": "In Chrome 63, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
+              },
+              {
+                "version_added": "23",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "56",
+                "notes": "In Chrome 63, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
+              },
+              {
+                "version_added": "25",
+                "prefix": "webkit"
+              }
+            ],
             "edge": {
               "version_added": "15"
             },
@@ -122,21 +149,21 @@
             "opera": [
               {
                 "version_added": "43",
-                "notes": "Promise-based version."
+                "notes": "In Opera 50, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
               },
               {
-                "version_added": "37",
-                "version_removed": "43"
+                "version_added": "15",
+                "prefix": "webkit"
               }
             ],
             "opera_android": [
               {
                 "version_added": "43",
-                "notes": "Promise-based version."
+                "notes": "In Opera Android 46, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
               },
               {
-                "version_added": "37",
-                "version_removed": "43"
+                "version_added": "14",
+                "prefix": "webkit"
               }
             ],
             "safari": {
@@ -145,13 +172,26 @@
             "safari_ios": {
               "version_added": "11"
             },
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
-            "webview_android": {
-              "version_added": "≤37",
-              "notes": "Before Chrome 63 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "6.0",
+                "notes": "In Samsung Internet 8.0, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
+              },
+              {
+                "version_added": "1.5",
+                "prefix": "webkit"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "56",
+                "notes": "In Chrome 63, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
+              },
+              {
+                "version_added": "≤37",
+                "prefix": "webkit"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -23,9 +23,15 @@
               "prefix": "webkit"
             }
           ],
-          "edge": {
-            "version_added": "15"
-          },
+          "edge": [
+            {
+              "version_added": "15"
+            },
+            {
+              "version_added": "15",
+              "prefix": "webkit"
+            }
+          ],
           "firefox": [
             {
               "version_added": "44"
@@ -122,9 +128,15 @@
                 "prefix": "webkit"
               }
             ],
-            "edge": {
-              "version_added": "15"
-            },
+            "edge": [
+              {
+                "version_added": "15"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "44"

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1628,10 +1628,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -1640,10 +1640,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1791,10 +1791,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -1840,7 +1840,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -1987,7 +1987,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -2010,7 +2010,7 @@
               "version_added": "24"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "15"
@@ -2025,10 +2025,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -2037,10 +2037,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -2059,7 +2059,7 @@
               "notes": "See <a href='https://crbug.com/697059'>bug 697059</a>."
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "25",
               "notes": "See <a href='https://crbug.com/697059'>bug 697059</a>."
             },
             "edge": {
@@ -2089,7 +2089,7 @@
               "version_removed": "12"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -2187,7 +2187,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -2533,7 +2533,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -2873,10 +2873,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -2885,10 +2885,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -261,6 +261,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "returns_promise": {
+          "__compat": {
+            "description": "Returns a promise",
+            "support": {
+              "chrome": {
+                "version_added": "51"
+              },
+              "chrome_android": {
+                "version_added": "51"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "66"
+              },
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": "43"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "6.0"
+              },
+              "webview_android": {
+                "version_added": "51"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "addStream": {
@@ -709,6 +757,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "returns_promise": {
+          "__compat": {
+            "description": "Returns a promise",
+            "support": {
+              "chrome": {
+                "version_added": "51"
+              },
+              "chrome_android": {
+                "version_added": "51"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "66"
+              },
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": "43"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "6.0"
+              },
+              "webview_android": {
+                "version_added": "51"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "createDataChannel": {
@@ -854,6 +950,54 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "returns_promise": {
+          "__compat": {
+            "description": "Returns a promise",
+            "support": {
+              "chrome": {
+                "version_added": "51"
+              },
+              "chrome_android": {
+                "version_added": "51"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "66"
+              },
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": "43"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "6.0"
+              },
+              "webview_android": {
+                "version_added": "51"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },
@@ -1451,59 +1595,51 @@
             }
           }
         },
-        "with_callbacks": {
+        "returns_promise": {
           "__compat": {
-            "description": "Uses callbacks instead of promises",
+            "description": "Returns a promise",
             "support": {
               "chrome": {
-                "version_added": "24",
-                "version_removed": "54"
+                "version_added": "51"
               },
               "chrome_android": {
-                "version_added": "25",
-                "version_removed": "54"
+                "version_added": "51"
               },
               "edge": {
-                "version_added": "15",
-                "version_removed": "79"
+                "version_added": "79"
               },
               "firefox": {
-                "version_added": "27",
-                "version_removed": "66"
+                "version_added": "66"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "66"
               },
               "ie": {
                 "version_added": false
               },
               "opera": {
-                "version_added": "15",
-                "version_removed": "41"
+                "version_added": "43"
               },
               "opera_android": {
-                "version_added": "14",
-                "version_removed": "41"
+                "version_added": "43"
               },
               "safari": {
-                "version_added": "11"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "11"
+                "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": "1.5",
-                "version_removed": "6.0"
+                "version_added": "6.0"
               },
               "webview_android": {
-                "version_added": "≤37",
-                "version_removed": "54"
+                "version_added": "51"
               }
             },
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         }
@@ -3258,6 +3394,54 @@
               "deprecated": false
             }
           }
+        },
+        "returns_promise": {
+          "__compat": {
+            "description": "Returns a promise",
+            "support": {
+              "chrome": {
+                "version_added": "51"
+              },
+              "chrome_android": {
+                "version_added": "51"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "66"
+              },
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": "43"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "6.0"
+              },
+              "webview_android": {
+                "version_added": "51"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "setRemoteDescription": {
@@ -3396,6 +3580,54 @@
               },
               "webview_android": {
                 "version_added": "80"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "returns_promise": {
+          "__compat": {
+            "description": "Returns a promise",
+            "support": {
+              "chrome": {
+                "version_added": "51"
+              },
+              "chrome_android": {
+                "version_added": "51"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "66"
+              },
+              "firefox_android": {
+                "version_added": "66"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "43"
+              },
+              "opera_android": {
+                "version_added": "43"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "6.0"
+              },
+              "webview_android": {
+                "version_added": "51"
               }
             },
             "status": {

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -111,7 +111,7 @@
             "chrome": [
               {
                 "version_added": "56",
-                "notes": "In Chrome 63, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
+                "notes": "Before Chrome 63 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
               },
               {
                 "prefix": "webkit",
@@ -121,7 +121,7 @@
             "chrome_android": [
               {
                 "version_added": "56",
-                "notes": "In Chrome 63, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
+                "notes": "Before Chrome 63 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
               },
               {
                 "prefix": "webkit",
@@ -161,7 +161,7 @@
             "opera": [
               {
                 "version_added": "43",
-                "notes": "In Opera 50, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
+                "notes": "Before Opera 50 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
               },
               {
                 "prefix": "webkit",
@@ -171,7 +171,7 @@
             "opera_android": [
               {
                 "version_added": "43",
-                "notes": "In Opera Android 46, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
+                "notes": "Before Opera Android 46 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
               },
               {
                 "prefix": "webkit",
@@ -187,7 +187,7 @@
             "samsunginternet_android": [
               {
                 "version_added": "6.0",
-                "notes": "In Samsung Internet 8.0, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
+                "notes": "Before Samsung Internet 8.0 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
               },
               {
                 "prefix": "webkit",
@@ -197,7 +197,7 @@
             "webview_android": [
               {
                 "version_added": "56",
-                "notes": "In WebView 63, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
+                "notes": "Before WebView 63 the default value for the <code>RTCConfiguration.rtcpMuxPolicy</code> parameter was <code>&quot;negotiate&quot;</code>"
               },
               {
                 "prefix": "webkit",

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -575,7 +575,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "59"
+              "version_added": "60"
             },
             "opera_android": {
               "version_added": "51"
@@ -625,7 +625,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "59"
+              "version_added": "60"
             },
             "opera_android": {
               "version_added": "51"

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1444,13 +1444,16 @@
             "description": "Uses callbacks instead of promises",
             "support": {
               "chrome": {
-                "version_added": "24"
+                "version_added": "24",
+                "version_removed": "54"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "25",
+                "version_removed": "54"
               },
               "edge": {
-                "version_added": "15"
+                "version_added": "15",
+                "version_removed": "79"
               },
               "firefox": {
                 "version_added": "27",
@@ -1463,10 +1466,12 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "45"
+                "version_added": "15",
+                "version_removed": "41"
               },
               "opera_android": {
-                "version_added": "43"
+                "version_added": "14",
+                "version_removed": "41"
               },
               "safari": {
                 "version_added": "11"
@@ -1475,10 +1480,12 @@
                 "version_added": "11"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5",
+                "version_removed": "6.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37",
+                "version_removed": "54"
               }
             },
             "status": {

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -10,8 +10,8 @@
               "version_added": "56"
             },
             {
-              "version_added": "23",
-              "prefix": "webkit"
+              "prefix": "webkit",
+              "version_added": "23"
             }
           ],
           "chrome_android": [
@@ -19,8 +19,8 @@
               "version_added": "56"
             },
             {
-              "version_added": "25",
-              "prefix": "webkit"
+              "prefix": "webkit",
+              "version_added": "25"
             }
           ],
           "edge": [
@@ -28,8 +28,8 @@
               "version_added": "15"
             },
             {
-              "version_added": "15",
-              "prefix": "webkit"
+              "prefix": "webkit",
+              "version_added": "15"
             }
           ],
           "firefox": [
@@ -58,8 +58,8 @@
               "version_added": "43"
             },
             {
-              "version_added": "15",
-              "prefix": "webkit"
+              "prefix": "webkit",
+              "version_added": "15"
             }
           ],
           "opera_android": [
@@ -67,8 +67,8 @@
               "version_added": "43"
             },
             {
-              "version_added": "14",
-              "prefix": "webkit"
+              "prefix": "webkit",
+              "version_added": "14"
             }
           ],
           "safari": {
@@ -82,8 +82,8 @@
               "version_added": "6.0"
             },
             {
-              "version_added": "1.5",
-              "prefix": "webkit"
+              "prefix": "webkit",
+              "version_added": "1.5"
             }
           ],
           "webview_android": [
@@ -91,8 +91,8 @@
               "version_added": "56"
             },
             {
-              "version_added": "≤37",
-              "prefix": "webkit"
+              "prefix": "webkit",
+              "version_added": "≤37"
             }
           ]
         },
@@ -114,8 +114,8 @@
                 "notes": "In Chrome 63, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
               },
               {
-                "version_added": "23",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "23"
               }
             ],
             "chrome_android": [
@@ -124,8 +124,8 @@
                 "notes": "In Chrome 63, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
               },
               {
-                "version_added": "25",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "25"
               }
             ],
             "edge": [
@@ -133,8 +133,8 @@
                 "version_added": "15"
               },
               {
-                "version_added": "15",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "15"
               }
             ],
             "firefox": [
@@ -164,8 +164,8 @@
                 "notes": "In Opera 50, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
               },
               {
-                "version_added": "15",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "15"
               }
             ],
             "opera_android": [
@@ -174,8 +174,8 @@
                 "notes": "In Opera Android 46, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
               },
               {
-                "version_added": "14",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "14"
               }
             ],
             "safari": {
@@ -190,8 +190,8 @@
                 "notes": "In Samsung Internet 8.0, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
               },
               {
-                "version_added": "1.5",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "1.5"
               }
             ],
             "webview_android": [
@@ -200,8 +200,8 @@
                 "notes": "In WebView 63, the default value for the <code>configuration.rtcpMuxPolicy</code> parameter changed from <code>&quot;negotiate&quot;</code> to <code>&quot;required&quot;</code>."
               },
               {
-                "version_added": "≤37",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "≤37"
               }
             ]
           },

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -205,24 +205,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/addIceCandidate",
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-peerconnection-addicecandidate",
           "support": {
-            "chrome": [
-              {
-                "version_added": "51",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "24"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "51",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": true
-              }
-            ],
+            "chrome": {
+              "version_added": "24"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "15"
             },
@@ -237,52 +225,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "11"
             },
             "safari_ios": {
               "version_added": "11"
             },
-            "samsunginternet_android": [
-              {
-                "notes": "Promise-based version and unprefixed.",
-                "version_added": "6.0"
-              },
-              {
-                "notes": "Promise-based version.",
-                "version_removed": "6.0",
-                "version_added": "5.0"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "51",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": true
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
           },
           "status": {
             "experimental": false,
@@ -315,26 +275,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "11",
               "version_removed": "12"
@@ -709,24 +655,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/createAnswer",
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-createanswer",
           "support": {
-            "chrome": [
-              {
-                "version_added": "51",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "24"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "51",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": true
-              }
-            ],
+            "chrome": {
+              "version_added": "24"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "15"
             },
@@ -739,52 +673,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "11"
             },
             "safari_ios": {
               "version_added": "11"
             },
-            "samsunginternet_android": [
-              {
-                "notes": "Promise-based version and unprefixed.",
-                "version_added": "6.0"
-              },
-              {
-                "notes": "Promise-based version.",
-                "version_removed": "6.0",
-                "version_added": "5.0"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "51",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": true
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
           },
           "status": {
             "experimental": false,
@@ -816,26 +722,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "11"
             },
@@ -878,26 +770,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "15"
+            },
             "safari": {
               "version_added": false
             },
@@ -923,24 +801,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/createOffer",
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-createoffer",
           "support": {
-            "chrome": [
-              {
-                "version_added": "51",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "24"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "51",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": true
-              }
-            ],
+            "chrome": {
+              "version_added": "24"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "15"
             },
@@ -953,52 +819,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "11"
             },
             "safari_ios": {
               "version_added": "11"
             },
-            "samsunginternet_android": [
-              {
-                "notes": "Promise-based version and unprefixed.",
-                "version_added": "6.0"
-              },
-              {
-                "notes": "Promise-based version.",
-                "version_removed": "6.0",
-                "version_added": "5.0"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "51",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": true
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
           },
           "status": {
             "experimental": false,
@@ -1030,26 +868,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "57"
+            },
+            "opera_android": {
+              "version_added": "49"
+            },
             "safari": {
               "version_added": "11"
             },
@@ -1192,26 +1016,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "35"
+            },
+            "opera_android": {
+              "version_added": "35"
+            },
             "safari": {
               "version_added": "12.1"
             },
@@ -1255,26 +1065,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "57"
+            },
+            "opera_android": {
+              "version_added": "49"
+            },
             "safari": {
               "version_added": "11"
             },
@@ -1319,26 +1115,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
@@ -1383,26 +1165,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "15"
+            },
             "safari": {
               "version_added": "11",
               "version_removed": "12"
@@ -1498,26 +1266,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "15"
+            },
             "safari": {
               "version_added": "11",
               "version_removed": "12"
@@ -1594,32 +1348,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/getStats",
           "spec_url": "https://w3c.github.io/webrtc-pc/#widl-RTCPeerConnection-getStats-Promise-RTCStatsReport--MediaStreamTrack-selector",
           "support": {
-            "chrome": [
-              {
-                "version_added": "58",
-                "notes": "Promise resolves with <code>RTCStatsReport</code>."
-              },
-              {
-                "version_added": "54",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "24"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "58",
-                "notes": "Promise resolves with <code>RTCStatsReport</code>."
-              },
-              {
-                "version_added": "54",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": true
-              }
-            ],
+            "chrome": {
+              "version_added": "24"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "15"
             },
@@ -1633,10 +1367,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "45"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -1644,32 +1378,12 @@
             "safari_ios": {
               "version_added": "11"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "7.0",
-                "notes": "Promise resolves with <code>RTCStatsReport</code>."
-              },
-              {
-                "version_added": "6.0",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": true
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "58",
-                "notes": "Promise resolves with <code>RTCStatsReport</code>."
-              },
-              {
-                "version_added": "54",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": true
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
           },
           "status": {
             "experimental": false,
@@ -1801,26 +1515,14 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "43",
+              "version_removed": "49"
+            },
+            "opera_android": {
+              "version_added": "43",
+              "version_removed": "46"
+            },
             "safari": {
               "version_added": "11",
               "version_removed": "12"
@@ -2019,26 +1721,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "11"
             },
@@ -2046,7 +1734,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "7.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -2132,26 +1820,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "11"
             },
@@ -2293,26 +1967,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "11"
             },
@@ -2407,26 +2067,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "11",
               "version_removed": "12"
@@ -2521,26 +2167,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "11"
             },
@@ -2570,7 +2202,7 @@
               "version_added": "24"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "15"
@@ -2584,26 +2216,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "11"
             },
@@ -2611,7 +2229,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -2696,26 +2314,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "15"
+            },
             "safari": {
               "version_added": "11"
             },
@@ -2723,7 +2327,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -2759,26 +2363,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "46"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
             "safari": {
               "version_added": "11"
             },
@@ -2808,7 +2398,7 @@
               "version_added": "24"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "15"
@@ -2822,26 +2412,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "11"
             },
@@ -2849,7 +2425,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -2871,7 +2447,7 @@
               "notes": "See <a href='https://crbug.com/697059'>bug 697059</a>."
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "25",
               "notes": "See <a href='https://crbug.com/697059'>bug 697059</a>."
             },
             "edge": {
@@ -2888,26 +2464,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": false
             },
@@ -2915,7 +2477,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -2951,26 +2513,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "15"
+            },
             "safari": {
               "version_added": "11"
             },
@@ -3014,26 +2562,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "51"
+            },
+            "opera_android": {
+              "version_added": "47"
+            },
             "safari": {
               "version_added": "11"
             },
@@ -3078,26 +2612,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
@@ -3105,7 +2625,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -3141,26 +2661,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "57"
+            },
+            "opera_android": {
+              "version_added": "49"
+            },
             "safari": {
               "version_added": "11"
             },
@@ -3204,26 +2710,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "57"
+            },
+            "opera_android": {
+              "version_added": "49"
+            },
             "safari": {
               "version_added": "11"
             },
@@ -3253,7 +2745,7 @@
               "version_added": "24"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "15"
@@ -3267,28 +2759,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version and unprefixed."
-              },
-              {
-                "version_added": "38",
-                "notes": "Promise-based version.",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version and unprefixed."
-              },
-              {
-                "version_added": "41",
-                "notes": "Promise-based version.",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "11"
             },
@@ -3296,7 +2772,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -3318,7 +2794,7 @@
               "notes": "See <a href='https://crbug.com/697059'>bug 697059</a>."
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "25",
               "notes": "See <a href='https://crbug.com/697059'>bug 697059</a>."
             },
             "edge": {
@@ -3334,26 +2810,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "11",
               "version_removed": "12"
@@ -3363,7 +2825,7 @@
               "version_removed": "12"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -3604,26 +3066,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "35"
+            },
+            "opera_android": {
+              "version_added": "35"
+            },
             "safari": {
               "version_added": "11"
             },
@@ -3668,26 +3116,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
@@ -3695,7 +3129,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -3714,24 +3148,12 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-peerconnection-setlocaldescription",
           "description": "<code>setLocalDescription()</code>",
           "support": {
-            "chrome": [
-              {
-                "version_added": "51",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "24"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "51",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": true
-              }
-            ],
+            "chrome": {
+              "version_added": "24"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "15"
             },
@@ -3745,52 +3167,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "11"
             },
             "safari_ios": {
               "version_added": "11"
             },
-            "samsunginternet_android": [
-              {
-                "notes": "Promise-based version and unprefixed.",
-                "version_added": "6.0"
-              },
-              {
-                "notes": "Promise-based version.",
-                "version_removed": "6.0",
-                "version_added": "5.0"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "51",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": true
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
           },
           "status": {
             "experimental": false,
@@ -3853,24 +3247,12 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-peerconnection-setremotedescription",
           "description": "<code>setRemoteDescription()</code>",
           "support": {
-            "chrome": [
-              {
-                "version_added": "51",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "24"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "51",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": true
-              }
-            ],
+            "chrome": {
+              "version_added": "24"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "15"
             },
@@ -3883,50 +3265,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "11"
             },
             "safari_ios": {
               "version_added": "11"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "5.0",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": true
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "51",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": true
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
           },
           "status": {
             "experimental": false,
@@ -4054,26 +3410,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43",
-                "notes": "Promise-based version."
-              },
-              {
-                "version_added": "37",
-                "version_removed": "43"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "11"
             },
@@ -4081,7 +3423,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -4119,10 +3461,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "15"
             },
             "safari": {
               "version_added": "11"
@@ -4131,10 +3473,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1547,54 +1547,6 @@
             "deprecated": false
           }
         },
-        "selector_parameter": {
-          "__compat": {
-            "description": "<code>selector</code> parameter",
-            "support": {
-              "chrome": {
-                "version_added": "67"
-              },
-              "chrome_android": {
-                "version_added": "67"
-              },
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": {
-                "version_added": null
-              },
-              "firefox_android": {
-                "version_added": null
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "54"
-              },
-              "opera_android": {
-                "version_added": "48"
-              },
-              "safari": {
-                "version_added": "11"
-              },
-              "safari_ios": {
-                "version_added": "11"
-              },
-              "samsunginternet_android": {
-                "version_added": "9.0"
-              },
-              "webview_android": {
-                "version_added": "67"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "returns_promise": {
           "__compat": {
             "description": "Returns a promise",
@@ -1634,6 +1586,54 @@
               },
               "webview_android": {
                 "version_added": "51"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "selector_parameter": {
+          "__compat": {
+            "description": "<code>selector</code> parameter",
+            "support": {
+              "chrome": {
+                "version_added": "67"
+              },
+              "chrome_android": {
+                "version_added": "67"
+              },
+              "edge": {
+                "version_added": "≤79"
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "54"
+              },
+              "opera_android": {
+                "version_added": "48"
+              },
+              "safari": {
+                "version_added": "11"
+              },
+              "safari_ios": {
+                "version_added": "11"
+              },
+              "samsunginternet_android": {
+                "version_added": "9.0"
+              },
+              "webview_android": {
+                "version_added": "67"
               }
             },
             "status": {


### PR DESCRIPTION
- Add Chrome's prefix data for RTCPeerConnection
- Remove unhelpful "promise-based version" notes; correct LOTS of Opera data
- Copy prior notes to dedicated "with_callbacks" feature
- Mirror version numbers to Samsung Internet, Opera, Chrome Android
- Apply remaining corrections
- Fix Opera version numbers
- Fix Edge prefix data (bad merge)
- Correct note for WebView
- Clean diff
- Revert note changes (cherry-picked in #12301)
- Add returns_promise subfeatures
- Fix sorting
- Add Chrome/Safari versions for DataTransfer API
