### PR TITLE
Update safari support of RGBA hexadecimal notation

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -132,7 +132,7 @@
                 "version_added": "47"
               },
               "safari": {
-                "version_added": "9.1"
+                "version_added": "10"
               },
               "safari_ios": {
                 "version_added": "9.3"


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Safari 9.1 hasn't support.

#### Test results and supporting details
Tested by me on Browserstack. Also see caniuse data: https://caniuse.com/css-rrggbbaa

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
