### PR TITLE
Update Deno 1.15 SubtleCrypto support

### DIFF
--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -221,7 +221,7 @@
               "version_added": "37"
             },
             "deno": {
-              "version_added": false
+              "version_added": "1.15"
             },
             "edge": {
               "version_added": "12",


### PR DESCRIPTION
#### Summary

Deno 1.15 supports more `SubtleCrypto` APIs.

https://dotcom-ki0pfr8jw-denoland.vercel.app/blog/v1.15#new-crypto-apis
