### PR TITLE
Set Chrome 94 as current

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -645,19 +645,28 @@
         "93": {
           "release_date": "2021-08-31",
           "release_notes": "https://chromereleases.googleblog.com/2021/08/stable-channel-update-for-desktop_31.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "93"
         },
         "94": {
-          "status": "beta",
+          "release_date": "2021-09-21",
+          "release_notes": "https://chromereleases.googleblog.com/2021/09/stable-channel-update-for-desktop_21.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "94"
         },
         "95": {
-          "status": "nightly",
+          "release_date": "2021-10-19",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "95"
+        },
+        "96": {
+          "release_date": "2021-11-16",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "96"
         }
       }
     }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -481,19 +481,28 @@
         "93": {
           "release_date": "2021-08-31",
           "release_notes": "https://chromereleases.googleblog.com/2021/08/chrome-for-android-update_0881967577.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "93"
         },
         "94": {
-          "status": "beta",
+          "release_date": "2021-09-21",
+          "release_notes": "https://chromereleases.googleblog.com/2021/09/chrome-for-android-update_21.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "94"
         },
         "95": {
-          "status": "nightly",
+          "release_date": "2021-10-19",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "95"
+        },
+        "96": {
+          "release_date": "2021-11-16",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "96"
         }
       }
     }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -446,19 +446,28 @@
         "93": {
           "release_date": "2021-08-31",
           "release_notes": "https://chromereleases.googleblog.com/2021/08/chrome-for-android-update_0881967577.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "93"
         },
         "94": {
-          "status": "beta",
+          "release_date": "2021-09-21",
+          "release_notes": "https://chromereleases.googleblog.com/2021/09/chrome-for-android-update_21.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "94"
         },
         "95": {
-          "status": "nightly",
+          "release_date": "2021-10-19",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "95"
+        },
+        "96": {
+          "release_date": "2021-11-16",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "96"
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Set Chrome, Chrome Android and Webview Android v94 as current.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://chromereleases.googleblog.com/2021/09/stable-channel-update-for-desktop_21.html

https://chromereleases.googleblog.com/2021/09/chrome-for-android-update_21.html

https://www.chromestatus.com/features/schedule - for the Chrome 95, and 96 release dates.
