### PR TITLE
Add Chromium versions for api.XMLHttpRequest.getAllResponseHeaders.lowercase

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -308,10 +308,10 @@
             "description": "Header names returned in all lower case",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "60"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "60"
               },
               "edge": {
                 "version_added": "79"
@@ -326,10 +326,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "47"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "44"
               },
               "safari": {
                 "version_added": true
@@ -338,10 +338,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "8.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "60"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `getAllResponseHeaders.lowercase` member of the `XMLHttpRequest` API, based upon commit history and date.

Commit: https://storage.googleapis.com/chromium-find-releases-static/99c.html#99c274ae8e7d366261dcfb89e0b98e733fb9d5f4
