### PR TITLE
Add Chromium versions for RTCDataChannelEvent API

### DIFF
--- a/api/RTCDataChannelEvent.json
+++ b/api/RTCDataChannelEvent.json
@@ -6,7 +6,7 @@
         "spec_url": "https://w3c.github.io/webrtc-pc/#rtcdatachannelevent",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "24"
           },
           "chrome_android": {
             "version_added": "28"
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤14"
           },
           "safari": {
             "version_added": "11"
@@ -39,7 +39,7 @@
             "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -104,7 +104,7 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-datachannelevent-channel",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "28"
@@ -122,10 +122,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": "11"
@@ -137,7 +137,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `RTCDataChannelEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCDataChannelEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
