### PR TITLE
Add Chromium versions for api.Selection.collapse.node_parameter_nullable

### DIFF
--- a/api/Selection.json
+++ b/api/Selection.json
@@ -250,10 +250,10 @@
             "description": "<code>node</code> parameter is nullable",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "39"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "39"
               },
               "edge": {
                 "version_added": "≤79"
@@ -268,10 +268,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "26"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "26"
               },
               "safari": {
                 "version_added": true
@@ -280,10 +280,10 @@
                 "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "39"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `collapse.node_parameter_nullable` member of the `Selection` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/dec10236ce89587d3eaf2fe9729017f171081538 (confirmed by private feature freeze dates and [public dev calendar](https://www.chromium.org/developers/calendar))
