### PR TITLE
Add an additional experimental guideline example

### DIFF
--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -280,6 +280,7 @@ A single-engine feature's `experimental` status may expire and switch to `false`
 | An HTTP header supported in Chrome and Firefox, behind flags.               | Yes          |
 | A CSS property value supported in Safari, released last week.               | Yes          |
 | An API supported in Firefox, released three years ago.                      | No           |
+| An API supported in Chrome, released last week, and Firefox, behind a flag. | Yes          |
 
 This guideline was proposed in [#6905](https://github.com/mdn/browser-compat-data/issues/6905) and adopted in [#9933](https://github.com/mdn/browser-compat-data/pull/9933).
 


### PR DESCRIPTION
This PR adds an additional example to the guideline on when to set the `experimental` status.  Based upon our past trends, we've only removed the `experimental` status when it's supported by default in two browsers, so I think this example would be helpful for some people!