### PR TITLE
Mark implicit to/from keyframe as supported in Chromium

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -728,15 +728,13 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/animate#Implicit_tofrom_keyframes",
             "support": {
               "chrome": {
-                "version_added": false,
-                "notes": "Currently Chrome Canary only"
+                "version_added": "84"
               },
               "chrome_android": {
-                "version_added": false,
-                "notes": "Currently Chrome Canary only"
+                "version_added": "84"
               },
               "edge": {
-                "version_added": false
+                "version_added": "84"
               },
               "firefox": {
                 "version_added": "75"
@@ -748,10 +746,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "70"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "60"
               },
               "safari": {
                 "version_added": "13.1",
@@ -764,10 +762,10 @@
                 "notes": "Implementation seems somewhat buggy. More information will follow when available."
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "14.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "84"
               }
             },
             "status": {


### PR DESCRIPTION
This was determined by testing Chrome 83 and 84 with this demo:
https://mdn.github.io/dom-examples/web-animations-api/implicit-keyframes.html

84 is also when lots of other Web Animations APIs were shipped, so this
seems plausible.