### PR TITLE
Updated data for font-synthesis property

### DIFF
--- a/css/properties/font-synthesis-small-caps.json
+++ b/css/properties/font-synthesis-small-caps.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "properties": {
+      "font-synthesis-small-caps": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-fonts/#font-synthesis-small-caps",
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "97"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "<a href='https://bugzil.la/1724892'>bug 1724892</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "<a href='https://bugzil.la/1724892'>bug 1724892</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "<a href='https://webkit.org/b/232009'>bug 232009</a>."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "<a href='https://webkit.org/b/232009'>bug 232009</a>."
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/font-synthesis-small-caps.json
+++ b/css/properties/font-synthesis-small-caps.json
@@ -12,7 +12,7 @@
               "version_added": "97"
             },
             "edge": {
-              "version_added": false
+              "version_added": "97"
             },
             "firefox": {
               "version_added": false,
@@ -26,7 +26,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "83"
             },
             "opera_android": {
               "version_added": false
@@ -43,7 +43,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "97"
             }
           },
           "status": {

--- a/css/properties/font-synthesis-style.json
+++ b/css/properties/font-synthesis-style.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "properties": {
+      "font-synthesis-style": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-fonts/#font-synthesis-style",
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "97"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "<a href='https://bugzil.la/1724892'>bug 1724892</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "<a href='https://bugzil.la/1724892'>bug 1724892</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "<a href='https://webkit.org/b/232009'>bug 232009</a>."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "<a href='https://webkit.org/b/232009'>bug 232009</a>."
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/font-synthesis-style.json
+++ b/css/properties/font-synthesis-style.json
@@ -47,7 +47,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/font-synthesis-style.json
+++ b/css/properties/font-synthesis-style.json
@@ -12,7 +12,7 @@
               "version_added": "97"
             },
             "edge": {
-              "version_added": false
+              "version_added": "97"
             },
             "firefox": {
               "version_added": false,
@@ -26,7 +26,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "83"
             },
             "opera_android": {
               "version_added": false
@@ -43,7 +43,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "97"
             }
           },
           "status": {

--- a/css/properties/font-synthesis-weight.json
+++ b/css/properties/font-synthesis-weight.json
@@ -47,7 +47,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/font-synthesis-weight.json
+++ b/css/properties/font-synthesis-weight.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "properties": {
+      "font-synthesis-weight": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-fonts/#font-synthesis-weight",
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "97"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "<a href='https://bugzil.la/1724892'>bug 1724892</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "<a href='https://bugzil.la/1724892'>bug 1724892</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false,
+              "notes": "<a href='https://webkit.org/b/232009'>bug 232009</a>."
+            },
+            "safari_ios": {
+              "version_added": false,
+              "notes": "<a href='https://webkit.org/b/232009'>bug 232009</a>."
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/font-synthesis-weight.json
+++ b/css/properties/font-synthesis-weight.json
@@ -12,7 +12,7 @@
               "version_added": "97"
             },
             "edge": {
-              "version_added": false
+              "version_added": "97"
             },
             "firefox": {
               "version_added": false,
@@ -26,7 +26,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "83"
             },
             "opera_android": {
               "version_added": false
@@ -43,7 +43,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "97"
             }
           },
           "status": {

--- a/css/properties/font-synthesis.json
+++ b/css/properties/font-synthesis.json
@@ -49,58 +49,6 @@
             "deprecated": false
           }
         },
-        "longhand": {
-          "__compat": {
-            "description": "<code>font-synthesis-weight, font-synthesis-style, font-synthesis-small-caps</code>",
-            "support": {
-              "chrome": {
-                "version_added": "97"
-              },
-              "chrome_android": {
-                "version_added": "97"
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false,
-                "notes": "<a href='https://bugzil.la/1724892'>bug 1724892</a>."
-              },
-              "firefox_android": {
-                "version_added": false,
-                "notes": "<a href='https://bugzil.la/1724892'>bug 1724892</a>."
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false,
-                "notes": "<a href='https://webkit.org/b/232009'>bug 232009</a>."
-              },
-              "safari_ios": {
-                "version_added": false,
-                "notes": "<a href='https://webkit.org/b/232009'>bug 232009</a>."
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "small-caps": {
           "__compat": {
             "description": "<code>small-caps</code>",

--- a/css/properties/font-synthesis.json
+++ b/css/properties/font-synthesis.json
@@ -13,7 +13,7 @@
               "version_added": "97"
             },
             "edge": {
-              "version_added": false
+              "version_added": "97"
             },
             "firefox": {
               "version_added": "34"
@@ -25,7 +25,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "83"
             },
             "opera_android": {
               "version_added": false
@@ -40,7 +40,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "97"
             }
           },
           "status": {
@@ -60,7 +60,7 @@
                 "version_added": "97"
               },
               "edge": {
-                "version_added": false
+                "version_added": "97"
               },
               "firefox": {
                 "version_added": "93"
@@ -72,7 +72,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "83"
               },
               "opera_android": {
                 "version_added": false
@@ -87,7 +87,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "97"
               }
             },
             "status": {

--- a/css/properties/font-synthesis.json
+++ b/css/properties/font-synthesis.json
@@ -49,6 +49,54 @@
             "deprecated": false
           }
         },
+        "longhand": {
+          "__compat": {
+            "description": "<code>longhand</code>",
+            "support": {
+              "chrome": {
+                "version_added": "97"
+              },
+              "chrome_android": {
+                "version_added": "97"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "small-caps": {
           "__compat": {
             "description": "<code>small-caps</code>",

--- a/css/properties/font-synthesis.json
+++ b/css/properties/font-synthesis.json
@@ -51,7 +51,7 @@
         },
         "longhand": {
           "__compat": {
-            "description": "<code>longhand</code>",
+            "description": "<code>font-synthesis-weight, font-synthesis-style, font-synthesis-small-caps</code>",
             "support": {
               "chrome": {
                 "version_added": "97"
@@ -63,10 +63,12 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "notes": "<a href='https://bugzil.la/1724892'>bug 1724892</a>."
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "<a href='https://bugzil.la/1724892'>bug 1724892</a>."
               },
               "ie": {
                 "version_added": false
@@ -78,10 +80,12 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "notes": "<a href='https://webkit.org/b/232009'>bug 232009</a>."
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": false,
+                "notes": "<a href='https://webkit.org/b/232009'>bug 232009</a>."
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/css/properties/font-synthesis.json
+++ b/css/properties/font-synthesis.json
@@ -7,10 +7,10 @@
           "spec_url": "https://drafts.csswg.org/css-fonts/#font-synthesis",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "97"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "97"
             },
             "edge": {
               "version_added": false
@@ -54,10 +54,10 @@
             "description": "<code>small-caps</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "97"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "97"
               },
               "edge": {
                 "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR sets Chromium version for font-synthesis CSS property and adds font-synthesis longhand

WARNING: font-synthesis property will be supported on Chrome 97 version, this CL has to be merged only after Chrome 97 version reaches the end of the [beta phase](https://chromiumdash.appspot.com/schedule)

#### Test results and supporting details

Support in Chrome, Chrome for Android is claimed on [Chromestatus](https://www.chromestatus.com/feature/5640605355999232)
 
Longhand for font-synthesis property, i.e. [font-synthesis-weight](https://drafts.csswg.org/css-fonts-4/#font-synthesis-weight), [font-synthesis-style](https://drafts.csswg.org/css-fonts-4/#font-synthesis-style) and [font-synthesis-small-caps](https://drafts.csswg.org/css-fonts-4/#font-synthesis-small-caps) not supported on Safari ([link on bug](https://bugs.webkit.org/show_bug.cgi?id=232009)) and Firefox ([link on bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1724892))
