### PR TITLE
Add Safari versions for api.Window.transitionend_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -9469,12 +9469,42 @@
             "opera_android": {
               "version_added": null
             },
-            "safari": {
-              "version_added": true
-            },
-            "safari_ios": {
-              "version_added": true
-            },
+            "safari": [
+              {
+                "version_added": "13.1"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "13.4"
+              },
+              {
+                "version_added": "12",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Web Animations"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "CSS Animations via Web Animations"
+                  }
+                ]
+              }
+            ],
             "samsunginternet_android": {
               "version_added": false
             },


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `transitionend_event` member of the `Window` API.  The data was copied from the other transition events for the Window interface.
