### PR TITLE
Add Chrome/Safari versions for api.Selection.extend.offset_parameter_optional

### DIFF
--- a/api/Selection.json
+++ b/api/Selection.json
@@ -709,10 +709,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "15"
+                "version_added": "≤15"
               },
               "opera_android": {
-                "version_added": "14"
+                "version_added": "≤14"
               },
               "safari": {
                 "version_added": "3.1"

--- a/api/Selection.json
+++ b/api/Selection.json
@@ -691,10 +691,10 @@
             "description": "<code>offset</code> parameter is optional",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "≤79"
@@ -709,22 +709,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
-                "version_added": true
+                "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "2"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "≤37"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds real values for Chrome and Safari for the `extend.offset_parameter_optional` member of the `Selection` API.  The reasoning behind these values are the same as #13064; please see that PR to see how these values were determined.
