### PR TITLE
Set Chrome 94 as supporting display-capture feature policy

### DIFF
--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -352,13 +352,13 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "94"
               },
               "chrome_android": {
                 "version_added": false
               },
               "edge": {
-                "version_added": false
+                "version_added": "94"
               },
               "firefox": {
                 "version_added": "67",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

This PR updates support for the `display-capture` feature policy, to include Chrome and Edge 94.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://www.chromestatus.com/feature/5144822362931200 - Shows this is enabled in Desktop 94.
