### PR TITLE
Add Chrome/Safari versions for api.Selection.containsNode.partialContainment_parameter_optional

### DIFF
--- a/api/Selection.json
+++ b/api/Selection.json
@@ -495,10 +495,10 @@
             "description": "<code>partialContainment</code> parameter is optional",
             "support": {
               "chrome": {
-                "version_added": "39"
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "39"
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "≤79"
@@ -513,22 +513,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "26"
+                "version_added": "≤15"
               },
               "opera_android": {
-                "version_added": "26"
+                "version_added": "≤14"
               },
               "safari": {
-                "version_added": true
+                "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "2"
               },
               "samsunginternet_android": {
-                "version_added": "4.0"
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "39"
+                "version_added": "≤37"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds real values for Chrome and Safari for the `containsNode.partialContainment_parameter_optional` member of the `Selection` API, based upon commit history and date.

Commit: https://github.com/WebKit/WebKit/blame/0af480a6dabb8e9b9e98eb8a46618e5acf51ad2c/Source/WebCore/page/DOMSelection.idl#L55 (Aas notable with the `LegacyDefaultOptionalArgument`, this was when arguments were optional by default in WebKit. This commit is also when `containsNode` itself was added)
