### PR TITLE
Remove claimed "moz" prefixes for RTCSessionDescription sub-features

### DIFF
--- a/api/RTCSessionDescription.json
+++ b/api/RTCSessionDescription.json
@@ -136,7 +136,6 @@
               "version_added": "15"
             },
             "firefox": {
-              "prefix": "moz",
               "version_added": true
             },
             "firefox_android": {
@@ -186,7 +185,6 @@
               "version_added": "15"
             },
             "firefox": {
-              "prefix": "moz",
               "version_added": true
             },
             "firefox_android": {
@@ -236,7 +234,6 @@
               "version_added": "15"
             },
             "firefox": {
-              "prefix": "moz",
               "version_added": true
             },
             "firefox_android": {


### PR DESCRIPTION
It's the interface (and thus the constructor) that has been prefixed,
not the properties and toJSON() method.
