### PR TITLE
Mark initial-letter as prefixed in Safari

### DIFF
--- a/css/properties/initial-letter.json
+++ b/css/properties/initial-letter.json
@@ -33,9 +33,11 @@
               "version_added": false
             },
             "safari": {
+              "prefix": "-webkit-",
               "version_added": "9"
             },
             "safari_ios": {
+              "prefix": "-webkit-",
               "version_added": "9"
             },
             "samsunginternet_android": {


### PR DESCRIPTION
Based on testing with mdn-bcd-collector:
http://mdn-bcd-collector.appspot.com/tests/css/properties/initial-letter
http://mdn-bcd-collector.appspot.com/tests/css/properties/-webkit-initial-letter

Safari 8 and 9.1 were tested to verify the version,
-webkit-initial-letter wasn't in 8 but was in 9.1.