### PR TITLE
Add Chromium versions for MediaStreamTrack API

### DIFF
--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -643,10 +643,10 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-muted",
           "support": {
             "chrome": {
-              "version_added": "46"
+              "version_added": "38"
             },
             "chrome_android": {
-              "version_added": "46"
+              "version_added": "38"
             },
             "edge": {
               "version_added": "12"
@@ -661,10 +661,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "33"
+              "version_added": "25"
             },
             "opera_android": {
-              "version_added": "33"
+              "version_added": "25"
             },
             "safari": {
               "version_added": "11"
@@ -673,10 +673,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "46"
+              "version_added": "38"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `MediaStreamTrack` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/42297c9f721082f2603213acd0bee2e702c7aaba (dated before Chrome 26) / https://source.chromium.org/chromium/chromium/src/+/5754131c83fd6812ca17302345379c1e33b66bab (dated before Chrome 26) / https://source.chromium.org/chromium/chromium/src/+/aaa0e971e713d21ac5c09d3f358503a68336359f (dated feature freeze for Chrome 38, confirmed by private feature freeze dates and [public dev calendar](https://www.chromium.org/developers/calendar))

This additionally mirrors the event handler data to the events as well.