### PR TITLE
Add IE versions for api.Element.keyup_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -4779,7 +4779,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": true
@@ -4788,7 +4788,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": null
+              "version_added": "9"
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `keyup_event` member of the `Element` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<input id="input" placeholder="Click here, then press down a key." size="40">
</div>

<script>
	var input = document.getElementById('input');

	input.addEventListener('keyup', function () {
		alert('Key up!');
	});
</script>
```
