### PR TITLE
Mark many ServiceWorkerGlobalScope members as not supported in Safari

### DIFF
--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -382,10 +382,10 @@
               "version_added": "27"
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -430,10 +430,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1069,10 +1069,10 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1119,10 +1119,10 @@
               "version_added": "34"
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -1266,10 +1266,10 @@
               "version_added": "26"
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1317,10 +1317,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false
@@ -1367,10 +1367,10 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -1468,10 +1468,10 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1520,10 +1520,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "11.3"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
These entries are changed from 11.1/11.3 to false:

api.ServiceWorkerGlobalScope.notificationclick_event
api.ServiceWorkerGlobalScope.onabortpayment
api.ServiceWorkerGlobalScope.onnotificationclick
api.ServiceWorkerGlobalScope.onnotificationclose
api.ServiceWorkerGlobalScope.onpush
api.ServiceWorkerGlobalScope.onpushsubscriptionchange
api.ServiceWorkerGlobalScope.onsync
api.ServiceWorkerGlobalScope.push_event
api.ServiceWorkerGlobalScope.pushsubscriptionchange_event

Lack of support for the on* entries was confirmed using this test on
Safari 15 on macOS:
https://staging-dot-mdn-bcd-collector.appspot.com/tests/api/ServiceWorkerGlobalScope

These were incorrectly set as supported in a previous PR:
https://github.com/mdn/browser-compat-data/pull/1881