### PR TITLE
Use alternative name for Node's Crypto interface

### DIFF
--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -36,7 +36,9 @@
           },
           "nodejs": {
             "version_added": "15.0.0",
-            "notes": "Exported from the <code>crypto</code> module as <code>webcrypto</code> but not globally available."
+            "alternative_name": "crypto.webcrypto",
+            "partial_implementation": true,
+            "notes": "<code>Crypto</code> is not a concrete interface, but calling <code>require('crypto').webcrypto</code> returns an instance of the <code>Crypto</code> class."
           },
           "opera": {
             "version_added": "15"


### PR DESCRIPTION
#### Summary

The existing note describes how Node.js provides the `Crypto` interface through an alternative name. This wasn't the whole story. Instead, it returns an instance of `Crpyto` via an alternative name. This expands the note (cribbing from Deno's similar note) and adds the fields for `alternative_name` and `partial_implementation`.

#### Test results and supporting details

* [Node.js docs for the Web Crypto API](https://nodejs.org/api/webcrypto.html#webcrypto_web_crypto_api)

#### Related issues

I noticed this while reviewing https://github.com/mdn/browser-compat-data/pull/12578.