### PR TITLE
Include API WebSocket supports for IE 10

### DIFF
--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -577,7 +577,7 @@
               "version_added": "7"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12.1"
@@ -629,7 +629,7 @@
               "version_added": "7"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12.1"
@@ -681,7 +681,7 @@
               "version_added": "7"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12.1"
@@ -889,7 +889,7 @@
               "version_added": "7"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12.1"
@@ -977,7 +977,7 @@
               }
             ],
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12.1"


### PR DESCRIPTION
This PR includes support for the `WebSocket` API in the Internet Explorer browser.

Closes #12616.