### PR TITLE
Update Blob support on Firefox for Android.

### DIFF
--- a/api/Blob.json
+++ b/api/Blob.json
@@ -128,7 +128,7 @@
               "version_added": "69"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -329,7 +329,7 @@
               "version_added": "69"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -382,7 +382,7 @@
               "version_added": "69"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
#### Summary
Gecko supports some new Blob APIs at 69, but BCD doesn't update this data for FxA due to Firefox → Fenix transition. So we should set that supported version is 79.

#### Test results and supporting details
Pass WPT (http://wpt.live/FileAPI/idlharness.html etc)

#### Related issues
- https://bugzilla.mozilla.org/show_bug.cgi?id=1557121
- https://github.com/mdn/browser-compat-data/pull/4816/