### PR TITLE
Add Firefox versions for api.MouseEvent.getModifierState.accel_support

### DIFF
--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -459,10 +459,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": null
+                "version_added": "32"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "32"
               },
               "ie": {
                 "version_added": null


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `getModifierState.accel_support` member of the `MouseEvent` API.  The internal code for `getModifierState` between mouse and keyboard events is the [same](https://searchfox.org/mozilla-central/rev/3b86063e6d46b2f130513c499343cd47773062b1/widget/WidgetEventImpl.cpp#609), so this PR just mirrors the data.
