### PR TITLE
Drop the spec URL for FontFaceSet»entries()

### DIFF
--- a/api/FontFaceSet.json
+++ b/api/FontFaceSet.json
@@ -296,7 +296,6 @@
       "entries": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSet/entries",
-          "spec_url": "https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-set-entries",
           "support": {
             "chrome": {
               "version_added": "48"


### PR DESCRIPTION
There is no `#dom-fontfaceset-set-entries` anchor in the https://drafts.csswg.org/css-font-loading/ spec — because the spec itself doesn’t define an `entries()` method; instead, because the interface it annotated with `setlike,` the WebIDL spec, at https://heycam.github.io/webidl/#idl-setlike, defines it as having an `entries()` method.

But we have previously intentionally chosen to not link to the WebIDL spec from BCD for these `setlike`-annotated interfaces.

So we just need to drop the spec URL for this.