### PR TITLE
Add IE versions for api.Element.msContentZoom_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -5429,7 +5429,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": true
+              "version_added": "11"
             },
             "opera": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `msContentZoom_event` member of the `Element` API.  This simply sets the value to "11" without any real testing or research, because this feature will be removed  around the end of the year and it's not worthwhile to hunt down the exact version number.
