### PR TITLE
self.structuredClone() added to FF94

### DIFF
--- a/api/_globals/structuredClone.json
+++ b/api/_globals/structuredClone.json
@@ -30,10 +30,10 @@
             "version_added": false
           },
           "firefox": {
-            "version_added": false
+            "version_added": "94"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "94"
           },
           "ie": {
             "version_added": false
@@ -61,7 +61,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -83,10 +83,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "94"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "94"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
- Support added for `structuredClone()` in FF94: https://bugzilla.mozilla.org/show_bug.cgi?id=1722576
- Docs tracked in https://github.com/mdn/content/issues/9370

This is not present on chromium yet - verified using
```
const original = { name: "MDN" };
const clone = structuredClone(original);
```
(returns error about function not being defined).