### PR TITLE
Add spec url for HTMLCollection.namedItem

### DIFF
--- a/api/HTMLCollection.json
+++ b/api/HTMLCollection.json
@@ -149,6 +149,7 @@
       "namedItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCollection/namedItem",
+          "spec_url": "https://dom.spec.whatwg.org/#dom-htmlcollection-nameditem-key",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Adds the spec link for HTMLCollection.namedItem method

#### Related issues
Blocks https://github.com/mdn/content/pull/9902
