### PR TITLE
Correctly represent support for webkitMediaStream

### DIFF
--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -23,9 +23,15 @@
               "prefix": "webkit"
             }
           ],
-          "edge": {
-            "version_added": "12"
-          },
+          "edge": [
+            {
+              "version_added": "12"
+            },
+            {
+              "version_added": "79",
+              "prefix": "webkit"
+            }
+          ],
           "firefox": {
             "version_added": "15"
           },
@@ -90,15 +96,33 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediastream-constructor",
           "description": "<code>MediaStream()</code> constructor",
           "support": {
-            "chrome": {
-              "version_added": "21"
-            },
-            "chrome_android": {
-              "version_added": "25"
-            },
-            "edge": {
-              "version_added": "12"
-            },
+            "chrome": [
+              {
+                "version_added": "55"
+              },
+              {
+                "version_added": "21",
+                "prefix": "webkit"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "55"
+              },
+              {
+                "version_added": "25",
+                "prefix": "webkit"
+              }
+            ],
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "version_added": "79",
+                "prefix": "webkit"
+              }
+            ],
             "firefox": {
               "version_added": "44"
             },
@@ -108,24 +132,48 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "42"
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "14",
+                "prefix": "webkit"
+              }
+            ],
             "safari": {
               "version_added": "11"
             },
             "safari_ios": {
               "version_added": "11"
             },
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
-            "webview_android": {
-              "version_added": "37"
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "6.0"
+              },
+              {
+                "version_added": "1.5",
+                "prefix": "webkit"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "55"
+              },
+              {
+                "version_added": "≤37",
+                "prefix": "webkit"
+              }
+            ]
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
Support for Edge in 79 and later was missing, and the constructor entry
was also missing the prefixes.