### PR TITLE
Add MediaTrackConstraints.resizeMode

### DIFF
--- a/api/MediaTrackConstraints.json
+++ b/api/MediaTrackConstraints.json
@@ -760,6 +760,55 @@
           }
         }
       },
+      "resizeMode": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/resizeMode",
+          "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraintset-resizemode",
+          "support": {
+            "chrome": {
+              "version_added": "72"
+            },
+            "chrome_android": {
+              "version_added": "72"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "60"
+            },
+            "opera_android": {
+              "version_added": "51"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "11.0"
+            },
+            "webview_android": {
+              "version_added": "72"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "sampleRate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/sampleRate",

--- a/api/MediaTrackSettings.json
+++ b/api/MediaTrackSettings.json
@@ -770,13 +770,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackSettings/resizeMode",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "72"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "72"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -788,10 +788,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "60"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "51"
             },
             "safari": {
               "version_added": false
@@ -800,10 +800,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "72"
             }
           },
           "status": {

--- a/api/MediaTrackSupportedConstraints.json
+++ b/api/MediaTrackSupportedConstraints.json
@@ -767,13 +767,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackSupportedConstraints/resizeMode",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "72"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "72"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -785,10 +785,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "60"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "51"
             },
             "safari": {
               "version_added": false
@@ -797,10 +797,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "72"
             }
           },
           "status": {


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
This PR adds the MediaTrackConstraint resizeMode to the compat data.
It also updates the supported constraints entry for chrome (https://www.chromestatus.com/feature/6206218032906240)

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://www.chromestatus.com/feature/6206218032906240
https://bugzilla.mozilla.org/show_bug.cgi?id=1433480
https://wpt.fyi/results/mediacapture-streams/MediaStreamTrack-getSettings.https.html?label=experimental&label=master&aligned

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #12562

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
