### PR TITLE
Add IE versions for api.Document.pointerlock_events

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -8660,7 +8660,7 @@
               }
             ],
             "edge": {
-              "version_added": "≤79"
+              "version_added": "13"
             },
             "firefox": [
               {
@@ -8683,7 +8683,7 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null
@@ -8752,7 +8752,7 @@
               }
             ],
             "edge": {
-              "version_added": "≤79"
+              "version_added": "13"
             },
             "firefox": [
               {
@@ -8775,7 +8775,7 @@
               }
             ],
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `pointerlock_events` member of the `Document` API.  The data was copied from the event handlers, as well as the rest of the pointer lock data.
