### PR TITLE
Add Chrome ≤15 and Firefox ≤4 as allowed ranges

### DIFF
--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -16,7 +16,9 @@ const validBrowserVersions = {};
 
 /** @type {Object<string, string[]>} */
 const VERSION_RANGE_BROWSERS = {
+  chrome: ['≤15'],
   edge: ['≤18', '≤79'],
+  firefox: ['≤4'],
   ie: ['≤6', '≤11'],
   opera: ['≤12.1', '≤15'],
   opera_android: ['≤12.1', '≤14'],


### PR DESCRIPTION
This PR fixes #12626 by adding ranges for the earliest Chrome and Firefox versions supported by BrowserStack.  This should help us get to 100% real values quicker, and these browser versions are so old that most consumers will not care about them.
