### PR TITLE
Add Safari versions for api.HTMLTrackElement.cuechange_event

### DIFF
--- a/api/HTMLTrackElement.json
+++ b/api/HTMLTrackElement.json
@@ -81,10 +81,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `cuechange_event` member of the `HTMLTrackElement` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<video id="video" controls width="250">
		<source src="/queengooborg/static/rabbit320.mp4" type="video/mp4" />
		<!-- https://mdn.github.io/learning-area/html/multimedia-and-embedding/video-and-audio-content/rabbit320.mp4 -->

		<track id="track" kind="captions" src="/queengooborg/static/rabbit320.vtt" srclang="en">
	</video>
</div>

<script>
	var track = document.getElementById('track');

	track.addEventListener('cuechange', function() {
	  alert('Cue change!');
	});
</script>
```

<details>
<summary>rabbit320.vtt</summary>
WEBVTT - Made with VTT Creator

00:00.000 --> 00:02.005
Hello World!

00:02.003 --> 00:04.003
How are you doing?

00:04.988 --> 00:06.988
I'm doing well!
</details>
