### PR TITLE
Add Firefox versions for api.RTCSessionDescription.toJSON

### DIFF
--- a/api/RTCSessionDescription.json
+++ b/api/RTCSessionDescription.json
@@ -186,10 +186,10 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "62"
+              "version_added": "24"
             },
             "firefox_android": {
-              "version_added": "62"
+              "version_added": "24"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `toJSON` member of the `RTCSessionDescription` API, based upon information in a tracking bug.

Tracking Bug: https://bugzil.la/1375829
