### PR TITLE
Error constructor missing filename/linenumber parameters

### DIFF
--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -110,61 +110,6 @@
               "deprecated": false
             }
           },
-          "options_cause_parameter": {
-            "__compat": {
-              "description": "<code>options.cause</code> parameter",
-              "spec_url": "https://tc39.es/proposal-error-cause/#sec-errorobjects-install-error-cause",
-              "support": {
-                "chrome": {
-                  "version_added": "93"
-                },
-                "chrome_android": {
-                  "version_added": "93"
-                },
-                "deno": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
-                "firefox": {
-                  "version_added": "91"
-                },
-                "firefox_android": {
-                  "version_added": "91"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "opera": {
-                  "version_added": "79"
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": "15"
-                },
-                "safari_ios": {
-                  "version_added": "15"
-                },
-                "samsunginternet_android": {
-                  "version_added": false
-                },
-                "webview_android": {
-                  "version_added": "93"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
           "fileName_parameter": {
             "__compat": {
               "description": "<code>fileName</code> parameter",
@@ -269,6 +214,61 @@
               "status": {
                 "experimental": false,
                 "standard_track": false,
+                "deprecated": false
+              }
+            }
+          },
+          "options_cause_parameter": {
+            "__compat": {
+              "description": "<code>options.cause</code> parameter",
+              "spec_url": "https://tc39.es/proposal-error-cause/#sec-errorobjects-install-error-cause",
+              "support": {
+                "chrome": {
+                  "version_added": "93"
+                },
+                "chrome_android": {
+                  "version_added": "93"
+                },
+                "deno": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "91"
+                },
+                "firefox_android": {
+                  "version_added": "91"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "79"
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": "15"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": "93"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
                 "deprecated": false
               }
             }

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -164,6 +164,114 @@
                 "deprecated": false
               }
             }
+          },
+          "fileName_parameter": {
+            "__compat": {
+              "description": "<code>fileName</code> parameter",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "deno": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "1"
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": false,
+                "deprecated": false
+              }
+            }
+          },
+          "lineNumber_parameter": {
+            "__compat": {
+              "description": "<code>lineNumber</code> parameter",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "deno": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "1"
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": false,
+                "deprecated": false
+              }
+            }
           }
         },
         "cause": {


### PR DESCRIPTION
[`Error` constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error) specifies that the constructor takes arguments `message`, `options.cause`, `fileName`, `lineNumber`.

` fileName`, `lineNumber` are in [javascript/builtins/Error.json](https://github.com/mdn/browser-compat-data/blob/main/javascript/builtins/Error.json) as properties, but not listed as error constructor options - so they aren't visible in MDN on the error constructor page.

This reproduces the data for the properties under the error constructor. Note that it does NOT reproduce message, which is assumed to match the parent constructor function.

This is part of fixing #10159