### PR TITLE
Add Safari 15 flag data

### DIFF
--- a/api/BroadcastChannel.json
+++ b/api/BroadcastChannel.json
@@ -351,6 +351,116 @@
           }
         }
       },
+      "onmessage": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BroadcastChannel/onmessage",
+          "spec_url": "https://html.spec.whatwg.org/multipage/web-messaging.html#handler-broadcastchannel-onmessage",
+          "support": {
+            "chrome": {
+              "version_added": "54"
+            },
+            "chrome_android": {
+              "version_added": "54"
+            },
+            "deno": {
+              "version_added": "1.11"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "38"
+            },
+            "firefox_android": {
+              "version_added": "38"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": "15.4.0"
+            },
+            "opera": {
+              "version_added": "41"
+            },
+            "opera_android": {
+              "version_added": "41"
+            },
+            "safari": {
+              "version_added": "15.4"
+            },
+            "safari_ios": {
+              "version_added": "15.4"
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": "54"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onmessageerror": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BroadcastChannel/onmessageerror",
+          "spec_url": "https://html.spec.whatwg.org/multipage/web-messaging.html#handler-broadcastchannel-onmessageerror",
+          "support": {
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "60"
+            },
+            "deno": {
+              "version_added": "1.11"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "57"
+            },
+            "firefox_android": {
+              "version_added": "57"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": "15.4.0"
+            },
+            "opera": {
+              "version_added": "47"
+            },
+            "opera_android": {
+              "version_added": "44"
+            },
+            "safari": {
+              "version_added": "15.4"
+            },
+            "safari_ios": {
+              "version_added": "15.4"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "60"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "postMessage": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BroadcastChannel/postMessage",

--- a/api/CSSCounterStyleRule.json
+++ b/api/CSSCounterStyleRule.json
@@ -30,11 +30,23 @@
             "version_added": "64"
           },
           "safari": {
-            "version_added": false,
+            "version_added": "15",
+            "flags": [
+              {
+                "name": "CSS @counter-style",
+                "type": "preference"
+              }
+            ],
             "notes": "See <a href='https://webkit.org/b/167645'>bug 167645</a>."
           },
           "safari_ios": {
-            "version_added": false,
+            "version_added": "15",
+            "flags": [
+              {
+                "name": "CSS @counter-style",
+                "type": "preference"
+              }
+            ],
             "notes": "See <a href='https://webkit.org/b/167645'>bug 167645</a>."
           },
           "samsunginternet_android": {
@@ -80,10 +92,22 @@
               "version_added": "64"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ]
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ]
             },
             "samsunginternet_android": {
               "version_added": "16.0"
@@ -129,10 +153,22 @@
               "version_added": "64"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ]
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ]
             },
             "samsunginternet_android": {
               "version_added": "16.0"
@@ -178,10 +214,22 @@
               "version_added": "64"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ]
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ]
             },
             "samsunginternet_android": {
               "version_added": "16.0"
@@ -227,10 +275,22 @@
               "version_added": "64"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ]
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ]
             },
             "samsunginternet_android": {
               "version_added": "16.0"
@@ -276,10 +336,22 @@
               "version_added": "64"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ]
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ]
             },
             "samsunginternet_android": {
               "version_added": "16.0"
@@ -325,10 +397,22 @@
               "version_added": "64"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ]
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ]
             },
             "samsunginternet_android": {
               "version_added": "16.0"
@@ -374,10 +458,22 @@
               "version_added": "64"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ]
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ]
             },
             "samsunginternet_android": {
               "version_added": "16.0"
@@ -423,10 +519,22 @@
               "version_added": "64"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ]
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ]
             },
             "samsunginternet_android": {
               "version_added": "16.0"
@@ -472,10 +580,22 @@
               "version_added": "64"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ]
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ]
             },
             "samsunginternet_android": {
               "version_added": "16.0"
@@ -521,10 +641,22 @@
               "version_added": "64"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ]
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ]
             },
             "samsunginternet_android": {
               "version_added": "16.0"
@@ -570,10 +702,22 @@
               "version_added": "64"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ]
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ]
             },
             "samsunginternet_android": {
               "version_added": "16.0"

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -714,11 +714,23 @@
               "version_added": "54"
             },
             "safari": {
-              "version_added": false,
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "Form requestSubmit",
+                  "type": "preference"
+                }
+              ],
               "notes": "See <a href='https://webkit.org/b/197958'>bug 197958</a>."
             },
             "safari_ios": {
-              "version_added": false,
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "Form requestSubmit",
+                  "type": "preference"
+                }
+              ],
               "notes": "See <a href='https://webkit.org/b/197958'>bug 197958</a>."
             },
             "samsunginternet_android": {

--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -176,10 +176,22 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "PerformanceResourceTiming.transferSize, encodedBodySize, and decodedBodySize",
+                  "type": "preference"
+                }
+              ]
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "PerformanceResourceTiming.transferSize, encodedBodySize, and decodedBodySize",
+                  "type": "preference"
+                }
+              ]
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -323,10 +335,22 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "PerformanceResourceTiming.transferSize, encodedBodySize, and decodedBodySize",
+                  "type": "preference"
+                }
+              ]
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "PerformanceResourceTiming.transferSize, encodedBodySize, and decodedBodySize",
+                  "type": "preference"
+                }
+              ]
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -911,10 +935,22 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "PerformanceResourceTiming.transferSize, encodedBodySize, and decodedBodySize",
+                  "type": "preference"
+                }
+              ]
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "PerformanceResourceTiming.transferSize, encodedBodySize, and decodedBodySize",
+                  "type": "preference"
+                }
+              ]
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/css/at-rules/counter-style.json
+++ b/css/at-rules/counter-style.json
@@ -32,11 +32,23 @@
               "version_added": "64"
             },
             "safari": {
-              "version_added": false,
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ],
               "notes": "See <a href='https://webkit.org/b/167645'>bug 167645</a>."
             },
             "safari_ios": {
-              "version_added": false,
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": "CSS @counter-style",
+                  "type": "preference"
+                }
+              ],
               "notes": "See <a href='https://webkit.org/b/167645'>bug 167645</a>."
             },
             "samsunginternet_android": {
@@ -83,10 +95,22 @@
                 "version_added": "64"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "name": "CSS @counter-style",
+                    "type": "preference"
+                  }
+                ]
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "name": "CSS @counter-style",
+                    "type": "preference"
+                  }
+                ]
               },
               "samsunginternet_android": {
                 "version_added": "16.0"
@@ -133,10 +157,22 @@
                 "version_added": "64"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "name": "CSS @counter-style",
+                    "type": "preference"
+                  }
+                ]
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "name": "CSS @counter-style",
+                    "type": "preference"
+                  }
+                ]
               },
               "samsunginternet_android": {
                 "version_added": "16.0"
@@ -183,10 +219,22 @@
                 "version_added": "64"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "name": "CSS @counter-style",
+                    "type": "preference"
+                  }
+                ]
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "name": "CSS @counter-style",
+                    "type": "preference"
+                  }
+                ]
               },
               "samsunginternet_android": {
                 "version_added": "16.0"
@@ -233,10 +281,22 @@
                 "version_added": "64"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "name": "CSS @counter-style",
+                    "type": "preference"
+                  }
+                ]
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "name": "CSS @counter-style",
+                    "type": "preference"
+                  }
+                ]
               },
               "samsunginternet_android": {
                 "version_added": "16.0"
@@ -283,10 +343,22 @@
                 "version_added": "64"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "name": "CSS @counter-style",
+                    "type": "preference"
+                  }
+                ]
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "name": "CSS @counter-style",
+                    "type": "preference"
+                  }
+                ]
               },
               "samsunginternet_android": {
                 "version_added": "16.0"
@@ -333,10 +405,22 @@
                 "version_added": "64"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "name": "CSS @counter-style",
+                    "type": "preference"
+                  }
+                ]
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "name": "CSS @counter-style",
+                    "type": "preference"
+                  }
+                ]
               },
               "samsunginternet_android": {
                 "version_added": "16.0"
@@ -383,10 +467,22 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "name": "CSS @counter-style",
+                    "type": "preference"
+                  }
+                ]
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "name": "CSS @counter-style",
+                    "type": "preference"
+                  }
+                ]
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -433,10 +529,22 @@
                 "version_added": "64"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "name": "CSS @counter-style",
+                    "type": "preference"
+                  }
+                ]
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "name": "CSS @counter-style",
+                    "type": "preference"
+                  }
+                ]
               },
               "samsunginternet_android": {
                 "version_added": "16.0"
@@ -497,10 +605,30 @@
                 "notes": "Does not support <code>&lt;image&gt;</code> as a value for the <code>symbols</code> descriptor."
               },
               "safari": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "name": "CSS @counter-style",
+                    "type": "preference"
+                  },
+                  {
+                    "name": "CSS @counter-style <image> symbols",
+                    "type": "preference"
+                  }
+                ]
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "name": "CSS @counter-style",
+                    "type": "preference"
+                  },
+                  {
+                    "name": "CSS @counter-style <image> symbols",
+                    "type": "preference"
+                  }
+                ]
               },
               "samsunginternet_android": {
                 "version_added": "16.0",
@@ -551,10 +679,22 @@
                 "version_added": "64"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "name": "CSS @counter-style",
+                    "type": "preference"
+                  }
+                ]
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "name": "CSS @counter-style",
+                    "type": "preference"
+                  }
+                ]
               },
               "samsunginternet_android": {
                 "version_added": "16.0"

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -94,16 +94,22 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "preview",
+                "version_added": "15",
                 "flags": [
                   {
-                    "type": "preference",
-                    "name": "CSS overflow: clip support"
+                    "name": "CSS overflow: clip support",
+                    "type": "preference"
                   }
                 ]
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15",
+                "flags": [
+                  {
+                    "name": "CSS overflow: clip support",
+                    "type": "preference"
+                  }
+                ]
               },
               "samsunginternet_android": {
                 "version_added": "15.0"

--- a/css/selectors/focus-visible.json
+++ b/css/selectors/focus-visible.json
@@ -104,11 +104,23 @@
               }
             ],
             "safari": {
-              "version_added": false,
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": ":focus-visible pseudo-class",
+                  "type": "preference"
+                }
+              ],
               "notes": "See <a href='https://webkit.org/b/185859'>bug 185859</a>."
             },
             "safari_ios": {
-              "version_added": false,
+              "version_added": "15",
+              "flags": [
+                {
+                  "name": ":focus-visible pseudo-class",
+                  "type": "preference"
+                }
+              ],
               "notes": "See <a href='https://webkit.org/b/185859'>bug 185859</a>."
             },
             "samsunginternet_android": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

This PR adds Safari 15 flag data. These are new (mostly) off by default flags that are added in Safari 15.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

This data comes from looking through the Experimental Features UI in Safari's interface (Settings -> Safari -> Advanced -> Experimental Features for iOS)
