### PR TITLE
Add Firefox versions for MediaTrackConstraints API

### DIFF
--- a/api/MediaTrackConstraints.json
+++ b/api/MediaTrackConstraints.json
@@ -15,10 +15,10 @@
             "version_added": "≤18"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "29"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "29"
           },
           "ie": {
             "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `MediaTrackConstraints` API.  This simply sets the dictionary's support to the lowest version number in any of its subfeatures as to get to 100% real values without removing this dictionary yet.
