### PR TITLE
Update Chromium versions for PresentationConnection API

### DIFF
--- a/api/PresentationConnection.json
+++ b/api/PresentationConnection.json
@@ -6,10 +6,10 @@
         "spec_url": "https://w3c.github.io/presentation-api/#interface-presentationconnection",
         "support": {
           "chrome": {
-            "version_added": "48"
+            "version_added": "47"
           },
           "chrome_android": {
-            "version_added": "48"
+            "version_added": "47"
           },
           "edge": {
             "version_added": "79"
@@ -40,10 +40,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "34"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "34"
           },
           "safari": {
             "version_added": false
@@ -70,10 +70,10 @@
           "spec_url": "https://w3c.github.io/presentation-api/#dom-presentationconnection-binarytype",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "edge": {
               "version_added": "79"
@@ -104,10 +104,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "34"
             },
             "safari": {
               "version_added": false
@@ -116,7 +116,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -169,10 +169,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "36"
             },
             "safari": {
               "version_added": false
@@ -200,10 +200,10 @@
           "spec_url": "https://w3c.github.io/presentation-api/#dom-presentationconnection-id",
           "support": {
             "chrome": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "edge": {
               "version_added": "79"
@@ -234,10 +234,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "34"
             },
             "safari": {
               "version_added": false
@@ -298,10 +298,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "37"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "37"
             },
             "safari": {
               "version_added": false
@@ -362,10 +362,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "37"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "37"
             },
             "safari": {
               "version_added": false
@@ -392,10 +392,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationConnection/onmessage",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "edge": {
               "version_added": "79"
@@ -426,10 +426,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "34"
             },
             "safari": {
               "version_added": false
@@ -438,7 +438,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -490,10 +490,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "37"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "37"
             },
             "safari": {
               "version_added": false
@@ -521,10 +521,10 @@
           "spec_url": "https://w3c.github.io/presentation-api/#dom-presentationconnection-send",
           "support": {
             "chrome": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "edge": {
               "version_added": "79"
@@ -555,10 +555,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "34"
             },
             "safari": {
               "version_added": false
@@ -586,10 +586,10 @@
           "spec_url": "https://w3c.github.io/presentation-api/#dom-presentationconnection-state",
           "support": {
             "chrome": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "edge": {
               "version_added": "79"
@@ -620,10 +620,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "34"
             },
             "safari": {
               "version_added": false
@@ -651,10 +651,10 @@
           "spec_url": "https://w3c.github.io/presentation-api/#dom-presentationconnection-terminate",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "48"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "48"
             },
             "edge": {
               "version_added": "79"
@@ -685,10 +685,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "35"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "35"
             },
             "safari": {
               "version_added": false
@@ -697,7 +697,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false
@@ -750,10 +750,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "44"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `PresentationConnection` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.3.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PresentationConnection
