### PR TITLE
Add Firefox versions for api.MediaStreamEvent.stream

### DIFF
--- a/api/MediaStreamEvent.json
+++ b/api/MediaStreamEvent.json
@@ -116,10 +116,10 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "24"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "24"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `stream` member of the `MediaStreamEvent` API, based upon commit history and date.

Commit: https://github.com/mozilla/gecko-dev/commit/98794b08f642c74005534b6aeea968a36dea467b#diff-a675b5d7d5d3210bdd14ca6d2743996b2f6ebc26f276ce8dd5903fdd3a33ca90 (when MediaStreamEvent was introduced)
