### PR TITLE
Updates edge to version 95

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -154,19 +154,26 @@
         "94": {
           "release_date": "2021-09-24",
           "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-94099231-september-24",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "94"
         },
         "95": {
-          "status": "beta",
+          "release_date": "2021-10-21",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-950102030-october-21",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "95"
         },
         "96": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "96"
+        },
+        "97": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "97"
         }
       }
     }


### PR DESCRIPTION
update edge version to 95 according to https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-950102030-october-21