### PR TITLE
Add IE/Edge versions for api.ImageData.worker_support

### DIFF
--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -256,7 +256,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "25"
@@ -265,7 +265,7 @@
               "version_added": "25"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `worker_support` member of the `ImageData` API.  This sets the versions to the same as the constructor's, because honestly speaking, I have no clue how one would go about getting an `ImageData` instance without the constructor in a worker.
