### PR TITLE
Add Safari versions for RTCDataChannel API

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -182,10 +182,10 @@
               "notes": "The default for <code>rtcpMuxPolicy<code> is <code>require<code>."
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "7.0",
@@ -628,10 +628,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -1028,10 +1028,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "1.5"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `RTCDataChannel` API.  The data was copied from their corresponding event handlers, which matches the versions when the interface was added.
