### PR TITLE
Add Firefox versions for api.Element.MozMousePixelScroll_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -166,14 +166,13 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "≤18",
-              "version_removed": "79"
+              "version_added": false
             },
             "firefox": {
-              "version_added": true
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `MozMousePixelScroll_event` member of the `Element` API, based upon manual testing.

Test Code Used:
```html
<style id="test-style">
    #test {
        height: 40000px;
    }
</style>
<div id="test"></div>

<script>
    document.body.addEventListener('MozMousePixelScroll', function () {
        alert('Scroll');
    });
</script>
```

Additionally, this PR sets Edge to `false` because there's no way this is supported in Edge.
