### PR TITLE
Add Safari versions for api.HTMLSelectElement.add.index_before_parameter

### DIFF
--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -126,10 +126,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": true
+                "version_added": "9"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "9"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `add.index_before_parameter` member of the `HTMLSelectElement` API, based upon commit history and date.

Commit: https://github.com/WebKit/WebKit/commit/dd3cd5789ed0014bd24e8852399778941a78a1d1#diff-5c50e7524d7a707bb97562f11a515be1c0551c084eb37c069d5d7ce2cc148b58 ([WebKit 601.1.14](https://github.com/WebKit/WebKit/blob/dd3cd5789ed0014bd24e8852399778941a78a1d1/Source/WebCore/Configurations/Version.xcconfig))
