### PR TITLE
Add Firefox versions for api.DeviceMotionEventAcceleration.secure_context_required

### DIFF
--- a/api/DeviceMotionEventAcceleration.json
+++ b/api/DeviceMotionEventAcceleration.json
@@ -92,10 +92,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `secure_context_required` member of the `DeviceMotionEventAcceleration` API.  There's no indication in Firefox's IDL (https://searchfox.org/mozilla-central/source/dom/webidl/DeviceMotionEvent.webidl) that the `DeviceMotionEvent` interface requires a secure context.
