### PR TITLE
Mark font-synthesis:small-caps supported since Safari 10.1

### DIFF
--- a/css/properties/font-synthesis.json
+++ b/css/properties/font-synthesis.json
@@ -78,10 +78,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -91,7 +91,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
This is based on WebKit source history:
https://trac.webkit.org/changeset/209875/webkit
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=209875

WebKit trunk version 603.1.17 suggests Safari 10.1 / iOS 10.3.