### PR TITLE
Add webextensions.onCommand.tab

### DIFF
--- a/webextensions/api/commands.json
+++ b/webextensions/api/commands.json
@@ -25,6 +25,54 @@
                 "version_added": "14"
               }
             }
+          },
+          "name": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": "14"
+                }
+              }
+            }
+          },
+          "tab": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "86"
+                },
+                "edge": {
+                  "version_added": "86"
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "72"
+                },
+                "safari": {
+                  "version_added": null
+                }
+              }
+            }
           }
         },
         "getAll": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Add compatibility data for WebExtension Commands API callback arguments. Specifically, this adds the second `tab` argument. `onCommand.name.__compat` is taken from `onCommand.__compat`.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
[Chromium docs](https://developer.chrome.com/docs/extensions/reference/commands/#event-onCommand) showing "Chrome 86+" next to `tabs`.
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
