### PR TITLE
Add Firefox versions for api.Element.copy/cut_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2283,10 +2283,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "ie": {
               "version_added": true
@@ -2471,10 +2471,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "ie": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `copy` and `cut` events of the `Element` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<div id="source" contenteditable="true">Try copying text from this box...</div>
	<div id="target" contenteditable="true">...and pasting it into this one</div>
</div>

<script>
	var source = document.getElementById('source');
	var target = document.getElementById('target');

	source.addEventListener('copy', function() {
		alert('Copy!');
	});

	source.addEventListener('cut', function() {
		alert('Cut!');
	});

	target.addEventListener('paste', function() {
		alert('Paste!');
	});
</script>
```
