### PR TITLE
Add all browsers versions for api.HTMLFormElement.reset_event

### DIFF
--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -789,40 +789,40 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-reset",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
-              "version_added": true
+              "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for all browsers for the `reset_event` member of the `HTMLFormElement` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<form id="form">
	  <label>Test field: <input type="text"></label>
	  <br><br>
	  <button type="reset">Reset form</button>
	</form>
	<p id="log"></p>
</div>

<script>
	function logReset(event) {
	  log.textContent = 'Form reset!';
	}

	var form = document.getElementById('form');
	var log = document.getElementById('log');
	form.addEventListener('reset', logReset);
</script>
```
