### PR TITLE
Change Chrome's SameSite cookie version

### DIFF
--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -335,13 +335,13 @@
                 ],
                 "chrome_android": [
                   {
-                      "version_added": "67"
+                    "version_added": "67"
                   },
                   {
-                      "version_added": "51",
-                      "version_removed": "67",
-                      "partial_implementation": true,
-                      "notes": "Rejects cookies with <code>SameSite=None</code>. See <a href='https://www.chromium.org/updates/same-site/incompatible-clients'>SameSite=None: Known Incompatible Clients</a>."
+                    "version_added": "51",
+                    "version_removed": "67",
+                    "partial_implementation": true,
+                    "notes": "Rejects cookies with <code>SameSite=None</code>. See <a href='https://www.chromium.org/updates/same-site/incompatible-clients'>SameSite=None: Known Incompatible Clients</a>."
                   }
                 ],
                 "edge": {
@@ -358,24 +358,24 @@
                 },
                 "opera": [
                   {
-                      "version_added": "67"
+                    "version_added": "67"
                   },
                   {
-                      "version_added": "51",
-                      "version_removed": "67",
-                      "partial_implementation": true,
-                      "notes": "Rejects cookies with <code>SameSite=None</code>. See <a href='https://www.chromium.org/updates/same-site/incompatible-clients'>SameSite=None: Known Incompatible Clients</a>."
+                    "version_added": "51",
+                    "version_removed": "67",
+                    "partial_implementation": true,
+                    "notes": "Rejects cookies with <code>SameSite=None</code>. See <a href='https://www.chromium.org/updates/same-site/incompatible-clients'>SameSite=None: Known Incompatible Clients</a>."
                   }
                 ],
                 "opera_android": [
                   {
-                      "version_added": "67"
+                    "version_added": "67"
                   },
                   {
-                      "version_added": "41",
-                      "version_removed": "67",
-                      "partial_implementation": true,
-                      "notes": "Rejects cookies with <code>SameSite=None</code>. See <a href='https://www.chromium.org/updates/same-site/incompatible-clients'>SameSite=None: Known Incompatible Clients</a>."
+                    "version_added": "41",
+                    "version_removed": "67",
+                    "partial_implementation": true,
+                    "notes": "Rejects cookies with <code>SameSite=None</code>. See <a href='https://www.chromium.org/updates/same-site/incompatible-clients'>SameSite=None: Known Incompatible Clients</a>."
                   }
                 ],
                 "safari": {
@@ -387,24 +387,24 @@
                 },
                 "samsunginternet_android": [
                   {
-                      "version_added": "67"
+                    "version_added": "67"
                   },
                   {
-                      "version_added": "5.4",
-                      "version_removed": "67",
-                      "partial_implementation": true,
-                      "notes": "Rejects cookies with <code>SameSite=None</code>. See <a href='https://www.chromium.org/updates/same-site/incompatible-clients'>SameSite=None: Known Incompatible Clients</a>."
+                    "version_added": "5.4",
+                    "version_removed": "67",
+                    "partial_implementation": true,
+                    "notes": "Rejects cookies with <code>SameSite=None</code>. See <a href='https://www.chromium.org/updates/same-site/incompatible-clients'>SameSite=None: Known Incompatible Clients</a>."
                   }
                 ],
                 "webview_android": [
                   {
-                      "version_added": "67"
+                    "version_added": "67"
                   },
                   {
-                      "version_added": "51",
-                      "version_removed": "67",
-                      "partial_implementation": true,
-                      "notes": "Rejects cookies with <code>SameSite=None</code>. See <a href='https://www.chromium.org/updates/same-site/incompatible-clients'>SameSite=None: Known Incompatible Clients</a>."
+                    "version_added": "51",
+                    "version_removed": "67",
+                    "partial_implementation": true,
+                    "notes": "Rejects cookies with <code>SameSite=None</code>. See <a href='https://www.chromium.org/updates/same-site/incompatible-clients'>SameSite=None: Known Incompatible Clients</a>."
                   }
                 ]
               },

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -322,13 +322,28 @@
             "__compat": {
               "description": "<code>SameSite=None</code>",
               "support": {
-                "chrome": {
-                  "version_added": "67",
-                  "notes": "Between versions 51 and 66, Chrome will reject websites with <code>SameSite=None</code> set."
-                },
-                "chrome_android": {
-                  "version_added": "51"
-                },
+                "chrome": [
+                  {
+                    "version_added": "67"
+                  },
+                  {
+                    "version_added": "51",
+                    "version_removed": "67",
+                    "partial_implementation": true,
+                    "notes": "Rejects cookies with <code>SameSite=None</code>. See <a href='https://www.chromium.org/updates/same-site/incompatible-clients'>SameSite=None: Known Incompatible Clients</a>."
+                  }
+                ],
+                "chrome_android": [
+                  {
+                      "version_added": "67"
+                  },
+                  {
+                      "version_added": "51",
+                      "version_removed": "67",
+                      "partial_implementation": true,
+                      "notes": "Rejects cookies with <code>SameSite=None</code>. See <a href='https://www.chromium.org/updates/same-site/incompatible-clients'>SameSite=None: Known Incompatible Clients</a>."
+                  }
+                ],
                 "edge": {
                   "version_added": "16"
                 },
@@ -341,12 +356,28 @@
                 "ie": {
                   "version_added": false
                 },
-                "opera": {
-                  "version_added": "39"
-                },
-                "opera_android": {
-                  "version_added": "41"
-                },
+                "opera": [
+                  {
+                      "version_added": "67"
+                  },
+                  {
+                      "version_added": "51",
+                      "version_removed": "67",
+                      "partial_implementation": true,
+                      "notes": "Rejects cookies with <code>SameSite=None</code>. See <a href='https://www.chromium.org/updates/same-site/incompatible-clients'>SameSite=None: Known Incompatible Clients</a>."
+                  }
+                ],
+                "opera_android": [
+                  {
+                      "version_added": "67"
+                  },
+                  {
+                      "version_added": "41",
+                      "version_removed": "67",
+                      "partial_implementation": true,
+                      "notes": "Rejects cookies with <code>SameSite=None</code>. See <a href='https://www.chromium.org/updates/same-site/incompatible-clients'>SameSite=None: Known Incompatible Clients</a>."
+                  }
+                ],
                 "safari": {
                   "version_added": "13",
                   "notes": "Not supported prior to macOS before version 10.15 (Catalina)."
@@ -354,12 +385,28 @@
                 "safari_ios": {
                   "version_added": "13"
                 },
-                "samsunginternet_android": {
-                  "version_added": "5.0"
-                },
-                "webview_android": {
-                  "version_added": "51"
-                }
+                "samsunginternet_android": [
+                  {
+                      "version_added": "67"
+                  },
+                  {
+                      "version_added": "5.4",
+                      "version_removed": "67",
+                      "partial_implementation": true,
+                      "notes": "Rejects cookies with <code>SameSite=None</code>. See <a href='https://www.chromium.org/updates/same-site/incompatible-clients'>SameSite=None: Known Incompatible Clients</a>."
+                  }
+                ],
+                "webview_android": [
+                  {
+                      "version_added": "67"
+                  },
+                  {
+                      "version_added": "51",
+                      "version_removed": "67",
+                      "partial_implementation": true,
+                      "notes": "Rejects cookies with <code>SameSite=None</code>. See <a href='https://www.chromium.org/updates/same-site/incompatible-clients'>SameSite=None: Known Incompatible Clients</a>."
+                  }
+                ],
               },
               "status": {
                 "experimental": false,

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -323,7 +323,8 @@
               "description": "<code>SameSite=None</code>",
               "support": {
                 "chrome": {
-                  "version_added": "67"
+                  "version_added": "67",
+                  "notes": "Between versions 51 and 66, Chrome will reject websites with <code>SameSite=None</code> set."
                 },
                 "chrome_android": {
                   "version_added": "51"

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -358,22 +358,22 @@
                 },
                 "opera": [
                   {
-                    "version_added": "67"
+                    "version_added": "54"
                   },
                   {
                     "version_added": "51",
-                    "version_removed": "67",
+                    "version_removed": "54",
                     "partial_implementation": true,
                     "notes": "Rejects cookies with <code>SameSite=None</code>. See <a href='https://www.chromium.org/updates/same-site/incompatible-clients'>SameSite=None: Known Incompatible Clients</a>."
                   }
                 ],
                 "opera_android": [
                   {
-                    "version_added": "67"
+                    "version_added": "48"
                   },
                   {
                     "version_added": "41",
-                    "version_removed": "67",
+                    "version_removed": "48",
                     "partial_implementation": true,
                     "notes": "Rejects cookies with <code>SameSite=None</code>. See <a href='https://www.chromium.org/updates/same-site/incompatible-clients'>SameSite=None: Known Incompatible Clients</a>."
                   }
@@ -387,11 +387,11 @@
                 },
                 "samsunginternet_android": [
                   {
-                    "version_added": "67"
+                    "version_added": "9.4"
                   },
                   {
                     "version_added": "5.4",
-                    "version_removed": "67",
+                    "version_removed": "9.4",
                     "partial_implementation": true,
                     "notes": "Rejects cookies with <code>SameSite=None</code>. See <a href='https://www.chromium.org/updates/same-site/incompatible-clients'>SameSite=None: Known Incompatible Clients</a>."
                   }

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -406,7 +406,7 @@
                       "partial_implementation": true,
                       "notes": "Rejects cookies with <code>SameSite=None</code>. See <a href='https://www.chromium.org/updates/same-site/incompatible-clients'>SameSite=None: Known Incompatible Clients</a>."
                   }
-                ],
+                ]
               },
               "status": {
                 "experimental": false,

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -151,7 +151,7 @@
             "description": "<code>SameSite</code>",
             "support": {
               "chrome": {
-                "version_added": "51"
+                "version_added": "67"
               },
               "chrome_android": {
                 "version_added": "51"

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -151,7 +151,7 @@
             "description": "<code>SameSite</code>",
             "support": {
               "chrome": {
-                "version_added": "67"
+                "version_added": "51"
               },
               "chrome_android": {
                 "version_added": "51"
@@ -323,7 +323,7 @@
               "description": "<code>SameSite=None</code>",
               "support": {
                 "chrome": {
-                  "version_added": "51"
+                  "version_added": "67"
                 },
                 "chrome_android": {
                   "version_added": "51"


### PR DESCRIPTION




#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
The Chromium Project says that Chrome versions 51 to 66 (inclusive) will outright reject a `SameSite=None` cookie.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Reference: https://www.chromium.org/updates/same-site/incompatible-clients

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
