### PR TITLE
Add Safari versions for api.Window.page[show/hide]_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -5856,7 +5856,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "5"
             },
             "safari_ios": {
               "version_added": "≤3"

--- a/api/Window.json
+++ b/api/Window.json
@@ -5806,7 +5806,7 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "5"
             },
             "safari_ios": {
               "version_added": "≤3"

--- a/api/Window.json
+++ b/api/Window.json
@@ -5809,7 +5809,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -5859,7 +5859,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/Window.json
+++ b/api/Window.json
@@ -5806,10 +5806,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -5856,10 +5856,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `pageshow_event` and `pagehide_event` members of the `Window` API by mirroring the data.
