### PR TITLE
Add Chrome/Safari versions for api.Worker.postMessage

### DIFF
--- a/api/Worker.json
+++ b/api/Worker.json
@@ -708,10 +708,10 @@
               "version_added": "10.5.0"
             },
             "opera": {
-              "version_added": "≤12.1"
+              "version_added": "10.6"
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": "11"
             },
             "safari": {
               "version_added": "4"
@@ -723,7 +723,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "4"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chrome and Safari for the `postMessage` member of the `Worker` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.3.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Worker/postMessage

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
