### PR TITLE
Add Firefox versions for api.IDBTransaction.objectStoreNames

### DIFF
--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -648,10 +648,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "10"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "ie": {
               "version_added": false
@@ -663,10 +663,10 @@
               "version_added": "35"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `objectStoreNames` member of the `IDBTransaction` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.3.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/IDBTransaction/objectStoreNames
