### PR TITLE
Add Chromium versions for TextTrackList API

### DIFF
--- a/api/TextTrackList.json
+++ b/api/TextTrackList.json
@@ -55,10 +55,10 @@
           "description": "<code>addtrack</code> event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -73,10 +73,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -85,10 +85,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -105,10 +105,10 @@
           "description": "<code>change</code> event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "18"
@@ -123,10 +123,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "20"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "20"
             },
             "safari": {
               "version_added": "7"
@@ -135,10 +135,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -412,10 +412,10 @@
           "description": "<code>removetrack</code> event",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "18"
@@ -430,10 +430,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "20"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "20"
             },
             "safari": {
               "version_added": "7"
@@ -442,10 +442,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `TextTrackList` API (specifically, their events), based upon manual testing.

Test Code Used:
```html
<div id="test">
	<video id="video" controls width="250">
		<source src="/queengooborg/static/rabbit320.mp4" type="video/mp4" />
		<!-- https://mdn.github.io/learning-area/html/multimedia-and-embedding/video-and-audio-content/rabbit320.mp4 -->

		<track id="track" kind="captions" src="/queengooborg/static/rabbit320.vtt" srclang="en">
	</video>

	<button id="add">Add track</button>
	<button id="remove">Remove track</button>
</div>

<script>
	var video = document.getElementById('video');
	var textTracks = video.textTracks;

	video.textTracks.addEventListener('addtrack', function() {
		alert("Track added!");
	});
	video.textTracks.addEventListener('change', function() {
		alert("Tracks changed!");
	});
	video.textTracks.addEventListener('removetrack', function() {
		alert("Track removed!");
	});

	function addTrack() {
		video.addTextTrack("captions", "Captions", "es");
	};

	function removeTrack() {
		var track = document.getElementById('track');
		track.parentNode.removeChild(track);
	}

	document.getElementById('add').onclick = addTrack;
	document.getElementById('remove').onclick = removeTrack;
</script>
```
