### PR TITLE
Add Safari versions for api.performance.worker_support

### DIFF
--- a/api/_globals/performance.json
+++ b/api/_globals/performance.json
@@ -83,10 +83,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `worker_support` member of the `performance` API, based upon commit history and date.

Commit: https://github.com/WebKit/WebKit/commit/95be369785d0ab836293c0a9bf447580e8abec4a ([WebKit 604.1.6](https://github.com/WebKit/WebKit/blob/95be369785d0ab836293c0a9bf447580e8abec4a/Source/WebCore/Configurations/Version.xcconfig))
