### PR TITLE
Update Firefox versions for RTCRtpReceiver API

### DIFF
--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -325,10 +325,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -588,10 +588,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `RTCRtpReceiver` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.3.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCRtpReceiver

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
