### PR TITLE
Add Chromium versions for api.HTMLElement.beforeinput_event

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -607,10 +607,10 @@
           "description": "<code>beforeinput</code> event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "60"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "60"
             },
             "edge": {
               "version_added": "79"
@@ -651,10 +651,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "47"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "safari": {
               "version_added": true
@@ -663,10 +663,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "60"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `beforeinput_event` member of the `HTMLElement` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<input id="name" placeholder="Enter some text" name="name"/>
	<p id="values"></p>
</div>

<script>
	var input = document.getElementById('name');
	var log = document.getElementById('values');

	input.addEventListener('beforeinput', updateValue);

	function updateValue(e) {
	  log.textContent = e.target.value;
	}
</script>
```
