### PR TITLE
Add Safari versions for api.set[Interval/Timeout].supports_parameters_for_callback

### DIFF
--- a/api/_globals/setInterval.json
+++ b/api/_globals/setInterval.json
@@ -94,10 +94,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true

--- a/api/_globals/setTimeout.json
+++ b/api/_globals/setTimeout.json
@@ -94,10 +94,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `supports_parameters_for_callback` member of the `setInterval` and `setTimeout` APIs, based upon commit history and date.

Commit: https://github.com/WebKit/WebKit/commit/8b06040ccc1e091e3becfc2974399eb8d724d87d ([WebKit 605.1.1](https://github.com/WebKit/WebKit/blob/8b06040ccc1e091e3becfc2974399eb8d724d87d/Source/WebCore/Configurations/Version.xcconfig))
