### PR TITLE
Update IE versions for WebSocket API events

### DIFF
--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -368,7 +368,7 @@
               "version_added": "7"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12.1"
@@ -473,7 +473,7 @@
               "version_added": "7"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12.1"
@@ -734,7 +734,7 @@
               "version_added": "7"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12.1"


### PR DESCRIPTION
This PR updates values for Internet Explorer for the `WebSocket` API's events.  This is a quick follow-up to #12667 which marked support for the event handlers (`on*`).
