### PR TITLE
Update data for BeforeInstallPrompt event

### DIFF
--- a/api/BeforeInstallPromptEvent.json
+++ b/api/BeforeInstallPromptEvent.json
@@ -5,10 +5,10 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/BeforeInstallPromptEvent",
         "support": {
           "chrome": {
-            "version_added": "45"
+            "version_added": "44"
           },
           "chrome_android": {
-            "version_added": "45"
+            "version_added": "44"
           },
           "edge": {
             "version_added": "79"
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "31"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "32"
           },
           "safari": {
             "version_added": false
@@ -38,7 +38,7 @@
             "version_added": "5.0"
           },
           "webview_android": {
-            "version_added": "45"
+            "version_added": "44"
           }
         },
         "status": {
@@ -53,10 +53,10 @@
           "description": "<code>BeforeInstallPromptEvent()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "44"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "44"
             },
             "edge": {
               "version_added": "79"
@@ -71,10 +71,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "31"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "32"
             },
             "safari": {
               "version_added": false
@@ -86,7 +86,7 @@
               "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "44"
             }
           },
           "status": {
@@ -101,10 +101,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BeforeInstallPromptEvent/platforms",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "44"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "44"
             },
             "edge": {
               "version_added": "79"
@@ -119,10 +119,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "31"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "32"
             },
             "safari": {
               "version_added": false
@@ -134,7 +134,7 @@
               "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "44"
             }
           },
           "status": {
@@ -149,10 +149,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BeforeInstallPromptEvent/prompt",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "44"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "44"
             },
             "edge": {
               "version_added": "79"
@@ -167,10 +167,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "31"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "32"
             },
             "safari": {
               "version_added": false
@@ -182,7 +182,7 @@
               "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "44"
             }
           },
           "status": {
@@ -197,10 +197,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BeforeInstallPromptEvent/userChoice",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "44"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "44"
             },
             "edge": {
               "version_added": "79"
@@ -215,10 +215,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "31"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "32"
             },
             "safari": {
               "version_added": false
@@ -230,7 +230,7 @@
               "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "44"
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -596,7 +596,6 @@
       "beforeinstallprompt_event": {
         "__compat": {
           "description": "<code>beforeinstallprompt</code> event",
-          "spec_url": "https://wicg.github.io/manifest-incubations/#installation-events",
           "support": {
             "chrome": {
               "version_added": "45"
@@ -3961,7 +3960,6 @@
       "onbeforeinstallprompt": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onbeforeinstallprompt",
-          "spec_url": "https://wicg.github.io/manifest-incubations/#extensions-to-the-window-object",
           "support": {
             "chrome": {
               "version_added": "61"

--- a/api/Window.json
+++ b/api/Window.json
@@ -598,10 +598,10 @@
           "description": "<code>beforeinstallprompt</code> event",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "44"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "44"
             },
             "edge": {
               "version_added": "≤79"
@@ -616,7 +616,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "31"
             },
             "opera_android": {
               "version_added": "32"
@@ -631,7 +631,7 @@
               "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "44"
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -596,6 +596,7 @@
       "beforeinstallprompt_event": {
         "__compat": {
           "description": "<code>beforeinstallprompt</code> event",
+          "spec_url": "https://wicg.github.io/manifest-incubations/#installation-events",
           "support": {
             "chrome": {
               "version_added": "45"
@@ -3960,6 +3961,7 @@
       "onbeforeinstallprompt": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onbeforeinstallprompt",
+          "spec_url": "https://wicg.github.io/manifest-incubations/#extensions-to-the-window-object",
           "support": {
             "chrome": {
               "version_added": "61"

--- a/api/Window.json
+++ b/api/Window.json
@@ -3914,10 +3914,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/onbeforeinstallprompt",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "61"
             },
             "edge": {
               "version_added": "≤79"
@@ -3932,10 +3932,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "45"
             },
             "safari": {
               "version_added": false
@@ -3944,10 +3944,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "61"
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -593,6 +593,53 @@
           }
         }
       },
+      "beforeinstallprompt_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "45"
+            },
+            "chrome_android": {
+              "version_added": "45"
+            },
+            "edge": {
+              "version_added": "≤79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "32"
+            },
+            "opera_android": {
+              "version_added": "32"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
+            "webview_android": {
+              "version_added": "45"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "beforeprint_event": {
         "__compat": {
           "description": "<code>beforeprint</code> event",

--- a/api/Window.json
+++ b/api/Window.json
@@ -595,6 +595,7 @@
       },
       "beforeinstallprompt_event": {
         "__compat": {
+          "description": "<code>beforeinstallprompt</code> event",
           "support": {
             "chrome": {
               "version_added": "45"


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `onbeforeinstallprompt` member of the `Window` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.3.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Window/onbeforeinstallprompt

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
