### PR TITLE
Add Firefox versions for api.HTMLMediaElement.abort_event

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -64,10 +64,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "9"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "9"
             },
             "ie": {
               "version_added": "9"


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `abort_event` member of the `HTMLMediaElement` API.  The data was copied from the event handler counterpart in `GlobalEventHandlers` (partly because I don't know how to simulate ththis event).
