### PR TITLE
Add Firefox versions for api.Text.replaceWholeText

### DIFF
--- a/api/Text.json
+++ b/api/Text.json
@@ -164,11 +164,11 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "10"
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "4",
               "version_removed": "10"
             },
             "ie": {


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `replaceWholeText` member of the `Text` API.  This is just setting a version number for this feature, because this feature is queued for removal as it is.  This is just to make sure that it doesn't get in the way of the real value percentage in the meantime.
