### PR TITLE
Adds spec_url for Document.clear()

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -1368,6 +1368,7 @@
       "clear": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/clear",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#dom-document-clear",
           "support": {
             "chrome": [
               {


### PR DESCRIPTION
HTML5 actually defines Document.clear()… as doing nothing.