### PR TITLE
Mark unprefixed `:autofill` supported in chrome 96

### DIFF
--- a/css/selectors/autofill.json
+++ b/css/selectors/autofill.json
@@ -7,18 +7,33 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:autofill",
           "spec_url": "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-autofill",
           "support": {
-            "chrome": {
-              "version_added": "1",
-              "prefix": "-webkit-"
-            },
-            "chrome_android": {
-              "version_added": "18",
-              "prefix": "-webkit-"
-            },
-            "edge": {
-              "version_added": "79",
-              "prefix": "-webkit-"
-            },
+            "chrome": [
+              {
+                "version_added": "96"
+              },
+              {
+                "version_added": "1",
+                "prefix": "-webkit-"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "96"
+              },
+              {
+                "version_added": "18",
+                "prefix": "-webkit-"
+              }
+            ],
+            "edge": [
+              {
+                "version_added": "96"
+              },
+              {
+                "version_added": "79",
+                "prefix": "-webkit-"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "86"
@@ -65,10 +80,15 @@
               "version_added": "1.0",
               "prefix": "-webkit-"
             },
-            "webview_android": {
-              "version_added": "1",
-              "prefix": "-webkit-"
-            }
+            "webview_android": [
+              {
+                "version_added": "96"
+              },
+              {
+                "version_added": "1",
+                "prefix": "-webkit-"
+              }
+            ]
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Adds Chrome 96 support data for unprefixed `:autofill` pseudo class.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://www.chromestatus.com/feature/5592445322526720

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
