### PR TITLE
Add Chromium versions for api.MediaStreamEvent.stream

### DIFF
--- a/api/MediaStreamEvent.json
+++ b/api/MediaStreamEvent.json
@@ -107,10 +107,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamEvent/stream",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "26"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "26"
             },
             "edge": {
               "version_added": "15"
@@ -125,10 +125,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11",
@@ -139,10 +139,10 @@
               "version_removed": "12"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `stream` member of the `MediaStreamEvent` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/1364c1eb207eac24ba4c763fc108f6523830af26
