### PR TITLE
Add Chromium versions for api.MessageEvent.source.MessageEventSource_type

### DIFF
--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -477,10 +477,10 @@
             "description": "Returns <code>MessageEventSource</code>",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": false
               },
               "deno": {
                 "version_added": "1.11"
@@ -498,10 +498,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": null
@@ -510,10 +510,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": false
               },
               "webview_android": {
-                "version_added": true
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `source.MessageEventSource_type` member of the `MessageEvent` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/events/message_event.idl;l=37;drc=0294eddf7bfffe366664390bf4ba10613387f2d8
