### PR TITLE
Safari 15 supports private class methods

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -631,10 +631,10 @@
               "version_added": "60"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15"
             },
             "samsunginternet_android": {
               "version_added": "14.0"


### PR DESCRIPTION
#### Summary

Updates compatibility data for private class methods to include Safari 15 updates.

#### Test results and supporting details

See release notes: https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes
Testcase: https://codepen.io/leaverou/pen/mdMMoag

#### Related issues

This closes #13185
