### PR TITLE
Add Chrome/Safari versions for api.Selection.collapse.offset_parameter_optional

### DIFF
--- a/api/Selection.json
+++ b/api/Selection.json
@@ -316,10 +316,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "15"
+                "version_added": "≤15"
               },
               "opera_android": {
-                "version_added": "14"
+                "version_added": "≤14"
               },
               "safari": {
                 "version_added": "1.3"

--- a/api/Selection.json
+++ b/api/Selection.json
@@ -298,10 +298,10 @@
             "description": "<code>offset</code> parameter is optional",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "≤79"
@@ -316,22 +316,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
-                "version_added": true
+                "version_added": "1.3"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds real values for Chrome and Safari for the `collapse.offset_parameter_optional` member of the `Selection` API.  The reasoning behind these values are the same as #13064; please see that PR to see how these values were determined.
