### PR TITLE
Fix preview consistency check

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "confluence": "node ./node_modules/mdn-confluence/main/generate.es6.js --output-dir=. --bcd-module=./index.js",
-    "mocha": "mocha \"*/**.test.js\"",
+    "mocha": "mocha \"**/*.test.js\"",
     "lint": "node test/lint",
     "fix": "node scripts/fix",
     "mirror": "node scripts/mirror",

--- a/test/linter/index.js
+++ b/test/linter/index.js
@@ -6,7 +6,7 @@ const testRealValues = require('./test-real-values.js');
 const testSchema = require('./test-schema.js');
 const testStyle = require('./test-style.js');
 const testVersions = require('./test-versions.js');
-const testConsistency = require('./test-consistency.js');
+const { testConsistency } = require('./test-consistency.js');
 const testDescriptions = require('./test-descriptions.js');
 
 module.exports = {

--- a/test/linter/test-consistency.js
+++ b/test/linter/test-consistency.js
@@ -413,4 +413,4 @@ function testConsistency(filename) {
   return false;
 }
 
-module.exports = testConsistency;
+module.exports = { ConsistencyChecker, testConsistency };

--- a/test/linter/test-consistency.js
+++ b/test/linter/test-consistency.js
@@ -275,35 +275,48 @@ class ConsistencyChecker {
   }
 
   /**
-   * @param {SupportStatement} compatData
+   * Return the earliest recorded version number from a support statement or null.
+   *
+   * @param {SupportStatement} supportStatement
    * @return {string | null}
    */
-  getVersionAdded(compatData) {
-    /** @type {string | null} */
-    var version_added = null;
+  getVersionAdded(supportStatement) {
+    // A convenience function squash non-real values and previews into null
+    const resolveVersionAddedValue = statement =>
+      [true, false, 'preview', null].includes(statement.version_added)
+        ? null
+        : statement.version_added;
 
-    if (typeof compatData.version_added === 'string')
-      return compatData.version_added;
-
-    if (compatData.constructor === Array) {
-      for (var i = compatData.length - 1; i >= 0; i--) {
-        var va = compatData[i].version_added;
-        if (
-          typeof va === 'string' &&
-          (version_added == null ||
-            (typeof version_added === 'string' &&
-              compareVersions.compare(
-                version_added.replace('≤', ''),
-                va.replace('≤', ''),
-                '>',
-              )))
-        ) {
-          version_added = va;
-        }
-      }
+    // Handle simple support statements
+    if (!Array.isArray(supportStatement)) {
+      return resolveVersionAddedValue(supportStatement);
     }
 
-    return version_added;
+    // Handle array support statements
+    let selectedValue = null;
+    for (const statement of supportStatement) {
+      const resolvedValue = resolveVersionAddedValue(statement);
+
+      if (resolvedValue === null) {
+        // we're not going to get a more specific version, so bail out now
+        return null;
+      }
+
+      if (selectedValue !== null) {
+        // Earlier value takes precedence
+        const resolvedIsEarlier = compareVersions.compare(
+          resolvedValue.replace('≤', ''),
+          selectedValue.replace('≤', ''),
+          '<',
+        );
+        if (resolvedIsEarlier) {
+          selectedValue = resolvedValue;
+        }
+      } else {
+        selectedValue = resolvedValue;
+      }
+    }
+    return selectedValue;
   }
 
   /**

--- a/test/linter/test-consistency.test.js
+++ b/test/linter/test-consistency.test.js
@@ -1,0 +1,52 @@
+const assert = require('assert').strict;
+
+const { ConsistencyChecker } = require('./test-consistency');
+
+const check = new ConsistencyChecker();
+
+describe('ConsistencyChecker.getVersionAdded()', function () {
+  it('returns null for non-real values', () => {
+    assert.equal(check.getVersionAdded({ version_added: null }), null);
+  });
+
+  it('returns null for "preview" values', () => {
+    assert.equal(check.getVersionAdded({ version_added: 'preview' }), null);
+  });
+
+  it('returns the value for real and ranged values', () => {
+    assert.equal(check.getVersionAdded({ version_added: '12' }), '12');
+    assert.equal(check.getVersionAdded({ version_added: '≤11' }), '≤11');
+  });
+
+  it('returns the earliest real value for an array support statement', () => {
+    assert.equal(
+      check.getVersionAdded([
+        { version_added: '≤11' },
+        { version_added: '101' },
+      ]),
+      '≤11',
+    );
+    assert.equal(
+      check.getVersionAdded([
+        { version_added: 'preview' },
+        { version_added: '≤11', flags: [] },
+      ]),
+      null,
+    );
+    assert.equal(
+      check.getVersionAdded([
+        { version_added: true },
+        { version_added: '≤11', flags: [] },
+      ]),
+      null,
+    );
+
+    assert.equal(
+      check.getVersionAdded([
+        { version_added: '87' },
+        { version_added: true, flags: [] },
+      ]),
+      null,
+    );
+  });
+});


### PR DESCRIPTION
#### Summary

@hamishwillee got an unexpected consistency failure with `"preview"` values. This PR adds some details to remove it.

#### Test results and supporting details

See https://github.com/mdn/browser-compat-data/pull/12194#issuecomment-921359678 for a test case.

You can also check out the first commit on this branch (5525c22) to see the tests fail, then check out the head to make them turn green.