### PR TITLE
Update Firefox support for feature-policy

### DIFF
--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -1446,64 +1446,30 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "92",
-                  "partial_implementation": true,
-                  "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements.",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "media.setsinkid.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                {
-                  "version_added": "92",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.security.featurePolicy.header.enabled",
-                      "value_to_set": "true"
-                    },
-                    {
-                      "type": "preference",
-                      "name": "media.setsinkid.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "92",
-                  "partial_implementation": true,
-                  "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements.",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "media.setsinkid.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                {
-                  "version_added": "92",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.security.featurePolicy.header.enabled",
-                      "value_to_set": "true"
-                    },
-                    {
-                      "type": "preference",
-                      "name": "media.setsinkid.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "92",
+                "partial_implementation": true,
+                "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.setsinkid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": {
+                "version_added": "92",
+                "partial_implementation": true,
+                "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "media.setsinkid.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
               "ie": {
                 "version_added": false
               },

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -15,26 +15,40 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "65",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.featurePolicy.header.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": {
-              "version_added": "65",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.featurePolicy.header.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "74",
+                "partial_implementation": true,
+                "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+              },
+              {
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "79",
+                "partial_implementation": true,
+                "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+              },
+              {
+                "version_added": "65",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.security.featurePolicy.header.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -62,7 +76,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -294,26 +308,40 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              "firefox_android": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "74",
+                  "partial_implementation": true,
+                  "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+                },
+                {
+                  "version_added": "65",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "79",
+                  "partial_implementation": true,
+                  "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+                },
+                {
+                  "version_added": "65",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -337,7 +365,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -551,27 +579,48 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": {
-                "version_added": "65",
-                "notes": "Before Firefox 80, applying <code>fullscreen</code> to an <code>&lt;iframe&gt;</code> (i.e. via the <code>allow</code> attribute) does not work unless the <code>allowfullscreen</code> attribute is also present.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              "firefox_android": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "74",
+                  "partial_implementation": true,
+                  "notes": [
+                    "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements.",
+                    "Before Firefox 80, applying <code>fullscreen</code> to an <code>&lt;iframe&gt;</code> (i.e. via the <code>allow</code> attribute) does not work unless the <code>allowfullscreen</code> attribute is also present."
+                  ]
+                },
+                {
+                  "version_added": "65",
+                  "notes": "Before Firefox 80, applying <code>fullscreen</code> to an <code>&lt;iframe&gt;</code> (i.e. via the <code>allow</code> attribute) does not work unless the <code>allowfullscreen</code> attribute is also present.",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "79",
+                  "partial_implementation": true,
+                  "notes": [
+                    "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements.",
+                    "Before Firefox 80, applying <code>fullscreen</code> to an <code>&lt;iframe&gt;</code> (i.e. via the <code>allow</code> attribute) does not work unless the <code>allowfullscreen</code> attribute is also present."
+                  ]
+                },
+                {
+                  "version_added": "65",
+                  "notes": "Before Firefox 80, applying <code>fullscreen</code> to an <code>&lt;iframe&gt;</code> (i.e. via the <code>allow</code> attribute) does not work unless the <code>allowfullscreen</code> attribute is also present.",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -595,7 +644,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -636,14 +685,48 @@
                   }
                 ]
               },
-              "firefox": {
-                "version_added": "91",
-                "notes": "The default allowlist is <code>*</code> instead of <code>self</code> (as required by the specification)."
-              },
-              "firefox_android": {
-                "version_added": "91",
-                "notes": "The default allowlist is <code>*</code> instead of <code>self</code> (as required by the specification)."
-              },
+              "firefox": [
+                {
+                  "version_added": "91",
+                  "partial_implementation": true,
+                  "notes": [
+                    "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements.",
+                    "The default allowlist is <code>*</code> instead of <code>self</code> (as required by the specification)."
+                  ]
+                },
+                {
+                  "version_added": "91",
+                  "notes": "The default allowlist is <code>*</code> instead of <code>self</code> (as required by the specification).",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "91",
+                  "partial_implementation": true,
+                  "notes": [
+                    "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements.",
+                    "The default allowlist is <code>*</code> instead of <code>self</code> (as required by the specification)."
+                  ]
+                },
+                {
+                  "version_added": "91",
+                  "notes": "The default allowlist is <code>*</code> instead of <code>self</code> (as required by the specification).",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -694,26 +777,40 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              "firefox_android": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "74",
+                  "partial_implementation": true,
+                  "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+                },
+                {
+                  "version_added": "65",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "79",
+                  "partial_implementation": true,
+                  "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+                },
+                {
+                  "version_added": "65",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -951,26 +1048,40 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              "firefox_android": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "74",
+                  "partial_implementation": true,
+                  "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+                },
+                {
+                  "version_added": "65",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "79",
+                  "partial_implementation": true,
+                  "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+                },
+                {
+                  "version_added": "65",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -994,7 +1105,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -1335,12 +1446,64 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "92"
-              },
-              "firefox_android": {
-                "version_added": "92"
-              },
+              "firefox": [
+                {
+                  "version_added": "92",
+                  "partial_implementation": true,
+                  "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements.",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "media.setsinkid.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "92",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    },
+                    {
+                      "type": "preference",
+                      "name": "media.setsinkid.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "92",
+                  "partial_implementation": true,
+                  "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements.",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "media.setsinkid.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "92",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    },
+                    {
+                      "type": "preference",
+                      "name": "media.setsinkid.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -1577,28 +1740,44 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "81",
-                "notes": "Firefox recognizes the <code>web-share</code> permissions policy, but this has no effect in versions of Firefox that do not support the <a href='https://developer.mozilla.org/docs/Web/API/Navigator/share'><code>share()</code></a> method.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              "firefox_android": {
-                "version_added": "81",
-                "notes": "Firefox recognizes the <code>web-share</code> permissions policy, but this has no effect in versions of Firefox that do not support the <a href='https://developer.mozilla.org/docs/Web/API/Navigator/share'><code>share()</code></a> method.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "81",
+                  "partial_implementation": true,
+                  "notes": [
+                    "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements.",
+                    "Firefox recognizes the <code>web-share</code> permissions policy, but this has no effect in versions of Firefox that do not support the <a href='https://developer.mozilla.org/docs/Web/API/Navigator/share'><code>share()</code></a> method."
+                  ]
+                },
+                {
+                  "version_added": "81",
+                  "notes": "Firefox recognizes the <code>web-share</code> permissions policy, but this has no effect in versions of Firefox that do not support the <a href='https://developer.mozilla.org/docs/Web/API/Navigator/share'><code>share()</code></a> method.",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "81",
+                  "partial_implementation": true,
+                  "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+                },
+                {
+                  "version_added": "81",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.security.featurePolicy.header.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

This updates Firefox support data for the feature policy functionality.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Tested on latest Firefox using https://demo.lukewarlow.uk/feature-policy/

https://bugzilla.mozilla.org/show_bug.cgi?id=1617219 - Shows it was enabled in 74

https://bugzilla.mozilla.org/show_bug.cgi?id=1483631 - Is what I've used to work out the initial values that were supported. Though I suspect others beyond the media and geolocation values were also supported.

`speaker-selection` and `gamepad` was tested on latest version.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

https://github.com/mdn/browser-compat-data/issues/12545 - The experimental features mentioned in a comment on this issue, I haven't added because I'm not sure how best to track their supported versions, or how valuable the data actually is.
