### PR TITLE
Add Firefox versions for api.KeyboardEvent.getModifierState

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -404,10 +404,10 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "15"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "15"
               },
               "ie": {
                 "version_added": null
@@ -452,10 +452,10 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "15"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "15"
               },
               "ie": {
                 "version_added": null
@@ -500,10 +500,10 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "15"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "15"
               },
               "ie": {
                 "version_added": null
@@ -548,10 +548,10 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "15"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "15"
               },
               "ie": {
                 "version_added": null
@@ -596,10 +596,10 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "15"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "15"
               },
               "ie": {
                 "version_added": null
@@ -740,10 +740,10 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "15"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "15"
               },
               "ie": {
                 "version_added": null
@@ -788,10 +788,10 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "15"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "15"
               },
               "ie": {
                 "version_added": null
@@ -843,10 +843,10 @@
                 }
               ],
               "firefox": {
-                "version_added": true
+                "version_added": "15"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "15"
               },
               "ie": {
                 "version_added": true,
@@ -899,10 +899,10 @@
                 }
               ],
               "firefox": {
-                "version_added": true
+                "version_added": "15"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "15"
               },
               "ie": {
                 "version_added": true,
@@ -948,10 +948,10 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "15"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "15"
               },
               "ie": {
                 "version_added": null


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `getModifierState` member of the `KeyboardEvent` API, based upon information in a tracking bug.

Tracking Bug: https://bugzil.la/731878
