### PR TITLE
Add IE/Edge versions for api.HTMLElement.transition_events

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -3464,7 +3464,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"
@@ -3473,7 +3473,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "62"
@@ -3557,11 +3557,11 @@
             ],
             "edge": [
               {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               {
                 "alternative_name": "webkitTransitionEnd",
-                "version_added": "≤79"
+                "version_added": "79"
               }
             ],
             "firefox": {
@@ -3658,7 +3658,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"
@@ -3667,7 +3667,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": "62"
@@ -3738,7 +3738,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "53"
@@ -3747,7 +3747,7 @@
               "version_added": "53"
             },
             "ie": {
-              "version_added": null
+              "version_added": "10"
             },
             "opera": {
               "version_added": "62"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `transition_events` member of the `HTMLElement` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<div id="transition"></div>
	<div id="message"></div>
</div>

<script>
	var message = document.getElementById('message');
	var el = document.getElementById('transition');

	el.addEventListener('transitionrun', function() {
	  message.textContent += 'run ';
	});

	el.addEventListener('transitionstart', function() {
	  message.textContent += 'start ';
	});

	el.addEventListener('transitioncancel', function() {
	  message.textContent += 'cancel ';
	});

	el.addEventListener('transitionend', function() {
	  message.textContent += 'end ';
	});
</script>
```
