### PR TITLE
Safari 15.1 updates for Performance API and list-style-type

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -1246,10 +1246,10 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.1"
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -1049,10 +1049,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -1097,10 +1097,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -2115,10 +2115,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -2641,10 +2641,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -2701,10 +2701,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -2965,10 +2965,10 @@
                 "version_added": "32"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -3013,10 +3013,10 @@
                 "version_added": "32"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -3061,10 +3061,10 @@
                 "version_added": "32"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -3979,10 +3979,10 @@
                 "version_added": "32"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -4039,10 +4039,10 @@
                 "version_added": "32"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -4796,10 +4796,10 @@
                 "version_added": "32"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -4856,10 +4856,10 @@
                 "version_added": "32"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.1"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"


### PR DESCRIPTION
#### Summary

There are two sets of changes for Safari 15.1:
- ` performance.timeOrigin` is available in Web Workers
- 12 new values for list-style-type: disclosure-closed, disclosure-open, ethiopic-numeric, japanese-formal, japanese-informal, korean-hangul-formal, korean-hanja-formal, korean-hanja-informal, simp-chinese-formal, simp-chinese informal, trad-chinese-formal, and trad-chinese-informal.

#### Test results and supporting details

[Improve more of the CSS list style implementations](​https://trac.webkit.org/changeset/279165/webkit)
[Performance API: Implement performance.timeOrigin](https://trac.webkit.org/changeset/278665/webkit)


