### PR TITLE
Add insertable stream interfaces.

### DIFF
--- a/api/MediaStreamTrackGenerator.json
+++ b/api/MediaStreamTrackGenerator.json
@@ -59,7 +59,7 @@
               "version_added": "94"
             },
             "edge": {
-              "version_added": false
+              "version_added": "94"
             },
             "firefox": {
               "version_added": false
@@ -71,7 +71,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -107,7 +107,7 @@
               "version_added": "94"
             },
             "edge": {
-              "version_added": false
+              "version_added": "94"
             },
             "firefox": {
               "version_added": false
@@ -119,7 +119,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false

--- a/api/MediaStreamTrackGenerator.json
+++ b/api/MediaStreamTrackGenerator.json
@@ -11,7 +11,7 @@
             "version_added": "94"
           },
           "edge": {
-            "version_added": false
+            "version_added": "94"
           },
           "firefox": {
             "version_added": false

--- a/api/MediaStreamTrackGenerator.json
+++ b/api/MediaStreamTrackGenerator.json
@@ -23,7 +23,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "80"
           },
           "opera_android": {
             "version_added": false

--- a/api/MediaStreamTrackGenerator.json
+++ b/api/MediaStreamTrackGenerator.json
@@ -43,7 +43,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": true,
+          "standard_track": false,
           "deprecated": false
         }
       },
@@ -91,7 +91,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -139,7 +139,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/api/MediaStreamTrackGenerator.json
+++ b/api/MediaStreamTrackGenerator.json
@@ -1,0 +1,149 @@
+{
+  "api": {
+    "MediaStreamTrackGenerator": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackGenerator",
+        "support": {
+          "chrome": {
+            "version_added": "94"
+          },
+          "chrome_android": {
+            "version_added": "94"
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "94"
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "MediaStreamTrackGenerator": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackGenerator/MediaStreamTrackGenerator",
+          "description": "<code>MediaStreamTrackGenerator()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": "94"
+            },
+            "chrome_android": {
+              "version_added": "94"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "94"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "writable": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackGenerator/writable",
+          "support": {
+            "chrome": {
+              "version_added": "94"
+            },
+            "chrome_android": {
+              "version_added": "94"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "94"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/MediaStreamTrackProcessor.json
+++ b/api/MediaStreamTrackProcessor.json
@@ -1,0 +1,149 @@
+{
+  "api": {
+    "MediaStreamTrackProcessor": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackProcessor",
+        "support": {
+          "chrome": {
+            "version_added": "94"
+          },
+          "chrome_android": {
+            "version_added": "94"
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "94"
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": false,
+          "deprecated": false
+        }
+      },
+      "MediaStreamTrackProcessor": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackProcessor/MediaStreamTrackProcessor",
+          "description": "<code>MediaStreamTrackProcessor()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": "94"
+            },
+            "chrome_android": {
+              "version_added": "94"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "94"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "readable": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackProcessor/readable",
+          "support": {
+            "chrome": {
+              "version_added": "94"
+            },
+            "chrome_android": {
+              "version_added": "94"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "94"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/MediaStreamTrackProcessor.json
+++ b/api/MediaStreamTrackProcessor.json
@@ -119,7 +119,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false

--- a/api/MediaStreamTrackProcessor.json
+++ b/api/MediaStreamTrackProcessor.json
@@ -11,7 +11,7 @@
             "version_added": "94"
           },
           "edge": {
-            "version_added": false
+            "version_added": "94"
           },
           "firefox": {
             "version_added": false
@@ -23,7 +23,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "80"
           },
           "opera_android": {
             "version_added": false
@@ -59,7 +59,7 @@
               "version_added": "94"
             },
             "edge": {
-              "version_added": false
+              "version_added": "94"
             },
             "firefox": {
               "version_added": false
@@ -71,7 +71,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false

--- a/api/MediaStreamTrackProcessor.json
+++ b/api/MediaStreamTrackProcessor.json
@@ -107,7 +107,7 @@
               "version_added": "94"
             },
             "edge": {
-              "version_added": false
+              "version_added": "94"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Adds data for [MediaStreamTrack Insertable Streams (a.k.a. Breakout Box)](https://www.chromestatus.com/feature/5499415634640896)

#### Test results and supporting details

Evidence of Chrome's support is in the link above. I ran this through [BCD Collector](https://github.com/foolip/mdn-bcd-collector) and found no additional results.

#### Related issues
Addresses: https://github.com/mdn/content/issues/9852

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
