### PR TITLE
Add IE versions for api.Element.click_event.on_disabled_form_elements

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1738,8 +1738,7 @@
                 "version_added": false
               },
               "ie": {
-                "version_added": true,
-                "notes": "Internet Explorer only triggers the <code>click</code> event on <code>&lt;input&gt;</code> elements of type <code>checkbox</code> or <code>radio</code> when the element is double-clicked."
+                "version_added": false
               },
               "opera": {
                 "version_added": true,


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `click_event.on_disabled_form_elements` member of the `Element` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<form>
		<input id="input" type="checkbox" disabled />
	</form>
</div>

<script>
	var el = document.getElementById('input');
	el.addEventListener('click', function() {
		alert('Click!');
	});
</script>
```