### PR TITLE
Add Firefox versions for api.TouchEvent.TouchEvent

### DIFF
--- a/api/TouchEvent.json
+++ b/api/TouchEvent.json
@@ -87,7 +87,7 @@
               "notes": "Edge only supports the following <code>touchEventInit</code> properties: <code>touches</code>, <code>targetTouches</code>, <code>changedTouches</code>."
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `TouchEvent` member of the `TouchEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TouchEvent/TouchEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
