### PR TITLE
Add notes to link to tracking bugs for scrollbar properties

### DIFF
--- a/css/properties/scrollbar-color.json
+++ b/css/properties/scrollbar-color.json
@@ -7,13 +7,16 @@
           "spec_url": "https://drafts.csswg.org/css-scrollbars/#scrollbar-color",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/891944'>bug 891944</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/891944'>bug 891944</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/891944'>bug 891944</a>."
             },
             "firefox": {
               "version_added": "64",
@@ -26,22 +29,28 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/891944'>bug 891944</a>."
             },
             "opera_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/891944'>bug 891944</a>."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/231590'>bug 231590</a>."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/231590'>bug 231590</a>."
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/891944'>bug 891944</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/891944'>bug 891944</a>."
             }
           },
           "status": {

--- a/css/properties/scrollbar-gutter.json
+++ b/css/properties/scrollbar-gutter.json
@@ -40,10 +40,12 @@
               "version_added": "94"
             },
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1715112'>bug 1715112</a>."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1715112'>bug 1715112</a>."
             },
             "ie": {
               "version_added": false
@@ -55,10 +57,12 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/167335'>bug 167335</a>."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/167335'>bug 167335</a>."
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/scrollbar-width.json
+++ b/css/properties/scrollbar-width.json
@@ -7,13 +7,16 @@
           "spec_url": "https://drafts.csswg.org/css-scrollbars/#scrollbar-width",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/891944'>bug 891944</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/891944'>bug 891944</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/891944'>bug 891944</a>."
             },
             "firefox": {
               "version_added": "64"
@@ -25,22 +28,28 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/891944'>bug 891944</a>."
             },
             "opera_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/891944'>bug 891944</a>."
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/231588'>bug 231588</a>."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/231588'>bug 231588</a>."
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/891944'>bug 891944</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/891944'>bug 891944</a>."
             }
           },
           "status": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Adds notes to browser tracking bugs for [`scrollbar-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color), [`scrollbar-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width) and [`scrollbar-gutter`](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter).

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Chromium:

`scrollbar-color` and `scrollbar-width`: https://crbug.com/891944

`scrollbar-gutter`: Shipped

Firefox:

`scrollbar-color` and `scrollbar-width`: Shipped

`scrollbar-gutter`: https://bugzil.la/1715112

WebKit:

`scrollbar-color`: https://webkit.org/b/231590

`scrollbar-width`: https://webkit.org/b/231588

`scrollbar-gutter`: https://webkit.org/b/167335
