### PR TITLE
Add Safari versions for OfflineAudioCompletionEvent API

### DIFF
--- a/api/OfflineAudioCompletionEvent.json
+++ b/api/OfflineAudioCompletionEvent.json
@@ -33,7 +33,7 @@
             "version_added": "6"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "6"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -81,10 +81,10 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "14"
             },
             "samsunginternet_android": {
               "version_added": "6.0",
@@ -135,7 +135,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `OfflineAudioCompletionEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.3.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/OfflineAudioCompletionEvent
