### PR TITLE
Add Firefox versions for DeviceMotionEventRotationRate API

### DIFF
--- a/api/DeviceMotionEventRotationRate.json
+++ b/api/DeviceMotionEventRotationRate.json
@@ -254,10 +254,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `DeviceMotionEventRotationRate` API.  There's no indication in Firefox's IDL (https://searchfox.org/mozilla-central/source/dom/webidl/DeviceMotionEvent.webidl) that the `DeviceMotionEvent` interface requires a secure context.
