### PR TITLE
Add Chromium versions for api.MediaStream.id

### DIFF
--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -644,11 +644,11 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediastream-id",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "26",
               "version_removed": "54"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "26",
               "version_removed": "54"
             },
             "edge": {
@@ -665,11 +665,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "15",
               "version_removed": "39"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "14",
               "version_removed": "41"
             },
             "safari": {
@@ -679,11 +679,11 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.5",
               "version_removed": "6.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "≤37",
               "version_removed": "54"
             }
           },


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `id` member of the `MediaStream` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/c3da046b9c188b34acbb864c09ef331892ada9b3
