### PR TITLE
Add Firefox versions for api.ServiceWorkerContainer.onmessageerror

### DIFF
--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -416,10 +416,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "65"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "65"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `onmessageerror` member of the `ServiceWorkerContainer` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.3.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ServiceWorkerContainer/onmessageerror

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
