### PR TITLE
Make notes around Touch events on Firefox desktop consistent

### DIFF
--- a/api/Touch.json
+++ b/api/Touch.json
@@ -16,13 +16,12 @@
           },
           "firefox": [
             {
-              "version_added": "52",
-              "notes": "Touch events support has been fixed and reenabled in Windows desktop platforms."
+              "version_added": "52"
             },
             {
               "version_added": "18",
               "version_removed": "24",
-              "notes": "Web compatibility issues seen in <a href='https://bugzil.la/888304'>bug 888304</a>."
+              "notes": "Removed in <a href='https://bugzil.la/888304'>bug 888304</a> due to web compatibility issues."
             }
           ],
           "firefox_android": {
@@ -216,13 +215,12 @@
             },
             "firefox": [
               {
-                "version_added": "52",
-                "notes": "Touch events support has been fixed and reenabled in Windows desktop platforms."
+                "version_added": "52"
               },
               {
                 "version_added": "18",
                 "version_removed": "24",
-                "notes": "Web compatibility issues seen in <a href='https://bugzil.la/888304'>bug 888304</a>."
+                "notes": "Removed in <a href='https://bugzil.la/888304'>bug 888304</a> due to web compatibility issues."
               }
             ],
             "firefox_android": {
@@ -273,13 +271,12 @@
             },
             "firefox": [
               {
-                "version_added": "52",
-                "notes": "Touch events support has been fixed and reenabled in Windows desktop platforms."
+                "version_added": "52"
               },
               {
                 "version_added": "18",
                 "version_removed": "24",
-                "notes": "Web compatibility issues seen in <a href='https://bugzil.la/888304'>bug 888304</a>."
+                "notes": "Removed in <a href='https://bugzil.la/888304'>bug 888304</a> due to web compatibility issues."
               }
             ],
             "firefox_android": {
@@ -379,13 +376,12 @@
             },
             "firefox": [
               {
-                "version_added": "52",
-                "notes": "Touch events support has been fixed and reenabled in Windows desktop platforms."
+                "version_added": "52"
               },
               {
                 "version_added": "18",
                 "version_removed": "24",
-                "notes": "Web compatibility issues seen in <a href='https://bugzil.la/888304'>bug 888304</a>."
+                "notes": "Removed in <a href='https://bugzil.la/888304'>bug 888304</a> due to web compatibility issues."
               }
             ],
             "firefox_android": {
@@ -436,13 +432,12 @@
             },
             "firefox": [
               {
-                "version_added": "52",
-                "notes": "Touch events support has been fixed and reenabled in Windows desktop platforms."
+                "version_added": "52"
               },
               {
                 "version_added": "18",
                 "version_removed": "24",
-                "notes": "Web compatibility issues seen in <a href='https://bugzil.la/888304'>bug 888304</a>."
+                "notes": "Removed in <a href='https://bugzil.la/888304'>bug 888304</a> due to web compatibility issues."
               }
             ],
             "firefox_android": {
@@ -493,13 +488,12 @@
             },
             "firefox": [
               {
-                "version_added": "52",
-                "notes": "Touch events support has been fixed and reenabled in Windows desktop platforms."
+                "version_added": "52"
               },
               {
                 "version_added": "18",
                 "version_removed": "24",
-                "notes": "Web compatibility issues seen in <a href='https://bugzil.la/888304'>bug 888304</a>."
+                "notes": "Removed in <a href='https://bugzil.la/888304'>bug 888304</a> due to web compatibility issues."
               }
             ],
             "firefox_android": {
@@ -697,13 +691,12 @@
             },
             "firefox": [
               {
-                "version_added": "52",
-                "notes": "Touch events support has been fixed and reenabled in Windows desktop platforms."
+                "version_added": "52"
               },
               {
                 "version_added": "18",
                 "version_removed": "24",
-                "notes": "Web compatibility issues seen in <a href='https://bugzil.la/888304'>bug 888304</a>."
+                "notes": "Removed in <a href='https://bugzil.la/888304'>bug 888304</a> due to web compatibility issues."
               }
             ],
             "firefox_android": {
@@ -754,13 +747,12 @@
             },
             "firefox": [
               {
-                "version_added": "52",
-                "notes": "Touch events support has been fixed and reenabled in Windows desktop platforms."
+                "version_added": "52"
               },
               {
                 "version_added": "18",
                 "version_removed": "24",
-                "notes": "Web compatibility issues seen in <a href='https://bugzil.la/888304'>bug 888304</a>."
+                "notes": "Removed in <a href='https://bugzil.la/888304'>bug 888304</a> due to web compatibility issues."
               }
             ],
             "firefox_android": {
@@ -811,13 +803,12 @@
             },
             "firefox": [
               {
-                "version_added": "52",
-                "notes": "Touch events support has been fixed and reenabled in Windows desktop platforms."
+                "version_added": "52"
               },
               {
                 "version_added": "18",
                 "version_removed": "24",
-                "notes": "Web compatibility issues seen in <a href='https://bugzil.la/888304'>bug 888304</a>."
+                "notes": "Removed in <a href='https://bugzil.la/888304'>bug 888304</a> due to web compatibility issues."
               }
             ],
             "firefox_android": {

--- a/api/TouchEvent.json
+++ b/api/TouchEvent.json
@@ -143,7 +143,8 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "24"
+                "version_removed": "24",
+                "notes": "Removed in <a href='https://bugzil.la/888304'>bug 888304</a> due to web compatibility issues."
               }
             ],
             "firefox_android": {
@@ -198,7 +199,8 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "24"
+                "version_removed": "24",
+                "notes": "Removed in <a href='https://bugzil.la/888304'>bug 888304</a> due to web compatibility issues."
               }
             ],
             "firefox_android": {
@@ -253,7 +255,8 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "24"
+                "version_removed": "24",
+                "notes": "Removed in <a href='https://bugzil.la/888304'>bug 888304</a> due to web compatibility issues."
               }
             ],
             "firefox_android": {
@@ -308,7 +311,8 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "24"
+                "version_removed": "24",
+                "notes": "Removed in <a href='https://bugzil.la/888304'>bug 888304</a> due to web compatibility issues."
               }
             ],
             "firefox_android": {
@@ -363,7 +367,8 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "24"
+                "version_removed": "24",
+                "notes": "Removed in <a href='https://bugzil.la/888304'>bug 888304</a> due to web compatibility issues."
               }
             ],
             "firefox_android": {
@@ -418,7 +423,8 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "24"
+                "version_removed": "24",
+                "notes": "Removed in <a href='https://bugzil.la/888304'>bug 888304</a> due to web compatibility issues."
               }
             ],
             "firefox_android": {
@@ -473,7 +479,8 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "24"
+                "version_removed": "24",
+                "notes": "Removed in <a href='https://bugzil.la/888304'>bug 888304</a> due to web compatibility issues."
               }
             ],
             "firefox_android": {

--- a/api/TouchList.json
+++ b/api/TouchList.json
@@ -20,7 +20,8 @@
             },
             {
               "version_added": "18",
-              "version_removed": "24"
+              "version_removed": "24",
+              "notes": "Removed in <a href='https://bugzil.la/888304'>bug 888304</a> due to web compatibility issues."
             }
           ],
           "firefox_android": {
@@ -74,7 +75,8 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "24"
+                "version_removed": "24",
+                "notes": "Removed in <a href='https://bugzil.la/888304'>bug 888304</a> due to web compatibility issues."
               }
             ],
             "firefox_android": {
@@ -129,7 +131,8 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "24"
+                "version_removed": "24",
+                "notes": "Removed in <a href='https://bugzil.la/888304'>bug 888304</a> due to web compatibility issues."
               }
             ],
             "firefox_android": {


### PR DESCRIPTION
The notes (and lack thereof) is now consistent with the notes
on the api.TouchEvent entry.

The main motivation for this is removing the "Touch events support has
been fixed and reenabled in Windows desktop platforms." notes, which
aren't helpful to show as an asterisk by default here:
https://developer.mozilla.org/en-US/docs/Web/API/Touch#browser_compatibility