### PR TITLE
Add IE versions for api.Window.page[show/hide]_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -5797,7 +5797,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "11"
             },
             "opera": {
               "version_added": true
@@ -5847,7 +5847,7 @@
               "version_added": true
             },
             "ie": {
-              "version_added": true
+              "version_added": "11"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `pageshow_event` and `pagehide_event` members of the `Window` API, based upon manual testing.

Test Code Used:
```js
window.addEventListener('pagehide', function() {
	console.log('Page hide!');
});
window.addEventListener('pageshow', function() {
	console.log('Page show!');
});
```
