### PR TITLE
Add Firefox versions for api.Window.beforeunload_event.preventdefault_activation

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -755,10 +755,10 @@
                 "version_removed": "79"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "6"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "6"
               },
               "ie": {
                 "version_added": "9"


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `beforeunload_event.preventdefault_activation` member of the `Window` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<button id="go">Click me!</button>
</div>

<script>
	var button = document.getElementById('go');

	window.addEventListener('beforeunload', function(event) {
		event.preventDefault();
	});

	button.onclick = function() {
		window.location.reload();
	}
</script>
```
