### PR TITLE
Add Chromium versions for api.Request.Request.cross_origin_stripped

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -158,10 +158,10 @@
             "description": "cross-origin <code>referrer</code> stripped out and <code>navigate</code> mode converted to <code>same-origin</code> when constructor created from existing <code>Request</code> object.",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "69"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "69"
               },
               "deno": {
                 "version_added": false
@@ -179,10 +179,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "56"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "48"
               },
               "safari": {
                 "version_added": "10.1"
@@ -191,10 +191,10 @@
                 "version_added": "10.3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "10.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "69"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Request.cross_origin_stripped` member of the `Request` API, based upon commit history and date.

Commit: https://storage.googleapis.com/chromium-find-releases-static/6fb.html#6fb5f98ffb279885f80232d46b0b3e2e4dd8a58a
