### PR TITLE
Add Chromium versions for RTCSessionDescription API

### DIFF
--- a/api/RTCSessionDescription.json
+++ b/api/RTCSessionDescription.json
@@ -177,10 +177,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcsessiondescription-tojson",
           "support": {
             "chrome": {
-              "version_added": "44"
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": "44"
+              "version_added": "43"
             },
             "edge": {
               "version_added": "15"
@@ -196,10 +196,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "31"
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "30"
             },
             "safari": {
               "version_added": "11"
@@ -211,7 +211,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "44"
+              "version_added": "43"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `RTCSessionDescription` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/ade4eec97f9e7e9da46aaefd36f45f375ffb190a (when RTCSessionDescription was introduced) / https://source.chromium.org/chromium/chromium/src/+/4a6ce1a6ad82c9b9f16bcb136303acadf08422ea (44 by date)
