### PR TITLE
Add Firefox versions for RTCSessionDescription API

### DIFF
--- a/api/RTCSessionDescription.json
+++ b/api/RTCSessionDescription.json
@@ -136,11 +136,10 @@
               "version_added": "15"
             },
             "firefox": {
-              "prefix": "moz",
-              "version_added": true
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "ie": {
               "version_added": false
@@ -236,11 +235,10 @@
               "version_added": "15"
             },
             "firefox": {
-              "prefix": "moz",
-              "version_added": true
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `RTCSessionDescription` API, based upon commit history and date.

Commit: https://github.com/mozilla/gecko-dev/commit/98794b08f642c74005534b6aeea968a36dea467b#diff-f1b1b2749655efc720c041322c39d0c64e4643b9ce2be6a726c6b43500386edc (when RTCSessionDescription is introduced)
