### PR TITLE
Fix the order of RTCPeerConnectionIceEvent entries

### DIFF
--- a/api/RTCPeerConnectionIceEvent.json
+++ b/api/RTCPeerConnectionIceEvent.json
@@ -7,22 +7,22 @@
         "support": {
           "chrome": [
             {
+              "version_added": "56"
+            },
+            {
               "alternative_name": "RTCIceCandidateEvent",
               "version_added": "24",
               "version_removed": "56"
-            },
-            {
-              "version_added": "56"
             }
           ],
           "chrome_android": [
             {
+              "version_added": "56"
+            },
+            {
               "alternative_name": "RTCIceCandidateEvent",
               "version_added": "25",
               "version_removed": "56"
-            },
-            {
-              "version_added": "56"
             }
           ],
           "edge": {
@@ -51,22 +51,22 @@
           },
           "samsunginternet_android": [
             {
+              "version_added": "6.0"
+            },
+            {
               "alternative_name": "RTCIceCandidateEvent",
               "version_added": "1.5",
               "version_removed": "6.0"
-            },
-            {
-              "version_added": "6.0"
             }
           ],
           "webview_android": [
             {
+              "version_added": "56"
+            },
+            {
               "alternative_name": "RTCIceCandidateEvent",
               "version_added": "≤37",
               "version_removed": "56"
-            },
-            {
-              "version_added": "56"
             }
           ]
         },


### PR DESCRIPTION
Currently it's red on MDN because the removed ranges is first:
https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnectionIceEvent