### PR TITLE
Add entry for `input-security` CSS property

### DIFF
--- a/css/properties/input-security.json
+++ b/css/properties/input-security.json
@@ -1,0 +1,64 @@
+{
+  "css": {
+    "properties": {
+      "input-security": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-ui/#input-security",
+          "support": {
+            "chrome": {
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/1253732'>bug 1253732</a>."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/1253732'>bug 1253732</a>."
+            },
+            "edge": {
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/1253732'>bug 1253732</a>."
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1735384'>bug 1735384</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1735384'>bug 1735384</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/1253732'>bug 1253732</a>."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/1253732'>bug 1253732</a>."
+            },
+            "safari": {
+              "version_added": "preview"
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/184510'>bug 184510</a>."
+            },
+            "samsunginternet_android": {
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/1253732'>bug 1253732</a>."
+            },
+            "webview_android": {
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/1253732'>bug 1253732</a>."
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Added an entry for the [`input-security`](https://drafts.csswg.org/css-ui/#input-security) CSS property.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://webkit.org/blog/11975/release-notes-for-safari-technology-preview-133/#:~:text=Added%20support%20for%20input-security - Safari TP ~~supposedly supports this property but I and someone else haven't been able to get it working so have left as false for now.~~ As of TP 134 this is now working so I've added it.

WebKit bug (implemented): https://webkit.org/b/184510

Firefox bug (in progress): https://bugzil.la/1735384

Chromium bug: https://crbug.com/1253732

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/12664

Related to mdn/content#9422