### PR TITLE
Details of support for partitionKey in cookies

### DIFF
--- a/webextensions/api/cookies.json
+++ b/webextensions/api/cookies.json
@@ -63,7 +63,7 @@
                   "version_added": "94"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "94"
                 },
                 "opera": {
                   "version_added": false
@@ -214,7 +214,7 @@
                   "version_added": "94"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "94"
                 },
                 "opera": {
                   "version_added": false
@@ -293,7 +293,7 @@
                   "version_added": "94"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "94"
                 },
                 "opera": {
                   "version_added": false
@@ -370,7 +370,7 @@
                   "version_added": "94"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "94"
                 },
                 "opera": {
                   "version_added": false
@@ -445,7 +445,7 @@
                   "version_added": "94"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "94"
                 },
                 "opera": {
                   "version_added": false
@@ -546,7 +546,7 @@
                   "version_added": "94"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "94"
                 },
                 "opera": {
                   "version_added": false


### PR DESCRIPTION
#### Summary
Details of support for `partitionKey` in the cookies API, specifically the `cookies` object and the `get`, `getAll`, `remove`, and `set` methods

#### Test results and supporting details
Executed `npm test` with no errors related to the change

#### Related issues
Adds information in support of [Bug 1669716](https://bugzilla.mozilla.org/show_bug.cgi?id=1669716)