### PR TITLE
Add Safari versions for api.CacheStorage.secure_context_required

### DIFF
--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -375,10 +375,10 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "9.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `secure_context_required` member of the `CacheStorage` API.  By looking at the commit history (https://bugs.webkit.org/show_bug.cgi?id=175201, https://github.com/WebKit/WebKit/commit/25941073a6118fe00317ba6f14939409f1184560#diff-596ea61dc2e49a442d0317ce66a2ee9fb8fd4938a32ad74d4d97e1eb332dfbbd), it appears that Safari required a secure context right when this interface was implemented.
