### PR TITLE
Add Chromium versions for api.DedicatedWorkerGlobalScope.name

### DIFF
--- a/api/DedicatedWorkerGlobalScope.json
+++ b/api/DedicatedWorkerGlobalScope.json
@@ -265,10 +265,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/workers.html#dom-dedicatedworkerglobalscope-name-dev",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "71"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "71"
             },
             "deno": {
               "version_added": "1.0"
@@ -286,10 +286,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "58"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "50"
             },
             "safari": {
               "version_added": "12.1"
@@ -298,10 +298,10 @@
               "version_added": "12.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "71"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `name` member of the `DedicatedWorkerGlobalScope` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/88937c31aa017301a3856a076fe283a3b9012e9c
