### PR TITLE
Intl.ListFormat is not supported on macOS Catalina

### DIFF
--- a/javascript/builtins/intl/ListFormat.json
+++ b/javascript/builtins/intl/ListFormat.json
@@ -39,7 +39,8 @@
                 "version_added": "51"
               },
               "safari": {
-                "version_added": "14.1"
+                "version_added": "14.1",
+                "notes": "Only available on macOS Big Sur (11) or above. Not supported in Safari 14/15 on macOS Catalina."
               },
               "safari_ios": {
                 "version_added": "14.5"
@@ -101,7 +102,8 @@
                   "version_added": "51"
                 },
                 "safari": {
-                  "version_added": "14.1"
+                  "version_added": "14.1",
+                  "notes": "Only available on macOS Big Sur (11) or above. Not supported in Safari 14/15 on macOS Catalina."
                 },
                 "safari_ios": {
                   "version_added": "14.5"
@@ -157,7 +159,8 @@
                   "version_added": "51"
                 },
                 "safari": {
-                  "version_added": "14.1"
+                  "version_added": "14.1",
+                  "notes": "Only available on macOS Big Sur (11) or above. Not supported in Safari 14/15 on macOS Catalina."
                 },
                 "safari_ios": {
                   "version_added": "14.5"
@@ -213,7 +216,8 @@
                   "version_added": "51"
                 },
                 "safari": {
-                  "version_added": "14.1"
+                  "version_added": "14.1",
+                  "notes": "Only available on macOS Big Sur (11) or above. Not supported in Safari 14/15 on macOS Catalina."
                 },
                 "safari_ios": {
                   "version_added": "14.5"
@@ -269,7 +273,8 @@
                   "version_added": "51"
                 },
                 "safari": {
-                  "version_added": "14.1"
+                  "version_added": "14.1",
+                  "notes": "Only available on macOS Big Sur (11) or above. Not supported in Safari 14/15 on macOS Catalina."
                 },
                 "safari_ios": {
                   "version_added": "14.5"
@@ -331,7 +336,8 @@
                   "version_added": "51"
                 },
                 "safari": {
-                  "version_added": "14.1"
+                  "version_added": "14.1",
+                  "notes": "Only available on macOS Big Sur (11) or above. Not supported in Safari 14/15 on macOS Catalina."
                 },
                 "safari_ios": {
                   "version_added": "14.5"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Adding a note to clarify that Intl.ListFormat is only supported on macOS Big Sur and above.
As described here : https://github.com/Financial-Times/polyfill-library/issues/1103

#### Test results and supporting details
This was tested manually by @srikarsam in macOS Catalina in both Safari 14.1 and Safari 15.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

If I read [this patch](https://bugs.webkit.org/attachment.cgi?id=412239&action=prettypatch) correctly `Intl.ListFormat` uses OS features which seem to be missing on Catalina.

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
