### PR TITLE
Reinstate Jean-Yves Perrier as a peer

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -54,14 +54,14 @@ It is important to recognize that being a Peer is a privilege, not a right. That
 
 #### List of current peers
 
-- Rachel Andrew (@rachelandrew)
-- Vinyl Da.i'gyu (@queengooborg)
 - Alexis Deveria (@Fyrd), Adobe, https://caniuse.com
-- Ryan Johnson (@escattone), Mozilla
+- Jean-Yves Perrier (@teoli2003), Open Web Docs
 - Joe Medley (@jpmedley), Google
 - Michael Smith (@sideshowbarker), W3C
 - Philip Jägenstedt (@foolip), Google
-- Jean-Yves Perrier (@teoli2003), Open Web Docs
+- Rachel Andrew (@rachelandrew)
+- Ryan Johnson (@escattone), Mozilla
+- Vinyl Da.i'gyu (@queengooborg)
 
 A Peer who shows an above-average level of contribution to the project, particularly with respect to its strategic direction and long-term health, may be nominated to become an Owner, described below.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -61,6 +61,7 @@ It is important to recognize that being a Peer is a privilege, not a right. That
 - Joe Medley (@jpmedley), Google
 - Michael Smith (@sideshowbarker), W3C
 - Philip Jägenstedt (@foolip), Google
+- Jean-Yves Perrier (@teoli2003), Open Web Docs
 
 A Peer who shows an above-average level of contribution to the project, particularly with respect to its strategic direction and long-term health, may be nominated to become an Owner, described below.
 
@@ -165,7 +166,6 @@ The moderator is responsible for summarizing the discussion of each agenda item 
 The `@mdn/browser-compat-data` project would like to thank the following former Owners and Peers for their contributions and the countless hours invested.
 
 - Richard Bloor (@rebloor) (Peer for WebExtensions compat data)
-- Jean-Yves Perrier (@teoli2003) (Former project lead, schema design co-author)
 - Eric Shepherd (@a2sheppy) (BCD peer until August 2020)
 - Kadir Topal (@atopal) (BCD co-owner until September 2020)
 - Estelle Weyl (@estelle) (Peer for CSS compat data)

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -165,11 +165,11 @@ The moderator is responsible for summarizing the discussion of each agenda item 
 
 The `@mdn/browser-compat-data` project would like to thank the following former Owners and Peers for their contributions and the countless hours invested.
 
-- Richard Bloor (@rebloor) (Peer for WebExtensions compat data)
 - Eric Shepherd (@a2sheppy) (BCD peer until August 2020)
-- Kadir Topal (@atopal) (BCD co-owner until September 2020)
 - Estelle Weyl (@estelle) (Peer for CSS compat data)
 - John Whitlock (@jwhitlock) (Technical design of the former compat data project)
+- Kadir Topal (@atopal) (BCD co-owner until September 2020)
+- Richard Bloor (@rebloor) (Peer for WebExtensions compat data)
 
 ## Credits
 


### PR DESCRIPTION
Recently, @teoli2003 has returned to active participation in the project, on behalf of Open Web Docs. I think it's time to reinstate Jean-Yves as a peer. This PR moves Jean-Yves to the list of active peers.

Since I was looking at this anyway, I've also sorted the peers and emeriti lists (the owners list needs a separate update—I'll fix that when I mess with it next). See the commits for a breakdown of the changes.

If Jean-Yves approves this PR and @Elchi3 merges it, then I'll reactivate Jean-Yves's power to commit data PRs.