### PR TITLE
Fix version for api.RTCIceCandidate.toJSON

### DIFF
--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -727,10 +727,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcicecandidate-tojson",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "43"
             },
             "edge": {
               "version_added": "15"
@@ -745,10 +745,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "30"
             },
             "safari": {
               "version_added": "11"
@@ -757,10 +757,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "43"
             }
           },
           "status": {


### PR DESCRIPTION
The source of this data is this comment:
https://github.com/mdn/browser-compat-data/pull/4398#pullrequestreview-259567982

However, because of a problem with Chromium's "Find Releases" tool,
Chrome 45 is often claimed for commits older than that:
https://github.com/mdn/browser-compat-data/issues/7844

Chrome 43 was confirmed by testing 42 and 43 with this test:
http://mdn-bcd-collector.appspot.com/tests/api/RTCIceCandidate/toJSON

Chrome 43 is also what commit date + branch point dates suggests:
https://source.chromium.org/chromium/chromium/src/+/4a6ce1a6ad82c9b9f16bcb136303acadf08422ea
https://www.chromium.org/developers/calendar
