### PR TITLE
Update Chromium support for scroll-margin-inline

### DIFF
--- a/css/properties/scroll-margin-inline.json
+++ b/css/properties/scroll-margin-inline.json
@@ -7,13 +7,13 @@
           "spec_url": "https://drafts.csswg.org/css-scroll-snap/#propdef-scroll-margin-inline",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "69"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "68"
@@ -25,10 +25,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": "14.1"
@@ -37,10 +37,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {


### PR DESCRIPTION
This is based on mdn-bcd-collector 4.0.0 results. It also matches the
existing data for scroll-margin-inline-start/end, which makes sense.
