### PR TITLE
Link Chromium bug for MathML support

### DIFF
--- a/api/MathMLElement.json
+++ b/api/MathMLElement.json
@@ -6,13 +6,16 @@
         "spec_url": "https://w3c.github.io/mathml-core/#dom-mathmlelement",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": false,
+            "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": false,
+            "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
           },
           "edge": {
-            "version_added": false
+            "version_added": false,
+            "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
           },
           "firefox": {
             "version_added": "71"
@@ -36,10 +39,12 @@
             "version_added": "13.4"
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": false,
+            "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
           },
           "webview_android": {
-            "version_added": false
+            "version_added": false,
+            "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
           }
         },
         "status": {

--- a/mathml/elements/maction.json
+++ b/mathml/elements/maction.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-maction",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/math.json
+++ b/mathml/elements/math.json
@@ -8,13 +8,16 @@
           "support": {
             "chrome": {
               "version_added": "24",
-              "version_removed": "25"
+              "version_removed": "25",
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": [
               {
@@ -51,10 +54,12 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/menclose.json
+++ b/mathml/elements/menclose.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml/#presm_menclose",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/merror.json
+++ b/mathml/elements/merror.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#error-message-merror",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/mfrac.json
+++ b/mathml/elements/mfrac.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#fractions-mfrac",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/mi.json
+++ b/mathml/elements/mi.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#identifier-mi",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/mmultiscripts.json
+++ b/mathml/elements/mmultiscripts.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#prescripts-and-tensor-indices-mmultiscripts",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/mn.json
+++ b/mathml/elements/mn.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#number-mn",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/mo.json
+++ b/mathml/elements/mo.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#operator-fence-separator-or-accent-mo",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/mover.json
+++ b/mathml/elements/mover.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#underscripts-and-overscripts-munder-mover-munderover",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/mpadded.json
+++ b/mathml/elements/mpadded.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#adjust-space-around-content-mpadded",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1",
@@ -38,10 +41,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/mphantom.json
+++ b/mathml/elements/mphantom.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#making-sub-expressions-invisible-mphantom",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/mroot.json
+++ b/mathml/elements/mroot.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#radicals-msqrt-mroot",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/mrow.json
+++ b/mathml/elements/mrow.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#horizontally-group-sub-expressions-mrow",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/ms.json
+++ b/mathml/elements/ms.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#string-literal-ms",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/mspace.json
+++ b/mathml/elements/mspace.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#space-mspace",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/msqrt.json
+++ b/mathml/elements/msqrt.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#radicals-msqrt-mroot",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/mstyle.json
+++ b/mathml/elements/mstyle.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#style-change-mstyle",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/msub.json
+++ b/mathml/elements/msub.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#subscripts-and-superscripts-msub-msup-msubsup",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/msubsup.json
+++ b/mathml/elements/msubsup.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#subscripts-and-superscripts-msub-msup-msubsup",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/msup.json
+++ b/mathml/elements/msup.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#subscripts-and-superscripts-msub-msup-msubsup",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/mtable.json
+++ b/mathml/elements/mtable.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#table-or-matrix-mtable",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/mtd.json
+++ b/mathml/elements/mtd.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#entry-in-table-or-matrix-mtd",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/mtext.json
+++ b/mathml/elements/mtext.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#text-mtext",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/mtr.json
+++ b/mathml/elements/mtr.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#row-in-table-or-matrix-mtr",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/munder.json
+++ b/mathml/elements/munder.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#underscripts-and-overscripts-munder-mover-munderover",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/munderover.json
+++ b/mathml/elements/munderover.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#underscripts-and-overscripts-munder-mover-munderover",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {

--- a/mathml/elements/semantics.json
+++ b/mathml/elements/semantics.json
@@ -7,13 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#semantics-and-presentation",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "firefox": {
               "version_added": "1"
@@ -37,10 +40,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
             }
           },
           "status": {


### PR DESCRIPTION
It's not linked for Opera, since Presto did have support and it would be
complicated to add the note for the mathml.elements.math entry.

Also don't link the bug for `<mfenced>`, which is deprecated.