### PR TITLE
Update support for ArrayBufferView and URLSearchParams in XHR.send

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1676,22 +1676,36 @@
                 "version_added": "44"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
-                "version_added": "12"
+                "version_added": "46"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "43"
               },
-              "safari": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/227477'>bug 227477</a>."
-              },
-              "safari_ios": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/227477'>bug 227477</a>."
-              },
+              "safari": [
+                {
+                  "version_added": "15"
+                },
+                {
+                  "version_added": "10.1",
+                  "version_removed": "15",
+                  "partial_implementation": true,
+                  "notes": "Doesn't send the correct <code>Content-Type</code> header by default. See <a href='https://webkit.org/b/227477'>bug 227477</a>."
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "15"
+                },
+                {
+                  "version_added": "10.3",
+                  "version_removed": "15",
+                  "partial_implementation": true,
+                  "notes": "Doesn't send the correct <code>Content-Type</code> header by default. See <a href='https://webkit.org/b/227477'>bug 227477</a>."
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": "7.0"
               },

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1489,10 +1489,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": "7"
+                "version_added": "6"
               },
               "safari_ios": {
-                "version_added": "7"
+                "version_added": "6"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -1529,7 +1529,7 @@
                 "version_added": "20"
               },
               "ie": {
-                "version_added": null
+                "version_added": "10"
               },
               "opera": {
                 "version_added": true

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1520,7 +1520,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "20"


### PR DESCRIPTION
#### Summary

Filled in `null` values, and corrected some erroneous entries for https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/send

#### Test results and supporting details

- `ArrayBuffer` and `ArrayBufferView`
    - IE: Support for `ArrayBufferView` was added in the same release as `ArrayBuffer` (10). I've previously written production code that relies on IE10 supporting `UInt8Array` in `xhr.send()`.
    - Safari: I think there was a mismatch in the existing data, where the support data for `ArrayBuffer` was listed in the `ArrayBufferView` section. As far as I can tell from WebKit issues, `ArrayBuffer` support was added in the same release (6) as `Blob` and `FormData` support ([bug 50199](https://bugs.webkit.org/show_bug.cgi?id=50199)), while `ArrayBufferView` was added later in version 7 ([bug 90536](https://bugs.webkit.org/show_bug.cgi?id=90536)).
 - `URLSearchParams`
    - Most of these updates were to align with the support data of the `URLSearchParams` object itself. https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
    - IE: Doesn't support `URLSearchParams` at all.
    - Opera: Was listed as version 12. But overall `URLSearchParams` object support is listed as being added in version 36, so it can't have supported `URLSearchParams` in `xhr.send()` in version 12. I've updated Opera and Opera Android to match their respective Chrome versions for this API.
    - Safari: Was listed as not supported, but I think that was a misunderstanding of the [linked bug (227477)](https://bugs.webkit.org/show_bug.cgi?id=227477). When `URLSearchParams` was added in Safari 10.1 (iOS 10.3), it was implicitly supported in `xhr.send()` via calling `.toString()` on the `body` argument. Bug 227477 corrected the `Content-Type` header, and was fixed and included in Safari Tech Preview 129 / Safari 15. I tested this manually by comparing results in Safari 14.1 and Safari 15.
