### PR TITLE
Add Firefox versions for api.Window.beforeunload_event.event_returnvalue_activation

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -706,10 +706,10 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "6"
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "6"
               },
               "ie": {
                 "version_added": true


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `beforeunload_event.event_returnvalue_activation` member of the `Window` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<button id="go">Click me!</button>
</div>

<script>
	var button = document.getElementById('go');

	window.addEventListener('beforeunload', function(event) {
		event.returnValue = "Farewell!";
	});

	button.onclick = function() {
		window.location.reload();
	}
</script>
```
