### PR TITLE
Add Firefox versions for MediaTrackSettings API

### DIFF
--- a/api/MediaTrackSettings.json
+++ b/api/MediaTrackSettings.json
@@ -18,10 +18,10 @@
             "version_added": "≤79"
           },
           "firefox": {
-            "version_added": true
+            "version_added": "36"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "36"
           },
           "ie": {
             "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `MediaTrackSettings` API.  This simply sets the dictionary's support to the lowest version number in any of its subfeatures as to get to 100% real values without removing this dictionary yet.
