### PR TITLE
Add Safari versions for api.Window.getComputedStyle.pseudo-element_support

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -2461,7 +2461,7 @@
                 "version_added": "5.1"
               },
               "safari_ios": {
-                "version_added": "6"
+                "version_added": "5"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `getComputedStyle.pseudo-element_support` member of the `Window` API, based upon manual testing.

Test Code Used: https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle#use_with_pseudo-elements
