### PR TITLE
Add Safari versions for api.MimeTypeArray.length

### DIFF
--- a/api/MimeTypeArray.json
+++ b/api/MimeTypeArray.json
@@ -132,7 +132,7 @@
               "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/MimeTypeArray.json
+++ b/api/MimeTypeArray.json
@@ -129,7 +129,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "≤3"

--- a/api/MimeTypeArray.json
+++ b/api/MimeTypeArray.json
@@ -129,10 +129,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `length` member of the `MimeTypeArray` API by mirroring the data.
