### PR TITLE
Fixed link to safari 15 release notes

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -178,7 +178,7 @@
         },
         "15": {
           "release_date": "2021-09-20",
-          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15-beta-release-notes",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes",
           "status": "current",
           "engine": "WebKit",
           "engine_version": "612.1.29"

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -149,7 +149,7 @@
         },
         "15": {
           "release_date": "2021-09-20",
-          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15-beta-release-notes",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes",
           "status": "current",
           "engine": "WebKit",
           "engine_version": "612.1.29"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Fixed link to Safari 15 release notes. Safari changed the URL without adding a redirect so the existing link is dead.

