### PR TITLE
Update all versions for api.Document.visibilityState.prerender

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -11338,15 +11338,14 @@
             "support": {
               "chrome": {
                 "version_added": "14",
-                "version_removed": "91"
+                "version_removed": "73"
               },
               "chrome_android": {
                 "version_added": "18",
-                "version_removed": "91"
+                "version_removed": "73"
               },
               "edge": {
-                "version_added": "≤79",
-                "version_removed": "91"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "49",
@@ -11361,11 +11360,11 @@
               },
               "opera": {
                 "version_added": "≤15",
-                "version_removed": "77"
+                "version_removed": "60"
               },
               "opera_android": {
                 "version_added": "≤14",
-                "version_removed": "61"
+                "version_removed": "52"
               },
               "safari": {
                 "version_added": "7",
@@ -11377,11 +11376,11 @@
               },
               "samsunginternet_android": {
                 "version_added": "1.0",
-                "version_removed": "16.0"
+                "version_removed": "11.0"
               },
               "webview_android": {
                 "version_added": "≤37",
-                "version_removed": "91"
+                "version_removed": "73"
               }
             },
             "status": {


### PR DESCRIPTION
This PR updates real values for all browsers for the `visibilityState.prerender` member of the `Document` API, based upon commit history and date (Chrome, Safari), as well as bug history (Firefox).  This feature was removed from most browsers, but our data had not reflected this.  (Note: I simply set IE to `false` because I have no idea how to properly test this and I didn't want this to affect the real values percentage, especially considering this will be removed in the future.)

Data:
Chrome/Safari Addition: https://source.chromium.org/chromium/chromium/src/+/0a1f326a2199d764d9d439f1eb92ff5b107639f6 / https://trac.webkit.org/changeset/88174/webkit
Chrome Removal: https://storage.googleapis.com/chromium-find-releases-static/759.html#759e84c17afddffd440315069801e280d7ca1d31
Safari Removal: https://trac.webkit.org/changeset/269665/webkit
Firefox Removal: https://bugzil.la/1383876
