### PR TITLE
Update api.Animation.pending as shipped in Chromium 76

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -661,16 +661,16 @@
       "pending": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/pending",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-currenttime",
+          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-pending",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "76"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "76"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "59",
@@ -684,10 +684,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "63"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": "13.1"
@@ -696,10 +696,10 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "76"
             }
           },
           "status": {


### PR DESCRIPTION
Chrome 76 is from mdn-bcd-collector results:
http://mdn-bcd-collector.appspot.com/tests/api/Animation/pending

The rest is mirrored, with the assumption that this wasn't in Edge 18.

Also fix the incorrect spec URL.
