### PR TITLE
Add Firefox versions for api.HTMLMediaElement.error_event

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -1347,10 +1347,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": "9"


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `error_event` member of the `HTMLMediaElement` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<video id="video"></video>
</div>

<script>
	var video = document.getElementById('video');
	var videoSrc = 'https://path/to/video.webm';

	video.addEventListener('error', function() {
	  alert('Error!');
	});

	video.setAttribute('src', videoSrc);
</script>
```
