### PR TITLE
Add Safari versions for api.EventTarget.removeEventListener.type_listener_parameters_optional

### DIFF
--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -838,10 +838,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "1.0",


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `removeEventListener.type_listener_parameters_optional` member of the `EventTarget` API.  I can't find any indication that these parameters were ever optional in the [commit history](https://github.com/WebKit/WebKit/blob/main/Source/WebCore/dom/EventTarget.idl).
