### PR TITLE
Update IE/Edge versions for api.WorkerGlobalScope.onlanguagechange

### DIFF
--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -429,7 +429,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "74"
@@ -438,7 +438,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "11.5"

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -221,7 +221,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "74"
@@ -230,7 +230,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "11.5"


### PR DESCRIPTION
This PR updates and corrects the real values for Internet Explorer and Edge for the `onlanguagechange` member of the `WorkerGlobalScope` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.3.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WorkerGlobalScope/onlanguagechange

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
