### PR TITLE
Added overrideContentColorScheme to browserSettings

### DIFF
--- a/webextensions/api/browserSettings.json
+++ b/webextensions/api/browserSettings.json
@@ -329,6 +329,31 @@
             }
           }
         },
+        "overrideContentColorScheme": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/overrideContentColorScheme",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "95"
+              },
+              "firefox_android": {
+                "version_added": "95"
+              },
+              "opera": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "overrideDocumentColors": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/overrideDocumentColors",


### PR DESCRIPTION
#### Summary
Adds `overrideContentColorScheme` to `browserSettings`

#### Test results and supporting details
`npm test`run with no errors

#### Related issues

Addresses documentation requirements for [Bug 1733461](https://bugzilla.mozilla.org/show_bug.cgi?id=1733461) (issue [#10146](https://github.com/mdn/content/issues/10146))
