### PR TITLE
Add Firefox versions for PresentationRequest API

### DIFF
--- a/api/PresentationRequest.json
+++ b/api/PresentationRequest.json
@@ -339,11 +339,11 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "51",
               "version_removed": "61"
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "51",
               "version_removed": "79"
             },
             "ie": {


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `PresentationRequest` API, based upon manual testing.

Test Code Used: `new PresentationRequest() // Tried in both secure and insecure contexts`
