### PR TITLE
Add all browsers versions for TextDecoder API

### DIFF
--- a/api/TextDecoder.json
+++ b/api/TextDecoder.json
@@ -54,7 +54,7 @@
             "version_added": "25"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "25"
           },
           "safari": {
             "version_added": "10.1"
@@ -91,7 +91,7 @@
               "version_added": "1.0"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -123,7 +123,7 @@
               "version_added": "25"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "25"
             },
             "safari": {
               "version_added": "10.1"
@@ -199,7 +199,7 @@
               "version_added": "25"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "safari": {
               "version_added": "10.1"
@@ -268,7 +268,7 @@
               "version_added": "25"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "safari": {
               "version_added": "10.1"
@@ -295,10 +295,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextDecoder/fatal",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "38"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "38"
             },
             "deno": {
               "version_added": "1.0"
@@ -307,10 +307,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "36"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "36"
             },
             "ie": {
               "version_added": false
@@ -319,10 +319,10 @@
               "version_added": "8.3.0"
             },
             "opera": {
-              "version_added": true
+              "version_added": "25"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "safari": {
               "version_added": "10.1"
@@ -331,10 +331,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "38"
             }
           },
           "status": {
@@ -349,10 +349,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextDecoder/ignoreBOM",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "38"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "38"
             },
             "deno": {
               "version_added": "1.0"
@@ -361,10 +361,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "63"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "63"
             },
             "ie": {
               "version_added": false
@@ -373,10 +373,10 @@
               "version_added": "8.3.0"
             },
             "opera": {
-              "version_added": true
+              "version_added": "25"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "safari": {
               "version_added": "10.1"
@@ -385,10 +385,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "38"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for all browsers for the `TextDecoder` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.3.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TextDecoder

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
