### PR TITLE
Remove api.isSecureContext.considers_window_opener

### DIFF
--- a/api/_globals/isSecureContext.json
+++ b/api/_globals/isSecureContext.json
@@ -48,54 +48,6 @@
           "deprecated": false
         }
       },
-      "considers_window_opener": {
-        "__compat": {
-          "description": "Considers <code>window.opener</code>",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": "49"
-            },
-            "firefox_android": {
-              "version_added": "49"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
-            "safari": {
-              "version_added": null
-            },
-            "safari_ios": {
-              "version_added": null
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "worker_support": {
         "__compat": {
           "description": "Available in workers",


### PR DESCRIPTION
This PR removes `api.isSecureContext.considers_window_opener` from BCD.  This feature is marked as standard and experimental, but looking through the spec I cannot find any mention of an `opener` or anything relevant for this property.  It's possible this was added to a draft version of the spec, added in Firefox, but then removed from the spec.

Additionally, there is no documentation on on the MDN page that discusses what this feature means exactly.
