### PR TITLE
Remove api.HTMLImageElement.error_event

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -489,56 +489,6 @@
           }
         }
       },
-      "error_event": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLImageElement/error_event",
-          "description": "<code>error</code> event",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": "51",
-              "notes": "May also be supported in earlier versions."
-            },
-            "firefox_android": {
-              "version_added": "51"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
-            "safari": {
-              "version_added": true
-            },
-            "safari_ios": {
-              "version_added": true
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "height": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLImageElement/height",


### PR DESCRIPTION
This PR removes the `error` event from the `HTMLImageElement` interface from BCD.  The MDN documentation has been removed and the page for the `HTMLImageElement` links to the `Element`'s `error` event page.
