### PR TITLE
Added missing support data for Opera 78 and 79

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -84,7 +84,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "79"
             },
             "opera_android": {
               "version_added": false

--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -150,7 +150,7 @@
               "version_added": "16.7.0"
             },
             "opera": {
-              "version_added": false
+              "version_added": "78"
             },
             "opera_android": {
               "version_added": false

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -791,7 +791,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "78"
               },
               "opera_android": {
                 "version_added": false

--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -78,7 +78,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "79"
             },
             "opera_android": {
               "version_added": false

--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -231,8 +231,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "79"
                 },
                 "opera_android": {
                   "version_added": false,

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -202,7 +202,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "opera_android": {
                   "version_added": false

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -243,7 +243,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "opera_android": {
                   "version_added": false

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -258,8 +258,7 @@
                   "notes": "This value is recognized, but has no effect."
                 },
                 "opera": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "79"
                 },
                 "opera_android": {
                   "version_added": false,

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -141,7 +141,7 @@
                 "version_added": "16.6.0"
               },
               "opera": {
-                "version_added": false
+                "version_added": "78"
               },
               "opera_android": {
                 "version_added": false

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -140,7 +140,7 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "79"
                 },
                 "opera_android": {
                   "version_added": false

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -197,7 +197,7 @@
                 "version_added": "16.6.0"
               },
               "opera": {
-                "version_added": false
+                "version_added": "78"
               },
               "opera_android": {
                 "version_added": false

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -140,7 +140,7 @@
                 "version_added": "16.6.0"
               },
               "opera": {
-                "version_added": false
+                "version_added": "78"
               },
               "opera_android": {
                 "version_added": false

--- a/javascript/builtins/intl/DateTimeFormat.json
+++ b/javascript/builtins/intl/DateTimeFormat.json
@@ -316,7 +316,7 @@
                       "version_added": false
                     },
                     "opera": {
-                      "version_added": false
+                      "version_added": "78"
                     },
                     "opera_android": {
                       "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds missing Opera 78 and 79 support data.

#### Test results and supporting details

Copies existing chrome support to Opera.

#### Related issues

Fixes: https://github.com/mdn/browser-compat-data/issues/12559
