### PR TITLE
Set most of <feGaussianBlur> to supported in all browsers

### DIFF
--- a/svg/elements/feGaussianBlur.json
+++ b/svg/elements/feGaussianBlur.json
@@ -28,19 +28,19 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": true
             },
             "safari": {
               "version_added": "9.1"
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": true
             },
             "samsunginternet_android": {
               "version_added": true
             },
             "webview_android": {
-              "version_added": null
+              "version_added": true
             }
           },
           "status": {
@@ -100,10 +100,10 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": "≤18"
@@ -115,25 +115,25 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": null
+                "version_added": true
               },
               "opera": {
                 "version_added": "9"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
                 "version_added": "9.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
-                "version_added": null
+                "version_added": true
               }
             },
             "status": {
@@ -147,10 +147,10 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": true
               },
               "chrome_android": {
-                "version_added": null
+                "version_added": true
               },
               "edge": {
                 "version_added": "≤18"
@@ -162,25 +162,25 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": null
+                "version_added": true
               },
               "opera": {
                 "version_added": "9"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": true
               },
               "safari": {
                 "version_added": "9.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": true
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": true
               },
               "webview_android": {
-                "version_added": null
+                "version_added": true
               }
             },
             "status": {


### PR DESCRIPTION
Support goes very long back and can also be confirmed by the data for
the SVGFEGaussianBlurElement interface:
https://github.com/mdn/browser-compat-data/blob/main/api/SVGFEGaussianBlurElement.json

The exact versions aren't copied, however, because this far back it's
possible that the elements were supported before the DOM API for them.

This is motivated by fixing an apparent Chrome-only omission of `in` and
`stdDeviation`, if null is interpreted as false which I did for
convenience in a spreadsheet exercise to find such Chrome-only
omissions.

The `edgeMode` data isn't updated, because it's seemingly Safari-only,
which seems wise to confirm before copying the data, and that would be a
lot of work.