### PR TITLE
Add Safari versions for api.Element.all_elements_selector

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -3998,10 +3998,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "≤4"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "≤3"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -4108,10 +4108,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "≤4"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "≤3"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `all_elements_selector` member of the `Element` API, based upon manual testing.

Test Code Used: `document.getElementsByTagName('*'); document.getElementsByTagNameNS('https://www.w3.org/1999/xhtml', "*");`
