### PR TITLE
Add Firefox versions for api.Window.animationend_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -323,10 +323,10 @@
               }
             ],
             "firefox": {
-              "version_added": true
+              "version_added": "51"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "51"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `animationend_event` member of the `Window` API, based upon manual testing.

Test Code Used (modified from https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/animationend_event#live_example):
```html
<div id="test">
	<div class="container">
        <p class="animation">You chose a cold night to visit our planet.</p>
    </div>
    <button class="activate" type="button">Activate animation</button>
    <div class="event-log"></div>
</div>

<script>
	var animation = document.querySelector('p.animation');
	var animationEventLog = document.querySelector('.event-log');
	var applyAnimation = document.querySelector('button.activate');
	var iterationCount = 0;

	window.addEventListener('animationstart', function() {
	  animationEventLog.textContent = `${animationEventLog.textContent}'animation started' `;
	});

	window.addEventListener('animationiteration', function() {
	  iterationCount++;
	  animationEventLog.textContent = `${animationEventLog.textContent}'animation iterations: ${iterationCount}' `;
	});

	window.addEventListener('animationend', function() {
	  animationEventLog.textContent = `${animationEventLog.textContent}'animation ended'`;
	  animation.classList.remove('active');
	  applyAnimation.textContent = "Activate animation";
	});

	window.addEventListener('animationcancel', function() {
	  animationEventLog.textContent = `${animationEventLog.textContent}'animation canceled'`;
	});

	applyAnimation.addEventListener('click', function() {
	  animation.classList.toggle('active');
	  animationEventLog.textContent = '';
	  iterationCount = 0;
	  let active = animation.classList.contains('active');
	  if (active) {
	    applyAnimation.textContent = "Cancel animation";
	  } else {
	    applyAnimation.textContent = "Activate animation";
	  }
	});
</script>
```
