### PR TITLE
Add Safari versions for api.Geolocation*.secure_context_required

### DIFF
--- a/api/Geolocation.json
+++ b/api/Geolocation.json
@@ -176,10 +176,10 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/GeolocationCoordinates.json
+++ b/api/GeolocationCoordinates.json
@@ -508,10 +508,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/GeolocationPosition.json
+++ b/api/GeolocationPosition.json
@@ -186,10 +186,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "5.0"

--- a/api/GeolocationPositionError.json
+++ b/api/GeolocationPositionError.json
@@ -223,10 +223,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `secure_context_required` member of the `Geolocation` APIs.  The data was copied from the `api.Navigator.geolocation.secure_context_required` feature.
