### PR TITLE
Add Safari versions for api.EventTarget.[add/remove]EventListener.useCapture_parameter_optional

### DIFF
--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -894,10 +894,10 @@
                 "version_added": "12"
               },
               "safari": {
-                "version_added": true
+                "version_added": "≤4"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "≤3"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `[add/remove]EventListener.useCapture_parameter_optional` member of the `EventTarget` API.  The data was mirrored from Chrome (Chrome 1 = something in between Safari 3.1 and 4).
