### PR TITLE
Add Firefox versions for api.Window.page[show/hide]_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -5791,10 +5791,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": true
@@ -5841,10 +5841,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "6"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `pageshow_event` and `pagehide_event` members of the `Window` API, based upon manual testing.

Test Code Used:
```js
window.addEventListener('pagehide', function() {
	console.log('Page hide!');
});
window.addEventListener('pageshow', function() {
	console.log('Page show!');
});
```
