### PR TITLE
Add Chromium/Edge versions for PushSubscriptionOptions API

### DIFF
--- a/api/PushSubscription.json
+++ b/api/PushSubscription.json
@@ -206,13 +206,13 @@
           "spec_url": "https://w3c.github.io/push-api/#dom-pushsubscription-options",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "54"
             },
             "chrome_android": {
-              "version_added": "42"
+              "version_added": "54"
             },
             "edge": {
-              "version_added": "16"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "44",
@@ -225,10 +225,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "29"
+              "version_added": "41"
             },
             "opera_android": {
-              "version_added": "29"
+              "version_added": "41"
             },
             "safari": {
               "version_added": false
@@ -237,7 +237,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PushSubscriptionOptions.json
+++ b/api/PushSubscriptionOptions.json
@@ -6,13 +6,13 @@
         "spec_url": "https://w3c.github.io/push-api/#dom-pushsubscriptionoptions",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "54"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "54"
           },
           "edge": {
-            "version_added": "16"
+            "version_added": "17"
           },
           "firefox": {
             "version_added": "44"
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "41"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "41"
           },
           "safari": {
             "version_added": false
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "6.0"
           },
           "webview_android": {
             "version_added": false,
@@ -55,10 +55,10 @@
           "spec_url": "https://w3c.github.io/push-api/#dom-pushsubscriptionoptions-applicationserverkey",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "54"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "54"
             },
             "edge": {
               "version_added": "17"
@@ -73,10 +73,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "41"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": false
@@ -85,7 +85,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -104,10 +104,10 @@
           "spec_url": "https://w3c.github.io/push-api/#dom-pushsubscriptionoptions-uservisibleonly",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "54"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "54"
             },
             "edge": {
               "version_added": "17"
@@ -122,10 +122,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "41"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": false
@@ -134,7 +134,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) and Edge for the `PushSubscriptionOptions` API, while also correcting the versions for `PushSubscription.options`, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.3.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PushSubscriptionOptions

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
