### PR TITLE
Add IE versions for api.Element.[copy/cut/paste]_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2289,7 +2289,8 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "9",
+              "notes": "Before Internet Explorer 9, this event is not supported via <code>addEventListener</code>; however, the event handler is supported since IE 5.5. The event can be listened to via <code>element.oncopy</code>."
             },
             "opera": {
               "version_added": "15"
@@ -2477,7 +2478,8 @@
               "version_added": true
             },
             "ie": {
-              "version_added": "9"
+              "version_added": "9",
+              "notes": "Before Internet Explorer 9, this event is not supported via <code>addEventListener</code>; however, the event handler is supported since IE 5.5. The event can be listened to via <code>element.oncopy</code>."
             },
             "opera": {
               "version_added": "15"
@@ -6029,7 +6031,10 @@
             },
             "ie": {
               "version_added": "9",
-              "notes": "Before Internet Explorer 11, copying files does not trigger the <code>paste</code> event."
+              "notes": [
+                "Before Internet Explorer 11, copying files does not trigger the <code>paste</code> event.",
+                "Before Internet Explorer 9, this event is not supported via <code>addEventListener</code>; however, the event handler is supported since IE 5.5. The event can be listened to via <code>element.oncopy</code>."
+              ]
             },
             "opera": {
               "version_added": "15"

--- a/api/Element.json
+++ b/api/Element.json
@@ -2280,7 +2280,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -2289,7 +2289,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": "15"
@@ -2468,7 +2468,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -2477,7 +2477,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
               "version_added": "15"
@@ -6028,7 +6028,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "8",
+              "version_added": "9",
               "notes": "Before Internet Explorer 11, copying files does not trigger the <code>paste</code> event."
             },
             "opera": {

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2378,7 +2378,8 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "5.5"
+              "version_added": "5.5",
+              "notes": "Before Internet Explorer 9, this event is not supported via <code>addEventListener</code>."
             },
             "opera": {
               "version_added": "≤12.1"
@@ -2426,7 +2427,8 @@
               "version_added": "9"
             },
             "ie": {
-              "version_added": "5.5"
+              "version_added": "5.5",
+              "notes": "Before Internet Explorer 9, this event is not supported via <code>addEventListener</code>."
             },
             "opera": {
               "version_added": "≤12.1"
@@ -2474,7 +2476,8 @@
               "version_added": "9"
             },
             "ie": {
-              "version_added": "5.5"
+              "version_added": "5.5",
+              "notes": "Before Internet Explorer 9, this event is not supported via <code>addEventListener</code>."
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `copy`, `cut`, and `paste` events of the `Element` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<div id="source" contenteditable="true">Try copying text from this box...</div>
	<div id="target" contenteditable="true">...and pasting it into this one</div>
</div>

<script>
	var source = document.getElementById('source');
	var target = document.getElementById('target');

	source.addEventListener('copy', function() {
		alert('Copy!');
	});

	source.addEventListener('cut', function() {
		alert('Cut!');
	});

	target.addEventListener('paste', function() {
		alert('Paste!');
	});
</script>
```
