### PR TITLE
Remove irrelevant notes about TextEncoder

### DIFF
--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -17,24 +17,12 @@
           "edge": {
             "version_added": "79"
           },
-          "firefox": [
-            {
-              "version_added": "19"
-            },
-            {
-              "version_added": "18",
-              "notes": "Firefox 18 implemented an earlier and slightly different version of the specification."
-            }
-          ],
-          "firefox_android": [
-            {
-              "version_added": "19"
-            },
-            {
-              "version_added": "18",
-              "notes": "Firefox 18 implemented an earlier and slightly different version of the specification."
-            }
-          ],
+          "firefox": {
+            "version_added": "18"
+          },
+          "firefox_android": {
+            "version_added": "18"
+          },
           "ie": {
             "version_added": false
           },
@@ -79,17 +67,9 @@
           "spec_url": "https://encoding.spec.whatwg.org/#ref-for-dom-textencoder①",
           "description": "<code>TextEncoder()</code> constructor",
           "support": {
-            "chrome": [
-              {
-                "version_added": "53",
-                "notes": "Does not accept parameters. Supports only <code>utf-8</code> encoding."
-              },
-              {
-                "version_added": "38",
-                "version_removed": "53",
-                "notes": "Throws <code>RangeError</code> exception for unknown encoding types."
-              }
-            ],
+            "chrome": {
+              "version_added": "38"
+            },
             "chrome_android": {
               "version_added": "38"
             },
@@ -97,49 +77,14 @@
               "version_added": "1.0"
             },
             "edge": {
-              "version_added": "79",
-              "notes": "Does not accept parameters. Supports only <code>utf-8</code> encoding."
+              "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "48",
-                "notes": "The constructor accepts an encoding type label argument, but the value is ignored. Only <code>utf-8</code> encoding is supported."
-              },
-              {
-                "version_added": "38",
-                "version_removed": "48",
-                "notes": "If the encoding type label argument is invalid, then a <code>RangeError</code> exception is thrown."
-              },
-              {
-                "version_added": "19",
-                "version_removed": "38",
-                "notes": "If the encoding type label argument is invalid, then a <code>TypeError</code> exception is thrown."
-              },
-              {
-                "version_added": "18",
-                "notes": "Firefox 18 implemented an earlier and slightly different version of the specification."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "48",
-                "notes": "The constructor accepts an encoding type label argument, but the value is ignored. Only <code>utf-8</code> encoding is supported."
-              },
-              {
-                "version_added": "38",
-                "version_removed": "48",
-                "notes": "If the encoding type label argument is invalid, then a <code>RangeError</code> exception is thrown."
-              },
-              {
-                "version_added": "19",
-                "version_removed": "38",
-                "notes": "If the encoding type label argument is invalid, then a <code>TypeError</code> exception is thrown."
-              },
-              {
-                "version_added": "18",
-                "notes": "Firefox 18 implemented an earlier and slightly different version of the specification."
-              }
-            ],
+            "firefox": {
+              "version_added": "18"
+            },
+            "firefox_android": {
+              "version_added": "18"
+            },
             "ie": {
               "version_added": false
             },
@@ -195,24 +140,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "19"
-              },
-              {
-                "version_added": "18",
-                "notes": "Firefox 18 implemented an earlier and slightly different version of the specification."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "19"
-              },
-              {
-                "version_added": "18",
-                "notes": "Firefox 18 implemented an earlier and slightly different version of the specification."
-              }
-            ],
+            "firefox": {
+              "version_added": "18"
+            },
+            "firefox_android": {
+              "version_added": "18"
+            },
             "ie": {
               "version_added": false
             },
@@ -317,24 +250,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "19"
-              },
-              {
-                "version_added": "18",
-                "notes": "Firefox 18 implemented an earlier and slightly different version of the specification."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "19"
-              },
-              {
-                "version_added": "18",
-                "notes": "Firefox 18 implemented an earlier and slightly different version of the specification."
-              }
-            ],
+            "firefox": {
+              "version_added": "18"
+            },
+            "firefox_android": {
+              "version_added": "18"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
There was once a parameter to use other encodings than UTF-8, but this
was now long ago, and this isn't something developers need to take into
account when supporting old browsers, since new TextEncoder() without
argument works just fine. If the parameter were represented as a
subfeature, it would be removed as irrelevant under this guideline:
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features

Also remove the notes about Firefox 18. No details are provided, and the
fact that some parts of the API shipped later is already captured. Basic
usage like this was confirmed to work in Firefox 18:
```js
var e = new TextEncoder();
console.log(e.encode('hallå'));
```

That the feature shipped in Chrome 38 + Firefox 18 was also reconfirmed
using this test:
http://mdn-bcd-collector.appspot.com/tests/api/TextEncoder