### PR TITLE
Add Safari versions for api.XMLHttpRequest.responseType

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -887,7 +887,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `responseType` member of the `XMLHttpRequest` API, based upon commit history and date.

Commit: https://github.com/WebKit/WebKit/commit/d57b7f6a75c86eaf3afbe2ed83c247f867e62a3a ([WebKit 534.13.0](https://github.com/WebKit/WebKit/blob/d57b7f6a75c86eaf3afbe2ed83c247f867e62a3a/WebCore/Configurations/Version.xcconfig))