### PR TITLE
Add Chromium versions for RTCIceServer API

### DIFF
--- a/api/RTCIceServer.json
+++ b/api/RTCIceServer.json
@@ -6,10 +6,10 @@
         "spec_url": "https://w3c.github.io/webrtc-pc/#rtciceserver-dictionary",
         "support": {
           "chrome": {
-            "version_added": true
+            "version_added": "23"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "25"
           },
           "edge": {
             "version_added": "≤79"
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "14"
           },
           "safari": {
             "version_added": "11"
@@ -36,7 +36,7 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": false
@@ -54,10 +54,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtciceserver-credential",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤79"
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -84,7 +84,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": false
@@ -103,10 +103,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtciceserver-credentialtype",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": "≤79"
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -133,7 +133,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -151,10 +151,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceServer/url",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "25"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤79"
@@ -169,10 +169,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -181,7 +181,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": false
@@ -200,10 +200,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtciceserver-urls",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "34"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "34"
             },
             "edge": {
               "version_added": "≤79"
@@ -218,10 +218,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "21"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "21"
             },
             "safari": {
               "version_added": "11"
@@ -230,7 +230,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": false
@@ -249,10 +249,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtciceserver-username",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "29"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "edge": {
               "version_added": "≤79"
@@ -267,10 +267,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "16"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "16"
             },
             "safari": {
               "version_added": "11"
@@ -279,7 +279,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `RTCIceServer` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/bbd07413241fe188459bb259ac7d515a343d08f5 / https://source.chromium.org/chromium/chromium/src/+/b1de52282bf70b7ed80286ce2254b87cf1e55b7f / https://source.chromium.org/chromium/chromium/src/+/4426ed8c87c03f2c5d38aa75648154fc22cc564f / https://source.chromium.org/chromium/chromium/src/+/8f4f8198efa91792b204d81d97e9f20e7515cd03 / https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/peerconnection/rtc_ice_server.idl;l=1;bpv=1
