### PR TITLE
Add Firefox versions for api.Document.execCommand.insertBrOnReturn

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4316,10 +4316,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `execCommand.insertBrOnReturn` member of the `Document` API, based upon information in a tracking bug.

Tracking Bug: https://bugzil.la/285873
