### PR TITLE
FF94 HTMLScriptElement.supports(type) supported

### DIFF
--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -521,6 +521,55 @@
           }
         }
       },
+      "supports": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/supports",
+          "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#dom-script-supports",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "94"
+            },
+            "firefox_android": {
+              "version_added": "94"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "text": {
         "__compat": {
           "support": {


### PR DESCRIPTION
`HTMLScriptElement.supports(type)` was recently added to FF94 by https://bugzilla.mozilla.org/show_bug.cgi?id=1729239
- FF docs work can be tracked in https://github.com/mdn/content/issues/9365
- Existence can be tested using `if (typeof HTMLScriptElement.supports == 'undefined') {`
- Tested and shown not yet in Chrome (and friends). Planned for Chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=1245528
- Planned for Safari/Webkit https://bugs.webkit.org/show_bug.cgi?id=229929
- Experimental because currently only in FF.
- I will create the MDN doc after this.

