### PR TITLE
Add Safari versions for api.HTMLElement.beforeinput_event

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -657,10 +657,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `beforeinput_event` member of the `HTMLElement` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<input id="name" placeholder="Enter some text" name="name"/>
	<p id="values"></p>
</div>

<script>
	var input = document.getElementById('name');
	var log = document.getElementById('values');

	input.addEventListener('beforeinput', updateValue);

	function updateValue(e) {
	  log.textContent = e.target.value;
	}
</script>
```
