### PR TITLE
Add Safari versions for api.XMLHttpRequest.send.ArrayBufferView

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1538,10 +1538,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `send.ArrayBufferView` member of the `XMLHttpRequest` API, based upon commit history and date.

Commit: https://github.com/WebKit/WebKit/commit/259582ad10ab080ce4db6522bd2b204cee3e09a4
