### PR TITLE
Add Firefox versions for api.Element.getElementsByTagName.all_elements_selector

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -3982,11 +3982,10 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true,
-                "notes": "Before Firefox 19, this method was returning a <code>NodeList</code>; it was then changed to reflect the change in the spec."
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "6"
@@ -4093,10 +4092,10 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `all_elements_selector` member of the `Element.all_elements_selector` API, based upon manual testing.

Test Code Used: `document.getElementsByTagName('*'); document.getElementsByTagNameNS('https://www.w3.org/1999/xhtml', "*");`
