### PR TITLE
Add Firefox versions for MediaStream API

### DIFF
--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -246,10 +246,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -692,10 +692,10 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `MediaStream` API, based upon commit history and date.

Commit: https://hg.mozilla.org/mozilla-central/rev/79525105ef9acc02ced1107f5540ea056b74edf4 (getTracks) / https://hg.mozilla.org/mozilla-central/rev/db0763589cc378a140c7bcf6d4a4123bc7717dc9 (removeTrack) / https://hg.mozilla.org/mozilla-central/rev/eb93d67c574758aea9936e5be6117bd2af3a3573 (onremovetrack) / https://searchfox.org/mozilla-central/source/dom/webidl/MediaStream.webidl (lack of support for rstop, onactive, oninactive)
