### PR TITLE
css: bg-attachment: fixed not supported on iOS

### DIFF
--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -90,9 +90,8 @@
               ],
               "safari_ios": {
                 "version_added": "5",
-                "version_removed": "13",
                 "partial_implementation": true,
-                "notes": "<code>local</code> is recognized but has no effect."
+                "notes": "<code>fixed<code> is recognized but has no effect. See <a href='https://webkit.org/b/219324'>bug 219324</a>."
               },
               "samsunginternet_android": {
                 "version_added": "1.0"

--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -90,6 +90,7 @@
               ],
               "safari_ios": {
                 "version_added": "5",
+                "version_removed": "13",
                 "partial_implementation": true,
                 "notes": "<code>local</code> is recognized but has no effect."
               },


### PR DESCRIPTION
`background-attachment: fixed` doesn't work since iOS 13, as you can verify using [this simple test](http://tools.simonsimon.nl/parallax.html) I wrote, or see in these links:

https://bugs.webkit.org/show_bug.cgi?id=196327
https://developer.apple.com/forums/thread/99883

