### PR TITLE
Remove api.EventTarget.removeEventListener.type_listener_parameters_optional

### DIFF
--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -800,65 +800,6 @@
             }
           }
         },
-        "type_listener_parameters_optional": {
-          "__compat": {
-            "description": "<code>type</code> and <code>listener</code> parameters are optional",
-            "support": {
-              "chrome": {
-                "version_added": "1",
-                "version_removed": "49"
-              },
-              "chrome_android": {
-                "version_added": "18",
-                "version_removed": "49"
-              },
-              "deno": {
-                "version_added": "1.0"
-              },
-              "edge": {
-                "version_added": "12",
-                "version_removed": "79"
-              },
-              "firefox": {
-                "version_added": true
-              },
-              "firefox_android": {
-                "version_added": true
-              },
-              "ie": {
-                "version_added": true
-              },
-              "nodejs": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0",
-                "version_removed": "5.0"
-              },
-              "webview_android": {
-                "version_added": "1",
-                "version_removed": "49"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "useCapture_parameter_optional": {
           "__compat": {
             "description": "<code>useCapture</code> parameter is optional",


### PR DESCRIPTION
This PR removes `api.EventTarget.removeEventListener.type_listener_parameters_optional` from BCD.  This feature should actually be reversed to when it was made `required`, but tracking down when this was made required in Firefox is more trouble than I feel it's worth.  I feel that it's safe to simply represent these parameters as always being required by removing this feature.

~~Closes #13060.~~