### PR TITLE
Add Chromium versions for api.Window.getComputedStyle.pseudo-element_support

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -2434,10 +2434,10 @@
             "description": "Pseudo-element support",
             "support": {
               "chrome": {
-                "version_added": "41"
+                "version_added": "11"
               },
               "chrome_android": {
-                "version_added": "41"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -2452,10 +2452,10 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": "28"
+                "version_added": "≤15"
               },
               "opera_android": {
-                "version_added": "28"
+                "version_added": "≤14"
               },
               "safari": {
                 "version_added": true
@@ -2464,10 +2464,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": "4.0"
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "41"
+                "version_added": "≤37"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `getComputedStyle.pseudo-element_support` member of the `Window` API, based upon manual testing.

Test Code Used: https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle#use_with_pseudo-elements

