### PR TITLE
Update IE versions for HTMLOptionsCollection API

### DIFF
--- a/api/HTMLOptionsCollection.json
+++ b/api/HTMLOptionsCollection.json
@@ -21,7 +21,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": true
+            "version_added": "≤6"
           },
           "opera": {
             "version_added": true
@@ -59,7 +59,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "4"
@@ -68,7 +68,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true
@@ -107,7 +107,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "13"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -116,7 +116,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": true
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true
@@ -155,7 +155,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "4"
@@ -164,7 +164,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true
@@ -203,7 +203,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -212,7 +212,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "≤6"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR updates and corrects the real values for Internet Explorer for the `HTMLOptionsCollection` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLOptionsCollection

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
