### PR TITLE
Add Safari versions for api.HTMLAreaElement.toString

### DIFF
--- a/api/_mixins/HTMLHyperlinkElementUtils__HTMLAreaElement.json
+++ b/api/_mixins/HTMLHyperlinkElementUtils__HTMLAreaElement.json
@@ -530,10 +530,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `toString` member of the `HTMLAreaElement` API, based upon manual testing.

Test Code Used:
```js
var el = document.createElement('area');
var href = 'https://mdn-bcd-collector.appspot.com/';
el.href = href; el.toString() == href;
```
