### PR TITLE
Remove api.Element.click_event.on_disabled_form_elements

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1714,62 +1714,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "on_disabled_form_elements": {
-          "__compat": {
-            "description": "On disabled form elements",
-            "support": {
-              "chrome": {
-                "version_added": true,
-                "notes": "Only works for <code>&lt;textarea&gt;</code> elements and some <code>&lt;input&gt;</code> element types."
-              },
-              "chrome_android": {
-                "version_added": true,
-                "notes": "Only works for <code>&lt;textarea&gt;</code> elements and some <code>&lt;input&gt;</code> element types."
-              },
-              "edge": {
-                "version_added": "79",
-                "notes": "Only works for <code>&lt;textarea&gt;</code> elements and some <code>&lt;input&gt;</code> element types."
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": true,
-                "notes": "Internet Explorer only triggers the <code>click</code> event on <code>&lt;input&gt;</code> elements of type <code>checkbox</code> or <code>radio</code> when the element is double-clicked."
-              },
-              "opera": {
-                "version_added": true,
-                "notes": "Only works for <code>&lt;textarea&gt;</code> elements and some <code>&lt;input&gt;</code> element types."
-              },
-              "opera_android": {
-                "version_added": true,
-                "notes": "Only works for <code>&lt;textarea&gt;</code> elements and some <code>&lt;input&gt;</code> element types."
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": true,
-                "notes": "Only works for <code>&lt;textarea&gt;</code> elements and some <code>&lt;input&gt;</code> element types."
-              },
-              "webview_android": {
-                "version_added": true,
-                "notes": "Only works for <code>&lt;textarea&gt;</code> elements and some <code>&lt;input&gt;</code> element types."
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "clientHeight": {


### PR DESCRIPTION
This PR removes the "On disabled form elements" subfeature of the Element's `click` event.  When attempting to run tests to determine what browser versions this behavior was supported in, I couldn't replicate the mentioned behavior in the notes in IE 11, Chrome 94, or Chrome 37.  This behavior is inaccurately marked as non-standard in BCD when there is no mention of it in the spec.

Test code used:
```html
<div id="test">
	<form>
		<!-- For IE, this was used -->
		<input id="input" type="checkbox" disabled />
		<!-- For Chrome, this was used -->
		<textarea id="input" disabled></textarea>
	</form>
</div>

<script>
	var el = document.getElementById('input');
	el.addEventListener('click', function() {
		alert('Click!');
	});
</script>
```
