### PR TITLE
Add IE versions for api.Window.[blur/focus]_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -917,7 +917,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "11"
             },
             "opera": {
               "version_added": "12.1"
@@ -2077,7 +2077,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "11"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `blur_event` and `focus_event` members of the `Window` API, based upon manual testing.

Test Code Used: https://developer.mozilla.org/en-US/docs/Web/API/Window/blur_event
