### PR TITLE
URLPattern is stabilized in Chrome/Edge 95

### DIFF
--- a/api/URLPattern.json
+++ b/api/URLPattern.json
@@ -4,26 +4,38 @@
       "__compat": {
         "spec_url": "https://wicg.github.io/urlpattern/#urlpattern",
         "support": {
-          "chrome": {
-            "version_added": "93",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#enable-experimental-web-platform-features",
-                "value_to_set": "Enabled"
-              }
-            ]
-          },
-          "chrome_android": {
-            "version_added": "93",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#enable-experimental-web-platform-features",
-                "value_to_set": "Enabled"
-              }
-            ]
-          },
+          "chrome": [
+            {
+              "version_added": "95"
+            },
+            {
+              "version_added": "93",
+              "version_removed": "95",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "95"
+            },
+            {
+              "version_added": "93",
+              "version_removed": "95",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
           "deno": {
             "version_added": "1.14",
             "flags": [
@@ -33,16 +45,22 @@
               }
             ]
           },
-          "edge": {
-            "version_added": "93",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#enable-experimental-web-platform-features",
-                "value_to_set": "Enabled"
-              }
-            ]
-          },
+          "edge": [
+            {
+              "version_added": "95"
+            },
+            {
+              "version_added": "93",
+              "version_removed": "95",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
           "firefox": {
             "version_added": false
           },


### PR DESCRIPTION
URLPattern is unflagged in Chrome 95, which is currently in beta. See
https://www.chromestatus.com/feature/5731920199548928