### PR TITLE
fix: broken export default link

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -751,7 +751,7 @@
         "default": {
           "__compat": {
             "description": "<code>default</code> keyword with <code>export</code>",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/default",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/export",
             "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-exports",
             "support": {
               "chrome": {


### PR DESCRIPTION
There is no `https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/default`, and it did go to the `switch` page.
I found out that the default is on the `export` page, so I've fixed it.
