### PR TITLE
Add Chromium versions for MediaTrackConstraints API

### DIFF
--- a/api/MediaTrackConstraints.json
+++ b/api/MediaTrackConstraints.json
@@ -103,10 +103,10 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraintset-autogaincontrol",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "67"
             },
             "edge": {
               "version_added": "≤79"
@@ -133,10 +133,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "54"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "safari": {
               "version_added": false
@@ -145,10 +145,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "67"
             }
           },
           "status": {
@@ -705,10 +705,10 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraintset-noisesuppression",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "67"
             },
             "edge": {
               "version_added": "≤79"
@@ -735,10 +735,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "54"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "safari": {
               "version_added": false
@@ -747,10 +747,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "67"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `MediaTrackConstraints` API, based upon commit history and date.

Commit: https://storage.googleapis.com/chromium-find-releases-static/457.html#457331359e46f16a5b8b45c308d99b8b448e028a
