### PR TITLE
Add Chromium versions for Touch API

### DIFF
--- a/api/Touch.json
+++ b/api/Touch.json
@@ -319,12 +319,26 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Touch/force",
           "spec_url": "https://w3c.github.io/touch-events/#dom-touch-force",
           "support": {
-            "chrome": {
-              "version_added": "38"
-            },
-            "chrome_android": {
-              "version_added": "38"
-            },
+            "chrome": [
+              {
+                "version_added": "38"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "22",
+                "version_removed": "47"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "38"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "25",
+                "version_removed": "47"
+              }
+            ],
             "edge": {
               "version_added": "≤79"
             },
@@ -337,24 +351,52 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "25"
-            },
-            "opera_android": {
-              "version_added": "25"
-            },
+            "opera": [
+              {
+                "version_added": "25"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "15",
+                "version_removed": "34"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "25"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "14",
+                "version_removed": "34"
+              }
+            ],
             "safari": {
               "version_added": false
             },
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": "3.0"
-            },
-            "webview_android": {
-              "version_added": "38"
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5",
+                "version_removed": "5.0"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "38"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "≤37",
+                "version_removed": "47"
+              }
+            ]
           },
           "status": {
             "experimental": true,
@@ -539,12 +581,26 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Touch/radiusX",
           "spec_url": "https://w3c.github.io/touch-events/#dom-touch-radiusx",
           "support": {
-            "chrome": {
-              "version_added": "43"
-            },
-            "chrome_android": {
-              "version_added": "43"
-            },
+            "chrome": [
+              {
+                "version_added": "38"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "22",
+                "version_removed": "47"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "38"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "25",
+                "version_removed": "47"
+              }
+            ],
             "edge": {
               "version_added": "≤79"
             },
@@ -557,24 +613,52 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "25"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "15",
+                "version_removed": "34"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "25"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "14",
+                "version_removed": "34"
+              }
+            ],
             "safari": {
               "version_added": false
             },
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": "4.0"
-            },
-            "webview_android": {
-              "version_added": "43"
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5",
+                "version_removed": "5.0"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "38"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "≤37",
+                "version_removed": "47"
+              }
+            ]
           },
           "status": {
             "experimental": true,
@@ -588,12 +672,26 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Touch/radiusY",
           "spec_url": "https://w3c.github.io/touch-events/#dom-touch-radiusy",
           "support": {
-            "chrome": {
-              "version_added": "43"
-            },
-            "chrome_android": {
-              "version_added": "43"
-            },
+            "chrome": [
+              {
+                "version_added": "38"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "22",
+                "version_removed": "47"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "38"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "25",
+                "version_removed": "47"
+              }
+            ],
             "edge": {
               "version_added": "≤79"
             },
@@ -606,24 +704,52 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "25"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "15",
+                "version_removed": "34"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "25"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "14",
+                "version_removed": "34"
+              }
+            ],
             "safari": {
               "version_added": false
             },
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": "4.0"
-            },
-            "webview_android": {
-              "version_added": "43"
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5",
+                "version_removed": "5.0"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "38"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "≤37",
+                "version_removed": "47"
+              }
+            ]
           },
           "status": {
             "experimental": true,
@@ -637,12 +763,26 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Touch/rotationAngle",
           "spec_url": "https://w3c.github.io/touch-events/#dom-touch-rotationangle",
           "support": {
-            "chrome": {
-              "version_added": "43"
-            },
-            "chrome_android": {
-              "version_added": "43"
-            },
+            "chrome": [
+              {
+                "version_added": "43"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "22",
+                "version_removed": "47"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "43"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "25",
+                "version_removed": "47"
+              }
+            ],
             "edge": {
               "version_added": "≤79"
             },
@@ -655,24 +795,52 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "30"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "15",
+                "version_removed": "34"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "30"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "14",
+                "version_removed": "34"
+              }
+            ],
             "safari": {
               "version_added": false
             },
             "safari_ios": {
               "version_added": true
             },
-            "samsunginternet_android": {
-              "version_added": "4.0"
-            },
-            "webview_android": {
-              "version_added": "43"
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "4.0"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5",
+                "version_removed": "5.0"
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "43"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "≤37",
+                "version_removed": "47"
+              }
+            ]
           },
           "status": {
             "experimental": true,

--- a/api/Touch.json
+++ b/api/Touch.json
@@ -320,10 +320,10 @@
           "spec_url": "https://w3c.github.io/touch-events/#dom-touch-force",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "38"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "38"
             },
             "edge": {
               "version_added": "≤79"
@@ -338,10 +338,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "25"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "safari": {
               "version_added": false
@@ -350,10 +350,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "38"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Touch` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/f2f38a58b8e7fd184a3632afd81bfcf8f2f910b6 (38 by date, addition of non-prefixed `radiusX`, `radiusY`, and `force`)
https://source.chromium.org/chromium/chromium/src/+/6bda89467e0cf513d1a3b7924ccf203b692ccb02 (45 by date, addition of non-prefixed `rotationAngle`)
https://source.chromium.org/chromium/chromium/src/+/e723bb1f08674e6c198d5ac4b32237652f91f54c (14 by date, addition of prefixed `force`)
https://source.chromium.org/chromium/chromium/src/+/6f07340ff1607f798050a18122c18b8e045802df (14 by date, addition of prefixed `radiusX`, `radiusY`, and `rotationAngle`)
https://storage.googleapis.com/chromium-find-releases-static/485.html#4850153414e5cb795d15db5635632b844eb51e98 (removal of prefixed versions for `radiusX`, `radiusY`, `rotationAngle`, and `force`)

Commit date to version mapping is confirmed by private feature freeze dates and [public dev calendar](https://www.chromium.org/developers/calendar).