### PR TITLE
Add Chromium versions for api.KeyboardEvent.getModifierState

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -395,10 +395,10 @@
             "description": "<code>\"Alt\"</code> as a parameter",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "30"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "30"
               },
               "edge": {
                 "version_added": "≤79"
@@ -413,10 +413,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": true
+                "version_added": "17"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "safari": {
                 "version_added": "10.1"
@@ -425,10 +425,10 @@
                 "version_added": "10.3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "4.4"
               }
             },
             "status": {
@@ -539,10 +539,10 @@
             "description": "<code>\"Control\"</code> as a parameter",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "30"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "30"
               },
               "edge": {
                 "version_added": "≤79"
@@ -557,10 +557,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": true
+                "version_added": "17"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "safari": {
                 "version_added": "10.1"
@@ -569,10 +569,10 @@
                 "version_added": "10.3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "4.4"
               }
             },
             "status": {
@@ -635,13 +635,13 @@
             "description": "<code>\"FnLock\"</code> as a parameter",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": false
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -653,10 +653,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": true
+                "version_added": false
               },
               "opera_android": {
-                "version_added": true
+                "version_added": false
               },
               "safari": {
                 "version_added": false
@@ -665,10 +665,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": false
               },
               "webview_android": {
-                "version_added": true
+                "version_added": false
               }
             },
             "status": {
@@ -683,13 +683,13 @@
             "description": "<code>\"Hyper\"</code> as a parameter",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": false
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -701,10 +701,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": true
+                "version_added": false
               },
               "opera_android": {
-                "version_added": true
+                "version_added": false
               },
               "safari": {
                 "version_added": false
@@ -713,10 +713,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": false
               },
               "webview_android": {
-                "version_added": true
+                "version_added": false
               }
             },
             "status": {
@@ -731,10 +731,10 @@
             "description": "<code>\"Meta\"</code> as a parameter",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "30"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "30"
               },
               "edge": {
                 "version_added": "≤79"
@@ -749,10 +749,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": true
+                "version_added": "17"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "safari": {
                 "version_added": "10.1"
@@ -761,10 +761,10 @@
                 "version_added": "10.3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "4.4"
               }
             },
             "status": {
@@ -832,10 +832,16 @@
               "chrome_android": {
                 "version_added": "48"
               },
-              "edge": {
-                "version_added": "12",
-                "alternative_name": "Win"
-              },
+              "edge": [
+                {
+                  "version_added": "79"
+                },
+                {
+                  "version_added": "12",
+                  "version_removed": "79",
+                  "alternative_name": "Win"
+                }
+              ],
               "firefox": {
                 "version_added": true
               },
@@ -882,10 +888,16 @@
               "chrome_android": {
                 "version_added": "48"
               },
-              "edge": {
-                "version_added": "12",
-                "alternative_name": "Scroll"
-              },
+              "edge": [
+                {
+                  "version_added": "79"
+                },
+                {
+                  "version_added": "12",
+                  "version_removed": "79",
+                  "alternative_name": "Scroll"
+                }
+              ],
               "firefox": {
                 "version_added": true
               },
@@ -927,10 +939,10 @@
             "description": "<code>\"Shift\"</code> as a parameter",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "30"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "30"
               },
               "edge": {
                 "version_added": "≤79"
@@ -945,10 +957,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": true
+                "version_added": "17"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "safari": {
                 "version_added": "10.1"
@@ -957,10 +969,10 @@
                 "version_added": "10.3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "4.4"
               }
             },
             "status": {
@@ -975,13 +987,13 @@
             "description": "<code>\"Super\"</code> as a parameter",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": false
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -993,10 +1005,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": true
+                "version_added": false
               },
               "opera_android": {
-                "version_added": true
+                "version_added": false
               },
               "safari": {
                 "version_added": false
@@ -1005,10 +1017,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": false
               },
               "webview_android": {
-                "version_added": true
+                "version_added": false
               }
             },
             "status": {
@@ -1071,13 +1083,13 @@
             "description": "<code>\"SymbolLock\"</code> as a parameter",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": false
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -1089,10 +1101,10 @@
                 "version_added": null
               },
               "opera": {
-                "version_added": true
+                "version_added": false
               },
               "opera_android": {
-                "version_added": true
+                "version_added": false
               },
               "safari": {
                 "version_added": false
@@ -1101,10 +1113,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": false
               },
               "webview_android": {
-                "version_added": true
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the various subfeatures of the `getModifierState` member of the `KeyboardEvent` API, based upon commit history and date.

Commits:
https://source.chromium.org/chromium/chromium/src/+/505226f3a97da1bc204283385cf2ac3ba9409fc3
https://source.chromium.org/chromium/chromium/src/+/299efe15d10d2dfbfb5bcc7c2f753ddc4f318832
https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/events/ui_event_with_key_state.cc;drc=916c12f8dabe24c951bb6b306580f7d408f95049
