### PR TITLE
Add all browsers versions for InputDeviceInfo API

### DIFF
--- a/api/InputDeviceInfo.json
+++ b/api/InputDeviceInfo.json
@@ -6,40 +6,40 @@
         "spec_url": "https://w3c.github.io/mediacapture-main/#dom-inputdeviceinfo",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "47"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "47"
           },
           "edge": {
             "version_added": "79"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "39"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "39"
           },
           "ie": {
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "34"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "34"
           },
           "safari": {
-            "version_added": false
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "5.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "47"
           }
         },
         "status": {


### PR DESCRIPTION
This PR adds real values for all browsers for the `InputDeviceInfo` API.  This is the interface returned by `MediaDevices.enumerateDevices()`, it doesn't make sense for this interface to have any compatibility differences.  The data was mirrored from `enumerateDevices()` accordingly.
