### PR TITLE
Add note for when Chromium started following border-radius for outline

### DIFF
--- a/css/properties/outline.json
+++ b/css/properties/outline.json
@@ -44,10 +44,12 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "1.2"
+              "version_added": "1.2",
+              "notes": "<code>outline</code> does not follow the shape of <code>border-radius</code>. See <a href='https://webkit.org/b/231433'>bug 231433</a>."
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "<code>outline</code> does not follow the shape of <code>border-radius</code>. See <a href='https://webkit.org/b/231433'>bug 231433</a>."
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Adds notes to Chrome, Edge, Opera etc to say when the outline property started following border radius.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://developer.mozilla.org/en-US/docs/Web/CSS/outline

![image](https://user-images.githubusercontent.com/32498324/136990989-855a1e0d-663a-4cc0-8eb7-1c084b0ef218.png)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Fixes https://github.com/mdn/browser-compat-data/issues/12760
