### PR TITLE
Add Chromium versions for api.TextMetrics.*ascent/*descent

### DIFF
--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -324,7 +324,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-emheightascent-dev",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "35",
               "flags": [
                 {
                   "type": "preference",
@@ -333,7 +333,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "35",
               "flags": [
                 {
                   "type": "preference",
@@ -398,7 +398,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-emheightdescent-dev",
           "support": {
             "chrome": {
-              "version_added": "45",
+              "version_added": "35",
               "flags": [
                 {
                   "type": "preference",
@@ -407,7 +407,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": "45",
+              "version_added": "35",
               "flags": [
                 {
                   "type": "preference",

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -324,7 +324,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-emheightascent-dev",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "45",
               "flags": [
                 {
                   "type": "preference",
@@ -333,7 +333,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "45",
               "flags": [
                 {
                   "type": "preference",
@@ -398,7 +398,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-emheightdescent-dev",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "45",
               "flags": [
                 {
                   "type": "preference",
@@ -407,7 +407,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "45",
               "flags": [
                 {
                   "type": "preference",
@@ -476,7 +476,8 @@
                 "version_added": "87"
               },
               {
-                "version_added": true,
+                "version_added": "45",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -490,7 +491,8 @@
                 "version_added": "87"
               },
               {
-                "version_added": true,
+                "version_added": "45",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -499,15 +501,21 @@
                 ]
               }
             ],
-            "edge": {
-              "version_added": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
-            },
+            "edge": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "79",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "74",
               "flags": [
@@ -560,7 +568,8 @@
                 "version_added": "87"
               },
               {
-                "version_added": true,
+                "version_added": "45",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -574,7 +583,8 @@
                 "version_added": "87"
               },
               {
-                "version_added": true,
+                "version_added": "45",
+                "version_removed": "87",
                 "flags": [
                   {
                     "type": "preference",
@@ -583,15 +593,21 @@
                 ]
               }
             ],
-            "edge": {
-              "version_added": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
-            },
+            "edge": [
+              {
+                "version_added": "87"
+              },
+              {
+                "version_added": "79",
+                "version_removed": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "74",
               "flags": [

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -476,7 +476,7 @@
                 "version_added": "87"
               },
               {
-                "version_added": "45",
+                "version_added": "35",
                 "version_removed": "87",
                 "flags": [
                   {
@@ -491,7 +491,7 @@
                 "version_added": "87"
               },
               {
-                "version_added": "45",
+                "version_added": "35",
                 "version_removed": "87",
                 "flags": [
                   {
@@ -568,7 +568,7 @@
                 "version_added": "87"
               },
               {
-                "version_added": "45",
+                "version_added": "35",
                 "version_removed": "87",
                 "flags": [
                   {
@@ -583,7 +583,7 @@
                 "version_added": "87"
               },
               {
-                "version_added": "45",
+                "version_added": "35",
                 "version_removed": "87",
                 "flags": [
                   {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `[emHeight/fontBoundingBox][ascent/descent]` members of the `TextMetrics` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/8e46c2cc56fd67a291b46add96b606c707163cd2 (35 by date, confirmed by private feature freeze dates and [public dev calendar](https://www.chromium.org/developers/calendar))
