### PR TITLE
Remove extra window.location.origin entry

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3178,64 +3178,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "window_location_origin": {
-          "__compat": {
-            "description": "<code>window.location.origin</code>",
-            "support": {
-              "chrome": {
-                "version_added": "31"
-              },
-              "chrome_android": {
-                "version_added": "31"
-              },
-              "deno": {
-                "version_added": "1.7",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--location",
-                    "value_to_set": "<desired origin>"
-                  }
-                ]
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "21"
-              },
-              "firefox_android": {
-                "version_added": "21"
-              },
-              "ie": {
-                "version_added": "11"
-              },
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": "7"
-              },
-              "safari_ios": {
-                "version_added": "7"
-              },
-              "samsunginternet_android": {
-                "version_added": "2.0"
-              },
-              "webview_android": {
-                "version_added": "37"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "locationbar": {


### PR DESCRIPTION
This is already represented here:
https://developer.mozilla.org/en-US/docs/Web/API/Location/origin#browser_compatibility

No effort was made to determine which data is correct in case they
disagree, Location.json is most likely more correct as it has recently
been updated using mdn-bcd-collector:
https://github.com/mdn/browser-compat-data/commits/main/api/Location.json