### PR TITLE
Update all browsers versions for Request + Response APIs

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -13,7 +13,7 @@
               "version_added": "40",
               "version_removed": "42",
               "partial_implementation": true,
-              "notes": "Only available via Service Workers."
+              "notes": "Only available via service workers."
             }
           ],
           "chrome_android": [
@@ -24,7 +24,7 @@
               "version_added": "40",
               "version_removed": "42",
               "partial_implementation": true,
-              "notes": "Only available via Service Workers."
+              "notes": "Only available via service workers."
             }
           ],
           "deno": {
@@ -50,7 +50,7 @@
               "version_added": "27",
               "version_removed": "29",
               "partial_implementation": true,
-              "notes": "Only available via Service Workers."
+              "notes": "Only available via service workers."
             }
           ],
           "opera_android": [
@@ -61,7 +61,7 @@
               "version_added": "27",
               "version_removed": "29",
               "partial_implementation": true,
-              "notes": "Only available via Service Workers."
+              "notes": "Only available via service workers."
             }
           ],
           "safari": {
@@ -81,7 +81,7 @@
               "version_added": "40",
               "version_removed": "42",
               "partial_implementation": true,
-              "notes": "Only available via Service Workers."
+              "notes": "Only available via service workers."
             }
           ]
         },

--- a/api/Request.json
+++ b/api/Request.json
@@ -5,12 +5,28 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Request",
         "spec_url": "https://fetch.spec.whatwg.org/#request-class",
         "support": {
-          "chrome": {
-            "version_added": "40"
-          },
-          "chrome_android": {
-            "version_added": "40"
-          },
+          "chrome": [
+            {
+              "version_added": "42"
+            },
+            {
+              "version_added": "40",
+              "version_removed": "42",
+              "partial_implementation": true,
+              "notes": "Only available via Service Workers."
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "42"
+            },
+            {
+              "version_added": "40",
+              "version_removed": "42",
+              "partial_implementation": true,
+              "notes": "Only available via Service Workers."
+            }
+          ],
           "deno": {
             "version_added": "1.0"
           },
@@ -26,12 +42,28 @@
           "ie": {
             "version_added": false
           },
-          "opera": {
-            "version_added": "27"
-          },
-          "opera_android": {
-            "version_added": "27"
-          },
+          "opera": [
+            {
+              "version_added": "29"
+            },
+            {
+              "version_added": "27",
+              "version_removed": "29",
+              "partial_implementation": true,
+              "notes": "Only available via Service Workers."
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "29"
+            },
+            {
+              "version_added": "27",
+              "version_removed": "29",
+              "partial_implementation": true,
+              "notes": "Only available via Service Workers."
+            }
+          ],
           "safari": {
             "version_added": "10.1"
           },
@@ -41,9 +73,17 @@
           "samsunginternet_android": {
             "version_added": "4.0"
           },
-          "webview_android": {
-            "version_added": "40"
-          }
+          "webview_android": [
+            {
+              "version_added": "42"
+            },
+            {
+              "version_added": "40",
+              "version_removed": "42",
+              "partial_implementation": true,
+              "notes": "Only available via Service Workers."
+            }
+          ]
         },
         "status": {
           "experimental": false,

--- a/api/Request.json
+++ b/api/Request.json
@@ -6,16 +6,16 @@
         "spec_url": "https://fetch.spec.whatwg.org/#request-class",
         "support": {
           "chrome": {
-            "version_added": "42"
+            "version_added": "40"
           },
           "chrome_android": {
-            "version_added": "42"
+            "version_added": "40"
           },
           "deno": {
             "version_added": "1.0"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "14"
           },
           "firefox": {
             "version_added": "39"
@@ -27,10 +27,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "28"
+            "version_added": "27"
           },
           "opera_android": {
-            "version_added": "28"
+            "version_added": "27"
           },
           "safari": {
             "version_added": "10.1"
@@ -42,7 +42,7 @@
             "version_added": "4.0"
           },
           "webview_android": {
-            "version_added": "42"
+            "version_added": "40"
           }
         },
         "status": {
@@ -58,11 +58,11 @@
           "description": "<code>Request()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "42",
+              "version_added": "40",
               "notes": "From Chrome 47, default values for the <code>init</code> argument's properties changed. <code>mode</code> defaults to <code>same-origin</code> (from <code>no-cors</code>). <code>credentials</code> defaults to <code>include</code> (from <code>same-origin</code>). <code>redirect</code> defaults to <code>follow</code> (from <code>manual</code>)."
             },
             "chrome_android": {
-              "version_added": "42",
+              "version_added": "40",
               "notes": "From Chrome 47, default values for the <code>init</code> argument's properties changed. <code>mode</code> defaults to <code>same-origin</code> (from <code>no-cors</code>). <code>credentials</code> defaults to <code>include</code> (from <code>same-origin</code>). <code>redirect</code> defaults to <code>follow</code> (from <code>manual</code>)."
             },
             "deno": {
@@ -70,7 +70,7 @@
               "notes": "Fetching with a <code>\"manual\"</code> redirect mode does not result in a <code>\"opaqueredirect\"</code> response, but a regular response."
             },
             "edge": {
-              "version_added": "15"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "39"
@@ -82,10 +82,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "29"
+              "version_added": "27"
             },
             "opera_android": {
-              "version_added": "29"
+              "version_added": "27"
             },
             "safari": {
               "version_added": "10.1"
@@ -103,7 +103,7 @@
               }
             ],
             "webview_android": {
-              "version_added": "42",
+              "version_added": "40",
               "notes": "From WebView 47, default values for the <code>init</code> argument's properties changed. <code>mode</code> defaults to <code>same-origin</code> (from <code>no-cors</code>). <code>credentials</code> defaults to <code>include</code> (from <code>same-origin</code>). <code>redirect</code> defaults to <code>follow</code> (from <code>manual</code>)."
             }
           },
@@ -391,7 +391,7 @@
               "version_added": "48"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "ie": {
               "version_added": false
@@ -479,10 +479,10 @@
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-request-clone①",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "chrome_android": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "deno": {
               "version_added": "1.0"
@@ -494,16 +494,16 @@
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "29"
+              "version_added": "27"
             },
             "opera_android": {
-              "version_added": "29"
+              "version_added": "27"
             },
             "safari": {
               "version_added": "10.1"
@@ -515,7 +515,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "40"
             }
           },
           "status": {
@@ -531,10 +531,10 @@
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-request-credentials②",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "chrome_android": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "deno": {
               "version_added": false
@@ -552,10 +552,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "29"
+              "version_added": "27"
             },
             "opera_android": {
-              "version_added": "29"
+              "version_added": "27"
             },
             "safari": {
               "version_added": "10.1"
@@ -567,7 +567,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "42"
+              "version_added": "40"
             }
           },
           "status": {
@@ -686,10 +686,10 @@
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-request-headers②",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "chrome_android": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "deno": {
               "version_added": "1.0"
@@ -707,10 +707,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "29"
+              "version_added": "27"
             },
             "opera_android": {
-              "version_added": "29"
+              "version_added": "27"
             },
             "safari": {
               "version_added": "10.1"
@@ -722,7 +722,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "42"
+              "version_added": "40"
             }
           },
           "status": {
@@ -759,10 +759,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "33"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "safari": {
               "version_added": "10.1"
@@ -774,7 +774,7 @@
               "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "46"
             }
           },
           "status": {
@@ -867,10 +867,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -892,10 +892,10 @@
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-request-method②",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "chrome_android": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "deno": {
               "version_added": "1.0"
@@ -913,10 +913,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "29"
+              "version_added": "27"
             },
             "opera_android": {
-              "version_added": "29"
+              "version_added": "27"
             },
             "safari": {
               "version_added": "10.1"
@@ -928,7 +928,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "42"
+              "version_added": "40"
             }
           },
           "status": {
@@ -944,10 +944,10 @@
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-request-mode②",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "chrome_android": {
-              "version_added": "49"
+              "version_added": "40"
             },
             "deno": {
               "version_added": false
@@ -965,10 +965,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "29"
+              "version_added": "27"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "27"
             },
             "safari": {
               "version_added": "10.1"
@@ -977,10 +977,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "49"
+              "version_added": "40"
             }
           },
           "status": {
@@ -1069,10 +1069,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "33"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "safari": {
               "version_added": "10.1"
@@ -1084,7 +1084,7 @@
               "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "46"
             }
           },
           "status": {
@@ -1100,10 +1100,10 @@
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-request-referrer①",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "chrome_android": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "deno": {
               "version_added": "1.0"
@@ -1112,19 +1112,19 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": "47"
+              "version_added": "39"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "29"
+              "version_added": "27"
             },
             "opera_android": {
-              "version_added": "29"
+              "version_added": "27"
             },
             "safari": {
               "version_added": "10.1"
@@ -1136,7 +1136,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "42"
+              "version_added": "40"
             }
           },
           "status": {
@@ -1164,10 +1164,10 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": "52"
+              "version_added": "47"
             },
             "firefox_android": {
-              "version_added": "52"
+              "version_added": "47"
             },
             "ie": {
               "version_added": false
@@ -1225,10 +1225,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "53"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "safari": {
               "version_added": "12.1"
@@ -1256,11 +1256,11 @@
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-request-url③",
           "support": {
             "chrome": {
-              "version_added": "42",
+              "version_added": "40",
               "notes": "Fragment support added in Chrome 59."
             },
             "chrome_android": {
-              "version_added": "42",
+              "version_added": "40",
               "notes": "Fragment support added in Chrome 59."
             },
             "deno": {
@@ -1279,11 +1279,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "29",
+              "version_added": "27",
               "notes": "Fragment support added in Opera 46."
             },
             "opera_android": {
-              "version_added": "29",
+              "version_added": "27",
               "notes": "Fragment support added in Opera 46."
             },
             "safari": {
@@ -1297,7 +1297,7 @@
               "notes": "Fragment support added in Samsung Internet 7.0."
             },
             "webview_android": {
-              "version_added": "42",
+              "version_added": "40",
               "notes": "Fragment support added in Chrome 59."
             }
           },

--- a/api/Request.json
+++ b/api/Request.json
@@ -13,7 +13,7 @@
               "version_added": "40",
               "version_removed": "42",
               "partial_implementation": true,
-              "notes": "Only available via service workers."
+              "notes": "Only available in service workers."
             }
           ],
           "chrome_android": [
@@ -24,7 +24,7 @@
               "version_added": "40",
               "version_removed": "42",
               "partial_implementation": true,
-              "notes": "Only available via service workers."
+              "notes": "Only available in service workers."
             }
           ],
           "deno": {
@@ -50,7 +50,7 @@
               "version_added": "27",
               "version_removed": "29",
               "partial_implementation": true,
-              "notes": "Only available via service workers."
+              "notes": "Only available in service workers."
             }
           ],
           "opera_android": [
@@ -61,7 +61,7 @@
               "version_added": "27",
               "version_removed": "29",
               "partial_implementation": true,
-              "notes": "Only available via service workers."
+              "notes": "Only available in service workers."
             }
           ],
           "safari": {
@@ -81,7 +81,7 @@
               "version_added": "40",
               "version_removed": "42",
               "partial_implementation": true,
-              "notes": "Only available via service workers."
+              "notes": "Only available in service workers."
             }
           ]
         },

--- a/api/Response.json
+++ b/api/Response.json
@@ -5,12 +5,28 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response",
         "spec_url": "https://fetch.spec.whatwg.org/#response-class",
         "support": {
-          "chrome": {
-            "version_added": "40"
-          },
-          "chrome_android": {
-            "version_added": "40"
-          },
+          "chrome": [
+            {
+              "version_added": "42"
+            },
+            {
+              "version_added": "40",
+              "version_removed": "42",
+              "partial_implementation": true,
+              "notes": "Only available via Service Workers."
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "42"
+            },
+            {
+              "version_added": "40",
+              "version_removed": "42",
+              "partial_implementation": true,
+              "notes": "Only available via Service Workers."
+            }
+          ],
           "deno": {
             "version_added": "1.0"
           },
@@ -26,12 +42,28 @@
           "ie": {
             "version_added": false
           },
-          "opera": {
-            "version_added": "29"
-          },
-          "opera_android": {
-            "version_added": "29"
-          },
+          "opera": [
+            {
+              "version_added": "29"
+            },
+            {
+              "version_added": "27",
+              "version_removed": "29",
+              "partial_implementation": true,
+              "notes": "Only available via Service Workers."
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "29"
+            },
+            {
+              "version_added": "27",
+              "version_removed": "29",
+              "partial_implementation": true,
+              "notes": "Only available via Service Workers."
+            }
+          ],
           "safari": {
             "version_added": "10.1"
           },
@@ -41,9 +73,17 @@
           "samsunginternet_android": {
             "version_added": "4.0"
           },
-          "webview_android": {
-            "version_added": "40"
-          }
+          "webview_android": [
+            {
+              "version_added": "42"
+            },
+            {
+              "version_added": "40",
+              "version_removed": "42",
+              "partial_implementation": true,
+              "notes": "Only available via Service Workers."
+            }
+          ]
         },
         "status": {
           "experimental": false,

--- a/api/Response.json
+++ b/api/Response.json
@@ -13,7 +13,7 @@
               "version_added": "40",
               "version_removed": "42",
               "partial_implementation": true,
-              "notes": "Only available via Service Workers."
+              "notes": "Only available via service workers."
             }
           ],
           "chrome_android": [
@@ -24,7 +24,7 @@
               "version_added": "40",
               "version_removed": "42",
               "partial_implementation": true,
-              "notes": "Only available via Service Workers."
+              "notes": "Only available via service workers."
             }
           ],
           "deno": {
@@ -50,7 +50,7 @@
               "version_added": "27",
               "version_removed": "29",
               "partial_implementation": true,
-              "notes": "Only available via Service Workers."
+              "notes": "Only available via service workers."
             }
           ],
           "opera_android": [
@@ -61,7 +61,7 @@
               "version_added": "27",
               "version_removed": "29",
               "partial_implementation": true,
-              "notes": "Only available via Service Workers."
+              "notes": "Only available via service workers."
             }
           ],
           "safari": {
@@ -81,7 +81,7 @@
               "version_added": "40",
               "version_removed": "42",
               "partial_implementation": true,
-              "notes": "Only available via Service Workers."
+              "notes": "Only available via service workers."
             }
           ]
         },

--- a/api/Response.json
+++ b/api/Response.json
@@ -1,32 +1,108 @@
 {
-    "api": {
+  "api": {
+    "Response": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response",
+        "spec_url": "https://fetch.spec.whatwg.org/#response-class",
+        "support": {
+          "chrome": [
+            {
+              "version_added": "42"
+            },
+            {
+              "version_added": "40",
+              "version_removed": "42",
+              "partial_implementation": true,
+              "notes": "Only available via service workers."
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "42"
+            },
+            {
+              "version_added": "40",
+              "version_removed": "42",
+              "partial_implementation": true,
+              "notes": "Only available via service workers."
+            }
+          ],
+          "deno": {
+            "version_added": "1.0"
+          },
+          "edge": {
+            "version_added": "14"
+          },
+          "firefox": {
+            "version_added": "39"
+          },
+          "firefox_android": {
+            "version_added": "39"
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": [
+            {
+              "version_added": "29"
+            },
+            {
+              "version_added": "27",
+              "version_removed": "29",
+              "partial_implementation": true,
+              "notes": "Only available via service workers."
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "29"
+            },
+            {
+              "version_added": "27",
+              "version_removed": "29",
+              "partial_implementation": true,
+              "notes": "Only available via service workers."
+            }
+          ],
+          "safari": {
+            "version_added": "10.1"
+          },
+          "safari_ios": {
+            "version_added": "10.3"
+          },
+          "samsunginternet_android": {
+            "version_added": "4.0"
+          },
+          "webview_android": [
+            {
+              "version_added": "42"
+            },
+            {
+              "version_added": "40",
+              "version_removed": "42",
+              "partial_implementation": true,
+              "notes": "Only available via service workers."
+            }
+          ]
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
       "Response": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response",
-          "spec_url": "https://fetch.spec.whatwg.org/#response-class",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/Response",
+          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response①",
+          "description": "<code>Response()</code> constructor",
           "support": {
-            "chrome": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "42",
-                "partial_implementation": true,
-                "notes": "Only available in service workers."
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "42",
-                "partial_implementation": true,
-                "notes": "Only available in service workers."
-              }
-            ],
+            "chrome": {
+              "version_added": "40"
+            },
+            "chrome_android": {
+              "version_added": "40"
+            },
             "deno": {
               "version_added": "1.0"
             },
@@ -42,28 +118,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "27",
-                "version_removed": "29",
-                "partial_implementation": true,
-                "notes": "Only available in service workers."
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "29"
-              },
-              {
-                "version_added": "27",
-                "version_removed": "29",
-                "partial_implementation": true,
-                "notes": "Only available in service workers."
-              }
-            ],
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
             "safari": {
               "version_added": "10.1"
             },
@@ -73,17 +133,9 @@
             "samsunginternet_android": {
               "version_added": "4.0"
             },
-            "webview_android": [
-              {
-                "version_added": "42"
-              },
-              {
-                "version_added": "40",
-                "version_removed": "42",
-                "partial_implementation": true,
-                "notes": "Only available in service workers."
-              }
-            ]
+            "webview_android": {
+              "version_added": "40"
+            }
           },
           "status": {
             "experimental": false,
@@ -91,204 +143,48 @@
             "deprecated": false
           }
         },
-        "Response": {
+        "accept_readablestream": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/Response",
-            "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response①",
-            "description": "<code>Response()</code> constructor",
+            "description": "body parameter accepts ReadableByteStream",
             "support": {
               "chrome": {
-                "version_added": "40"
+                "version_added": "52"
               },
               "chrome_android": {
-                "version_added": "40"
+                "version_added": "52"
               },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "≤79"
               },
               "firefox": {
-                "version_added": "39"
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": "39"
+                "version_added": false
               },
               "ie": {
                 "version_added": false
               },
               "opera": {
-                "version_added": "29"
+                "version_added": "39"
               },
               "opera_android": {
-                "version_added": "29"
+                "version_added": "41"
               },
               "safari": {
-                "version_added": "10.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3"
-              },
-              "samsunginternet_android": {
-                "version_added": "4.0"
-              },
-              "webview_android": {
-                "version_added": "40"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          },
-          "accept_readablestream": {
-            "__compat": {
-              "description": "body parameter accepts ReadableByteStream",
-              "support": {
-                "chrome": {
-                  "version_added": "52"
-                },
-                "chrome_android": {
-                  "version_added": "52"
-                },
-                "deno": {
-                  "version_added": "1.0"
-                },
-                "edge": {
-                  "version_added": "≤79"
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "39"
-                },
-                "opera_android": {
-                  "version_added": "41"
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": "10.3"
-                },
-                "samsunginternet_android": {
-                  "version_added": "6.0"
-                },
-                "webview_android": {
-                  "version_added": "52"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "body_param_null": {
-            "__compat": {
-              "description": "body parameter can be <code>null</code>",
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "deno": {
-                  "version_added": "1.0"
-                },
-                "edge": {
-                  "version_added": "≤79"
-                },
-                "firefox": {
-                  "version_added": "59"
-                },
-                "firefox_android": {
-                  "version_added": true
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": true
-                },
-                "opera_android": {
-                  "version_added": true
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "samsunginternet_android": {
-                  "version_added": true
-                },
-                "webview_android": {
-                  "version_added": true
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
-        "clone": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/clone",
-            "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-clone①",
-            "support": {
-              "chrome": {
-                "version_added": "40"
-              },
-              "chrome_android": {
-                "version_added": "40"
-              },
-              "deno": {
-                "version_added": "1.0"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "39"
-              },
-              "firefox_android": {
-                "version_added": "39"
-              },
-              "ie": {
                 "version_added": false
               },
-              "opera": {
-                "version_added": "29"
-              },
-              "opera_android": {
-                "version_added": "29"
-              },
-              "safari": {
-                "version_added": "10.1"
-              },
               "safari_ios": {
                 "version_added": "10.3"
               },
               "samsunginternet_android": {
-                "version_added": "4.0"
+                "version_added": "6.0"
               },
               "webview_android": {
-                "version_added": "40"
+                "version_added": "52"
               }
             },
             "status": {
@@ -298,465 +194,48 @@
             }
           }
         },
-        "error": {
+        "body_param_null": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/error",
-            "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-error①",
+            "description": "body parameter can be <code>null</code>",
             "support": {
               "chrome": {
-                "version_added": "43"
+                "version_added": true
               },
               "chrome_android": {
-                "version_added": "43"
+                "version_added": true
               },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "16"
+                "version_added": "≤79"
               },
               "firefox": {
-                "version_added": "39"
+                "version_added": "59"
               },
               "firefox_android": {
-                "version_added": "39"
+                "version_added": true
               },
               "ie": {
                 "version_added": false
               },
               "opera": {
-                "version_added": "30"
+                "version_added": true
               },
               "opera_android": {
-                "version_added": "30"
+                "version_added": true
               },
               "safari": {
-                "version_added": "10.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3"
-              },
-              "samsunginternet_android": {
-                "version_added": "4.0"
-              },
-              "webview_android": {
-                "version_added": "43"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "headers": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/headers",
-            "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-headers①",
-            "support": {
-              "chrome": {
-                "version_added": "40"
-              },
-              "chrome_android": {
-                "version_added": "42"
-              },
-              "deno": {
-                "version_added": "1.0"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "39"
-              },
-              "firefox_android": {
-                "version_added": "39"
-              },
-              "ie": {
                 "version_added": false
               },
-              "opera": {
-                "version_added": "29"
-              },
-              "opera_android": {
-                "version_added": "29"
-              },
-              "safari": {
-                "version_added": "10.1"
-              },
               "safari_ios": {
-                "version_added": "10.3"
-              },
-              "samsunginternet_android": {
-                "version_added": "4.0"
-              },
-              "webview_android": {
-                "version_added": "40"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "ok": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/ok",
-            "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-ok②",
-            "support": {
-              "chrome": {
-                "version_added": "42"
-              },
-              "chrome_android": {
-                "version_added": "42"
-              },
-              "deno": {
-                "version_added": "1.0"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "39"
-              },
-              "firefox_android": {
-                "version_added": "39"
-              },
-              "ie": {
                 "version_added": false
               },
-              "opera": {
-                "version_added": "29"
-              },
-              "opera_android": {
-                "version_added": "29"
-              },
-              "safari": {
-                "version_added": "10.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3"
-              },
               "samsunginternet_android": {
-                "version_added": "4.0"
+                "version_added": true
               },
               "webview_android": {
-                "version_added": "42"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "redirect": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/redirect",
-            "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-redirect①",
-            "support": {
-              "chrome": {
-                "version_added": "44"
-              },
-              "chrome_android": {
-                "version_added": "44"
-              },
-              "deno": {
-                "version_added": "1.0"
-              },
-              "edge": {
-                "version_added": "16"
-              },
-              "firefox": {
-                "version_added": "39"
-              },
-              "firefox_android": {
-                "version_added": "39"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "30"
-              },
-              "opera_android": {
-                "version_added": "30"
-              },
-              "safari": {
-                "version_added": "10.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3"
-              },
-              "samsunginternet_android": {
-                "version_added": "4.0"
-              },
-              "webview_android": {
-                "version_added": "44"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "redirected": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/redirected",
-            "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-redirected①",
-            "support": {
-              "chrome": {
-                "version_added": "57"
-              },
-              "chrome_android": {
-                "version_added": "57"
-              },
-              "deno": {
-                "version_added": "1.0"
-              },
-              "edge": {
-                "version_added": "16"
-              },
-              "firefox": {
-                "version_added": "49"
-              },
-              "firefox_android": {
-                "version_added": "49"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "44"
-              },
-              "opera_android": {
-                "version_added": "43"
-              },
-              "safari": {
-                "version_added": "10.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3"
-              },
-              "samsunginternet_android": {
-                "version_added": "8.0"
-              },
-              "webview_android": {
-                "version_added": "60"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "status": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/status",
-            "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-status①",
-            "support": {
-              "chrome": {
-                "version_added": "40"
-              },
-              "chrome_android": {
-                "version_added": "40"
-              },
-              "deno": {
-                "version_added": "1.0"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "39"
-              },
-              "firefox_android": {
-                "version_added": "39"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "29"
-              },
-              "opera_android": {
-                "version_added": "29"
-              },
-              "safari": {
-                "version_added": "10.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3"
-              },
-              "samsunginternet_android": {
-                "version_added": "4.0"
-              },
-              "webview_android": {
-                "version_added": "40"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "statusText": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/statusText",
-            "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-statustext①",
-            "support": {
-              "chrome": {
-                "version_added": "40"
-              },
-              "chrome_android": {
-                "version_added": "40"
-              },
-              "deno": {
-                "version_added": "1.0"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "39"
-              },
-              "firefox_android": {
-                "version_added": "39"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "29"
-              },
-              "opera_android": {
-                "version_added": "29"
-              },
-              "safari": {
-                "version_added": "10.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3"
-              },
-              "samsunginternet_android": {
-                "version_added": "4.0"
-              },
-              "webview_android": {
-                "version_added": "40"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "type": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/type",
-            "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-type①",
-            "support": {
-              "chrome": {
-                "version_added": "40"
-              },
-              "chrome_android": {
-                "version_added": "40"
-              },
-              "deno": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "39"
-              },
-              "firefox_android": {
-                "version_added": "39"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "29"
-              },
-              "opera_android": {
-                "version_added": "29"
-              },
-              "safari": {
-                "version_added": "10.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3"
-              },
-              "samsunginternet_android": {
-                "version_added": "4.0"
-              },
-              "webview_android": {
-                "version_added": "40"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "url": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/url",
-            "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-url①",
-            "support": {
-              "chrome": {
-                "version_added": "40"
-              },
-              "chrome_android": {
-                "version_added": "40"
-              },
-              "deno": {
-                "version_added": "1.0"
-              },
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "39"
-              },
-              "firefox_android": {
-                "version_added": "39"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "29"
-              },
-              "opera_android": {
-                "version_added": "29"
-              },
-              "safari": {
-                "version_added": "10.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3"
-              },
-              "samsunginternet_android": {
-                "version_added": "4.0"
-              },
-              "webview_android": {
-                "version_added": "40"
+                "version_added": true
               }
             },
             "status": {
@@ -766,7 +245,527 @@
             }
           }
         }
+      },
+      "clone": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/clone",
+          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-clone①",
+          "support": {
+            "chrome": {
+              "version_added": "40"
+            },
+            "chrome_android": {
+              "version_added": "40"
+            },
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "39"
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "error": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/error",
+          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-error①",
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "43"
+            },
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "39"
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "30"
+            },
+            "opera_android": {
+              "version_added": "30"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "43"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "headers": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/headers",
+          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-headers①",
+          "support": {
+            "chrome": {
+              "version_added": "40"
+            },
+            "chrome_android": {
+              "version_added": "42"
+            },
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "39"
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ok": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/ok",
+          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-ok②",
+          "support": {
+            "chrome": {
+              "version_added": "42"
+            },
+            "chrome_android": {
+              "version_added": "42"
+            },
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "39"
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "42"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "redirect": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/redirect",
+          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-redirect①",
+          "support": {
+            "chrome": {
+              "version_added": "44"
+            },
+            "chrome_android": {
+              "version_added": "44"
+            },
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "39"
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "30"
+            },
+            "opera_android": {
+              "version_added": "30"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "44"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "redirected": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/redirected",
+          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-redirected①",
+          "support": {
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "57"
+            },
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": {
+              "version_added": "49"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "44"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": "60"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "status": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/status",
+          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-status①",
+          "support": {
+            "chrome": {
+              "version_added": "40"
+            },
+            "chrome_android": {
+              "version_added": "40"
+            },
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "39"
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "statusText": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/statusText",
+          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-statustext①",
+          "support": {
+            "chrome": {
+              "version_added": "40"
+            },
+            "chrome_android": {
+              "version_added": "40"
+            },
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "39"
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "type": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/type",
+          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-type①",
+          "support": {
+            "chrome": {
+              "version_added": "40"
+            },
+            "chrome_android": {
+              "version_added": "40"
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "39"
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "url": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/url",
+          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-url①",
+          "support": {
+            "chrome": {
+              "version_added": "40"
+            },
+            "chrome_android": {
+              "version_added": "40"
+            },
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "39"
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }
-  
+}

--- a/api/Response.json
+++ b/api/Response.json
@@ -1,108 +1,32 @@
 {
-  "api": {
-    "Response": {
-      "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response",
-        "spec_url": "https://fetch.spec.whatwg.org/#response-class",
-        "support": {
-          "chrome": [
-            {
-              "version_added": "42"
-            },
-            {
-              "version_added": "40",
-              "version_removed": "42",
-              "partial_implementation": true,
-              "notes": "Only available via service workers."
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_added": "42"
-            },
-            {
-              "version_added": "40",
-              "version_removed": "42",
-              "partial_implementation": true,
-              "notes": "Only available via service workers."
-            }
-          ],
-          "deno": {
-            "version_added": "1.0"
-          },
-          "edge": {
-            "version_added": "14"
-          },
-          "firefox": {
-            "version_added": "39"
-          },
-          "firefox_android": {
-            "version_added": "39"
-          },
-          "ie": {
-            "version_added": false
-          },
-          "opera": [
-            {
-              "version_added": "29"
-            },
-            {
-              "version_added": "27",
-              "version_removed": "29",
-              "partial_implementation": true,
-              "notes": "Only available via service workers."
-            }
-          ],
-          "opera_android": [
-            {
-              "version_added": "29"
-            },
-            {
-              "version_added": "27",
-              "version_removed": "29",
-              "partial_implementation": true,
-              "notes": "Only available via service workers."
-            }
-          ],
-          "safari": {
-            "version_added": "10.1"
-          },
-          "safari_ios": {
-            "version_added": "10.3"
-          },
-          "samsunginternet_android": {
-            "version_added": "4.0"
-          },
-          "webview_android": [
-            {
-              "version_added": "42"
-            },
-            {
-              "version_added": "40",
-              "version_removed": "42",
-              "partial_implementation": true,
-              "notes": "Only available via service workers."
-            }
-          ]
-        },
-        "status": {
-          "experimental": false,
-          "standard_track": true,
-          "deprecated": false
-        }
-      },
+    "api": {
       "Response": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/Response",
-          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response①",
-          "description": "<code>Response()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response",
+          "spec_url": "https://fetch.spec.whatwg.org/#response-class",
           "support": {
-            "chrome": {
-              "version_added": "40"
-            },
-            "chrome_android": {
-              "version_added": "40"
-            },
+            "chrome": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "40",
+                "version_removed": "42",
+                "partial_implementation": true,
+                "notes": "Only available in service workers."
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "40",
+                "version_removed": "42",
+                "partial_implementation": true,
+                "notes": "Only available in service workers."
+              }
+            ],
             "deno": {
               "version_added": "1.0"
             },
@@ -118,12 +42,28 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "29"
-            },
-            "opera_android": {
-              "version_added": "29"
-            },
+            "opera": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "27",
+                "version_removed": "29",
+                "partial_implementation": true,
+                "notes": "Only available in service workers."
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "29"
+              },
+              {
+                "version_added": "27",
+                "version_removed": "29",
+                "partial_implementation": true,
+                "notes": "Only available in service workers."
+              }
+            ],
             "safari": {
               "version_added": "10.1"
             },
@@ -133,9 +73,17 @@
             "samsunginternet_android": {
               "version_added": "4.0"
             },
-            "webview_android": {
-              "version_added": "40"
-            }
+            "webview_android": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "40",
+                "version_removed": "42",
+                "partial_implementation": true,
+                "notes": "Only available in service workers."
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -143,48 +91,204 @@
             "deprecated": false
           }
         },
-        "accept_readablestream": {
+        "Response": {
           "__compat": {
-            "description": "body parameter accepts ReadableByteStream",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/Response",
+            "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response①",
+            "description": "<code>Response()</code> constructor",
             "support": {
               "chrome": {
-                "version_added": "52"
+                "version_added": "40"
               },
               "chrome_android": {
-                "version_added": "52"
+                "version_added": "40"
               },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "14"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "39"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "39"
               },
               "ie": {
                 "version_added": false
               },
               "opera": {
-                "version_added": "39"
+                "version_added": "29"
               },
               "opera_android": {
-                "version_added": "41"
+                "version_added": "29"
               },
               "safari": {
-                "version_added": false
+                "version_added": "10.1"
               },
               "safari_ios": {
                 "version_added": "10.3"
               },
               "samsunginternet_android": {
-                "version_added": "6.0"
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": "52"
+                "version_added": "40"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "accept_readablestream": {
+            "__compat": {
+              "description": "body parameter accepts ReadableByteStream",
+              "support": {
+                "chrome": {
+                  "version_added": "52"
+                },
+                "chrome_android": {
+                  "version_added": "52"
+                },
+                "deno": {
+                  "version_added": "1.0"
+                },
+                "edge": {
+                  "version_added": "≤79"
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "39"
+                },
+                "opera_android": {
+                  "version_added": "41"
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": "10.3"
+                },
+                "samsunginternet_android": {
+                  "version_added": "6.0"
+                },
+                "webview_android": {
+                  "version_added": "52"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "body_param_null": {
+            "__compat": {
+              "description": "body parameter can be <code>null</code>",
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "chrome_android": {
+                  "version_added": true
+                },
+                "deno": {
+                  "version_added": "1.0"
+                },
+                "edge": {
+                  "version_added": "≤79"
+                },
+                "firefox": {
+                  "version_added": "59"
+                },
+                "firefox_android": {
+                  "version_added": true
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "opera_android": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": true
+                },
+                "webview_android": {
+                  "version_added": true
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
+        },
+        "clone": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/clone",
+            "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-clone①",
+            "support": {
+              "chrome": {
+                "version_added": "40"
+              },
+              "chrome_android": {
+                "version_added": "40"
+              },
+              "deno": {
+                "version_added": "1.0"
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "39"
+              },
+              "firefox_android": {
+                "version_added": "39"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "29"
+              },
+              "opera_android": {
+                "version_added": "29"
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              },
+              "samsunginternet_android": {
+                "version_added": "4.0"
+              },
+              "webview_android": {
+                "version_added": "40"
               }
             },
             "status": {
@@ -194,48 +298,465 @@
             }
           }
         },
-        "body_param_null": {
+        "error": {
           "__compat": {
-            "description": "body parameter can be <code>null</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/error",
+            "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-error①",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "43"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "43"
               },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "16"
               },
               "firefox": {
-                "version_added": "59"
+                "version_added": "39"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "39"
               },
               "ie": {
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "30"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "30"
               },
               "safari": {
-                "version_added": false
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "43"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "headers": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/headers",
+            "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-headers①",
+            "support": {
+              "chrome": {
+                "version_added": "40"
+              },
+              "chrome_android": {
+                "version_added": "42"
+              },
+              "deno": {
+                "version_added": "1.0"
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "39"
+              },
+              "firefox_android": {
+                "version_added": "39"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "29"
+              },
+              "opera_android": {
+                "version_added": "29"
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              },
+              "samsunginternet_android": {
+                "version_added": "4.0"
+              },
+              "webview_android": {
+                "version_added": "40"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "ok": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/ok",
+            "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-ok②",
+            "support": {
+              "chrome": {
+                "version_added": "42"
+              },
+              "chrome_android": {
+                "version_added": "42"
+              },
+              "deno": {
+                "version_added": "1.0"
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "39"
+              },
+              "firefox_android": {
+                "version_added": "39"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "29"
+              },
+              "opera_android": {
+                "version_added": "29"
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              },
+              "samsunginternet_android": {
+                "version_added": "4.0"
+              },
+              "webview_android": {
+                "version_added": "42"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "redirect": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/redirect",
+            "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-redirect①",
+            "support": {
+              "chrome": {
+                "version_added": "44"
+              },
+              "chrome_android": {
+                "version_added": "44"
+              },
+              "deno": {
+                "version_added": "1.0"
+              },
+              "edge": {
+                "version_added": "16"
+              },
+              "firefox": {
+                "version_added": "39"
+              },
+              "firefox_android": {
+                "version_added": "39"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "30"
+              },
+              "opera_android": {
+                "version_added": "30"
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              },
+              "samsunginternet_android": {
+                "version_added": "4.0"
+              },
+              "webview_android": {
+                "version_added": "44"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "redirected": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/redirected",
+            "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-redirected①",
+            "support": {
+              "chrome": {
+                "version_added": "57"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "deno": {
+                "version_added": "1.0"
+              },
+              "edge": {
+                "version_added": "16"
+              },
+              "firefox": {
+                "version_added": "49"
+              },
+              "firefox_android": {
+                "version_added": "49"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "44"
+              },
+              "opera_android": {
+                "version_added": "43"
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              },
+              "samsunginternet_android": {
+                "version_added": "8.0"
+              },
+              "webview_android": {
+                "version_added": "60"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "status": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/status",
+            "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-status①",
+            "support": {
+              "chrome": {
+                "version_added": "40"
+              },
+              "chrome_android": {
+                "version_added": "40"
+              },
+              "deno": {
+                "version_added": "1.0"
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "39"
+              },
+              "firefox_android": {
+                "version_added": "39"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "29"
+              },
+              "opera_android": {
+                "version_added": "29"
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              },
+              "samsunginternet_android": {
+                "version_added": "4.0"
+              },
+              "webview_android": {
+                "version_added": "40"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "statusText": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/statusText",
+            "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-statustext①",
+            "support": {
+              "chrome": {
+                "version_added": "40"
+              },
+              "chrome_android": {
+                "version_added": "40"
+              },
+              "deno": {
+                "version_added": "1.0"
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "39"
+              },
+              "firefox_android": {
+                "version_added": "39"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "29"
+              },
+              "opera_android": {
+                "version_added": "29"
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              },
+              "samsunginternet_android": {
+                "version_added": "4.0"
+              },
+              "webview_android": {
+                "version_added": "40"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "type": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/type",
+            "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-type①",
+            "support": {
+              "chrome": {
+                "version_added": "40"
+              },
+              "chrome_android": {
+                "version_added": "40"
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "39"
+              },
+              "firefox_android": {
+                "version_added": "39"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "29"
+              },
+              "opera_android": {
+                "version_added": "29"
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              },
+              "samsunginternet_android": {
+                "version_added": "4.0"
+              },
+              "webview_android": {
+                "version_added": "40"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "url": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/url",
+            "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-url①",
+            "support": {
+              "chrome": {
+                "version_added": "40"
+              },
+              "chrome_android": {
+                "version_added": "40"
+              },
+              "deno": {
+                "version_added": "1.0"
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "39"
+              },
+              "firefox_android": {
+                "version_added": "39"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "29"
+              },
+              "opera_android": {
+                "version_added": "29"
+              },
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": {
+                "version_added": "10.3"
+              },
+              "samsunginternet_android": {
+                "version_added": "4.0"
+              },
+              "webview_android": {
+                "version_added": "40"
               }
             },
             "status": {
@@ -245,527 +766,7 @@
             }
           }
         }
-      },
-      "clone": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/clone",
-          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-clone①",
-          "support": {
-            "chrome": {
-              "version_added": "40"
-            },
-            "chrome_android": {
-              "version_added": "40"
-            },
-            "deno": {
-              "version_added": "1.0"
-            },
-            "edge": {
-              "version_added": "14"
-            },
-            "firefox": {
-              "version_added": "39"
-            },
-            "firefox_android": {
-              "version_added": "39"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "29"
-            },
-            "opera_android": {
-              "version_added": "29"
-            },
-            "safari": {
-              "version_added": "10.1"
-            },
-            "safari_ios": {
-              "version_added": "10.3"
-            },
-            "samsunginternet_android": {
-              "version_added": "4.0"
-            },
-            "webview_android": {
-              "version_added": "40"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "error": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/error",
-          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-error①",
-          "support": {
-            "chrome": {
-              "version_added": "43"
-            },
-            "chrome_android": {
-              "version_added": "43"
-            },
-            "deno": {
-              "version_added": "1.0"
-            },
-            "edge": {
-              "version_added": "16"
-            },
-            "firefox": {
-              "version_added": "39"
-            },
-            "firefox_android": {
-              "version_added": "39"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "30"
-            },
-            "opera_android": {
-              "version_added": "30"
-            },
-            "safari": {
-              "version_added": "10.1"
-            },
-            "safari_ios": {
-              "version_added": "10.3"
-            },
-            "samsunginternet_android": {
-              "version_added": "4.0"
-            },
-            "webview_android": {
-              "version_added": "43"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "headers": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/headers",
-          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-headers①",
-          "support": {
-            "chrome": {
-              "version_added": "40"
-            },
-            "chrome_android": {
-              "version_added": "42"
-            },
-            "deno": {
-              "version_added": "1.0"
-            },
-            "edge": {
-              "version_added": "14"
-            },
-            "firefox": {
-              "version_added": "39"
-            },
-            "firefox_android": {
-              "version_added": "39"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "29"
-            },
-            "opera_android": {
-              "version_added": "29"
-            },
-            "safari": {
-              "version_added": "10.1"
-            },
-            "safari_ios": {
-              "version_added": "10.3"
-            },
-            "samsunginternet_android": {
-              "version_added": "4.0"
-            },
-            "webview_android": {
-              "version_added": "40"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "ok": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/ok",
-          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-ok②",
-          "support": {
-            "chrome": {
-              "version_added": "42"
-            },
-            "chrome_android": {
-              "version_added": "42"
-            },
-            "deno": {
-              "version_added": "1.0"
-            },
-            "edge": {
-              "version_added": "14"
-            },
-            "firefox": {
-              "version_added": "39"
-            },
-            "firefox_android": {
-              "version_added": "39"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "29"
-            },
-            "opera_android": {
-              "version_added": "29"
-            },
-            "safari": {
-              "version_added": "10.1"
-            },
-            "safari_ios": {
-              "version_added": "10.3"
-            },
-            "samsunginternet_android": {
-              "version_added": "4.0"
-            },
-            "webview_android": {
-              "version_added": "42"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "redirect": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/redirect",
-          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-redirect①",
-          "support": {
-            "chrome": {
-              "version_added": "44"
-            },
-            "chrome_android": {
-              "version_added": "44"
-            },
-            "deno": {
-              "version_added": "1.0"
-            },
-            "edge": {
-              "version_added": "16"
-            },
-            "firefox": {
-              "version_added": "39"
-            },
-            "firefox_android": {
-              "version_added": "39"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "30"
-            },
-            "opera_android": {
-              "version_added": "30"
-            },
-            "safari": {
-              "version_added": "10.1"
-            },
-            "safari_ios": {
-              "version_added": "10.3"
-            },
-            "samsunginternet_android": {
-              "version_added": "4.0"
-            },
-            "webview_android": {
-              "version_added": "44"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "redirected": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/redirected",
-          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-redirected①",
-          "support": {
-            "chrome": {
-              "version_added": "57"
-            },
-            "chrome_android": {
-              "version_added": "57"
-            },
-            "deno": {
-              "version_added": "1.0"
-            },
-            "edge": {
-              "version_added": "16"
-            },
-            "firefox": {
-              "version_added": "49"
-            },
-            "firefox_android": {
-              "version_added": "49"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "44"
-            },
-            "opera_android": {
-              "version_added": "43"
-            },
-            "safari": {
-              "version_added": "10.1"
-            },
-            "safari_ios": {
-              "version_added": "10.3"
-            },
-            "samsunginternet_android": {
-              "version_added": "8.0"
-            },
-            "webview_android": {
-              "version_added": "60"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "status": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/status",
-          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-status①",
-          "support": {
-            "chrome": {
-              "version_added": "40"
-            },
-            "chrome_android": {
-              "version_added": "40"
-            },
-            "deno": {
-              "version_added": "1.0"
-            },
-            "edge": {
-              "version_added": "14"
-            },
-            "firefox": {
-              "version_added": "39"
-            },
-            "firefox_android": {
-              "version_added": "39"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "29"
-            },
-            "opera_android": {
-              "version_added": "29"
-            },
-            "safari": {
-              "version_added": "10.1"
-            },
-            "safari_ios": {
-              "version_added": "10.3"
-            },
-            "samsunginternet_android": {
-              "version_added": "4.0"
-            },
-            "webview_android": {
-              "version_added": "40"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "statusText": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/statusText",
-          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-statustext①",
-          "support": {
-            "chrome": {
-              "version_added": "40"
-            },
-            "chrome_android": {
-              "version_added": "40"
-            },
-            "deno": {
-              "version_added": "1.0"
-            },
-            "edge": {
-              "version_added": "14"
-            },
-            "firefox": {
-              "version_added": "39"
-            },
-            "firefox_android": {
-              "version_added": "39"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "29"
-            },
-            "opera_android": {
-              "version_added": "29"
-            },
-            "safari": {
-              "version_added": "10.1"
-            },
-            "safari_ios": {
-              "version_added": "10.3"
-            },
-            "samsunginternet_android": {
-              "version_added": "4.0"
-            },
-            "webview_android": {
-              "version_added": "40"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "type": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/type",
-          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-type①",
-          "support": {
-            "chrome": {
-              "version_added": "40"
-            },
-            "chrome_android": {
-              "version_added": "40"
-            },
-            "deno": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": "14"
-            },
-            "firefox": {
-              "version_added": "39"
-            },
-            "firefox_android": {
-              "version_added": "39"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "29"
-            },
-            "opera_android": {
-              "version_added": "29"
-            },
-            "safari": {
-              "version_added": "10.1"
-            },
-            "safari_ios": {
-              "version_added": "10.3"
-            },
-            "samsunginternet_android": {
-              "version_added": "4.0"
-            },
-            "webview_android": {
-              "version_added": "40"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "url": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/url",
-          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-url①",
-          "support": {
-            "chrome": {
-              "version_added": "40"
-            },
-            "chrome_android": {
-              "version_added": "40"
-            },
-            "deno": {
-              "version_added": "1.0"
-            },
-            "edge": {
-              "version_added": "14"
-            },
-            "firefox": {
-              "version_added": "39"
-            },
-            "firefox_android": {
-              "version_added": "39"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "29"
-            },
-            "opera_android": {
-              "version_added": "29"
-            },
-            "safari": {
-              "version_added": "10.1"
-            },
-            "safari_ios": {
-              "version_added": "10.3"
-            },
-            "samsunginternet_android": {
-              "version_added": "4.0"
-            },
-            "webview_android": {
-              "version_added": "40"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
       }
     }
   }
-}
+  

--- a/api/Response.json
+++ b/api/Response.json
@@ -6,10 +6,10 @@
         "spec_url": "https://fetch.spec.whatwg.org/#response-class",
         "support": {
           "chrome": {
-            "version_added": "42"
+            "version_added": "40"
           },
           "chrome_android": {
-            "version_added": "42"
+            "version_added": "40"
           },
           "deno": {
             "version_added": "1.0"
@@ -42,7 +42,7 @@
             "version_added": "4.0"
           },
           "webview_android": {
-            "version_added": "42"
+            "version_added": "40"
           }
         },
         "status": {
@@ -58,10 +58,10 @@
           "description": "<code>Response()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "chrome_android": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "deno": {
               "version_added": "1.0"
@@ -73,7 +73,7 @@
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
@@ -94,7 +94,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "42"
+              "version_added": "40"
             }
           },
           "status": {
@@ -212,10 +212,10 @@
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-clone①",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "40"
             },
             "deno": {
               "version_added": "1.0"
@@ -227,111 +227,7 @@
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "29"
-            },
-            "opera_android": {
-              "version_added": "29"
-            },
-            "safari": {
-              "version_added": "10.1"
-            },
-            "safari_ios": {
-              "version_added": "10.3"
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "error": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/error",
-          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-error①",
-          "support": {
-            "chrome": {
-              "version_added": true
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "deno": {
-              "version_added": "1.0"
-            },
-            "edge": {
-              "version_added": "16"
-            },
-            "firefox": {
-              "version_added": true
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": true
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "headers": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/headers",
-          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-headers①",
-          "support": {
-            "chrome": {
-              "version_added": "42"
-            },
-            "chrome_android": {
-              "version_added": "42"
-            },
-            "deno": {
-              "version_added": "1.0"
-            },
-            "edge": {
-              "version_added": "14"
-            },
-            "firefox": {
               "version_added": "39"
-            },
-            "firefox_android": {
-              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -352,7 +248,111 @@
               "version_added": "4.0"
             },
             "webview_android": {
+              "version_added": "40"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "error": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/error",
+          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-error①",
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "43"
+            },
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "39"
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "ie": {
               "version_added": false
+            },
+            "opera": {
+              "version_added": "30"
+            },
+            "opera_android": {
+              "version_added": "30"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "43"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "headers": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/headers",
+          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-headers①",
+          "support": {
+            "chrome": {
+              "version_added": "40"
+            },
+            "chrome_android": {
+              "version_added": "42"
+            },
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "39"
+            },
+            "firefox_android": {
+              "version_added": "39"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "29"
+            },
+            "opera_android": {
+              "version_added": "29"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "40"
             }
           },
           "status": {
@@ -420,10 +420,10 @@
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-redirect①",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "44"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "44"
             },
             "deno": {
               "version_added": "1.0"
@@ -432,31 +432,31 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "39"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "30"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "44"
             }
           },
           "status": {
@@ -472,10 +472,10 @@
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-redirected①",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": "57"
             },
             "chrome_android": {
-              "version_added": "60"
+              "version_added": "57"
             },
             "deno": {
               "version_added": "1.0"
@@ -493,10 +493,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "47"
+              "version_added": "44"
             },
             "opera_android": {
-              "version_added": "44"
+              "version_added": "43"
             },
             "safari": {
               "version_added": "10.1"
@@ -524,10 +524,10 @@
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-status①",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "40"
             },
             "deno": {
               "version_added": "1.0"
@@ -539,7 +539,7 @@
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
@@ -557,10 +557,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "40"
             }
           },
           "status": {
@@ -576,10 +576,10 @@
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-statustext①",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "40"
             },
             "deno": {
               "version_added": "1.0"
@@ -591,7 +591,7 @@
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
@@ -603,16 +603,16 @@
               "version_added": "29"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "40"
             }
           },
           "status": {
@@ -628,10 +628,10 @@
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-type①",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "40"
             },
             "deno": {
               "version_added": false
@@ -643,7 +643,7 @@
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
@@ -655,16 +655,16 @@
               "version_added": "29"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "40"
             }
           },
           "status": {
@@ -680,10 +680,10 @@
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-url①",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "40"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "40"
             },
             "deno": {
               "version_added": "1.0"
@@ -695,7 +695,7 @@
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
@@ -707,16 +707,16 @@
               "version_added": "29"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "40"
             }
           },
           "status": {

--- a/api/Response.json
+++ b/api/Response.json
@@ -13,7 +13,7 @@
               "version_added": "40",
               "version_removed": "42",
               "partial_implementation": true,
-              "notes": "Only available via service workers."
+              "notes": "Only available in service workers."
             }
           ],
           "chrome_android": [
@@ -24,7 +24,7 @@
               "version_added": "40",
               "version_removed": "42",
               "partial_implementation": true,
-              "notes": "Only available via service workers."
+              "notes": "Only available in service workers."
             }
           ],
           "deno": {
@@ -50,7 +50,7 @@
               "version_added": "27",
               "version_removed": "29",
               "partial_implementation": true,
-              "notes": "Only available via service workers."
+              "notes": "Only available in service workers."
             }
           ],
           "opera_android": [
@@ -61,7 +61,7 @@
               "version_added": "27",
               "version_removed": "29",
               "partial_implementation": true,
-              "notes": "Only available via service workers."
+              "notes": "Only available in service workers."
             }
           ],
           "safari": {
@@ -81,7 +81,7 @@
               "version_added": "40",
               "version_removed": "42",
               "partial_implementation": true,
-              "notes": "Only available via service workers."
+              "notes": "Only available in service workers."
             }
           ]
         },

--- a/api/_mixins/LinkStyle__ProcessingInstruction.json
+++ b/api/_mixins/LinkStyle__ProcessingInstruction.json
@@ -13,7 +13,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -22,10 +22,10 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
             "opera": {
-              "version_added": "≤12.1"
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": "14"

--- a/api/_mixins/LinkStyle__ProcessingInstruction.json
+++ b/api/_mixins/LinkStyle__ProcessingInstruction.json
@@ -13,7 +13,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "1"
@@ -22,10 +22,10 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "9"
+              "version_added": false
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
               "version_added": "14"


### PR DESCRIPTION
This PR updates real values for all browsers for the `Request` and `Response` APIs, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.3.0).

Tests Used:
https://mdn-bcd-collector.appspot.com/tests/api/Request
https://mdn-bcd-collector.appspot.com/tests/api/Response

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
