### PR TITLE
Add Firefox versions for api.OfflineAudioContext.length

### DIFF
--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -323,10 +323,10 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "49"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `length` member of the `OfflineAudioContext` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.3.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/OfflineAudioContext/length
