### PR TITLE
Add Safari versions for api.MessageEvent.source.MessageEventSource_type

### DIFF
--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -504,10 +504,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "11.3"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `source.MessageEventSource_type` member of the `MessageEvent` API, based upon commit history and date.

Commit: https://github.com/WebKit/WebKit/commit/ad9ae5e5f24c6b083ffc77ac3d704e6dec0947ed ([WebKit 605.1.13](https://github.com/WebKit/WebKit/blob/ad9ae5e5f24c6b083ffc77ac3d704e6dec0947ed/Source/WebCore/Configurations/Version.xcconfig))
