### PR TITLE
Add Safari versions for SVGAnimationElement API

### DIFF
--- a/api/SVGAnimationElement.json
+++ b/api/SVGAnimationElement.json
@@ -173,10 +173,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -317,10 +317,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -655,10 +655,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `SVGAnimationElement` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<svg id="svg" xmlns="http://www.w3.org/2000/svg" width="300px" height="100px">
	  <title>SVG SMIL Animate with Path</title>
	  <circle cx="0" cy="50" r="50" fill="blue" stroke="black" stroke-width="1">
	    <animateMotion
	       id="animation"
	       path="M 0 0 H 300 Z"
	       dur="0.4s" repeatCount="2" />
	  </circle>
	</svg>

	<hr>

	<ul id="list">

	</ul>
</div>

<script>
	// Modified from https://developer.mozilla.org/en-US/docs/Web/API/SVGAnimationElement/beginEvent_event
	
	var svgElem = document.getElementById('svg');
	var animateElem = document.getElementById('animation');
	var list = document.getElementById('list');

	animateElem.addEventListener('beginEvent', function() {
	  var listItem = document.createElement('li');
	  listItem.textContent = 'beginEvent fired';
	  list.appendChild(listItem);
	})

	animateElem.addEventListener('repeatEvent', function(e) {
	  var listItem = document.createElement('li');
	  var msg = 'repeatEvent fired';
	  if(e.detail) {
	    msg += '; repeat number: ' + e.detail;
	  }
	  listItem.textContent = msg;
	  list.appendChild(listItem);
	});

	animateElem.addEventListener('endEvent', function() {
	  var listItem = document.createElement('li');
	  listItem.textContent = 'endEvent fired';
	  list.appendChild(listItem);
	})
</script>
```
