### PR TITLE
Remove api.CanvasRenderingContext2D.drawImage.smoothing_downscaling

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1229,56 +1229,6 @@
               "deprecated": false
             }
           }
-        },
-        "smoothing_downscaling": {
-          "__compat": {
-            "description": "Smoothing when downscaling",
-            "support": {
-              "chrome": {
-                "version_added": "54"
-              },
-              "chrome_android": {
-                "version_added": "54"
-              },
-              "edge": {
-                "version_added": "79"
-              },
-              "firefox": {
-                "version_added": "56",
-                "notes": "See <a href='https://bugzil.la/1360415'>bug 1360415</a> for details."
-              },
-              "firefox_android": {
-                "version_added": "56",
-                "notes": "See <a href='https://bugzil.la/1360415'>bug 1360415</a> for details."
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "41"
-              },
-              "opera_android": {
-                "version_added": "41"
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": null
-              },
-              "samsunginternet_android": {
-                "version_added": "6.0"
-              },
-              "webview_android": {
-                "version_added": "54"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "drawWidgetAsOnScreen": {


### PR DESCRIPTION
This PR removes the `smoothing_downscaling` subfeature of the `drawImage` method of `CanvasRenderingContext2D`.  This feature was a remnant from the old wiki migration.  There is nothing in the docs explaining what exactly this means, so it's unclear how to test support for this.  With that, plus the fact that this isn't a spec-defined behavior, I think it makes sense to simply remove this subfeature from BCD.
