### PR TITLE
Add IE/Edge versions for api.KeyboardEvent.getModifierState

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -401,7 +401,7 @@
                 "version_added": "30"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": true
@@ -410,7 +410,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": null
+                "version_added": "9"
               },
               "opera": {
                 "version_added": "17"
@@ -449,7 +449,7 @@
                 "version_added": "48"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": true
@@ -458,7 +458,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "35"
@@ -497,7 +497,7 @@
                 "version_added": "48"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": true
@@ -506,7 +506,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": null
+                "version_added": "9"
               },
               "opera": {
                 "version_added": "35"
@@ -545,7 +545,7 @@
                 "version_added": "30"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": true
@@ -554,7 +554,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": null
+                "version_added": "9"
               },
               "opera": {
                 "version_added": "17"
@@ -593,7 +593,7 @@
                 "version_added": "48"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": true
@@ -602,7 +602,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "35"
@@ -737,7 +737,7 @@
                 "version_added": "30"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": true
@@ -746,7 +746,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "17"
@@ -794,7 +794,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": null
+                "version_added": "9"
               },
               "opera": {
                 "version_added": "35"
@@ -849,7 +849,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true,
+                "version_added": "9",
                 "alternative_name": "Win"
               },
               "opera": {
@@ -905,7 +905,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true,
+                "version_added": "9",
                 "alternative_name": "Scroll"
               },
               "opera": {
@@ -945,7 +945,7 @@
                 "version_added": "30"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": true
@@ -954,7 +954,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": null
+                "version_added": "9"
               },
               "opera": {
                 "version_added": "17"
@@ -1041,7 +1041,7 @@
                 "version_added": "48"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false
@@ -1050,7 +1050,7 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "35"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `getModifierState` member of the `KeyboardEvent` API, based upon manual testing.

Test Code Used:
```js
document.addEventListener('keydown', function(event) {
	var states = ['alt', 'altgraph', 'capslock', 'control', 'fn', 'fnlock', 'hyper', 'meta', 'numlock', 'win', 'scroll', 'shift', 'super', 'symbol', 'symbollock'];
	var result = "";
	for (var i = 0; i < states.length; i++) {
		var state = event.getModifierState(states[i])
		if (state) {
			if (result.length) {
				result += ", ";
			}
			result += states[i];
		}
	}
	alert(result);
});
```
