### PR TITLE
Set Chrome 95 as stable

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -652,21 +652,28 @@
         "94": {
           "release_date": "2021-09-21",
           "release_notes": "https://chromereleases.googleblog.com/2021/09/stable-channel-update-for-desktop_21.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "94"
         },
         "95": {
           "release_date": "2021-10-19",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2021/10/stable-channel-update-for-desktop_19.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "95"
         },
         "96": {
           "release_date": "2021-11-16",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "96"
+        },
+        "97": {
+          "release_date": "2022-01-04",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "97"
         }
       }
     }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -488,21 +488,28 @@
         "94": {
           "release_date": "2021-09-21",
           "release_notes": "https://chromereleases.googleblog.com/2021/09/chrome-for-android-update_21.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "94"
         },
         "95": {
           "release_date": "2021-10-19",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2021/10/chrome-for-android-update_01703513036.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "95"
         },
         "96": {
           "release_date": "2021-11-16",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "96"
+        },
+        "97": {
+          "release_date": "2022-01-04",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "97"
         }
       }
     }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -453,21 +453,28 @@
         "94": {
           "release_date": "2021-09-21",
           "release_notes": "https://chromereleases.googleblog.com/2021/09/chrome-for-android-update_21.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "94"
         },
         "95": {
           "release_date": "2021-10-19",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2021/10/chrome-for-android-update_01703513036.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "95"
         },
         "96": {
           "release_date": "2021-11-16",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "96"
+        },
+        "97": {
+          "release_date": "2022-01-04",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "97"
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Sets Chrome 95 as stable

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://chromereleases.googleblog.com/2021/10/stable-channel-update-for-desktop_19.html
https://chromereleases.googleblog.com/2021/10/chrome-for-android-update_01703513036.html

https://www.chromestatus.com/roadmap - for the Chrome 97 release date.
