### PR TITLE
Node.js has global atob/btoa in version 16

### DIFF
--- a/api/_globals/atob.json
+++ b/api/_globals/atob.json
@@ -38,6 +38,9 @@
           "ie": {
             "version_added": "10"
           },
+          "nodejs": {
+            "version_added": "16.0.0"
+          },
           "opera": {
             "version_added": "10.5"
           },

--- a/api/_globals/btoa.json
+++ b/api/_globals/btoa.json
@@ -26,6 +26,9 @@
           "ie": {
             "version_added": "10"
           },
+          "nodejs": {
+            "version_added": "16.0.0"
+          },
           "opera": {
             "version_added": "10.5"
           },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Notes availability of global `atob` and `btoa` in node.js version 16.0.0.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

https://nodejs.org/api/globals.html#globals_atob_data

Note that the documentation marks it as "legacy" which means it shouldn't be used in new code, but is unlikely to be removed. Not sure if that's worth noting in the compat data.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
