### PR TITLE
Add Safari versions for api.IDBIndex/IDBObjectStore.name.renaming_with_name_setter

### DIFF
--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -618,10 +618,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -859,10 +859,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `name.renaming_with_name_setter` member of the `IDBIndex` and `IDBObjectStore` APIs, based upon commit history and date.

Commit: https://github.com/WebKit/WebKit/commit/819e8d4f49a293a7684957beba99bcd132e80e87#diff-eb78cd73ad50ad6a69e2ee8a72382e5f7b5744b07cd1e4562d1e7af9b4d03593R105 ([WebKit 603.1.11](https://github.com/WebKit/WebKit/blob/819e8d4f49a293a7684957beba99bcd132e80e87/Source/WebCore/Configurations/Version.xcconfig))