### PR TITLE
Add partial_implementation to Element members moved from HTMLElement

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -3871,6 +3871,7 @@
               {
                 "version_added": "12",
                 "version_removed": "16",
+                "partial_implementation": true,
                 "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLElement'><code>HTMLElement</code></a>, not all <code>Element</code> objects, such as <a href='https://developer.mozilla.org/docs/Web/API/SVGElement'><code>SVGElement</code></a>."
               }
             ],
@@ -3883,6 +3884,7 @@
             },
             "ie": {
               "version_added": "9",
+              "partial_implementation": true,
               "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLElement'><code>HTMLElement</code></a>, not all <code>Element</code> objects, such as <a href='https://developer.mozilla.org/docs/Web/API/SVGElement'><code>SVGElement</code></a>."
             },
             "opera": {
@@ -4504,6 +4506,7 @@
               {
                 "version_added": "12",
                 "version_removed": "17",
+                "partial_implementation": true,
                 "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLElement'><code>HTMLElement</code></a>, not all <code>Element</code> objects, such as <a href='https://developer.mozilla.org/docs/Web/API/SVGElement'><code>SVGElement</code></a>."
               }
             ],
@@ -4515,6 +4518,7 @@
             },
             "ie": {
               "version_added": "5",
+              "partial_implementation": true,
               "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLElement'><code>HTMLElement</code></a>, not all <code>Element</code> objects, such as <a href='https://developer.mozilla.org/docs/Web/API/SVGElement'><code>SVGElement</code></a>."
             },
             "opera": {
@@ -4561,6 +4565,7 @@
               {
                 "version_added": "12",
                 "version_removed": "17",
+                "partial_implementation": true,
                 "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLElement'><code>HTMLElement</code></a>, not all <code>Element</code> objects, such as <a href='https://developer.mozilla.org/docs/Web/API/SVGElement'><code>SVGElement</code></a>."
               }
             ],
@@ -4572,6 +4577,7 @@
             },
             "ie": {
               "version_added": "4",
+              "partial_implementation": true,
               "notes": [
                 "Before Internet Explorer 10, throws an \"Invalid target element for this operation.\" error when called on a <code>&lt;table&gt;</code>, <code>&lt;tbody&gt;</code>, <code>&lt;thead&gt;</code>, or <code>&lt;tr&gt;</code> element.",
                 "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLElement'><code>HTMLElement</code></a>, not all <code>Element</code> objects, such as <a href='https://developer.mozilla.org/docs/Web/API/SVGElement'><code>SVGElement</code></a>."
@@ -4621,6 +4627,7 @@
               {
                 "version_added": "12",
                 "version_removed": "17",
+                "partial_implementation": true,
                 "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLElement'><code>HTMLElement</code></a>, not all <code>Element</code> objects, such as <a href='https://developer.mozilla.org/docs/Web/API/SVGElement'><code>SVGElement</code></a>."
               }
             ],
@@ -4632,6 +4639,7 @@
             },
             "ie": {
               "version_added": "5",
+              "partial_implementation": true,
               "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLElement'><code>HTMLElement</code></a>, not all <code>Element</code> objects, such as <a href='https://developer.mozilla.org/docs/Web/API/SVGElement'><code>SVGElement</code></a>."
             },
             "opera": {
@@ -7281,6 +7289,7 @@
               {
                 "version_added": "12",
                 "version_removed": "17",
+                "partial_implementation": true,
                 "notes": [
                   "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLElement'><code>HTMLElement</code></a>, not all <code>Element</code> objects, such as <a href='https://developer.mozilla.org/docs/Web/API/SVGElement'><code>SVGElement</code></a>.",
                   "No support for <code>smooth</code> behavior."
@@ -7295,6 +7304,7 @@
             },
             "ie": {
               "version_added": "5",
+              "partial_implementation": true,
               "notes": [
                 "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/HTMLElement'><code>HTMLElement</code></a>, not all <code>Element</code> objects, such as <a href='https://developer.mozilla.org/docs/Web/API/SVGElement'><code>SVGElement</code></a>.",
                 "No support for <code>smooth</code> behavior or <code>center</code> options."


### PR DESCRIPTION
This was already done in some places. Do it consistently in
Element.json, following this guideline:
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#apis-moved-on-the-prototype-chain