### PR TITLE
Add Safari versions for api.HTMLFieldSetElement.elements.type_HTMLCollection

### DIFF
--- a/api/HTMLFieldSetElement.json
+++ b/api/HTMLFieldSetElement.json
@@ -219,10 +219,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": true
+                "version_added": "13"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "13"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `element.type_HTMLCollection` member of the `HTMLFieldSetElement` API, based upon manual testing.

Test Code Used:
```js
var el = document.createElement('fieldset');
alert(el.elements.constructor.name);
```
