### PR TITLE
Add all browsers versions for api.set[Interval/Timeout].supports_parameters_for_callback

### DIFF
--- a/api/_globals/setInterval.json
+++ b/api/_globals/setInterval.json
@@ -76,10 +76,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"

--- a/api/_globals/setTimeout.json
+++ b/api/_globals/setTimeout.json
@@ -76,10 +76,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"


### PR DESCRIPTION
This PR adds real values for Chrome, Safari and Firefox for the `supports_parameters_for_callback` member of the `setInterval` and `setTimeout` globals, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<button id="go">Go!</button>
</div>

<script>
	var button = document.getElementById('go');
	button.onclick = function() {
		setTimeout(function(arg) { alert(arg) }, 0, 'Supported!');
	}
</script>
```
