### PR TITLE
Add Chromium versions for HTMLDialogElement API

### DIFF
--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -71,7 +71,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-cancel",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "37"
             },
             "chrome_android": {
               "version_added": false
@@ -89,7 +89,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "24"
             },
             "opera_android": {
               "version_added": false
@@ -186,7 +186,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-close",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "37"
             },
             "chrome_android": {
               "version_added": false
@@ -204,7 +204,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "24"
             },
             "opera_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `HTMLDialogElement` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<dialog id="example-dialog">
	    <button id="close" type="reset">Close</button>
	</dialog>

	<button id="open-dialog">Open dialog</button>

	<div id="result"></div>
</div>

<script>
	var result = document.getElementById('result');
	var dialog = document.getElementById('example-dialog');

	dialog.addEventListener('cancel', function(event) {
	  result.textContent = 'dialog was canceled';
	});

	dialog.addEventListener('close', function(event) {
	  result.textContent = 'dialog was closed';
	});

	const openDialog = document.getElementById('open-dialog');
	openDialog.addEventListener('click', function() {
	  if (typeof dialog.showModal === 'function') {
	      dialog.showModal();
	      result.textContent = '';
	  } else {
	      result.textContent = 'The dialog API is not supported by this browser';
	  }
	});

	const closeButton = document.getElementById('close');
	closeButton.addEventListener('click', function() {
	    dialog.close();
	});
</script>
```
