### PR TITLE
Add Safari versions for MediaStream API

### DIFF
--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -360,10 +360,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -999,10 +999,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `MediaStream` API.  The data was copied from their corresponding event handlers, which matches the versions when the `addTrack` and `removeTrack` methods were added.
