### PR TITLE
Add IE versions for api.Document.wheel_event

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -11562,7 +11562,7 @@
               "version_added": "17"
             },
             "ie": {
-              "version_added": true
+              "version_added": false
             },
             "opera": {
               "version_added": "48"

--- a/api/Document.json
+++ b/api/Document.json
@@ -11562,7 +11562,8 @@
               "version_added": "17"
             },
             "ie": {
-              "version_added": false
+              "version_added": "9",
+              "notes": "Internet Explorer only exposes the wheel event via <code>addEventListener</code>; there is no <code>onwheel</code> attribute on DOM objects. See <a href='https://connect.microsoft.com/IE/feedback/details/782835/missing-onwheel-attribute-for-the-wheel-event-although-its-supported-via-addeventlistener'>IE bug 782835</a>."
             },
             "opera": {
               "version_added": "48"


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `wheel_event` member of the `Document` API, based upon manual testing.

Test Code Used: https://developer.mozilla.org/en-US/docs/Web/API/Document/wheel_event
