### PR TITLE
Update Safari support data for scroll-padding properties

### DIFF
--- a/css/properties/scroll-padding-bottom.json
+++ b/css/properties/scroll-padding-bottom.json
@@ -30,16 +30,28 @@
             "opera_android": {
               "version_added": "48"
             },
-            "safari": {
-              "version_added": "11",
-              "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-            },
-            "safari_ios": {
-              "version_added": "11",
-              "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-            },
+            "safari": [
+              {
+                "version_added": "14.1"
+              },
+              {
+                "version_added": "11",
+                "version_removed": "14.1",
+                "partial_implementation": true,
+                "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14.5"
+              },
+              {
+                "version_added": "11",
+                "version_removed": "14.5",
+                "partial_implementation": true,
+                "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "10.0"
             },

--- a/css/properties/scroll-padding-left.json
+++ b/css/properties/scroll-padding-left.json
@@ -30,16 +30,28 @@
             "opera_android": {
               "version_added": "48"
             },
-            "safari": {
-              "version_added": "11",
-              "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-            },
-            "safari_ios": {
-              "version_added": "11",
-              "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-            },
+            "safari": [
+              {
+                "version_added": "14.1"
+              },
+              {
+                "version_added": "11",
+                "version_removed": "14.1",
+                "partial_implementation": true,
+                "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14.5"
+              },
+              {
+                "version_added": "11",
+                "version_removed": "14.5",
+                "partial_implementation": true,
+                "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "10.0"
             },

--- a/css/properties/scroll-padding-right.json
+++ b/css/properties/scroll-padding-right.json
@@ -30,16 +30,28 @@
             "opera_android": {
               "version_added": "48"
             },
-            "safari": {
-              "version_added": "11",
-              "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-            },
-            "safari_ios": {
-              "version_added": "11",
-              "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-            },
+            "safari": [
+              {
+                "version_added": "14.1"
+              },
+              {
+                "version_added": "11",
+                "version_removed": "14.1",
+                "partial_implementation": true,
+                "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14.5"
+              },
+              {
+                "version_added": "11",
+                "version_removed": "14.5",
+                "partial_implementation": true,
+                "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "10.0"
             },

--- a/css/properties/scroll-padding-top.json
+++ b/css/properties/scroll-padding-top.json
@@ -30,16 +30,28 @@
             "opera_android": {
               "version_added": "48"
             },
-            "safari": {
-              "version_added": "11",
-              "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-            },
-            "safari_ios": {
-              "version_added": "11",
-              "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-            },
+            "safari": [
+              {
+                "version_added": "14.1"
+              },
+              {
+                "version_added": "11",
+                "version_removed": "14.1",
+                "partial_implementation": true,
+                "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14.5"
+              },
+              {
+                "version_added": "11",
+                "version_removed": "14.5",
+                "partial_implementation": true,
+                "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "10.0"
             },

--- a/css/properties/scroll-padding.json
+++ b/css/properties/scroll-padding.json
@@ -30,16 +30,28 @@
             "opera_android": {
               "version_added": "48"
             },
-            "safari": {
-              "version_added": "11",
-              "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-            },
-            "safari_ios": {
-              "version_added": "11",
-              "partial_implementation": true,
-              "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
-            },
+            "safari": [
+              {
+                "version_added": "14.1"
+              },
+              {
+                "version_added": "11",
+                "version_removed": "14.1",
+                "partial_implementation": true,
+                "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14.5"
+              },
+              {
+                "version_added": "11",
+                "version_removed": "14.5",
+                "partial_implementation": true,
+                "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "10.0"
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

This PR updates Safari support data for scroll-padding to mark as no longer partial as of Safari 14.1

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Tested on Safari for iOS 14.5 (on simulator) with https://output.jsbin.com/zekegip/quiet

Also confirmed to work on desktop Safari as of 15.1 (Beta 2) and based on iOS support I believe it will be the same between Desktop and iOS.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Fixes https://github.com/mdn/browser-compat-data/issues/12483
