### PR TITLE
Add Chromium versions for SVGAnimationElement API

### DIFF
--- a/api/SVGAnimationElement.json
+++ b/api/SVGAnimationElement.json
@@ -149,10 +149,10 @@
           "spec_url": "https://svgwg.org/svg2-draft/interact.html#BeginEvent",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "31"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "edge": {
               "version_added": "79"
@@ -167,10 +167,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "18"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "safari": {
               "version_added": true
@@ -179,10 +179,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -293,10 +293,10 @@
           "spec_url": "https://svgwg.org/svg2-draft/interact.html#EndEvent",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "31"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "edge": {
               "version_added": "79"
@@ -311,10 +311,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "18"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "safari": {
               "version_added": true
@@ -323,10 +323,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -631,10 +631,10 @@
           "spec_url": "https://svgwg.org/svg2-draft/interact.html#RepeatEvent",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "31"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "edge": {
               "version_added": "79"
@@ -649,10 +649,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "18"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "safari": {
               "version_added": true
@@ -661,10 +661,10 @@
               "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `SVGAnimationElement` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<svg id="svg" xmlns="http://www.w3.org/2000/svg" width="300px" height="100px">
	  <title>SVG SMIL Animate with Path</title>
	  <circle cx="0" cy="50" r="50" fill="blue" stroke="black" stroke-width="1">
	    <animateMotion
	       id="animation"
	       path="M 0 0 H 300 Z"
	       dur="0.4s" repeatCount="2" />
	  </circle>
	</svg>

	<hr>

	<ul id="list">

	</ul>
</div>

<script>
	// Modified from https://developer.mozilla.org/en-US/docs/Web/API/SVGAnimationElement/beginEvent_event
	
	var svgElem = document.getElementById('svg');
	var animateElem = document.getElementById('animation');
	var list = document.getElementById('list');

	animateElem.addEventListener('beginEvent', function() {
	  var listItem = document.createElement('li');
	  listItem.textContent = 'beginEvent fired';
	  list.appendChild(listItem);
	})

	animateElem.addEventListener('repeatEvent', function(e) {
	  var listItem = document.createElement('li');
	  var msg = 'repeatEvent fired';
	  if(e.detail) {
	    msg += '; repeat number: ' + e.detail;
	  }
	  listItem.textContent = msg;
	  list.appendChild(listItem);
	});

	animateElem.addEventListener('endEvent', function() {
	  var listItem = document.createElement('li');
	  listItem.textContent = 'endEvent fired';
	  list.appendChild(listItem);
	})
</script>
```
