### PR TITLE
Add Firefox versions for api.Worker.postMessage

### DIFF
--- a/api/Worker.json
+++ b/api/Worker.json
@@ -695,10 +695,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10",


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `postMessage` member of the `Worker` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.3.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Worker/postMessage

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
