### PR TITLE
Add Safari versions for api.XMLHttpRequest.loadend_event

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -484,10 +484,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `loadend_event` member of the `XMLHttpRequest` API, based upon manual testing.

Test Code Used: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/loadend_event
