### PR TITLE
Add Firefox versions for api.HTMLMediaElement.loadstart_event

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -1639,10 +1639,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": "9"


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `loadstart_event` member of the `HTMLMediaElement` API, based upon manual testing.

Test Code Used (modified from https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/loadstart_event):
```html
<div id="test">
	<button id="button" type="button">Load video</button>
    <video id="video" controls width="250"></video>

    <div class="event-log">
        <label>Event log:</label>
        <p id="event-log-contents"></p>
    </div>
</div>

<script>
	var loadVideo = document.getElementById('button');
	var video = document.getElementById('video');
	var eventLog = document.getElementById('event-log-contents');
	var source = null;

	function handleEvent(event) {
	    eventLog.textContent += event.type + ' ';
	}

	video.addEventListener('loadstart', handleEvent);
	video.addEventListener('progress', handleEvent);
	video.addEventListener('canplay', handleEvent);
	video.addEventListener('canplaythrough', handleEvent);

	loadVideo.addEventListener('click', function() {

	    if (source) {
	        document.location.reload();
	    } else {
	        loadVideo.textContent = "Reset example";
	        source = document.createElement('source');
	        source.setAttribute('src', 'https://interactive-examples.mdn.mozilla.net/media/examples/flower.webm');
	        source.setAttribute('type', 'video/webm');

	        video.appendChild(source);
	    }
	});
</script>
```
