### PR TITLE
FF94: enterkeyhint support added

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1075,25 +1075,24 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.forms.enterkeyhint",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "94"
+              },
+              {
+                "version_added": "79",
+                "version_removed": "94",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.forms.enterkeyhint",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+            ],
             "firefox_android": {
-              "version_added": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.forms.enterkeyhint",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "94"
             },
             "ie": {
               "version_added": false

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -892,25 +892,24 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.forms.enterkeyhint",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "94"
+              },
+              {
+                "version_added": "79",
+                "version_removed": "94",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.forms.enterkeyhint",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+            ],
             "firefox_android": {
-              "version_added": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.forms.enterkeyhint",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "94"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
FF94 ships enterkeyhint - as per https://bugzilla.mozilla.org/show_bug.cgi?id=1648332 , which was formerly behind the preference `dom.forms.enterkeyhint`.

Other docs work for this can be tracked in https://github.com/mdn/content/issues/9367