### PR TITLE
Remove irrelevant api.MediaStream.label feature

### DIFF
--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -743,61 +743,6 @@
           }
         }
       },
-      "label": {
-        "__compat": {
-          "support": {
-            "chrome": {
-              "version_added": true,
-              "version_removed": "54",
-              "notes": "Deprecated in Chrome 45."
-            },
-            "chrome_android": {
-              "version_added": true,
-              "version_removed": "54",
-              "notes": "Deprecated in Chrome 45."
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": null
-            },
-            "firefox_android": {
-              "version_added": null
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": true,
-              "version_removed": "6.0",
-              "notes": "Deprecated in Samsung Internet 5.0."
-            },
-            "webview_android": {
-              "version_added": true,
-              "version_removed": "54",
-              "notes": "Deprecated in Chrome 45."
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
-      },
       "onactive": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStream/onactive",


### PR DESCRIPTION
This PR removes the irrelevant `label` member of the `MediaStream` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features). The lack of current support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.3.0), even if the current BCD suggests support.
