### PR TITLE
Add Chrome/Safari versions for api.HTMLDetailsElement.toggle_event

### DIFF
--- a/api/HTMLDetailsElement.json
+++ b/api/HTMLDetailsElement.json
@@ -103,10 +103,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-toggle",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "36"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "36"
             },
             "edge": {
               "version_added": "79"
@@ -121,22 +121,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "23"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "24"
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chrome and Safari for the `toggle_event` member of the `HTMLDetailsElement` API, based upon manual testing.

Test Code Used:
```html
<style id="test-style">
    summary.active {
        color: lightblue;
    }
</style>
<div id="test">
  <details id="ch">
    <summary id="title">Chapter I</summary>
    Philosophy reproves Boethius for the foolishness of his complaints against Fortune. Her very nature is caprice.
  </details>
</div>

<script>
    var details = document.getElementById('ch');
    var title = document.getElementById('title');

    details.addEventListener('toggle', function() {
        title.classList.toggle('active');
    });
</script>
```
