### PR TITLE
Add Safari versions for api.XMLHttpRequestEventTarget.onloadend

### DIFF
--- a/api/XMLHttpRequestEventTarget.json
+++ b/api/XMLHttpRequestEventTarget.json
@@ -225,10 +225,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `onloadend` member of the `XMLHttpRequestEventTarget` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.3.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/XMLHttpRequestEventTarget/onloadend

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
