### PR TITLE
Add links to tracking bugs for Cookie Store API

### DIFF
--- a/api/CookieStore.json
+++ b/api/CookieStore.json
@@ -15,10 +15,12 @@
             "version_added": "87"
           },
           "firefox": {
-            "version_added": false
+            "version_added": false,
+            "notes": "See <a href='https://bugzil.la/1475599'>bug 1475599</a>."
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": false,
+            "notes": "See <a href='https://bugzil.la/1475599'>bug 1475599</a>."
           },
           "ie": {
             "version_added": false
@@ -30,10 +32,12 @@
             "version_added": "62"
           },
           "safari": {
-            "version_added": false
+            "version_added": false,
+            "notes": "See <a href='https://webkit.org/b/231750'>bug 231750</a>."
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": false,
+            "notes": "See <a href='https://webkit.org/b/231750'>bug 231750</a>."
           },
           "samsunginternet_android": {
             "version_added": "14.0"

--- a/api/Window.json
+++ b/api/Window.json
@@ -1349,10 +1349,12 @@
               "version_added": "87"
             },
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1475599'>bug 1475599</a>."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1475599'>bug 1475599</a>."
             },
             "ie": {
               "version_added": false
@@ -1364,10 +1366,12 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/231750'>bug 231750</a>."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/231750'>bug 231750</a>."
             },
             "samsunginternet_android": {
               "version_added": "14.0"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Adds links to tracking bugs for Firefox and WebKit for the cookie store api.

#### Test results and supporting details

WebKit Bug: https://webkit.org/b/231750

Firefox Bug: https://bugzil.la/1475599
