### PR TITLE
Add Firefox versions for api.HTMLElement.animationend_event

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -242,10 +242,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "51"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "51"
             },
             "ie": {
               "version_added": "10"


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `animationend_event` member of the `HTMLElement` API, based upon manual testing.

Test Code Used: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/animationend_event
