### PR TITLE
Add Firefox versions for api.fetch.streaming_response_body

### DIFF
--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -222,12 +222,8 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "64",
               "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.enabled"
-                },
                 {
                   "type": "preference",
                   "name": "javascript.options.streams"


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `streaming_response_body` member of the `fetch` global, based upon commit history and date.

Commit: https://hg.mozilla.org/mozilla-central/rev/8ef0b50e1d1bb06611c4f67f66f40fdeb9d1f70f

This commit was when the `dom.streams.enabled` flag was dropped, so only `javascript.options.streams` was required.  Since this change was made in Fx64, prior flag data is irrelevant and does not need to be included.
