### PR TITLE
Add Chromium versions for api.performance.worker_support

### DIFF
--- a/api/_globals/performance.json
+++ b/api/_globals/performance.json
@@ -80,7 +80,7 @@
               "version_added": "17"
             },
             "opera_android": {
-              "version_added": "17"
+              "version_added": "18"
             },
             "safari": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `worker_support` member of the `performance` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/6bad4be186ef5d7192d388072db35b86257ca1da
