### PR TITLE
Update FontFaceSet data

### DIFF
--- a/api/FontFaceSet.json
+++ b/api/FontFaceSet.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "22"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "22"
           },
           "safari": {
             "version_added": "10"
@@ -36,14 +36,14 @@
             "version_added": "10"
           },
           "samsunginternet_android": {
-            "version_added": "4.0"
+            "version_added": "3.0"
           },
           "webview_android": {
-            "version_added": "37"
+            "version_added": "4.4.3"
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -101,13 +101,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/add",
           "support": {
             "chrome": {
-              "version_added": "48"
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": "48"
+              "version_added": "35"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "41"
@@ -119,10 +119,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "35"
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": "35"
+              "version_added": "22"
             },
             "safari": {
               "version_added": "10"
@@ -131,14 +131,14 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "48"
+              "version_added": "4.4.3"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -156,7 +156,7 @@
               "version_added": "35"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "41"
@@ -168,10 +168,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "22"
             },
             "safari": {
               "version_added": "10"
@@ -180,14 +180,14 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "4.4.3"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -198,13 +198,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/clear",
           "support": {
             "chrome": {
-              "version_added": "48"
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": "48"
+              "version_added": "35"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "41"
@@ -216,10 +216,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "35"
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": "35"
+              "version_added": "22"
             },
             "safari": {
               "version_added": "10"
@@ -228,14 +228,14 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "48"
+              "version_added": "4.4.3"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -246,13 +246,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/delete",
           "support": {
             "chrome": {
-              "version_added": "48"
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": "48"
+              "version_added": "35"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "41"
@@ -264,10 +264,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "35"
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": "35"
+              "version_added": "22"
             },
             "safari": {
               "version_added": "10"
@@ -276,14 +276,14 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "48"
+              "version_added": "4.4.3"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -293,13 +293,13 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "48"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "41"
@@ -311,10 +311,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "35"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "35"
             },
             "safari": {
               "version_added": "10"
@@ -323,10 +323,10 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "48"
             }
           },
           "status": {
@@ -340,13 +340,13 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "35"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "41"
@@ -358,10 +358,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "22"
             },
             "safari": {
               "version_added": "10"
@@ -370,10 +370,10 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -387,13 +387,13 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "35"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "41"
@@ -405,10 +405,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "22"
             },
             "safari": {
               "version_added": "10"
@@ -417,10 +417,10 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -434,13 +434,13 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "48"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "41"
@@ -452,10 +452,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "35"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "35"
             },
             "safari": {
               "version_added": "10"
@@ -464,10 +464,10 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "48"
             }
           },
           "status": {
@@ -489,7 +489,7 @@
               "version_added": "35"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "41"
@@ -501,10 +501,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "35"
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": "35"
+              "version_added": "22"
             },
             "safari": {
               "version_added": "10"
@@ -513,14 +513,14 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "4.4.3"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -531,13 +531,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/onloading",
           "support": {
             "chrome": {
-              "version_added": "48"
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": "48"
+              "version_added": "35"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "41"
@@ -549,10 +549,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "35"
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": "35"
+              "version_added": "22"
             },
             "safari": {
               "version_added": "10"
@@ -561,14 +561,14 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "48"
+              "version_added": "4.4.3"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -579,13 +579,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/onloadingdone",
           "support": {
             "chrome": {
-              "version_added": "48"
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": "48"
+              "version_added": "35"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "41"
@@ -597,10 +597,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "35"
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": "35"
+              "version_added": "22"
             },
             "safari": {
               "version_added": "10"
@@ -609,14 +609,14 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "48"
+              "version_added": "4.4.3"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -627,13 +627,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/onloadingerror",
           "support": {
             "chrome": {
-              "version_added": "48"
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": "48"
+              "version_added": "35"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "41"
@@ -645,10 +645,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "35"
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": "35"
+              "version_added": "22"
             },
             "safari": {
               "version_added": "10"
@@ -657,14 +657,14 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "48"
+              "version_added": "4.4.3"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -682,7 +682,7 @@
               "version_added": "35"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "41"
@@ -694,10 +694,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "35"
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": "35"
+              "version_added": "22"
             },
             "safari": {
               "version_added": "10"
@@ -706,14 +706,14 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "4.4.3"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -723,13 +723,13 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "35"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "41"
@@ -741,10 +741,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "22"
             },
             "safari": {
               "version_added": "10"
@@ -753,10 +753,10 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -771,13 +771,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/status",
           "support": {
             "chrome": {
-              "version_added": "48"
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": "48"
+              "version_added": "35"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "41"
@@ -789,10 +789,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "35"
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": "35"
+              "version_added": "22"
             },
             "safari": {
               "version_added": "10"
@@ -801,14 +801,14 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "48"
+              "version_added": "4.4.3"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -818,13 +818,13 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "48"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "41"
@@ -836,10 +836,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "35"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "35"
             },
             "safari": {
               "version_added": "10"
@@ -848,10 +848,10 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "48"
             }
           },
           "status": {
@@ -884,10 +884,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "safari": {
               "version_added": false
@@ -903,7 +903,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
Chrome and Edge versions are from mdn-bcd-collector:
https://mdn-bcd-collector.appspot.com/tests/api/FontFaceSet

See https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes
for how the collector works.

The other data was mirrored from Chrome.

Note that the data now better matches document.fonts:
https://developer.mozilla.org/en-US/docs/Web/API/Document/fonts#browser_compatibility
