### PR TITLE
Add Chrome/Safari versions for api.Range.collapse.toStart_parameter_optional

### DIFF
--- a/api/Range.json
+++ b/api/Range.json
@@ -255,10 +255,10 @@
             "description": "<code>toStart</code> parameter is optional",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "≤79"
@@ -280,16 +280,16 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds real values for Chrome and Safari for the `collapse.toStart_parameter_optional` member of the `Range` API.  The reasoning behind these values are the same as #13064; please see that PR to see how these values were determined.
