### PR TITLE
Opera Android 65 is released

### DIFF
--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -351,9 +351,15 @@
         },
         "64": {
           "release_date": "2021-05-25",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "91"
+        },
+        "65": {
+          "release_date": "2021-09-30",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "92"
         }
       }
     }


### PR DESCRIPTION
Release date source: https://opera-browser.en.uptodown.com/android/download/3984533

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
