### PR TITLE
Add Safari versions for api.History.pushState/replaceState.title

### DIFF
--- a/api/History.json
+++ b/api/History.json
@@ -425,11 +425,11 @@
               },
               "safari": {
                 "version_added": "5",
-                "notes": "This feature is planned to be removed in the two feature, see <a href='https://webkit.org/b/223190'>bug 223190</a>."
+                "notes": "This feature may be removed, see <a href='https://webkit.org/b/223190'>bug 223190</a>."
               },
               "safari_ios": {
                 "version_added": "4",
-                "notes": "This feature is planned to be removed in the two feature, see <a href='https://webkit.org/b/223190'>bug 223190</a>."
+                "notes": "This feature may be removed, see <a href='https://webkit.org/b/223190'>bug 223190</a>."
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `pushState.title` and `replaceState.title` members of the `History` API, based upon commit history and date.

Commit: https://github.com/WebKit/WebKit/commit/e544495d282d4726fcb491e0e441ddba338b5ec1#diff-1c0cd85bfa317b5070b76a1c711400243e789721245124ca340bc17efb237f45
