### PR TITLE
FF94 supports Shadowroot.delegatesFocus

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1180,12 +1180,10 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1413836'>bug 1413836</a>."
+                "version_added": "94"
               },
               "firefox_android": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1413836'>bug 1413836</a>."
+                "version_added": "94"
               },
               "ie": {
                 "version_added": false

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -51,7 +51,7 @@
       "delegatesFocus": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/delegatesFocus",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-shadowroot-delegatesfocus",
+          "spec_url": "https://dom.spec.whatwg.org/#shadowroot-delegates-focus",
           "support": {
             "chrome": {
               "version_added": "53"
@@ -63,12 +63,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1706275'>bug 1706275</a>."
+              "version_added": "94"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1706275'>bug 1706275</a>."
+              "version_added": "94"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Support for [ShadowRoot.delegatesFocus](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus) was added in FF94 - see https://bugzilla.mozilla.org/show_bug.cgi?id=1413836

Other docs work for this tracked in https://github.com/mdn/content/issues/9364