### PR TITLE
Remove "moz" prefix for api.RTCSessionDescription.toJSON

### DIFF
--- a/api/RTCSessionDescription.json
+++ b/api/RTCSessionDescription.json
@@ -185,7 +185,6 @@
               "version_added": "15"
             },
             "firefox": {
-              "prefix": "moz",
               "version_added": true
             },
             "firefox_android": {


### PR DESCRIPTION
It's the interface (and thus the constructor) that has been prefixed,
not the toJSON() method. Two other incorrect prefixes were removed here:
https://github.com/mdn/browser-compat-data/pull/12897
