### PR TITLE
Add Safari versions for api.Worker.Worker.mime_checks

### DIFF
--- a/api/Worker.json
+++ b/api/Worker.json
@@ -236,10 +236,12 @@
                 "notes": "See <a href='https://crbug.com/794548'>Chromium bug 794548</a>."
               },
               "safari": {
-                "version_added": null
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/192749'>WebKit bug 192749</a>."
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/192749'>WebKit bug 192749</a>."
               },
               "samsunginternet_android": {
                 "version_added": false,


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `Worker.mime_checks` member of the `Worker` API, based upon information in a tracking bug.

Tracking Bug: https://webkit.org/b/192749
