### PR TITLE
Add IE/Edge versions for api.Document.createElementNS.options_parameter

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -2213,7 +2213,7 @@
                 "notes": "For backwards compatibility, the <code>options</code> parameter can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "edge": {
-                "version_added": "≤79",
+                "version_added": "79",
                 "notes": "For backwards compatibility, the <code>options</code> parameter can be an object or a string with the custom element tag name, although the string version is deprecated."
               },
               "firefox": {
@@ -2225,7 +2225,7 @@
                 "notes": "Firefox accepts a string instead of an object here, but only from version 51 onwards. In version 50, options must be an object."
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "43",


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `createElementNS.options_parameter` member of the `Document` API.  The data for `createElement.options_parameter` was set to `false` for IE and pre-Chromium Edge in https://github.com/mdn/browser-compat-data/pull/4975.  I doubt that this would be supported in `createElementNS` if `createElement` doesn't support it.
