### PR TITLE
Update support data for the datalist element

### DIFF
--- a/html/elements/datalist.json
+++ b/html/elements/datalist.json
@@ -18,10 +18,17 @@
             "firefox": {
               "version_added": "4"
             },
-            "firefox_android": {
-              "version_added": "4",
-              "notes": "Since Firefox for Android 79, the dropdown menu containing available options does not appear. See <a href='https://bugzil.la/1535985'>bug 1535985</a>."
-            },
+            "firefox_android": [
+              {
+                "version_added": "79",
+                "partial_implementation": true,
+                "notes": "The dropdown menu containing available options does not appear. See <a href='https://bugzil.la/1535985'>bug 1535985</a>."
+              },
+              {
+                "version_added": "4",
+                "version_removed": "79"
+              }
+            ],
             "ie": {
               "version_added": "10"
             },
@@ -29,9 +36,7 @@
               "version_added": "9.5"
             },
             "opera_android": {
-              "version_added": true,
-              "partial_implementation": true,
-              "notes": "The dropdown menu containing available options does not appear in Opera for Android."
+              "version_added": "20"
             },
             "safari": {
               "version_added": "12.1"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Added Opera Android support, also change Firefox Android support entry to better reflect that it's a partial implementation for v79+.

#### Test results and supporting details

Tested latest Opera Android and the dropdown does show. Assuming it was added to the release based on Chrome 33, based on Chrome Android support data.

Also confirmed Firefox Android still doesn't render a dropdown (or other UI) for the options.
