### PR TITLE
Add Chromium versions for api.TextMetrics.*Baseline

### DIFF
--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -250,7 +250,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-alphabeticbaseline-dev",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "35",
               "version_removed": "70",
               "flags": [
                 {
@@ -260,7 +260,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "35",
               "version_removed": "70",
               "flags": [
                 {
@@ -636,7 +636,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-hangingbaseline-dev",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "35",
               "version_removed": "70",
               "flags": [
                 {
@@ -646,7 +646,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "35",
               "version_removed": "70",
               "flags": [
                 {
@@ -706,7 +706,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-ideographicbaseline-dev",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "35",
               "version_removed": "70",
               "flags": [
                 {
@@ -716,7 +716,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "35",
               "version_removed": "70",
               "flags": [
                 {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `*Baseline` members of the `TextMetrics` API, based upon commit history and date.

Commits:
https://chromium.googlesource.com/chromium/src/+/8e46c2cc56fd67a291b46add96b606c707163cd2
https://chromium.googlesource.com/chromium/src/+/716e107615f9eb6b7a2c5217c0906685545ac44e