### PR TITLE
Update speech media type support for Opera browser

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1779,7 +1779,7 @@
               },
               "opera_android": {
                 "version_added": "10.1",
-                "version_removed": "15"
+                "version_removed": "14"
               },
               "safari": {
                 "version_added": false

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1774,10 +1774,12 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "9.2"
+                "version_added": "9.2",
+                "version_removed": "15"
               },
               "opera_android": {
-                "version_added": "10.1"
+                "version_added": "10.1",
+                "version_removed": "64"
               },
               "safari": {
                 "version_added": false

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1779,7 +1779,7 @@
               },
               "opera_android": {
                 "version_added": "10.1",
-                "version_removed": "64"
+                "version_removed": "15"
               },
               "safari": {
                 "version_added": false


### PR DESCRIPTION
#### Summary

`@media speech` introduced in Opera Presto engine is not supported in Chromium based Opera.

Support data states otherwise because it’s lacking `version_removed` keys.

#### Test results and supporting details

Unfortunately I don’t see any [related tests in WPT](https://wpt.fyi/results/css/mediaqueries?label=experimental&label=master&aligned), but as a former Opera Software employee I can assure you that there were no plans in 2012–2013 during engine switch to implement any web platform APIs previously supported by Presto.

I don’t see it mentioned anywhere in [Opera version history](https://help.opera.com/en/opera-version-history/).