### PR TITLE
Add Safari versions for api.EventTarget.addEventListener.options_parameter

### DIFF
--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -273,10 +273,10 @@
                   "version_added": true
                 },
                 "safari": {
-                  "version_added": true
+                  "version_added": "10"
                 },
                 "safari_ios": {
-                  "version_added": true
+                  "version_added": "10"
                 },
                 "samsunginternet_android": {
                   "version_added": "6.0"
@@ -328,10 +328,10 @@
                   "version_added": "42"
                 },
                 "safari": {
-                  "version_added": true
+                  "version_added": "10"
                 },
                 "safari_ios": {
-                  "version_added": true
+                  "version_added": "10"
                 },
                 "samsunginternet_android": {
                   "version_added": "6.0"
@@ -383,10 +383,10 @@
                   "version_added": true
                 },
                 "safari": {
-                  "version_added": true
+                  "version_added": "10"
                 },
                 "safari_ios": {
-                  "version_added": true
+                  "version_added": "10"
                 },
                 "samsunginternet_android": {
                   "version_added": "5.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `addEventListener.options_parameter` member of the `EventTarget` API, based upon commit history and date.

Commit: https://github.com/WebKit/WebKit/commit/3cb07f93a16164321c700d0915ea7f57a69a32c9 ([WebKit 602.1.36](https://github.com/WebKit/WebKit/blob/3cb07f93a16164321c700d0915ea7f57a69a32c9/Source/WebCore/Configurations/Version.xcconfig))
