### PR TITLE
Remove mdn_url from MouseWheelEvent.*

### DIFF
--- a/api/MouseWheelEvent.json
+++ b/api/MouseWheelEvent.json
@@ -49,7 +49,6 @@
       },
       "wheelDelta": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseWheelEvent/wheelDelta",
           "support": {
             "chrome": {
               "version_added": false
@@ -98,7 +97,6 @@
       },
       "wheelDeltaX": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseWheelEvent/wheelDeltaX",
           "support": {
             "chrome": {
               "version_added": true
@@ -146,7 +144,6 @@
       },
       "wheelDeltaY": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseWheelEvent/wheelDeltaY",
           "support": {
             "chrome": {
               "version_added": true


### PR DESCRIPTION
These pages don't exist and as the properties are deprecated they will never be documented on MDN. 