### PR TITLE
Add Chrome/Safari versions for api.Window.focus_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -920,10 +920,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": "12.1"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "12.1"
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "5.1"
@@ -2080,10 +2080,10 @@
               "version_added": true
             },
             "opera": {
-              "version_added": "12.1"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "12.1"
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "5.1"


### PR DESCRIPTION
This PR adds real values for Chrome and Safari for the `focus_event` member of the `Window` API, based upon manual testing.

Test Code Used: https://developer.mozilla.org/en-US/docs/Web/API/Window/blur_event
