### PR TITLE
Safari support for `Notification.requestPermission` no longer partial

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -948,9 +948,17 @@
             "opera_android": {
               "version_added": "24"
             },
-            "safari": {
-              "version_added": "7"
-            },
+            "safari": [
+              {
+                "version_added": "15"
+              },
+              {
+                "version_added": "7",
+                "version_removed": "15",
+                "partial_implementation": true,
+                "notes": "Only supported the deprecated callback syntax."
+              }
+            ],
             "safari_ios": {
               "version_added": false
             },


### PR DESCRIPTION
#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Updates Safari support data for `Notifcation.requestPermission()`. This MR marks Safari as partial implementation due to it not supporting the newer promise syntax.

Mark Safari as fully supported from 15. 

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Tested on Safari 15.1 Beta 2 with https://jsfiddle.net/knsyhjcw/

Assuming it was in 15 from the looks of https://github.com/WebKit/WebKit/commit/129e9cc342cb67c600833cf5c0d136325985c3ed.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Fixes https://github.com/mdn/browser-compat-data/issues/12625
