### PR TITLE
Add Safari versions for api.MouseEvent.getModifierState.accel_support

### DIFF
--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -474,10 +474,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `getModifierState.accel_support` member of the `MouseEvent` API.  There doesn't seem to be any support for this entry based upon the code for `getModifierState`:
https://github.com/WebKit/WebKit/blob/4117bbbfeba9d1095ddd152b2ddc876bd8b641cc/Source/WebCore/dom/UIEventWithKeyState.cpp#L48-L64
