### PR TITLE
Tweak notes for document.queryCommandSupported("paste")

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -9441,7 +9441,8 @@
               {
                 "version_added": "1",
                 "version_removed": "41",
-                "notes": "<code>paste</code> argument incorrectly returned <code>true</code> when the paste feature was available but the calling script had insufficient privileges to actually perform the action."
+                "partial_implementation": true,
+                "notes": "The <code>\"paste\"</code> command is reported as supported when the paste feature is available even if the calling script has insufficient privileges to actually perform the action."
               }
             ],
             "firefox_android": [
@@ -9451,7 +9452,8 @@
               {
                 "version_added": "4",
                 "version_removed": "41",
-                "notes": "<code>paste</code> argument incorrectly returned <code>true</code> when the paste feature was available but the calling script had insufficient privileges to actually perform the action."
+                "partial_implementation": true,
+                "notes": "The <code>\"paste\"</code> command is reported as supported when the paste feature is available even if the calling script has insufficient privileges to actually perform the action."
               }
             ],
             "ie": {


### PR DESCRIPTION
The note made it look like there was an argument named `paste` for this
method, but it's the argument value "paste" that's intended. Tweak the
note to clarify.
