### PR TITLE
Add Safari versions for api.Element.webkitmouseforce_events

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -8991,10 +8991,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -9040,10 +9040,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -9089,10 +9089,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -9138,10 +9138,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `webkitmouseforce_events` member of the `Element` API.  The Apple documentation states that "Force Touch events are available in macOS 10.11 and later on devices equipped with Force Touch trackpads."  While I have access to Force Touch-capable trackpads, I would not be able to test support.  I assumed Safari 9 since [Safari 9](https://en.wikipedia.org/wiki/Safari_version_history#Safari_9) was bundled with macOS 10.11.
