### PR TITLE
Add Chromium versions for api.HTMLMarqueeElement.trueSpeed

### DIFF
--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -686,10 +686,10 @@
               "version_added": "4"
             },
             "opera": {
-              "version_added": "≤12.1"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": "14"
             },
             "safari": {
               "version_added": false

--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -668,10 +668,10 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "9"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -686,10 +686,10 @@
               "version_added": "4"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": false
@@ -698,10 +698,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `trueSpeed` member of the `HTMLMarqueeElement` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/2e6de492be4b89312f7c7c7be7cbc0607c42a9e6
