### PR TITLE
spec and mdn urls for fontfaceset

### DIFF
--- a/api/FontFaceSet.json
+++ b/api/FontFaceSet.json
@@ -50,6 +50,7 @@
       },
       "FontFaceSet": {
         "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-fontfaceset",
           "description": "<code>FontFaceSet()</code> constructor",
           "support": {
             "chrome": {
@@ -99,6 +100,7 @@
       "add": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/add",
+          "spec_url": "https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-add",
           "support": {
             "chrome": {
               "version_added": "35"
@@ -147,7 +149,7 @@
       "check": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/check",
-          "spec_url": "https://drafts.csswg.org/css-font-loading/#font-face-set-check",
+          "spec_url": "https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-check",
           "support": {
             "chrome": {
               "version_added": "35"
@@ -196,6 +198,7 @@
       "clear": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/clear",
+          "spec_url": "https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-clear",
           "support": {
             "chrome": {
               "version_added": "35"
@@ -244,6 +247,7 @@
       "delete": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/delete",
+          "spec_url": "https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-delete",
           "support": {
             "chrome": {
               "version_added": "35"
@@ -291,6 +295,8 @@
       },
       "entries": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/entries",
+          "spec_url": "https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-set-entries",
           "support": {
             "chrome": {
               "version_added": "48"
@@ -338,6 +344,7 @@
       },
       "forEach": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/forEach",
           "support": {
             "chrome": {
               "version_added": "35"
@@ -385,6 +392,7 @@
       },
       "has": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/has",
           "support": {
             "chrome": {
               "version_added": "35"
@@ -432,6 +440,7 @@
       },
       "keys": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/keys",
           "support": {
             "chrome": {
               "version_added": "48"
@@ -480,7 +489,7 @@
       "load": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/load",
-          "spec_url": "https://drafts.csswg.org/css-font-loading/#font-face-set-load",
+          "spec_url": "https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-load",
           "support": {
             "chrome": {
               "version_added": "35"
@@ -529,6 +538,7 @@
       "onloading": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/onloading",
+          "spec_url": "https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-onloading",
           "support": {
             "chrome": {
               "version_added": "35"
@@ -577,6 +587,7 @@
       "onloadingdone": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/onloadingdone",
+          "spec_url": "https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-onloadingdone",
           "support": {
             "chrome": {
               "version_added": "35"
@@ -625,6 +636,7 @@
       "onloadingerror": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/onloadingerror",
+          "spec_url": "https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-onloadingerror",
           "support": {
             "chrome": {
               "version_added": "35"
@@ -721,6 +733,7 @@
       },
       "size": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/size",
           "support": {
             "chrome": {
               "version_added": "35"
@@ -769,6 +782,7 @@
       "status": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/status",
+          "spec_url": "https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-status",
           "support": {
             "chrome": {
               "version_added": "35"
@@ -816,6 +830,7 @@
       },
       "values": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/values",
           "support": {
             "chrome": {
               "version_added": "48"


### PR DESCRIPTION
Some of the methods don't have a spec URL due to being 'setlike', their behavior seems just to be assumed.

https://drafts.csswg.org/css-font-loading/#fontfaceset