### PR TITLE
Add Chromium versions for api.TextTrack.cuechange_event

### DIFF
--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -153,10 +153,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/media.html#event-media-cuechange",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -171,10 +171,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari": {
               "version_added": true
@@ -183,10 +183,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `cuechange_event` member of the `TextTrack` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<video id="video" controls width="250">
		<source src="/queengooborg/static/rabbit320.mp4" type="video/mp4" />
		<!-- https://mdn.github.io/learning-area/html/multimedia-and-embedding/video-and-audio-content/rabbit320.mp4 -->

		<track id="track" kind="captions" src="/queengooborg/static/rabbit320.vtt" srclang="en">
	</video>
</div>

<script>
	var track = document.getElementById('track');

	track.addEventListener('cuechange', function() {
	  alert('Cue change!');
	});
</script>
```

<details>
<summary>rabbit320.vtt</summary>
WEBVTT - Made with VTT Creator

00:00.000 --> 00:02.005
Hello World!

00:02.003 --> 00:04.003
How are you doing?

00:04.988 --> 00:06.988
I'm doing well!
</details>
