### PR TITLE
Update Firefox/IE versions for select.add(..., index) support

### DIFF
--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -117,7 +117,7 @@
                 "version_added": "8"
               },
               "ie": {
-                "version_added": "≤9"
+                "version_added": "5.5"
               },
               "opera": {
                 "version_added": "22"


### PR DESCRIPTION
The data for Chromium and WebKit was just updated:
https://github.com/mdn/browser-compat-data/pull/13061
https://github.com/mdn/browser-compat-data/pull/13063

http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=9763 was
used to confirm, and with the same test I found that the Firefox
version was off by 1, and can confirm support in IE9.