### PR TITLE
Add Firefox versions for api.Element.key[down/press/up]_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -4676,10 +4676,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": "9"
@@ -4728,11 +4728,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "6",
               "notes": "As of Firefox 65, the <code>keypress</code> event is no longer fired for <a href='https://developer.mozilla.org/docs/Web/API/KeyboardEvent/keyCode#Non-printable_keys_(function_keys)'>non-printable keys</a>, except for the Enter key, and the Shift + Enter and Ctrl + Enter key combinations (these were kept for cross-browser compatibility purposes)."
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "6",
               "notes": "As of Firefox 65, the <code>keypress</code> event is no longer fired for <a href='https://developer.mozilla.org/docs/Web/API/KeyboardEvent/keyCode#Non-printable_keys_(function_keys)'>non-printable keys</a>, except for the Enter key, and the Shift + Enter and Ctrl + Enter key combinations (these were kept for cross-browser compatibility purposes)."
             },
             "ie": {
@@ -4782,10 +4782,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `keydown_event`, `keypress_event`, and `keyup_event` members of the `Element` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<input id="input" placeholder="Click here, then press down a key." size="40">
</div>

<script>
	var input = document.getElementById('input');

	input.addEventListener('keydown', function () {
		alert('Key down!');
	});

	input.addEventListener('keypress', function () {
		alert('Key press!');
	});

	input.addEventListener('keyup', function () {
		alert('Key up!');
	});
</script>
```
