### PR TITLE
Update Firefox versions for RTCDataChannel API

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -14,26 +14,12 @@
           "edge": {
             "version_added": "79"
           },
-          "firefox": [
-            {
-              "version_added": "24"
-            },
-            {
-              "alternative_name": "DataChannel",
-              "version_added": "18",
-              "version_removed": "60"
-            }
-          ],
-          "firefox_android": [
-            {
-              "version_added": "24"
-            },
-            {
-              "alternative_name": "DataChannel",
-              "version_added": "18",
-              "version_removed": "60"
-            }
-          ],
+          "firefox": {
+            "version_added": "22"
+          },
+          "firefox_android": {
+            "version_added": "22"
+          },
           "ie": {
             "version_added": false
           },
@@ -77,10 +63,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "18"
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": "18"
+              "version_added": "22"
             },
             "ie": {
               "version_added": false
@@ -126,10 +112,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "18"
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": "18"
+              "version_added": "22"
             },
             "ie": {
               "version_added": false
@@ -232,10 +218,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "44"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "44"
             },
             "ie": {
               "version_added": false
@@ -281,10 +267,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "ie": {
               "version_added": false
@@ -430,10 +416,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "ie": {
               "version_added": false
@@ -479,10 +465,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "ie": {
               "version_added": false
@@ -728,10 +714,10 @@
               "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
             },
             "firefox": {
-              "version_added": true
+              "version_added": "44"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "ie": {
               "version_added": false
@@ -781,10 +767,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "ie": {
               "version_added": false
@@ -879,10 +865,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "ie": {
               "version_added": false
@@ -928,10 +914,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "ie": {
               "version_added": false
@@ -977,10 +963,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "ie": {
               "version_added": false
@@ -1076,10 +1062,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "ie": {
               "version_added": false
@@ -1173,10 +1159,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "ie": {
               "version_added": false
@@ -1222,10 +1208,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "ie": {
               "version_added": false
@@ -1270,10 +1256,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "22"
             },
             "ie": {
               "version_added": false
@@ -1367,10 +1353,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `RTCDataChannel` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.3.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCDataChannel
