### PR TITLE
JS class static inititialization blocks

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -160,62 +160,6 @@
           "deprecated": false
         }
       },
-      "static_initialization_blocks": {
-        "__compat": {
-          "description": "Class static initialization blocks",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Class_static_initialization_blocks",
-          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#prod-ClassStaticBlock",
-          "support": {
-            "chrome": {
-              "version_added": "94"
-            },
-            "chrome_android": {
-              "version_added": "94"
-            },
-            "deno": {
-              "version_added": "1.14"
-            },
-            "edge": {
-              "version_added": "94"
-            },
-            "firefox": {
-              "version_added": "93"
-            },
-            "firefox_android": {
-              "version_added": "93"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "nodejs": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "80"
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": "94"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "constructor": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/constructor",
@@ -986,6 +930,62 @@
             },
             "webview_android": {
               "version_added": "72"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "static_initialization_blocks": {
+        "__compat": {
+          "description": "Class static initialization blocks",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Class_static_initialization_blocks",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#prod-ClassStaticBlock",
+          "support": {
+            "chrome": {
+              "version_added": "94"
+            },
+            "chrome_android": {
+              "version_added": "94"
+            },
+            "deno": {
+              "version_added": "1.14"
+            },
+            "edge": {
+              "version_added": "94"
+            },
+            "firefox": {
+              "version_added": "93"
+            },
+            "firefox_android": {
+              "version_added": "93"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "80"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "94"
             }
           },
           "status": {

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -160,6 +160,62 @@
           "deprecated": false
         }
       },
+      "class_static_initialization_blocks": {
+        "__compat": {
+          "description": "Class static initialization blocks",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Class_static_initialization_blocks",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#prod-ClassStaticBlock",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "93"
+            },
+            "firefox_android": {
+              "version_added": "93"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "constructor": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/constructor",

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -160,7 +160,7 @@
           "deprecated": false
         }
       },
-      "class_static_initialization_blocks": {
+      "static_initialization_blocks": {
         "__compat": {
           "description": "Class static initialization blocks",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/Class_static_initialization_blocks",

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -210,7 +210,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -167,16 +167,16 @@
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#prod-ClassStaticBlock",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "94"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "94"
             },
             "deno": {
-              "version_added": false
+              "version_added": "1.14"
             },
             "edge": {
-              "version_added": false
+              "version_added": "94"
             },
             "firefox": {
               "version_added": "93"
@@ -191,7 +191,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -206,7 +206,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "94"
             }
           },
           "status": {


### PR DESCRIPTION
FF93 just added support for class static initialization blocks: https://bugzilla.mozilla.org/show_bug.cgi?id=1725689 (actually they were present behind a preference in FF92, but I didn't know about that, and I'm not sure it's useful).

This is present in FF93. It is present in v8 engine [from v9.4](https://v8.dev/blog/v8-release-94) went into Chrome 94 and Deno 1.14. I also tested this in nodejs using the latest NVM I can get v16.9.1 on Ubuntu and that says we're still at v8 engine `9.3.345.16-node.12`.

Test code is just a block of javascript that either dumps output to console or gives me a syntax error:
```js
class C {
  // This block will run when the class itself is evaluated
  static { 
    console.log("C's static block");
  }
}
```

Explainer on this feature here: https://v8.dev/features/class-static-initializer-blocks (MDN docs under construction)