### PR TITLE
Mark Safari 15.1 and Safari for iOS 15.1 as released

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -179,14 +179,15 @@
         "15": {
           "release_date": "2021-09-20",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "612.1.29"
         },
         "15.1": {
-          "status": "beta",
+          "release_date": "2021-10-25",
+          "status": "current",
           "engine": "WebKit",
-          "engine_version": "612.2.6"
+          "engine_version": "612.2.9"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -150,9 +150,15 @@
         "15": {
           "release_date": "2021-09-20",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "612.1.29"
+        },
+        "15.1": {
+          "release_date": "2021-10-25",
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "612.2.9"
         }
       }
     }

--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -1049,10 +1049,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -1097,10 +1097,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -2115,10 +2115,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -2641,10 +2641,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -2701,10 +2701,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -2965,10 +2965,10 @@
                 "version_added": "32"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -3013,10 +3013,10 @@
                 "version_added": "32"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -3061,10 +3061,10 @@
                 "version_added": "32"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -3979,10 +3979,10 @@
                 "version_added": "32"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -4039,10 +4039,10 @@
                 "version_added": "32"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -4796,10 +4796,10 @@
                 "version_added": "32"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -4856,10 +4856,10 @@
                 "version_added": "32"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Updates the engine version for Safari 15.1 and set it as current for desktop and iOS.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://webkit.org/blog/11989/new-webkit-features-in-safari-15/#:~:text=Now%20with%20Safari%2015.1

![image](https://user-images.githubusercontent.com/32498324/138751088-b5c94b10-c92c-437c-983f-61ba089b244c.png)

