### PR TITLE
Add Firefox versions for api.MessagePort.message_event

### DIFF
--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -129,10 +129,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "41"
             },
             "ie": {
               "version_added": "10"


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `message_event` member of the `MessagePort` API.  The data was mirrored from its event handler counterpart (`onmessage`), which matches the parent.
