### PR TITLE
Add Firefox versions for api.fetch.blob_data_support

### DIFF
--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -69,10 +69,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": "39"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "39"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `blob_data_support` member of the `fetch` API, based upon manual testing.

Test Code Used:
```js
fetch("data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==").then(function() {
	console.log('Fetched!');
}).catch(function() {
	console.log('Fail!');
});
```
