### PR TITLE
`prefers-contrast` is coming in Chrome 96

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1397,7 +1397,7 @@
                 "version_added": "96"
               },
               "edge": {
-                "version_added": false
+                "version_added": "96"
               },
               "firefox": {
                 "version_added": "80",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
- pretty much title 0:-)
- https://twitter.com/argyleink/status/1445741380379168769
- https://chromestatus.com/feature/5646323212615680
- https://bugs.chromium.org/p/chromium/issues/detail?id=1107431

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
https://wpt.fyi/results/css/mediaqueries/prefers-contrast.html?label=master&label=experimental&aligned&q=prefers-contrast

and also tested myself:

<http://wpt.live/css/mediaqueries/prefers-contrast.html>:
![image](https://user-images.githubusercontent.com/2644614/136406627-9fa77c28-e0f4-446d-9315-d58783070fd3.png)


<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
