### PR TITLE
Remove api.MessageEvent.origin.USVString_type from BCD

### DIFF
--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -316,57 +316,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "USVString_type": {
-          "__compat": {
-            "description": "Returns <code>USVString</code> (was previously <code>DOMString</code>)",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "deno": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "55"
-              },
-              "firefox_android": {
-                "version_added": "55"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": "10.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3"
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "ports": {


### PR DESCRIPTION
This PR removes the `USVString_type` subfeature from `api.MessageEvent.origin` from BCD.  This feature wouldn't be noticeable to end users.
