### PR TITLE
Updates edge to version 94

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -167,6 +167,7 @@
           "status": "nightly",
           "engine": "Blink",
           "engine_version": "96"
+        }
       }
     }
   }

--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -147,20 +147,26 @@
         "93": {
           "release_date": "2021-09-02",
           "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-93096138-september-02",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "93"
         },
         "94": {
-          "status": "beta",
+          "release_date": "2021-09-24",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-94099231-september-24",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "94"
         },
         "95": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "95"
-        }
+        },
+        "96": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "96"
       }
     }
   }


### PR DESCRIPTION
Hello everyone!

According to [this update](https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-94099231-september-24), edge has been updated to version 94.