### PR TITLE
Initial compat data for the EyeDropper API

### DIFF
--- a/api/EyeDropper.json
+++ b/api/EyeDropper.json
@@ -1,0 +1,152 @@
+{
+  "api": {
+    "EyeDropper": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/EyeDropper",
+        "spec_url": "https://wicg.github.io/eyedropper-api/#eyedropper-interface",
+        "support": {
+          "chrome": {
+            "version_added": "95"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": "95"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "81"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": false,
+          "deprecated": false
+        }
+      },
+      "EyeDropper": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/EyeDropper/EyeDropper",
+          "spec_url": "https://wicg.github.io/eyedropper-api/#eyedropper-interface",
+          "description": "<code>EyeDropper()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": "95"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "95"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "81"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "open": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/EyeDropper/open",
+          "spec_url": "https://wicg.github.io/eyedropper-api/#dom-eyedropper-open",
+          "support": {
+            "chrome": {
+              "version_added": "95"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "95"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "81"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
This PR adds some initial compat data for the new EyeDropper API.

This API is incubating at the moment, and has been implemented by Microsoft in Chromium. Starting with 95, both Edge and Chrome can use this new API. It is also available in Opera. I tested and found out that the API existed in Opera 81, though it seems buggy there.

#### Test results and supporting details
I ran the tests locally and they passed.

Here is the link to the API: https://wicg.github.io/eyedropper-api/
And here is the MDN content PR to add docs about it: https://github.com/mdn/content/pull/9985
