### PR TITLE
Add Safari versions for api.InputEvent.inputType.insertFromPasteAsQuotation

### DIFF
--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -355,10 +355,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `inputType.insertFromPasteAsQuotation` member of the `InputEvent` API, based upon commit history and date.

Commit: https://github.com/WebKit/WebKit/blob/0b0d1cb6e98a4d6212db24562a62d556b0e53c93/Source/WebCore/editing/EditCommand.cpp#L40-L122
