### PR TITLE
Update Firefox versions for api.RTCPeerConnection.getStats

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1660,10 +1660,10 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "27"
             },
             "firefox_android": {
-              "version_added": "22"
+              "version_added": "27"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `getStats` member of the `RTCPeerConnection` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCPeerConnection/getStats

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
