### PR TITLE
Add Chrome/Safari versions for api.Window.webkitConvertPointFromPageToNode

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -10411,11 +10411,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/webkitConvertPointFromNodeToPage",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "39"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "39"
             },
             "edge": {
@@ -10431,25 +10431,25 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "15",
               "version_removed": "26"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "14",
               "version_removed": "26"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "4.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "≤37",
               "version_removed": "39"
             }
           },
@@ -10465,11 +10465,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/webkitConvertPointFromPageToNode",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "version_removed": "39"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "version_removed": "39"
             },
             "edge": {
@@ -10485,25 +10485,25 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "15",
               "version_removed": "26"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "14",
               "version_removed": "26"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "version_removed": "4.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "≤37",
               "version_removed": "39"
             }
           },


### PR DESCRIPTION
This PR adds real values for Chrome and Safari for the `webkitConvertPointFromPageToNode` member of the `Window` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.3.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Window/webkitConvertPointFromPageToNode

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
