### PR TITLE
Add Deno data for Object.assign

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -122,6 +122,9 @@
               "chrome_android": {
                 "version_added": "45"
               },
+              "deno": {
+                "version_added": "1.0"
+              },
               "edge": {
                 "version_added": "12"
               },


### PR DESCRIPTION
#### Summary
This PR adds Deno version data for `Object.assign` JS builtin

#### Test results and supporting details

Downgrade deno to v1.0 with the command `deno upgrade --version 1.0.0`, and you can check that Object.assign exists with the below commands:
```shellsession
$ deno --version
deno 1.0.0
v8 8.4.300
typescript 3.9.2
$ deno eval "console.log(Object.assign({foo: 1}, {bar: 2}))"
{ foo: 1, bar: 2 }
```
