### PR TITLE
Move the crypto property to api.crypto (in _globals)

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1432,59 +1432,6 @@
           }
         }
       },
-      "crypto": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/crypto",
-          "spec_url": "https://w3c.github.io/webcrypto/#crypto-interface",
-          "support": {
-            "chrome": {
-              "version_added": "37"
-            },
-            "chrome_android": {
-              "version_added": "37"
-            },
-            "deno": {
-              "version_added": "1.0"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "1"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
-            "ie": {
-              "version_added": "11",
-              "prefix": "ms"
-            },
-            "opera": {
-              "version_added": "24"
-            },
-            "opera_android": {
-              "version_added": "24"
-            },
-            "safari": {
-              "version_added": "5"
-            },
-            "safari_ios": {
-              "version_added": "5"
-            },
-            "samsunginternet_android": {
-              "version_added": "3.0"
-            },
-            "webview_android": {
-              "version_added": "37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "customElements": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/customElements",

--- a/api/_globals/crypto.json
+++ b/api/_globals/crypto.json
@@ -1,0 +1,108 @@
+{
+  "api": {
+    "crypto": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/crypto_property",
+        "spec_url": "https://w3c.github.io/webcrypto/#dom-windoworworkerglobalscope-crypto",
+        "support": {
+          "chrome": {
+            "version_added": "37"
+          },
+          "chrome_android": {
+            "version_added": "37"
+          },
+          "deno": {
+            "version_added": "1.0"
+          },
+          "edge": {
+            "version_added": "12"
+          },
+          "firefox": {
+            "version_added": "1"
+          },
+          "firefox_android": {
+            "version_added": "4"
+          },
+          "ie": {
+            "version_added": "11",
+            "prefix": "ms"
+          },
+          "opera": {
+            "version_added": "24"
+          },
+          "opera_android": {
+            "version_added": "24"
+          },
+          "safari": {
+            "version_added": "5"
+          },
+          "safari_ios": {
+            "version_added": "5"
+          },
+          "samsunginternet_android": {
+            "version_added": "3.0"
+          },
+          "webview_android": {
+            "version_added": "37"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "worker_support": {
+        "__compat": {
+          "description": "Available in workers",
+          "support": {
+            "chrome": {
+              "version_added": "37"
+            },
+            "chrome_android": {
+              "version_added": "37"
+            },
+            "deno": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "48"
+            },
+            "firefox_android": {
+              "version_added": "48"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "24"
+            },
+            "opera_android": {
+              "version_added": "24"
+            },
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": {
+              "version_added": "10.3"
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
+            "webview_android": {
+              "version_added": "37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/_globals/crypto.json
+++ b/api/_globals/crypto.json
@@ -63,7 +63,7 @@
               "version_added": "37"
             },
             "deno": {
-              "version_added": null
+              "version_added": "1.0"
             },
             "edge": {
               "version_added": "79"


### PR DESCRIPTION
Worker support versions in Chrome and Firefox were determined with this test:
https://mdn-bcd-collector.appspot.com/tests/api/WorkerGlobalScope/crypto

For Safari, worker support in 10.1 was tested and also verified by source:
https://trac.webkit.org/changeset/204481/webkit
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=204481