### PR TITLE
Add Safari versions for api.XMLHttpRequest.getAllResponseHeaders.lowercase

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -332,10 +332,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "11"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `getAllResponseHeaders.lowercase` member of the `XMLHttpRequest` API, based upon commit history and date.

Commit: https://github.com/WebKit/WebKit/commit/960fce156ad8ac10bb8b0e05579f2c75642adf9b
