### PR TITLE
Add Firefox versions for Touch API

### DIFF
--- a/api/Touch.json
+++ b/api/Touch.json
@@ -327,13 +327,12 @@
             },
             "firefox": [
               {
-                "version_added": "52",
-                "notes": "Touch events support has been fixed and reenabled in Windows desktop platforms."
+                "version_added": "52"
               },
               {
                 "version_added": "18",
                 "version_removed": "24",
-                "notes": "Web compatibility issues seen in <a href='https://bugzil.la/888304'>bug 888304</a>."
+                "notes": "Removed in <a href='https://bugzil.la/888304'>bug 888304</a> due to web compatibility issues."
               }
             ],
             "firefox_android": {
@@ -552,13 +551,12 @@
             },
             "firefox": [
               {
-                "version_added": "52",
-                "notes": "Touch events support has been fixed and reenabled in Windows desktop platforms."
+                "version_added": "52"
               },
               {
                 "version_added": "18",
                 "version_removed": "24",
-                "notes": "Web compatibility issues seen in <a href='https://bugzil.la/888304'>bug 888304</a>."
+                "notes": "Removed in <a href='https://bugzil.la/888304'>bug 888304</a> due to web compatibility issues."
               }
             ],
             "firefox_android": {
@@ -609,13 +607,12 @@
             },
             "firefox": [
               {
-                "version_added": "52",
-                "notes": "Touch events support has been fixed and reenabled in Windows desktop platforms."
+                "version_added": "52"
               },
               {
                 "version_added": "18",
                 "version_removed": "24",
-                "notes": "Web compatibility issues seen in <a href='https://bugzil.la/888304'>bug 888304</a>."
+                "notes": "Removed in <a href='https://bugzil.la/888304'>bug 888304</a> due to web compatibility issues."
               }
             ],
             "firefox_android": {
@@ -666,13 +663,12 @@
             },
             "firefox": [
               {
-                "version_added": "52",
-                "notes": "Touch events support has been fixed and reenabled in Windows desktop platforms."
+                "version_added": "52"
               },
               {
                 "version_added": "18",
                 "version_removed": "24",
-                "notes": "Web compatibility issues seen in <a href='https://bugzil.la/888304'>bug 888304</a>."
+                "notes": "Removed in <a href='https://bugzil.la/888304'>bug 888304</a> due to web compatibility issues."
               }
             ],
             "firefox_android": {


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `Touch` API, based upon commit history and date.

Commit: https://github.com/mozilla/gecko-dev/commit/2cc83ff3e698678e596e71462692518aeff55a0d#diff-9467c209feb61705449ffb3249617afb5a307556efbf55ad23efbec9155401e6 (when the Touch interface was first added)
