### PR TITLE
Add Chromium versions for api.BaseAudioContext.createPeriodicWave.disableNormalisation_supported

### DIFF
--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -948,10 +948,10 @@
             "description": "Possible to disable normalisation",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "46"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "46"
               },
               "edge": {
                 "version_added": "≤18"
@@ -966,10 +966,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "33"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "33"
               },
               "safari": {
                 "version_added": false
@@ -978,10 +978,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "46"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `createPeriodicWave.disableNormalisation_supported` member of the `BaseAudioContext` API, based upon commit history and date.

Commit: https://storage.googleapis.com/chromium-find-releases-static/97a.html#97a08057876f4387c40fad8b1363cbf558e7eede
