### PR TITLE
Add Firefox versions for api.EventTarget.addEventListener.options_parameter.*

### DIFF
--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -313,7 +313,7 @@
                   "version_added": "50"
                 },
                 "firefox_android": {
-                  "version_added": "49"
+                  "version_added": "50"
                 },
                 "ie": {
                   "version_added": false

--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -310,7 +310,7 @@
                   "version_added": "≤18"
                 },
                 "firefox": {
-                  "version_added": "49"
+                  "version_added": "50"
                 },
                 "firefox_android": {
                   "version_added": "49"

--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -255,10 +255,10 @@
                   "version_added": "≤18"
                 },
                 "firefox": {
-                  "version_added": true
+                  "version_added": "49"
                 },
                 "firefox_android": {
-                  "version_added": true
+                  "version_added": "49"
                 },
                 "ie": {
                   "version_added": false
@@ -310,10 +310,10 @@
                   "version_added": "≤18"
                 },
                 "firefox": {
-                  "version_added": "50"
+                  "version_added": "49"
                 },
                 "firefox_android": {
-                  "version_added": "50"
+                  "version_added": "49"
                 },
                 "ie": {
                   "version_added": false
@@ -365,10 +365,10 @@
                   "version_added": "≤18"
                 },
                 "firefox": {
-                  "version_added": true
+                  "version_added": "49"
                 },
                 "firefox_android": {
-                  "version_added": true
+                  "version_added": "49"
                 },
                 "ie": {
                   "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `addEventListener.options_parameter` members of the `EventTarget` API, based upon commit history and date.

Commit: https://hg.mozilla.org/mozilla-central/rev/5b7777972750aa3c57e6f6f6d4e4621072741617
