### PR TITLE
Remove irrelevant Firefox flag data for api.Document.featurePolicy

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4735,32 +4735,19 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "69",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.webidl.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "65",
-                "version_removed": "69",
-                "alternative_name": "policy",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.webidl.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "69",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.security.featurePolicy.webidl.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": "65",
+              "version_removed": "79",
               "alternative_name": "policy",
               "flags": [
                 {


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `featurePolicy` member of the `Document` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/queengooborg/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
