### PR TITLE
Add Chrome/Safari versions for api.HTMLTableRowElement.insertCell.index_parameter_negative_one

### DIFF
--- a/api/HTMLTableRowElement.json
+++ b/api/HTMLTableRowElement.json
@@ -407,10 +407,10 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": "15"
+                "version_added": "≤15"
               },
               "opera_android": {
-                "version_added": "14"
+                "version_added": "≤14"
               },
               "safari": {
                 "version_added": "3"

--- a/api/HTMLTableRowElement.json
+++ b/api/HTMLTableRowElement.json
@@ -389,10 +389,10 @@
             "description": "<code>index</code> parameter can be <code>-1</code>",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -407,22 +407,22 @@
                 "version_added": true
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
-                "version_added": true
+                "version_added": "3"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds real values for Chrome and Safari for the `insertCell.index_parameter_negative_one` member of the `HTMLTableRowElement` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/f6c5fe78a5c6a5b1057fbe1e465e30337174a6a9:third_party/WebKit/WebCore/html/html_tableimpl.cpp;l=602;drf=third_party%2FWebKit%2FWebCore%2Fkhtml%2Fhtml%2Fhtml_tableimpl.cpp;drc=d869b93fe74f4d6cb2dd6f6c3e9bf9daee39ba19;bpv=1;bpt=0 (the initial commit that adds this interface)