### PR TITLE
Add Safari versions for api.fetch.blob_data_support

### DIFF
--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -84,10 +84,10 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `blob_data_support` member of the `fetch` API, based upon manual testing.

Test Code Used:
```js
fetch("data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==").then(function() {
	console.log('Fetched!');
}).catch(function() {
	console.log('Fail!');
});
```
