### PR TITLE
Add Chromium versions for api.Window.scroll[X/Y].subpixel_precision

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -8210,10 +8210,10 @@
             "description": "Subpixel precision",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "40"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "40"
               },
               "edge": {
                 "version_added": "≤18"
@@ -8228,10 +8228,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "27"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "27"
               },
               "safari": {
                 "version_added": true
@@ -8240,10 +8240,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "40"
               }
             },
             "status": {
@@ -8374,10 +8374,10 @@
             "description": "Subpixel precision",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "40"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "40"
               },
               "edge": {
                 "version_added": "≤18"
@@ -8392,10 +8392,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "27"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "27"
               },
               "safari": {
                 "version_added": true
@@ -8404,10 +8404,10 @@
                 "version_added": null
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "40"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `scroll[X/Y].subpixel_precision` member of the `Window` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/861452d6016c4772c7b06d1f77455f3401d4cc0a
