### PR TITLE
Add Chromium versions for api.Selection.containsNode.partialContainment_parameter_optional

### DIFF
--- a/api/Selection.json
+++ b/api/Selection.json
@@ -495,10 +495,10 @@
             "description": "<code>partialContainment</code> parameter is optional",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "39"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "39"
               },
               "edge": {
                 "version_added": "≤79"
@@ -513,10 +513,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "26"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "26"
               },
               "safari": {
                 "version_added": true
@@ -525,10 +525,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "39"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `containsNode.partialContainment_parameter_optional` member of the `Selection` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/0d91ded63135349f0d926bab4a3ac4fb1b080276 (confirmed by private feature freeze dates and [public dev calendar](https://www.chromium.org/developers/calendar))

_Note: in Chrome's IDL, this property was initially called `allowPartial`, followed by `allowPartialContainment`, before being referred to as `partialContainment`._
