### PR TITLE
Rename "argument" to "parameter" in more places

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -2099,15 +2099,15 @@
             "support": {
               "chrome": {
                 "version_added": "56",
-                "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
+                "notes": "For backwards compatibility, the <code>options</code> parameter can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "chrome_android": {
                 "version_added": "56",
-                "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
+                "notes": "For backwards compatibility, the <code>options</code> parameter can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "edge": {
                 "version_added": "79",
-                "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
+                "notes": "For backwards compatibility, the <code>options</code> parameter can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "firefox": {
                 "version_added": "50",
@@ -2122,11 +2122,11 @@
               },
               "opera": {
                 "version_added": "43",
-                "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
+                "notes": "For backwards compatibility, the <code>options</code> parameter can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "opera_android": {
                 "version_added": "43",
-                "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
+                "notes": "For backwards compatibility, the <code>options</code> parameter can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "safari": {
                 "version_added": false
@@ -2136,11 +2136,11 @@
               },
               "samsunginternet_android": {
                 "version_added": "6.0",
-                "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
+                "notes": "For backwards compatibility, the <code>options</code> parameter can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "webview_android": {
                 "version_added": "56",
-                "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
+                "notes": "For backwards compatibility, the <code>options</code> parameter can be an object or a string with the custom element tag name, although the string version is deprecated."
               }
             },
             "status": {
@@ -2206,15 +2206,15 @@
             "support": {
               "chrome": {
                 "version_added": "56",
-                "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
+                "notes": "For backwards compatibility, the <code>options</code> parameter can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "chrome_android": {
                 "version_added": "56",
-                "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
+                "notes": "For backwards compatibility, the <code>options</code> parameter can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "edge": {
                 "version_added": "≤79",
-                "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
+                "notes": "For backwards compatibility, the <code>options</code> parameter can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "firefox": {
                 "version_added": "50",
@@ -2229,11 +2229,11 @@
               },
               "opera": {
                 "version_added": "43",
-                "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
+                "notes": "For backwards compatibility, the <code>options</code> parameter can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "opera_android": {
                 "version_added": "43",
-                "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
+                "notes": "For backwards compatibility, the <code>options</code> parameter can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "safari": {
                 "version_added": false
@@ -2243,11 +2243,11 @@
               },
               "samsunginternet_android": {
                 "version_added": "6.0",
-                "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
+                "notes": "For backwards compatibility, the <code>options</code> parameter can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "webview_android": {
                 "version_added": "56",
-                "notes": "For backwards compatibility, the <code>options</code> argument can be an object or a string with the custom element tag name, although the string version is deprecated."
+                "notes": "For backwards compatibility, the <code>options</code> parameter can be an object or a string with the custom element tag name, although the string version is deprecated."
               }
             },
             "status": {

--- a/api/HTMLTableElement.json
+++ b/api/HTMLTableElement.json
@@ -793,11 +793,11 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Starting with Firefox 20, the index argument has been made optional and defaults to -1 as per HTML specification."
+              "notes": "Starting with Firefox 20, the <code>index</code> parameter has been made optional and defaults to -1 as per HTML specification."
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "Starting with Firefox 20, the index argument has been made optional and defaults to -1 as per HTML specification."
+              "notes": "Starting with Firefox 20, the <code>index</code> parameter has been made optional and defaults to -1 as per HTML specification."
             },
             "ie": {
               "version_added": "5.5"

--- a/api/History.json
+++ b/api/History.json
@@ -294,9 +294,9 @@
             "deprecated": false
           }
         },
-        "title": {
+        "title_parameter": {
           "__compat": {
-            "description": "Whether the <code>title</code> argument is used",
+            "description": "Whether the <code>title</code> parameter is used",
             "support": {
               "chrome": {
                 "version_added": false
@@ -393,9 +393,9 @@
             "deprecated": false
           }
         },
-        "title": {
+        "title_parameter": {
           "__compat": {
-            "description": "Whether the <code>title</code> argument is used",
+            "description": "Whether the <code>title</code> parameter is used",
             "support": {
               "chrome": {
                 "version_added": false

--- a/api/ImageCapture.json
+++ b/api/ImageCapture.json
@@ -268,7 +268,7 @@
                 "version_added": "59",
                 "partial_implementation": true,
                 "version_removed": "60",
-                "notes": "<code>photoSettings</code> argument not supported."
+                "notes": "<code>photoSettings</code> parameter not supported."
               }
             ],
             "chrome_android": [
@@ -279,7 +279,7 @@
                 "version_added": "59",
                 "partial_implementation": true,
                 "version_removed": "60",
-                "notes": "<code>photoSettings</code> argument not supported."
+                "notes": "<code>photoSettings</code> parameter not supported."
               }
             ],
             "edge": {
@@ -304,7 +304,7 @@
                 "version_added": "46",
                 "partial_implementation": true,
                 "version_removed": "47",
-                "notes": "<code>photoSettings</code> argument not supported."
+                "notes": "<code>photoSettings</code> parameter not supported."
               }
             ],
             "opera_android": [
@@ -315,7 +315,7 @@
                 "version_added": "43",
                 "partial_implementation": true,
                 "version_removed": "44",
-                "notes": "<code>photoSettings</code> argument not supported."
+                "notes": "<code>photoSettings</code> parameter not supported."
               }
             ],
             "safari": {
@@ -332,7 +332,7 @@
                 "partial_implementation": true,
                 "version_added": "7.0",
                 "version_removed": "8.0",
-                "notes": "<code>photoSettings</code> argument not supported."
+                "notes": "<code>photoSettings</code> parameter not supported."
               }
             ],
             "webview_android": [
@@ -343,7 +343,7 @@
                 "version_added": "59",
                 "partial_implementation": true,
                 "version_removed": "60",
-                "notes": "<code>photoSettings</code> argument not supported."
+                "notes": "<code>photoSettings</code> parameter not supported."
               }
             ]
           },

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2846,7 +2846,7 @@
               "notes": [
                 "Allowed schemes include <code>mailto</code>, <code>mms</code>, <code>nntp</code>, <code>rtsp</code>, and <code>webcal</code>. Custom protocols must be prefixed with <code>web+</code>.",
                 "From Chrome 77, the URL parameter only accepts <code>http</code> or <code>https</code> URLs.",
-                "The obsolete <code>title</code> argument is required."
+                "The obsolete <code>title</code> parameter is required."
               ]
             },
             "chrome_android": {
@@ -2856,7 +2856,7 @@
               "version_added": "79",
               "notes": [
                 "Allowed schemes include <code>mailto</code>, <code>mms</code>, <code>nntp</code>, <code>rtsp</code>, and <code>webcal</code>. Custom protocols must be prefixed with <code>web+</code>.",
-                "The obsolete <code>title</code> argument is required."
+                "The obsolete <code>title</code> parameter is required."
               ]
             },
             "firefox": {
@@ -2870,7 +2870,7 @@
             },
             "opera": {
               "version_added": "11.6",
-              "notes": "The obsolete <code>title</code> argument is required."
+              "notes": "The obsolete <code>title</code> parameter is required."
             },
             "opera_android": {
               "version_added": false

--- a/api/Text.json
+++ b/api/Text.json
@@ -213,11 +213,11 @@
           "support": {
             "chrome": {
               "version_added": "1",
-              "notes": "Before Chrome 30, the <code>offset</code> argument was optional."
+              "notes": "Before Chrome 30, the <code>offset</code> parameter was optional."
             },
             "chrome_android": {
               "version_added": "18",
-              "notes": "Before Chrome 30, the <code>offset</code> argument was optional."
+              "notes": "Before Chrome 30, the <code>offset</code> parameter was optional."
             },
             "edge": {
               "version_added": "12"
@@ -233,27 +233,27 @@
             },
             "opera": {
               "version_added": true,
-              "notes": "Before Opera 17, the <code>offset</code> argument was optional."
+              "notes": "Before Opera 17, the <code>offset</code> parameter was optional."
             },
             "opera_android": {
               "version_added": true,
-              "notes": "Before Opera 17, the <code>offset</code> argument was optional."
+              "notes": "Before Opera 17, the <code>offset</code> parameter was optional."
             },
             "safari": {
               "version_added": "1",
-              "notes": "The <code>offset</code> argument is optional."
+              "notes": "The <code>offset</code> parameter is optional."
             },
             "safari_ios": {
               "version_added": "1",
-              "notes": "The <code>offset</code> argument is optional."
+              "notes": "The <code>offset</code> parameter is optional."
             },
             "samsunginternet_android": {
               "version_added": "1.0",
-              "notes": "Before Samsung Internet 2.0, the <code>offset</code> argument was optional."
+              "notes": "Before Samsung Internet 2.0, the <code>offset</code> parameter was optional."
             },
             "webview_android": {
               "version_added": true,
-              "notes": "Before version 4.4, the <code>offset</code> argument was optional."
+              "notes": "Before version 4.4, the <code>offset</code> parameter was optional."
             }
           },
           "status": {


### PR DESCRIPTION
Previous renames:
https://github.com/mdn/browser-compat-data/pull/10695
https://github.com/mdn/browser-compat-data/pull/10700
https://github.com/mdn/browser-compat-data/pull/11328