### PR TITLE
Update Chromium support for PositionSensorVRDevice

### DIFF
--- a/api/PositionSensorVRDevice.json
+++ b/api/PositionSensorVRDevice.json
@@ -5,15 +5,17 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PositionSensorVRDevice",
         "support": {
           "chrome": {
-            "version_added": true,
-            "notes": "The support in Chrome is currently experimental. To find information on Chrome's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Chrome</a> by Brandon Jones."
+            "version_added": "65",
+            "version_removed": "80",
+            "notes": "Support in Chrome was only available in Nightly/Canary builds. To find information on Chrome's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Chrome</a> by Brandon Jones."
           },
           "chrome_android": {
             "version_added": false
           },
           "edge": {
             "version_added": "79",
-            "notes": "The support in Edge is currently experimental. To find information on Edge's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Edge</a> by Brandon Jones."
+            "version_removed": "80",
+            "notes": "Support in Edge was only available in Nightly/Canary builds. To find information on Edge's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Chrome</a> by Brandon Jones."
           },
           "firefox": {
             "version_added": "39",
@@ -74,15 +76,17 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PositionSensorVRDevice/getImmediateState",
           "support": {
             "chrome": {
-              "version_added": true,
-              "notes": "The support in Chrome is currently experimental. To find information on Chrome's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Chrome</a> by Brandon Jones."
+              "version_added": "65",
+              "version_removed": "80",
+              "notes": "Support in Chrome was only available in Nightly/Canary builds. To find information on Chrome's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Chrome</a> by Brandon Jones."
             },
             "chrome_android": {
               "version_added": false
             },
             "edge": {
               "version_added": "79",
-              "notes": "The support in Edge is currently experimental. To find information on Edge's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Edge</a> by Brandon Jones."
+              "version_removed": "80",
+              "notes": "Support in Edge was only available in Nightly/Canary builds. To find information on Edge's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Chrome</a> by Brandon Jones."
             },
             "firefox": {
               "version_added": "39",
@@ -144,15 +148,17 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PositionSensorVRDevice/getState",
           "support": {
             "chrome": {
-              "version_added": true,
-              "notes": "The support in Chrome is currently experimental. To find information on Chrome's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Chrome</a> by Brandon Jones."
+              "version_added": "65",
+              "version_removed": "80",
+              "notes": "Support in Chrome was only available in Nightly/Canary builds. To find information on Chrome's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Chrome</a> by Brandon Jones."
             },
             "chrome_android": {
               "version_added": false
             },
             "edge": {
               "version_added": "79",
-              "notes": "The support in Edge is currently experimental. To find information on Edge's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Edge</a> by Brandon Jones."
+              "version_removed": "80",
+              "notes": "Support in Edge was only available in Nightly/Canary builds. To find information on Edge's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Chrome</a> by Brandon Jones."
             },
             "firefox": {
               "version_added": "39",
@@ -214,15 +220,17 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PositionSensorVRDevice/resetSensor",
           "support": {
             "chrome": {
-              "version_added": true,
-              "notes": "The support in Chrome is currently experimental. To find information on Chrome's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Chrome</a> by Brandon Jones."
+              "version_added": "65",
+              "version_removed": "80",
+              "notes": "Support in Chrome was only available in Nightly/Canary builds. To find information on Chrome's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Chrome</a> by Brandon Jones."
             },
             "chrome_android": {
               "version_added": false
             },
             "edge": {
               "version_added": "79",
-              "notes": "The support in Edge is currently experimental. To find information on Edge's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Edge</a> by Brandon Jones."
+              "version_removed": "80",
+              "notes": "Support in Edge was only available in Nightly/Canary builds. To find information on Edge's WebVR implementation status including supporting builds, check out <a href='http://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html'>Bringing VR to Chrome</a> by Brandon Jones."
             },
             "firefox": {
               "version_added": "39",


### PR DESCRIPTION
This PR adds version numbers for the `PositionSensorVRDevice` API and corrects the notes.  Support in Chrome was introduced in Canary builds in Chrome 65 (source: https://webvr.info/get-chrome/); before then, one had to check out and build the experimental branch to get access (source: https://blog.tojicode.com/2014/07/bringing-vr-to-chrome.html).  This interface had never reached a stable build, however, and was removed in Chrome 80 (source: https://www.chromestatus.com/features/4532810371039232).

Note: I think we should really just remove this interface, along with all the other WebVR data, from BCD.  See #12573 for more on that.
