### PR TITLE
Add Firefox versions for api.Window.[copy/cut/paste]_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1403,10 +1403,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": false
@@ -1502,10 +1502,10 @@
               "version_added": "≤18"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": false
@@ -6038,10 +6038,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": "11"


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the clipboard event members of the `Window` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<input value="Copy/cut/paste me!" />
</div>

<script>
	window.addEventListener('copy', function() {
		alert("Copy!");
	});
	window.addEventListener('cut', function() {
		alert("Cut!");
	});
	window.addEventListener('paste', function() {
		alert("Paste!");
	});
</script>
```
