### PR TITLE
Add Firefox versions for MediaStreamTrack API

### DIFF
--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -455,10 +455,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "ie": {
               "version_added": false
@@ -504,10 +504,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "ie": {
               "version_added": false
@@ -553,10 +553,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "22"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "ie": {
               "version_added": false
@@ -948,10 +948,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `MediaStreamTrack` API, based upon commit history and date.

Commit: https://hg.mozilla.org/mozilla-central/rev/925d5b6c917130f83634f3ea9d5ee71f98ce6c80 (id, kind, label) / https://searchfox.org/mozilla-central/source/dom/webidl/MediaStreamTrack.webidl (lack of support for remote)
