### PR TITLE
Add Chrome/Safari versions for api.HTMLTableRowElement.index_parameter_optional

### DIFF
--- a/api/HTMLTableRowElement.json
+++ b/api/HTMLTableRowElement.json
@@ -437,10 +437,10 @@
             "description": "<code>index</code> parameter is optional",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -455,22 +455,22 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
-                "version_added": true
+                "version_added": "3"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds real values for Chrome and Safari for the `index_parameter_optional` member of the `HTMLTableRowElement` API.  Based upon the description of a specific [commit](https://source.chromium.org/chromium/chromium/src/+/d9bac2cdbd811d30bb4843e03528bbc2bac897bf), all arguments are optional by default in WebKit, and based upon the commit history for this API, there was no introduction of any "required" keyword.  The [commit history](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/html/html_table_row_element.idl;l=1;bpv=1;bpt=0;drc=9aae9c4e971747c2bb9dd7bc0fed3b416f6f8b19;drf=third_party%2FWebKit%2FWebCore%2Fhtml%2FHTMLTableRowElement.idl) also shows that when the default for arguments changed from "optional" to "required", an `LegacyDefaultOptionalArguments` ExtAttr was introduced, and then immediately replaced with the `optional` keyword.  In other words, the argument was always optional in WebKit.
