### PR TITLE
Add IE versions for api.Element.composition[start/end/update]_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2039,7 +2039,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "11"
             },
             "opera": {
               "version_added": true
@@ -2089,7 +2089,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "11"
             },
             "opera": {
               "version_added": true
@@ -2139,7 +2139,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "11"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `composition` event members of the `Element` API, based upon manual testing.

Note: this was tested by enabling Chinese Pinyin typing mode.

Test Code Used:
```html
<div id="test">
	<div class="control">
	  <label for="name">On macOS, click in the textbox below,<br> then type <kbd>option</kbd> + <kbd>`</kbd>, then <kbd>a</kbd>:</label>
	  <input type="text" id="example" name="example">
	</div>

	<div class="event-log">
	  <label>Event log:</label>
	  <textarea readonly class="event-log-contents" rows="8" cols="25"></textarea>
	  <button class="clear-log">Clear</button>
	</div>
</div>

<script>
	const inputElement = document.querySelector('input[type="text"]');
	const log = document.querySelector('.event-log-contents');
	const clearLog = document.querySelector('.clear-log');

	clearLog.addEventListener('click', function() {
	    log.textContent = '';
	});

	function handleEvent(event) {
	    log.textContent = log.textContent + event.type + ': ' + event.data + '\n';
	}

	inputElement.addEventListener('compositionstart', handleEvent);
	inputElement.addEventListener('compositionupdate', handleEvent);
	inputElement.addEventListener('compositionend', handleEvent);
</script>
```
