### PR TITLE
Add Chrome/Safari versions for api.HTMLMediaElement.waiting_event

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -4082,10 +4082,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/media.html#event-media-waiting",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -4100,22 +4100,22 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chrome and Safari for the `waiting_event` member of the `HTMLMediaElement` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<video id="video" controls width="250"></video>
</div>

<script>
	var video = document.getElementById('video');
	var videoSrc = '/queengooborg/static/rabbit320.mp4';
	// https://mdn.github.io/learning-area/html/multimedia-and-embedding/video-and-audio-content/rabbit320.mp4

	video.addEventListener('waiting', function() {
	  console.log('Waiting!');
	  // Triggered by loading the page, then disabling the connection to the server before playing the video
	});

	var source = document.createElement('source');
	source.setAttribute('src', videoSrc);
	source.setAttribute('type', 'video/mp4');

	video.appendChild(source);
</script>
```
