### PR TITLE
Remove irrelevant Firefox flag data for CSSPseudoElement API

### DIFF
--- a/api/CSSPseudoElement.json
+++ b/api/CSSPseudoElement.json
@@ -106,42 +106,18 @@
                     "name": "dom.animations-api.getAnimations.enabled"
                   }
                 ]
-              },
-              {
-                "alternative_name": "parentElement",
-                "version_added": "63",
-                "version_removed": "67",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.getAnimations.enabled"
-                  }
-                ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "67",
-                "version_removed": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.getAnimations.enabled"
-                  }
-                ]
-              },
-              {
-                "alternative_name": "parentElement",
-                "version_added": "63",
-                "version_removed": "67",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.animations-api.getAnimations.enabled"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "67",
+              "version_removed": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.animations-api.getAnimations.enabled"
+                }
+              ]
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `CSSPseudoElement` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/queengooborg/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
