### PR TITLE
Add Firefox versions for api.Performance.resourcetimingbufferfull_event

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -1076,10 +1076,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "35"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "35"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `resourcetimingbufferfull_event` member of the `Performance` API.  The data was copied from its event handler counterpart.
