### PR TITLE
Fix the order of XMLHttpRequest entries in Opera

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -978,11 +978,11 @@
             },
             "opera": [
               {
-                "version_added": "12",
-                "version_removed": "15"
+                "version_added": "18"
               },
               {
-                "version_added": "18"
+                "version_added": "12",
+                "version_removed": "15"
               }
             ],
             "opera_android": {
@@ -1031,11 +1031,11 @@
               },
               "opera": [
                 {
-                  "version_added": "12",
-                  "version_removed": "15"
+                  "version_added": "18"
                 },
                 {
-                  "version_added": "18"
+                  "version_added": "12",
+                  "version_removed": "15"
                 }
               ],
               "opera_android": {
@@ -1181,11 +1181,11 @@
               },
               "opera": [
                 {
-                  "version_added": "12",
-                  "version_removed": "15"
+                  "version_added": "18"
                 },
                 {
-                  "version_added": "18"
+                  "version_added": "12",
+                  "version_removed": "15"
                 }
               ],
               "opera_android": {


### PR DESCRIPTION
Currently there's red on MDN because the removed range is first:
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType#browser_compatibility