### PR TITLE
Mark SubmitEvent as partially supported in Safari 15

### DIFF
--- a/api/SubmitEvent.json
+++ b/api/SubmitEvent.json
@@ -127,11 +127,20 @@
             "opera_android": {
               "version_added": null
             },
-            "safari": {
-              "version_added": "15"
-            },
+            "safari": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "15",
+                "partial_implementation": true,
+                "notes": "Property is not set for <code>&lt;button&gt;</code> elements. See <a href='https://webkit.org/b/229660'>bug 229660</a>."
+              }
+            ],
             "safari_ios": {
-              "version_added": "15"
+              "version_added": "15",
+              "partial_implementation": true,
+              "notes": "Property is not set for <code>&lt;button&gt;</code> elements. See <a href='https://webkit.org/b/229660'>bug 229660</a>."
             },
             "samsunginternet_android": {
               "version_added": "13.0"


### PR DESCRIPTION
#### Summary

The `SubmitEvent` constructor is fully supported, but the `submitter` property only partially works: https://webkit.org/b/229660
The bug is fixed in Tech Preview 132, but it missed the release cut for Safari 15. ~I would have added an extra `version_added: "preview"` section, but got bitten by #12663 when running linting locally.~ (Edit: Fixed)

#### Test results and supporting details

Tested manually in Safari 15 (macOS and iOS).

Release notes:
* Initial implementation in TP 130: https://webkit.org/blog/11958/release-notes-for-safari-technology-preview-130/
* Bug fix for `submitter` in TP 132: https://webkit.org/blog/11971/release-notes-for-safari-technology-preview-132/

#### Related issues

This will cause a merge conflict with the TP info provided by #12439