### PR TITLE
Add Chromium versions for api.MediaStream.stop

### DIFF
--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -1022,11 +1022,11 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "29",
               "version_removed": "47"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "29",
               "version_removed": "47"
             },
             "edge": {
@@ -1055,11 +1055,11 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "2.0",
               "version_removed": "5.0"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "≤37",
               "version_removed": "47"
             }
           },


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `stop` member of the `MediaStream` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/0821d61b1229606ab650d844807481f5163c3bdd
