### PR TITLE
Fix support for MediaStream.id and MediaStreamTrack.id

### DIFF
--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -586,16 +586,13 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediastream-id",
           "support": {
             "chrome": {
-              "version_added": "26",
-              "version_removed": "54"
+              "version_added": "26"
             },
             "chrome_android": {
-              "version_added": "26",
-              "version_removed": "54"
+              "version_added": "26"
             },
             "edge": {
-              "version_added": "12",
-              "version_removed": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "41"
@@ -607,12 +604,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "15",
-              "version_removed": "39"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "14",
-              "version_removed": "41"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -621,12 +616,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "1.5",
-              "version_removed": "6.0"
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "≤37",
-              "version_removed": "54"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -6,10 +6,10 @@
         "spec_url": "https://w3c.github.io/mediacapture-main/#mediastreamtrack",
         "support": {
           "chrome": {
-            "version_added": "29"
+            "version_added": "26"
           },
           "chrome_android": {
-            "version_added": "29"
+            "version_added": "26"
           },
           "edge": {
             "version_added": "12"
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "16"
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": "16"
+            "version_added": "14"
           },
           "safari": {
             "version_added": "11"
@@ -36,7 +36,7 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": "2.0"
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": "≤37"
@@ -446,10 +446,10 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-id",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "26"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "edge": {
               "version_added": "12"
@@ -464,10 +464,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -476,10 +476,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
Current support in Chrome 94 can be easily confirmed:
https://mdn-bcd-collector.appspot.com/tests/api/MediaStream/id
https://mdn-bcd-collector.appspot.com/tests/api/MediaStreamTrack/id

These were both introduced in WebKit trunk version 537.26:
https://trac.webkit.org/changeset/139352/webkit
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=139352

That maps to Chrome 26, matching the existing `version_added`.

The original data here came from wiki migration:
https://github.com/mdn/browser-compat-data/pull/1212

The data for api.MediaStreamTrack also has to be updated to pass the
lint. Support for MediaStreamTrack in Chrome 26 can be confirmed with
this test:
http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=9656

The interface object wasn't exposed in Chrome 26-28, which is the most
likely explanation for why support was set to 29 in this PR:
https://github.com/mdn/browser-compat-data/pull/5844

Don't both with `partial_implementation` and notes for this, since
there's no constructor and it doesn't really matter if the interface
object is exposed or not.