### PR TITLE
Add Chrome/Safari versions for api.Element.compositionstart/end_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2024,10 +2024,10 @@
           "spec_url": "https://w3c.github.io/uievents/#event-type-compositionend",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "15"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2042,22 +2042,22 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -2074,10 +2074,10 @@
           "spec_url": "https://w3c.github.io/uievents/#event-type-compositionstart",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "15"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -2092,22 +2092,22 @@
               "version_added": true
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chrome and Safari for the `compositionstart_event` and `compositionend_event` members of the `Element` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<div class="control">
	  <label for="name">On macOS, click in the textbox below,<br> then type <kbd>option</kbd> + <kbd>`</kbd>, then <kbd>a</kbd>:</label>
	  <input type="text" id="example" name="example">
	</div>

	<div class="event-log">
	  <label>Event log:</label>
	  <textarea readonly class="event-log-contents" rows="8" cols="25"></textarea>
	  <button class="clear-log">Clear</button>
	</div>
</div>

<script>
	const inputElement = document.querySelector('input[type="text"]');
	const log = document.querySelector('.event-log-contents');
	const clearLog = document.querySelector('.clear-log');

	clearLog.addEventListener('click', function() {
	    log.textContent = '';
	});

	function handleEvent(event) {
	    log.textContent = log.textContent + event.type + ': ' + event.data + '\n';
	}

	inputElement.addEventListener('compositionstart', handleEvent);
	inputElement.addEventListener('compositionupdate', handleEvent);
	inputElement.addEventListener('compositionend', handleEvent);
</script>
```
