### PR TITLE
Add Chromium versions for api.SharedWorker.SharedWorker.options_name_parameter

### DIFF
--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -165,7 +165,7 @@
             "description": "<code>options.name</code> parameter",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "70"
               },
               "chrome_android": {
                 "version_added": false
@@ -183,7 +183,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "57"
               },
               "opera_android": {
                 "version_added": false
@@ -195,8 +195,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": "4.0",
-                "version_removed": "5.0"
+                "version_added": false
               },
               "webview_android": {
                 "version_added": false


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `SharedWorker.options_name_parameter` member of the `SharedWorker` API, based upon commit history and date.

Commit: https://storage.googleapis.com/chromium-find-releases-static/42d.html#42dcb573d0aff2e2e1b349c4c200dbbaaf0405de
