### PR TITLE
Add Firefox versions for api.Window.[blur/focus]_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -902,19 +902,19 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": true,
-                "notes": "Apart from firing the event on <code>window</code> as other browsers do, Firefox also fires the event on the <code>document</code> object. See <a href='https://bugzil.la/1228802'>bug 1228802</a>."
-              },
-              {
-                "version_added": true,
-                "version_removed": "24",
-                "notes": "The interface for this event is <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/FocusEvent'><code>FocusEvent</code></a>."
-              }
-            ],
+            "firefox": {
+              "version_added": "6",
+              "notes": [
+                "Apart from firing the event on <code>window</code> as other browsers do, Firefox also fires the event on the <code>document</code> object. See <a href='https://bugzil.la/1228802'>bug 1228802</a>.",
+                "Before Firefox 24, the interface for this event is a plain <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/FocusEvent'><code>FocusEvent</code></a>."
+              ]
+            },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6",
+              "notes": [
+                "Apart from firing the event on <code>window</code> as other browsers do, Firefox also fires the event on the <code>document</code> object. See <a href='https://bugzil.la/1228802'>bug 1228802</a>.",
+                "Before Firefox 24, the interface for this event is a plain <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/FocusEvent'><code>FocusEvent</code></a>."
+              ]
             },
             "ie": {
               "version_added": true
@@ -2062,19 +2062,19 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": true,
-                "notes": "Apart from firing the event on <code>window</code> as other browsers do, Firefox also fires the event on the <code>document</code> object. See <a href='https://bugzil.la/1228802'>bug 1228802</a>."
-              },
-              {
-                "version_added": true,
-                "version_removed": "24",
-                "notes": "The interface for this event is <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/FocusEvent'><code>FocusEvent</code></a>."
-              }
-            ],
+            "firefox": {
+              "version_added": "6",
+              "notes": [
+                "Apart from firing the event on <code>window</code> as other browsers do, Firefox also fires the event on the <code>document</code> object. See <a href='https://bugzil.la/1228802'>bug 1228802</a>.",
+                "Before Firefox 24, the interface for this event is a plain <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/FocusEvent'><code>FocusEvent</code></a>."
+              ]
+            },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6",
+              "notes": [
+                "Apart from firing the event on <code>window</code> as other browsers do, Firefox also fires the event on the <code>document</code> object. See <a href='https://bugzil.la/1228802'>bug 1228802</a>.",
+                "Before Firefox 24, the interface for this event is a plain <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/FocusEvent'><code>FocusEvent</code></a>."
+              ]
             },
             "ie": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `blur_event` and `focus_event` members of the `Window` API, based upon manual testing.

Test Code Used: https://developer.mozilla.org/en-US/docs/Web/API/Window/blur_event
