### PR TITLE
Missing Samsung Internet 16.0 support data

### DIFF
--- a/api/CSSCounterStyleRule.json
+++ b/api/CSSCounterStyleRule.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "16.0"
           },
           "webview_android": {
             "version_added": "91"
@@ -84,7 +84,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "16.0"
             },
             "webview_android": {
               "version_added": "91"
@@ -133,7 +133,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "16.0"
             },
             "webview_android": {
               "version_added": "91"
@@ -182,7 +182,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "16.0"
             },
             "webview_android": {
               "version_added": "91"
@@ -231,7 +231,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "16.0"
             },
             "webview_android": {
               "version_added": "91"
@@ -280,7 +280,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "16.0"
             },
             "webview_android": {
               "version_added": "91"
@@ -329,7 +329,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "16.0"
             },
             "webview_android": {
               "version_added": "91"
@@ -378,7 +378,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "16.0"
             },
             "webview_android": {
               "version_added": "91"
@@ -427,7 +427,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "16.0"
             },
             "webview_android": {
               "version_added": "91"
@@ -476,7 +476,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "16.0"
             },
             "webview_android": {
               "version_added": "91"
@@ -525,7 +525,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "16.0"
             },
             "webview_android": {
               "version_added": "91"
@@ -574,7 +574,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "16.0"
             },
             "webview_android": {
               "version_added": "91"

--- a/api/GravitySensor.json
+++ b/api/GravitySensor.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "16.0"
           },
           "webview_android": {
             "version_added": "91"
@@ -85,7 +85,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "16.0"
             },
             "webview_android": {
               "version_added": "91"

--- a/css/at-rules/counter-style.json
+++ b/css/at-rules/counter-style.json
@@ -38,7 +38,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "16.0"
             },
             "webview_android": {
               "version_added": "91"
@@ -87,7 +87,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "16.0"
               },
               "webview_android": {
                 "version_added": "91"
@@ -137,7 +137,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "16.0"
               },
               "webview_android": {
                 "version_added": "91"
@@ -187,7 +187,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "16.0"
               },
               "webview_android": {
                 "version_added": "91"
@@ -237,7 +237,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "16.0"
               },
               "webview_android": {
                 "version_added": "91"
@@ -287,7 +287,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "16.0"
               },
               "webview_android": {
                 "version_added": "91"
@@ -337,7 +337,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "16.0"
               },
               "webview_android": {
                 "version_added": "91"
@@ -437,7 +437,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "16.0"
               },
               "webview_android": {
                 "version_added": "91"
@@ -501,7 +501,9 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "16.0",
+                "partial_implementation": true,
+                "notes": "Does not support <code>&lt;image&gt;</code> as a value for the <code>symbols</code> descriptor."
               },
               "webview_android": {
                 "version_added": "91",
@@ -553,7 +555,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "16.0"
               },
               "webview_android": {
                 "version_added": "91"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Added missing Support Information from Samsung Internet 16.0

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

This is data from Chrome 91 that wasn't copied across when Samsung Internet 16 was originally added.
