### PR TITLE
Add Chromium versions for api.ImageData.worker_support

### DIFF
--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -250,10 +250,10 @@
           "description": "Available in workers",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "36"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "36"
             },
             "edge": {
               "version_added": "≤79"
@@ -268,10 +268,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": null
+              "version_added": "23"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "24"
             },
             "safari": {
               "version_added": "7"
@@ -280,10 +280,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `worker_support` member of the `ImageData` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/75b340bb689f246e5250ce9c49ce8033d1a29c0c (confirmed by private feature freeze dates and [public dev calendar](https://www.chromium.org/developers/calendar))
