### PR TITLE
Add Firefox versions for api.Element.select_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -8000,10 +8000,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": "9"


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `select_event` member of the `Element` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<input id="input" value="Try selecting some text in this element.">
</div>

<script>
	function logSelection(event) {
	  var selection = event.target.value.substring(event.target.selectionStart, event.target.selectionEnd);
	  alert('You selected: ' + selection);
	}

	var input = document.getElementById('input');
	input.addEventListener('select', logSelection);
</script>
```