### PR TITLE
Mark Safari 15 as current version

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -172,14 +172,16 @@
         "14.1": {
           "release_date": "2021-04-26",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14_1-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "611.1.21.161.3"
         },
         "15": {
+          "release_date": "2021-09-20",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15-beta-release-notes",
-          "status": "beta",
-          "engine": "WebKit"
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "612.1.29.41.4"
         }
       }
     }

--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -181,7 +181,7 @@
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15-beta-release-notes",
           "status": "current",
           "engine": "WebKit",
-          "engine_version": "612.1.29.41.4"
+          "engine_version": "612.1.29"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -143,14 +143,16 @@
         "14.5": {
           "release_date": "2021-04-26",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14_1-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "611.1.21.161.6"
         },
         "15": {
+          "release_date": "2021-09-20",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15-beta-release-notes",
-          "status": "beta",
-          "engine": "WebKit"
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "612.1.29.41.4"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -152,7 +152,7 @@
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15-beta-release-notes",
           "status": "current",
           "engine": "WebKit",
-          "engine_version": "612.1.29.41.4"
+          "engine_version": "612.1.29"
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

iOS 15 has been released which includes Safari 15, and Safari 15 on mac has been release. This MR sets 15 as the current Safari (and Safari iOS) version.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

![image](https://user-images.githubusercontent.com/32498324/134068172-1829770c-bbde-4f81-a3d1-5ddb5ecf8a02.png)

