### PR TITLE
Add Firefox versions for api.Element.scroll_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -7013,10 +7013,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": "9"


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `scroll_event` member of the `Element` API, based upon manual testing.

Test Code Used:
```js
document.addEventListener('scroll', function () {
	alert('Scroll');
});
```
