### PR TITLE
Add Safari versions for api.XMLHttpRequestEventTarget.ontimeout

### DIFF
--- a/api/XMLHttpRequestEventTarget.json
+++ b/api/XMLHttpRequestEventTarget.json
@@ -372,10 +372,10 @@
               "version_added": "16"
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `ontimeout` member of the `XMLHttpRequestEventTarget` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v3.3.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/XMLHttpRequestEventTarget/ontimeout

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
