### PR TITLE
Add Chromium versions for api.MessageEvent.origin.USVString_type

### DIFF
--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -331,7 +331,7 @@
                 "version_added": false
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "55"


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `origin.USVString_type` member of the `MessageEvent` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/events/message_event.idl;l=35;bpv=1;bpt=0 (Still a `DOMString`)
