### PR TITLE
Add all browsers versions for api.Window.error_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1803,10 +1803,10 @@
           "spec_url": "https://w3c.github.io/uievents/#event-type-error",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "10"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "deno": {
               "version_added": false
@@ -1815,31 +1815,31 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": null
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14"
             },
             "safari": {
-              "version_added": null
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for all browsers for the `error_event` member of the `Window` API, based upon manual testing.

Test Code Used:
```js
window.addEventListener('error', function() {
	alert('Your code has an oopsie!');
});

oops-I-did-it-again;
```
