### PR TITLE
Add Chromium versions for MutationRecord API

### DIFF
--- a/api/MutationRecord.json
+++ b/api/MutationRecord.json
@@ -6,10 +6,10 @@
         "spec_url": "https://dom.spec.whatwg.org/#interface-mutationrecord",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "28"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "28"
           },
           "edge": {
             "version_added": "12"
@@ -24,10 +24,10 @@
             "version_added": "11"
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": "7"
@@ -36,10 +36,10 @@
             "version_added": "7"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -53,10 +53,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/addedNodes",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "28"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "edge": {
               "version_added": "12"
@@ -71,10 +71,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "7"
@@ -83,10 +83,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -101,10 +101,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/attributeName",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "28"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "edge": {
               "version_added": "12"
@@ -119,10 +119,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "7"
@@ -131,10 +131,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -149,10 +149,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/attributeNamespace",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "28"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "edge": {
               "version_added": "12"
@@ -167,10 +167,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "7"
@@ -179,10 +179,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -197,10 +197,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/nextSibling",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "28"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "edge": {
               "version_added": "12"
@@ -215,10 +215,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "7"
@@ -227,10 +227,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -245,10 +245,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/oldValue",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "28"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "edge": {
               "version_added": "12"
@@ -263,10 +263,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "7"
@@ -275,10 +275,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -293,10 +293,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/previousSibling",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "28"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "edge": {
               "version_added": "12"
@@ -311,10 +311,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "7"
@@ -323,10 +323,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -341,10 +341,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/removedNodes",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "28"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "edge": {
               "version_added": "12"
@@ -359,10 +359,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "7"
@@ -371,10 +371,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -389,10 +389,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/target",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "28"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "edge": {
               "version_added": "12"
@@ -407,10 +407,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "7"
@@ -419,10 +419,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -437,10 +437,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/type",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "28"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "edge": {
               "version_added": "12"
@@ -455,10 +455,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "7"
@@ -467,10 +467,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/MutationRecord.json
+++ b/api/MutationRecord.json
@@ -6,7 +6,7 @@
         "spec_url": "https://dom.spec.whatwg.org/#interface-mutationrecord",
         "support": {
           "chrome": {
-            "version_added": "20"
+            "version_added": "16"
           },
           "chrome_android": {
             "version_added": "25"
@@ -53,7 +53,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/addedNodes",
           "support": {
             "chrome": {
-              "version_added": "20"
+              "version_added": "16"
             },
             "chrome_android": {
               "version_added": "25"
@@ -101,7 +101,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/attributeName",
           "support": {
             "chrome": {
-              "version_added": "20"
+              "version_added": "16"
             },
             "chrome_android": {
               "version_added": "25"
@@ -149,7 +149,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/attributeNamespace",
           "support": {
             "chrome": {
-              "version_added": "20"
+              "version_added": "16"
             },
             "chrome_android": {
               "version_added": "25"
@@ -197,7 +197,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/nextSibling",
           "support": {
             "chrome": {
-              "version_added": "20"
+              "version_added": "16"
             },
             "chrome_android": {
               "version_added": "25"
@@ -245,7 +245,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/oldValue",
           "support": {
             "chrome": {
-              "version_added": "20"
+              "version_added": "16"
             },
             "chrome_android": {
               "version_added": "25"
@@ -293,7 +293,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/previousSibling",
           "support": {
             "chrome": {
-              "version_added": "20"
+              "version_added": "16"
             },
             "chrome_android": {
               "version_added": "25"
@@ -341,7 +341,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/removedNodes",
           "support": {
             "chrome": {
-              "version_added": "20"
+              "version_added": "16"
             },
             "chrome_android": {
               "version_added": "25"
@@ -389,7 +389,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/target",
           "support": {
             "chrome": {
-              "version_added": "20"
+              "version_added": "16"
             },
             "chrome_android": {
               "version_added": "25"
@@ -437,7 +437,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/type",
           "support": {
             "chrome": {
-              "version_added": "20"
+              "version_added": "16"
             },
             "chrome_android": {
               "version_added": "25"

--- a/api/MutationRecord.json
+++ b/api/MutationRecord.json
@@ -6,10 +6,10 @@
         "spec_url": "https://dom.spec.whatwg.org/#interface-mutationrecord",
         "support": {
           "chrome": {
-            "version_added": "28"
+            "version_added": "20"
           },
           "chrome_android": {
-            "version_added": "28"
+            "version_added": "25"
           },
           "edge": {
             "version_added": "12"
@@ -53,10 +53,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/addedNodes",
           "support": {
             "chrome": {
-              "version_added": "28"
+              "version_added": "20"
             },
             "chrome_android": {
-              "version_added": "28"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -101,10 +101,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/attributeName",
           "support": {
             "chrome": {
-              "version_added": "28"
+              "version_added": "20"
             },
             "chrome_android": {
-              "version_added": "28"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -149,10 +149,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/attributeNamespace",
           "support": {
             "chrome": {
-              "version_added": "28"
+              "version_added": "20"
             },
             "chrome_android": {
-              "version_added": "28"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -197,10 +197,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/nextSibling",
           "support": {
             "chrome": {
-              "version_added": "28"
+              "version_added": "20"
             },
             "chrome_android": {
-              "version_added": "28"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -245,10 +245,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/oldValue",
           "support": {
             "chrome": {
-              "version_added": "28"
+              "version_added": "20"
             },
             "chrome_android": {
-              "version_added": "28"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -293,10 +293,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/previousSibling",
           "support": {
             "chrome": {
-              "version_added": "28"
+              "version_added": "20"
             },
             "chrome_android": {
-              "version_added": "28"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -341,10 +341,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/removedNodes",
           "support": {
             "chrome": {
-              "version_added": "28"
+              "version_added": "20"
             },
             "chrome_android": {
-              "version_added": "28"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -389,10 +389,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/target",
           "support": {
             "chrome": {
-              "version_added": "28"
+              "version_added": "20"
             },
             "chrome_android": {
-              "version_added": "28"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -437,10 +437,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationRecord/type",
           "support": {
             "chrome": {
-              "version_added": "28"
+              "version_added": "20"
             },
             "chrome_android": {
-              "version_added": "28"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `MutationRecord` API, based upon commit history and date.

Commits: https://source.chromium.org/chromium/chromium/src/+/312007166b154657025bd14c72574888e2779076
https://source.chromium.org/chromium/chromium/src/+/4e5368c3ba5b6cdf4a878fe39888f090d77dc585