### PR TITLE
Remove the "type and listener parameters are optional" feature

### DIFF
--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -800,65 +800,6 @@
             }
           }
         },
-        "type_listener_parameters_optional": {
-          "__compat": {
-            "description": "<code>type</code> and <code>listener</code> parameters are optional",
-            "support": {
-              "chrome": {
-                "version_added": "1",
-                "version_removed": "49"
-              },
-              "chrome_android": {
-                "version_added": "18",
-                "version_removed": "49"
-              },
-              "deno": {
-                "version_added": "1.0"
-              },
-              "edge": {
-                "version_added": "12",
-                "version_removed": "79"
-              },
-              "firefox": {
-                "version_added": true
-              },
-              "firefox_android": {
-                "version_added": true
-              },
-              "ie": {
-                "version_added": true
-              },
-              "nodejs": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": {
-                "version_added": true
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0",
-                "version_removed": "5.0"
-              },
-              "webview_android": {
-                "version_added": "1",
-                "version_removed": "49"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "useCapture_parameter_optional": {
           "__compat": {
             "description": "<code>useCapture</code> parameter is optional",


### PR DESCRIPTION
This is the inversion of the non-standard "feature" that the following
don't throw an exception but instead do nothing:
```js
window.addEventListener()
window.addEventListener('load')
```

That "feature" has been removed from all browsers, confirmed by manually
testing whether `window.addEventListener('load')` throws.

Notably, it did throw in Edge 18. Exactly when the parameters were made
required in Chrome, Firefox and Safari hasn't been tested. It was
probably long ago, but ultimately it doesn't matter, since the "feature"
here is not a feature at all, just a quirk that was only important at
the moment it was being fixed, when it could have broken sites.