### PR TITLE
HTTP WWW-Authenticate - add scheme and algorithm info

### DIFF
--- a/http/headers/authorization.json
+++ b/http/headers/authorization.json
@@ -1,10 +1,10 @@
 {
   "http": {
     "headers": {
-      "WWW-Authenticate": {
+      "Authorization": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/WWW-Authenticate",
-          "spec_url": "https://httpwg.org/specs/rfc7235.html#header.www-authenticate",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Authorization",
+          "spec_url": "https://httpwg.org/specs/rfc7235.html#header.authorization",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/www-authenticate.json
+++ b/http/headers/www-authenticate.json
@@ -48,6 +48,346 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "Basic": {
+          "__compat": {
+            "description": "<code>Basic</code> authentication",
+            "spec_url": "https://httpwg.org/specs/rfc7617#top",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": "1"
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": true
+              },
+              "webview_android": {
+                "version_added": "37"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "Digest": {
+          "__compat": {
+            "description": "<code>Digest</code> authentication",
+            "spec_url": "https://httpwg.org/specs/rfc7616#top",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "SHA-256": {
+            "__compat": {
+              "description": "SHA2-256 digest authentication",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": "93"
+                },
+                "firefox_android": {
+                  "version_added": "93"
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "SHA-512": {
+            "__compat": {
+              "description": "SHA2-512 digest authentication",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "md5": {
+            "__compat": {
+              "description": "MD5 digest authentication",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": {
+                  "version_added": null
+                },
+                "edge": {
+                  "version_added": null
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "opera": {
+                  "version_added": null
+                },
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": {
+                  "version_added": null
+                },
+                "webview_android": {
+                  "version_added": null
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
+        },
+        "Negotiate": {
+          "__compat": {
+            "description": "<code>Negotiate</code> (Kerberos) authentication",
+            "spec_url": "https://datatracker.ietf.org/doc/html/rfc4120#top",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "NTLM": {
+          "__compat": {
+            "description": "<code>NTLM</code> authentication",
+            "spec_url": "https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-ntht/#published-version",
+            "support": {
+              "chrome": {
+                "version_added": null
+              },
+              "chrome_android": {
+                "version_added": null
+              },
+              "edge": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": true
+              },
+              "ie": {
+                "version_added": null
+              },
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/http/headers/www-authenticate.json
+++ b/http/headers/www-authenticate.json
@@ -31,10 +31,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": null
+              "version_added": true
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
@@ -79,10 +79,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": true
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -104,13 +104,13 @@
             "spec_url": "https://httpwg.org/specs/rfc7616#top",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
-                "version_added": null
+                "version_added": true
               },
               "firefox": {
                 "version_added": true
@@ -122,10 +122,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": true
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
                 "version_added": null
@@ -134,10 +134,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
-                "version_added": null
+                "version_added": true
               }
             },
             "status": {
@@ -151,13 +151,13 @@
               "description": "SHA2-256 digest authentication",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": "93"
@@ -166,13 +166,13 @@
                   "version_added": "93"
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari": {
                   "version_added": null
@@ -181,10 +181,10 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "webview_android": {
-                  "version_added": null
+                  "version_added": false
                 }
               },
               "status": {
@@ -199,13 +199,13 @@
               "description": "SHA2-512 digest authentication",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox": {
                   "version_added": false
@@ -214,13 +214,13 @@
                   "version_added": false
                 },
                 "ie": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari": {
                   "version_added": null
@@ -229,10 +229,10 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "webview_android": {
-                  "version_added": null
+                  "version_added": false
                 }
               },
               "status": {
@@ -247,10 +247,10 @@
               "description": "MD5 digest authentication",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "chrome_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "edge": {
                   "version_added": null
@@ -265,10 +265,10 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari": {
                   "version_added": null
@@ -277,10 +277,10 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "webview_android": {
-                  "version_added": null
+                  "version_added": false
                 }
               },
               "status": {
@@ -297,13 +297,13 @@
             "spec_url": "https://datatracker.ietf.org/doc/html/rfc4120#top",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": true
@@ -315,10 +315,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": null
@@ -327,10 +327,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {
@@ -346,13 +346,13 @@
             "spec_url": "https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-ntht/#published-version",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": false
               },
               "edge": {
-                "version_added": null
+                "version_added": false
               },
               "firefox": {
                 "version_added": true
@@ -364,10 +364,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": null
@@ -376,10 +376,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": false
               },
               "webview_android": {
-                "version_added": null
+                "version_added": false
               }
             },
             "status": {

--- a/http/headers/www-authenticate.json
+++ b/http/headers/www-authenticate.json
@@ -247,13 +247,13 @@
               "description": "MD5 digest authentication",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": true
                 },
                 "chrome_android": {
-                  "version_added": false
+                  "version_added": true
                 },
                 "edge": {
-                  "version_added": null
+                  "version_added": true
                 },
                 "firefox": {
                   "version_added": true
@@ -265,10 +265,10 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": true
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": true
                 },
                 "safari": {
                   "version_added": null
@@ -277,10 +277,10 @@
                   "version_added": null
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": true
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": true
                 }
               },
               "status": {
@@ -297,13 +297,13 @@
             "spec_url": "https://datatracker.ietf.org/doc/html/rfc4120#top",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": true
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": true
               },
               "firefox": {
                 "version_added": true
@@ -315,10 +315,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": false
+                "version_added": true
               },
               "opera_android": {
-                "version_added": false
+                "version_added": true
               },
               "safari": {
                 "version_added": null
@@ -327,10 +327,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": true
               },
               "webview_android": {
-                "version_added": false
+                "version_added": true
               }
             },
             "status": {
@@ -346,13 +346,13 @@
             "spec_url": "https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-ntht/#published-version",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": true
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": true
               },
               "edge": {
-                "version_added": false
+                "version_added": true
               },
               "firefox": {
                 "version_added": true
@@ -364,10 +364,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": false
+                "version_added": true
               },
               "opera_android": {
-                "version_added": false
+                "version_added": true
               },
               "safari": {
                 "version_added": null
@@ -376,10 +376,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": true
               },
               "webview_android": {
-                "version_added": false
+                "version_added": true
               }
             },
             "status": {

--- a/http/headers/www-authenticate.json
+++ b/http/headers/www-authenticate.json
@@ -52,7 +52,7 @@
         "Basic": {
           "__compat": {
             "description": "<code>Basic</code> authentication",
-            "spec_url": "https://httpwg.org/specs/rfc7617#top",
+            "spec_url": "https://www.rfc-editor.org/rfc/rfc7617#top",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -101,7 +101,7 @@
         "Digest": {
           "__compat": {
             "description": "<code>Digest</code> authentication",
-            "spec_url": "https://httpwg.org/specs/rfc7616#top",
+            "spec_url": "https://www.rfc-editor.org/rfc/rfc7616#top",
             "support": {
               "chrome": {
                 "version_added": true
@@ -294,7 +294,7 @@
         "Negotiate": {
           "__compat": {
             "description": "<code>Negotiate</code> (Kerberos) authentication",
-            "spec_url": "https://datatracker.ietf.org/doc/html/rfc4120#top",
+            "spec_url": "https://www.rfc-editor.org/rfc/rfc4120#top",
             "support": {
               "chrome": {
                 "version_added": true


### PR DESCRIPTION
[WWW-Authenticate](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate) and [Authorization](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization) together are the HTTP headers used in the general [HTTP authentication framework](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication). Note, compatibility for these should mirror each other.

Thing is, this is a framework, not a specific implementation. So saying that Firefox or whatever supports this in version X tells you very little. The useful compatibility information is 
- which authentication methods are supported - basic, digest, kerberos etc.
- within some authentication methods, which algorithms are supported.

What I have done here is a draft that attempts to start adding that information. I really don't want to go all the way with this, but I'd like to at least cover the methods supported by Firefox and Chrome, down to algorithm level. Right now this just starts the job for Firefox, since there is not much point me chasing this too far if BCD team disagree with this approach. 

What I know. 
- Firefox supports:  basic, digest (on all platforms), and ntlm and negotiate (kerberos) depending on whether OS support is available ([from here](https://bugzilla.mozilla.org/show_bug.cgi?id=472823#c49))
   - Firefox supports digest authentication with MD5 and SHA256 (from FF93). Not SHA 512.
   - Basic doesn't use any algorithms. 
   - I whether NTLM/negotiate use algorithms that require separate support statements.
- Chrome supports the same set, but it isn't clear what algorithms: https://www.chromium.org/developers/design-documents/http-authentication , and no OS restrictions other than Chrome OS are noted. 
  - Chrome does NOT support SHA256 as of Sept 29 https://bugs.chromium.org/p/chromium/issues/detail?id=1160478 - nothing supports SHA512. 
- In addition to those schemes above [there are more listed here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#authentication_schemes) - including HOBA, Mutual, Bearer, AWS4-HMAC-SHA256. I propose not to add info about support for those until yet, but people could add that if they knew something was supported.
- Safari itself has no clear statement about what it supports but there is enough info to be sure it does for Basic authentication: https://developer.apple.com/forums/thread/96293 - albeit poorly. No clear info on digest support. If someone had a mac you could test maybe using a method from here https://httpbin.org/#/Auth

Questions
- Is this approach acceptable? Should I keep going?
- The specs are giving me errors. How can I fix this?
- [Authorization](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization) should mirror this. OK to just copy this when we're done? - EDITED. Yes.



Fixes #12370. Actually, it's a draft to help test whether the approach is reasonable. 