### PR TITLE
adding at layer rule

### DIFF
--- a/css/at-rules/layer.json
+++ b/css/at-rules/layer.json
@@ -1,0 +1,77 @@
+{
+  "css": {
+    "at-rules": {
+      "layer": {
+        "__compat": {
+          "description": "<code>@layer</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@layer",
+          "spec_url": "https://drafts.csswg.org/css-cascade-5/#layering",
+          "support": {
+            "chrome": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-cascade-layers",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "94",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.cascade-layers.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "94",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.cascade-layers.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Adding the `@layer` rule for CSS which is available under a flag in both Chrome (97) and Firefox (94)

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

It doesn't like the spec url I have added - I'm not sure how to resolve this

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

The only thing I got is this https://bugzilla.mozilla.org/show_bug.cgi?id=1699217 - but I've written some code which works in both browsers with the flags turned on

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

https://github.com/mdn/content/issues/9369

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
