### PR TITLE
Remove irrelevant api.MediaStream.error feature

### DIFF
--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -380,64 +380,6 @@
           }
         }
       },
-      "ended": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStream/ended",
-          "support": {
-            "chrome": {
-              "version_added": true,
-              "version_removed": "54",
-              "notes": "Deprecated in Chrome 52."
-            },
-            "chrome_android": {
-              "version_added": true,
-              "version_removed": "54",
-              "notes": "Deprecated in Chrome 52."
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": true,
-              "version_removed": "39"
-            },
-            "opera_android": {
-              "version_added": true,
-              "version_removed": "41"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": true,
-              "version_removed": "6.0",
-              "notes": "Deprecated in Samsung Internet 6.0."
-            },
-            "webview_android": {
-              "version_added": true,
-              "version_removed": "54",
-              "notes": "Deprecated in Chrome 52."
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
-      },
       "getAudioTracks": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStream/getAudioTracks",


### PR DESCRIPTION
This PR removes the irrelevant `error` member of the `MediaStream` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features). The lack of current support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.3.0), even if the current BCD suggests support.
