### PR TITLE
Update Chromium support for StaticRange constructor

### DIFF
--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -56,13 +56,13 @@
           "description": "<code>StaticRange()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "90"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "90"
             },
             "edge": {
-              "version_added": false
+              "version_added": "90"
             },
             "firefox": {
               "version_added": "71"
@@ -74,10 +74,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "76"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": "13.1"
@@ -86,10 +86,10 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "15.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "90"
             }
           },
           "status": {


### PR DESCRIPTION
Confirmed by testing in Chrome 89 and 90 with this test:
https://mdn-bcd-collector.appspot.com/tests/api/StaticRange/StaticRange

Commit mapping also confirms 90:
https://storage.googleapis.com/chromium-find-releases-static/dac.html#dacde3d838e0b050d380eedc5c0ff07d7ba50ce3