### PR TITLE
Add Chrome/Safari versions for api.Range.insertNode.collapsed_ranges

### DIFF
--- a/api/Range.json
+++ b/api/Range.json
@@ -1008,10 +1008,10 @@
             "description": "Collapsed ranges",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1032,16 +1032,16 @@
                 "version_added": "10.1"
               },
               "safari": {
-                "version_added": true
+                "version_added": "4"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "≤37"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds real values for Chrome and Safari for the `insertNode.collapsed_ranges` member of the `Range` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/93dc784929a88c3a7ed460e20dc7f00d14234b42 ([WebKit 526.1.0](https://source.chromium.org/chromium/chromium/src/+/93dc784929a88c3a7ed460e20dc7f00d14234b42:third_party/WebKit/WebCore/Configurations/Version.xcconfig))
