### PR TITLE
Add Firefox versions for api.Window.getComputedStyle.pseudo-element_support

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -2443,10 +2443,10 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "3.5"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `getComputedStyle.pseudo-element_support` member of the `Window` API, based upon manual testing.

Test Code Used: https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle#use_with_pseudo-elements
