### PR TITLE
Add Safari versions for api.MessageEvent.origin.USVString_type

### DIFF
--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -349,10 +349,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `origin.USVString_type` member of the `MessageEvent` API, based upon commit history and date.

Commit: https://github.com/WebKit/WebKit/commit/e78a3a50353edda2f410c23196c2d2eda46b64ed#diff-96abbaf633e7927b4cae1277917a00cfc8959b0264d6ec338bba96d7ead6375f
