### PR TITLE
Add Safari 15.1 beta

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -182,6 +182,11 @@
           "status": "current",
           "engine": "WebKit",
           "engine_version": "612.1.29"
+        },
+        "15.1": {
+          "status": "beta",
+          "engine": "WebKit",
+          "engine_version": "612.2.6"
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

This adds Safari 15.1 as a beta release.

![image](https://user-images.githubusercontent.com/32498324/135719853-538064f9-3c03-4b02-812e-0ea4acc7b277.png)


#### Related issues
Fixes #12681 
