### PR TITLE
Add Chromium versions for api.HTMLSelectElement.add.index_before_parameter

### DIFF
--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -102,10 +102,10 @@
             "description": "Index as <code>before</code> parameter",
             "support": {
               "chrome": {
-                "version_added": "36"
+                "version_added": "35"
               },
               "chrome_android": {
-                "version_added": "36"
+                "version_added": "35"
               },
               "edge": {
                 "version_added": "12"
@@ -120,10 +120,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": "23"
+                "version_added": "22"
               },
               "opera_android": {
-                "version_added": "24"
+                "version_added": "22"
               },
               "safari": {
                 "version_added": true


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `add.index_before_parameter` member of the `HTMLSelectElement` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/b6ebe1b7fe308a47a978f1695f78858ca6931361
