### PR TITLE
Added self.reportError compat data.

### DIFF
--- a/api/_globals/reportError.json
+++ b/api/_globals/reportError.json
@@ -1,0 +1,112 @@
+{
+  "api": {
+    "reportError": {
+      "__compat": {
+        "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#runtime-script-errors",
+        "support": {
+          "chrome": {
+            "version_added": "95"
+          },
+          "chrome_android": {
+            "version_added": "95"
+          },
+          "deno": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": "95"
+          },
+          "firefox": {
+            "version_added": "93"
+          },
+          "firefox_android": {
+            "version_added": "93"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "nodejs": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "preview"
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "95"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "worker_support": {
+        "__compat": {
+          "description": "Available in workers",
+          "support": {
+            "chrome": {
+              "version_added": "95"
+            },
+            "chrome_android": {
+              "version_added": "95"
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "95"
+            },
+            "firefox": {
+              "version_added": "93"
+            },
+            "firefox_android": {
+              "version_added": "93"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "preview"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "95"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Adds browser support data for `self.reportError()`. 

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Firefox tracking bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1722448 - Milestone 93

Chrome feature status: https://www.chromestatus.com/feature/5634523220934656 - Milestone 95

Safari TP release notes: https://webkit.org/blog/11971/release-notes-for-safari-technology-preview-132/#:~:text=Implemented%20self.reportError()
