### PR TITLE
Add Firefox versions for MediaTrackSupportedConstraints API

### DIFF
--- a/api/MediaTrackSupportedConstraints.json
+++ b/api/MediaTrackSupportedConstraints.json
@@ -116,7 +116,7 @@
                 "version_added": "55"
               },
               {
-                "version_added": true,
+                "version_added": "46",
                 "version_removed": "55",
                 "prefix": "moz"
               }
@@ -126,7 +126,7 @@
                 "version_added": "55"
               },
               {
-                "version_added": true,
+                "version_added": "46",
                 "version_removed": "55",
                 "prefix": "moz"
               }
@@ -718,7 +718,7 @@
                 "version_added": "55"
               },
               {
-                "version_added": true,
+                "version_added": "46",
                 "version_removed": "55",
                 "prefix": "moz"
               }
@@ -728,7 +728,7 @@
                 "version_added": "55"
               },
               {
-                "version_added": true,
+                "version_added": "46",
                 "version_removed": "55",
                 "prefix": "moz"
               }


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `MediaTrackSupportedConstraints` API, based upon commit history and date.

Commit: https://hg.mozilla.org/mozilla-central/rev/728713d8e7c65a41945dcce6c5241e7643d1d77d
