### PR TITLE
Add Firefox versions for api.HTMLDetailsElement.toggle_event

### DIFF
--- a/api/HTMLDetailsElement.json
+++ b/api/HTMLDetailsElement.json
@@ -112,10 +112,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "49"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "49"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `toggle_event` member of the `HTMLDetailsElement` API, based upon manual testing.

Test Code Used:
```html
<style id="test-style">
    summary.active {
        color: lightblue;
    }
</style>
<div id="test">
  <details id="ch">
    <summary id="title">Chapter I</summary>
    Philosophy reproves Boethius for the foolishness of his complaints against Fortune. Her very nature is caprice.
  </details>
</div>

<script>
    var details = document.getElementById('ch');
    var title = document.getElementById('title');

    details.addEventListener('toggle', function() {
        title.classList.toggle('active');
    });
</script>
```
