### PR TITLE
Set Opera 80 as stable and update support data

### DIFF
--- a/api/AudioData.json
+++ b/api/AudioData.json
@@ -24,7 +24,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "80"
           },
           "opera_android": {
             "version_added": false
@@ -73,7 +73,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -122,7 +122,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -171,7 +171,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -220,7 +220,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -269,7 +269,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -318,7 +318,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -367,7 +367,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -416,7 +416,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -465,7 +465,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -514,7 +514,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false

--- a/api/AudioDecoder.json
+++ b/api/AudioDecoder.json
@@ -24,7 +24,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "80"
           },
           "opera_android": {
             "version_added": false
@@ -73,7 +73,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -122,7 +122,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -171,7 +171,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -220,7 +220,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -269,7 +269,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -318,7 +318,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -367,7 +367,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -416,7 +416,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false

--- a/api/AudioEncoder.json
+++ b/api/AudioEncoder.json
@@ -24,7 +24,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "80"
           },
           "opera_android": {
             "version_added": false
@@ -73,7 +73,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -122,7 +122,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -171,7 +171,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -220,7 +220,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -318,7 +318,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -367,7 +367,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false

--- a/api/EncodedAudioChunk.json
+++ b/api/EncodedAudioChunk.json
@@ -24,7 +24,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "80"
           },
           "opera_android": {
             "version_added": false
@@ -73,7 +73,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -122,7 +122,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -171,7 +171,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -220,7 +220,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -269,7 +269,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -318,7 +318,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false

--- a/api/EncodedVideoChunk.json
+++ b/api/EncodedVideoChunk.json
@@ -24,7 +24,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "80"
           },
           "opera_android": {
             "version_added": false
@@ -73,7 +73,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -122,7 +122,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -171,7 +171,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -220,7 +220,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -269,7 +269,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -318,7 +318,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false

--- a/api/ImageDecoder.json
+++ b/api/ImageDecoder.json
@@ -24,7 +24,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "80"
           },
           "opera_android": {
             "version_added": false
@@ -73,7 +73,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -122,7 +122,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -171,7 +171,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -220,7 +220,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -269,7 +269,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -318,7 +318,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -367,7 +367,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -386,7 +386,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/ImageTrack.json
+++ b/api/ImageTrack.json
@@ -24,7 +24,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "80"
           },
           "opera_android": {
             "version_added": false
@@ -72,7 +72,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -121,7 +121,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -170,7 +170,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -219,7 +219,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false

--- a/api/ImageTrackList.json
+++ b/api/ImageTrackList.json
@@ -24,7 +24,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "80"
           },
           "opera_android": {
             "version_added": false
@@ -72,7 +72,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -121,7 +121,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -170,7 +170,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -219,7 +219,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false

--- a/api/URLPattern.json
+++ b/api/URLPattern.json
@@ -54,7 +54,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "81"
           },
           "opera_android": {
             "version_added": false
@@ -106,7 +106,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "81"
             },
             "opera_android": {
               "version_added": false
@@ -158,7 +158,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "81"
             },
             "opera_android": {
               "version_added": false
@@ -210,7 +210,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "81"
             },
             "opera_android": {
               "version_added": false
@@ -262,7 +262,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "81"
             },
             "opera_android": {
               "version_added": false
@@ -314,7 +314,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "81"
             },
             "opera_android": {
               "version_added": false
@@ -366,7 +366,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "81"
             },
             "opera_android": {
               "version_added": false
@@ -418,7 +418,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "81"
             },
             "opera_android": {
               "version_added": false
@@ -470,7 +470,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "81"
             },
             "opera_android": {
               "version_added": false
@@ -522,7 +522,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "81"
             },
             "opera_android": {
               "version_added": false
@@ -574,7 +574,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "81"
             },
             "opera_android": {
               "version_added": false
@@ -626,7 +626,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "81"
             },
             "opera_android": {
               "version_added": false

--- a/api/VideoColorSpace.json
+++ b/api/VideoColorSpace.json
@@ -24,7 +24,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "80"
           },
           "opera_android": {
             "version_added": false
@@ -73,7 +73,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -122,7 +122,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -171,7 +171,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -220,7 +220,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -269,7 +269,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -318,7 +318,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false

--- a/api/VideoEncoder.json
+++ b/api/VideoEncoder.json
@@ -24,7 +24,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "80"
           },
           "opera_android": {
             "version_added": false
@@ -73,7 +73,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -122,7 +122,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -171,7 +171,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -220,7 +220,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -269,7 +269,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -318,7 +318,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -367,7 +367,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false

--- a/api/VideoFrame.json
+++ b/api/VideoFrame.json
@@ -24,7 +24,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "80"
           },
           "opera_android": {
             "version_added": false
@@ -73,7 +73,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -122,7 +122,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -171,7 +171,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -220,7 +220,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -269,7 +269,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -318,7 +318,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -367,7 +367,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -416,7 +416,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -465,7 +465,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -514,7 +514,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -563,7 +563,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -612,7 +612,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -661,7 +661,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -710,7 +710,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false

--- a/api/_globals/reportError.json
+++ b/api/_globals/reportError.json
@@ -29,7 +29,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "81"
           },
           "opera_android": {
             "version_added": false
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "81"
             },
             "opera_android": {
               "version_added": false

--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -608,14 +608,21 @@
         "79": {
           "release_date": "2021-09-14",
           "release_notes": "https://blogs.opera.com/desktop/2021/09/opera-79-stable/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "93"
         },
         "80": {
-          "status": "beta",
+          "release_date": "2021-10-05",
+          "release_notes": "https://blogs.opera.com/desktop/2021/10/opera-80-stable/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "94"
+        },
+        "81": {
+          "status": "beta",
+          "engine": "Blink",
+          "engine_version": "95"
         }
       }
     }

--- a/css/properties/scrollbar-gutter.json
+++ b/css/properties/scrollbar-gutter.json
@@ -37,7 +37,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -384,7 +384,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "80"
               },
               "opera_android": {
                 "version_added": false


### PR DESCRIPTION
Also adds support data

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Sets Opera 80 as stable, adds Opera 81 as beta. Updates support data.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Mostly just copying across Blink 94 and 95.

See https://github.com/mdn/browser-compat-data/pull/12526 for `display-capture` feature policy change evidence

See https://github.com/mdn/browser-compat-data/pull/12331 for `scrollbar-gutter` evidence

See https://github.com/mdn/browser-compat-data/pull/12635 for `URLPattern` evidence

https://blogs.opera.com/desktop/2021/10/opera-80-stable/

https://blogs.opera.com/desktop/changelog-for-81/
