### PR TITLE
Add Firefox versions for api.RTCPeerConnection.getStats.selector_parameter

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1755,10 +1755,10 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": "22"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "22"
               },
               "ie": {
                 "version_added": false

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1755,10 +1755,10 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": "22"
+                "version_added": "27"
               },
               "firefox_android": {
-                "version_added": "22"
+                "version_added": "27"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `getStats.selector_parameter` member of the `RTCPeerConnection` API, based upon commit history and date.

Commit: https://hg.mozilla.org/mozilla-central/rev/5372aea57cdb429e4fcf6a951e2ae1e754d64034?revcount=120
