### PR TITLE
Add Safari versions for Screen API

### DIFF
--- a/api/Screen.json
+++ b/api/Screen.json
@@ -376,7 +376,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -775,7 +775,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `Screen` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.3.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Screen
