### PR TITLE
Add Intl.getSupportedValuesOf()

### DIFF
--- a/javascript/builtins/intl/Intl.json
+++ b/javascript/builtins/intl/Intl.json
@@ -110,6 +110,61 @@
             }
           }
         },
+        "supportedValuesOf": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf",
+            "spec_url": "https://tc39.es/ecma402/#sec-intl.supportedvaluesof",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "93"
+              },
+              "firefox_android": {
+                "version_added": "93"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "@@toStringTag": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/@@toStringTag",


### PR DESCRIPTION
This adds `Intl.getSupportedValuesOf()` which was added to FF93 in https://bugzilla.mozilla.org/show_bug.cgi?id=1670033.
Docs work tracking in https://github.com/mdn/content/issues/8618

I have tested and it is not in Chrome, which matches the tracking bug: https://bugs.chromium.org/p/v8/issues/detail?id=10743. I can't find evidence of it in Safari either (but have not tested). 

NOTE, the spec this is in is at stage 3: https://github.com/tc39/proposal-intl-enumeration
The URL for the "proposal spec" is not allowed (https://tc39.es/proposal-intl-enumeration/#sec-intl.supportedvaluesof). What I have done is put in the spec URL where the record will eventually go .

Marked experimental as FF is currently only implementation.