### PR TITLE
Move the performance attribute to api.performance (in _globals)

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -6367,58 +6367,6 @@
           }
         }
       },
-      "performance": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/performance",
-          "spec_url": "https://w3c.github.io/hr-time/#the-performance-attribute",
-          "support": {
-            "chrome": {
-              "version_added": "6"
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "deno": {
-              "version_added": "1.0"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "7"
-            },
-            "firefox_android": {
-              "version_added": "7"
-            },
-            "ie": {
-              "version_added": "9"
-            },
-            "opera": {
-              "version_added": "15"
-            },
-            "opera_android": {
-              "version_added": "14"
-            },
-            "safari": {
-              "version_added": "8"
-            },
-            "safari_ios": {
-              "version_added": "9"
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "personalbar": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/personalbar",

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -570,58 +570,6 @@
           }
         }
       },
-      "performance": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/performance",
-          "spec_url": "https://w3c.github.io/hr-time/#the-performance-attribute",
-          "support": {
-            "chrome": {
-              "version_added": true
-            },
-            "chrome_android": {
-              "version_added": true
-            },
-            "deno": {
-              "version_added": "1.0"
-            },
-            "edge": {
-              "version_added": "≤79"
-            },
-            "firefox": {
-              "version_added": "34"
-            },
-            "firefox_android": {
-              "version_added": "34"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": true
-            },
-            "safari_ios": {
-              "version_added": true
-            },
-            "samsunginternet_android": {
-              "version_added": true
-            },
-            "webview_android": {
-              "version_added": true
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "self": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/self",

--- a/api/_globals/performance.json
+++ b/api/_globals/performance.json
@@ -1,0 +1,107 @@
+{
+  "api": {
+    "performance": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/performance",
+        "spec_url": "https://w3c.github.io/hr-time/#the-performance-attribute",
+        "support": {
+          "chrome": {
+            "version_added": "6"
+          },
+          "chrome_android": {
+            "version_added": true
+          },
+          "deno": {
+            "version_added": "1.0"
+          },
+          "edge": {
+            "version_added": "12"
+          },
+          "firefox": {
+            "version_added": "7"
+          },
+          "firefox_android": {
+            "version_added": "7"
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": "15"
+          },
+          "opera_android": {
+            "version_added": "14"
+          },
+          "safari": {
+            "version_added": "8"
+          },
+          "safari_ios": {
+            "version_added": "9"
+          },
+          "samsunginternet_android": {
+            "version_added": true
+          },
+          "webview_android": {
+            "version_added": true
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "worker_support": {
+        "__compat": {
+          "description": "Available in workers",
+          "support": {
+            "chrome": {
+              "version_added": true
+            },
+            "chrome_android": {
+              "version_added": true
+            },
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "≤79"
+            },
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "34"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": {
+              "version_added": true
+            },
+            "webview_android": {
+              "version_added": true
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/_globals/performance.json
+++ b/api/_globals/performance.json
@@ -2,7 +2,7 @@
   "api": {
     "performance": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/performance",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/performance_property",
         "spec_url": "https://w3c.github.io/hr-time/#the-performance-attribute",
         "support": {
           "chrome": {


### PR DESCRIPTION
This was missed in https://github.com/mdn/browser-compat-data/pull/11518.

This is defined using WindowOrWorkerGlobalScope in the spec:
https://w3c.github.io/hr-time/#the-performance-attribute

None of the data was validated or changed, just moved.