### PR TITLE
Link bugs and fix experimental status for ruby-position

### DIFF
--- a/css/properties/ruby-position.json
+++ b/css/properties/ruby-position.json
@@ -95,7 +95,7 @@
             ]
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -105,7 +105,8 @@
             "description": "<code>alternate</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/1191394'>bug 1191394</a>."
               },
               "chrome_android": {
                 "version_added": false
@@ -153,7 +154,8 @@
             "description": "<code>inter-character</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/1258284'>bug 1258284</a>."
               },
               "chrome_android": {
                 "version_added": false


### PR DESCRIPTION
The over/under values are not experimental, but the alternate and
inter-character ones are, going by implementation status.