### PR TITLE
Add Firefox versions for api.HTMLMediaElement.progress_event

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2959,10 +2959,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": "9"


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `progress_event` member of the `HTMLMediaElement` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<video id="video" controls width="250"></video>
</div>

<script>
	var video = document.getElementById('video');
	var videoSrc = '/queengooborg/static/rabbit320.webm';
	/// https://mdn.github.io/learning-area/html/multimedia-and-embedding/video-and-audio-content/rabbit320.mp4 converted to VP8-codec WebM

	video.addEventListener('progress', function() {
	  console.log('Progress!');
	});

	var source = document.createElement('source');
	source.setAttribute('src', videoSrc);
	source.setAttribute('type', 'video/webm');

	video.appendChild(source);
</script>
```
