### PR TITLE
Add Chromium versions for MediaTrackSettings API

### DIFF
--- a/api/MediaTrackSettings.json
+++ b/api/MediaTrackSettings.json
@@ -27,10 +27,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "46"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "43"
           },
           "safari": {
             "version_added": "11"
@@ -57,10 +57,10 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatracksettings-aspectratio",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "edge": {
               "version_added": "≤79"
@@ -75,10 +75,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -87,10 +87,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "59"
             }
           },
           "status": {
@@ -106,10 +106,10 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatracksettings-autogaincontrol",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "67"
             },
             "edge": {
               "version_added": "≤79"
@@ -138,10 +138,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "54"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "48"
             },
             "safari": {
               "version_added": false
@@ -150,10 +150,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "67"
             }
           },
           "status": {
@@ -267,10 +267,10 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatracksettings-deviceid",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "edge": {
               "version_added": "≤79"
@@ -285,10 +285,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -297,10 +297,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "59"
             }
           },
           "status": {
@@ -365,10 +365,10 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatracksettings-echocancellation",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "edge": {
               "version_added": "≤79"
@@ -383,10 +383,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -395,10 +395,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "59"
             }
           },
           "status": {
@@ -414,10 +414,10 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatracksettings-facingmode",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "edge": {
               "version_added": "≤79"
@@ -432,10 +432,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -444,10 +444,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "59"
             }
           },
           "status": {
@@ -463,10 +463,10 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatracksettings-framerate",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "edge": {
               "version_added": "≤79"
@@ -481,10 +481,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -493,10 +493,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "59"
             }
           },
           "status": {
@@ -512,10 +512,10 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatracksettings-groupid",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "edge": {
               "version_added": "≤79"
@@ -530,10 +530,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -542,10 +542,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "59"
             }
           },
           "status": {
@@ -561,10 +561,10 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatracksettings-height",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "edge": {
               "version_added": "≤79"
@@ -579,10 +579,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -591,10 +591,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "59"
             }
           },
           "status": {
@@ -708,10 +708,10 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatracksettings-noisesuppression",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "67"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "67"
             },
             "edge": {
               "version_added": "≤79"
@@ -740,10 +740,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "54"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "48"
             },
             "safari": {
               "version_added": false
@@ -752,10 +752,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "67"
             }
           },
           "status": {
@@ -819,13 +819,13 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatracksettings-samplerate",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "59"
             },
             "edge": {
-              "version_added": false
+              "version_added": "≤79"
             },
             "firefox": {
               "version_added": false
@@ -837,10 +837,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -849,10 +849,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "59"
             }
           },
           "status": {
@@ -868,10 +868,10 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatracksettings-samplesize",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "edge": {
               "version_added": "≤79"
@@ -886,10 +886,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -898,10 +898,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "59"
             }
           },
           "status": {
@@ -965,10 +965,10 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediatracksettings-width",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "edge": {
               "version_added": "≤79"
@@ -983,10 +983,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -995,10 +995,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "59"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `MediaTrackSettings` API, based upon commit history and date.

Commit: https://storage.googleapis.com/chromium-find-releases-static/aa4.html#aa40992364d32544f7301ad6791b302736f651d5 / https://storage.googleapis.com/chromium-find-releases-static/32f.html#32ff2fb2094b94ad384c99ce508a662a3abb673b
