### PR TITLE
Add Safari versions for api.Window.beforeunload_event.event_returnvalue_activation

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -721,7 +721,7 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": null
+                "version_added": "8"
               },
               "safari_ios": {
                 "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `beforeunload_event.event_returnvalue_activation` member of the `Window` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<button id="go">Click me!</button>
</div>

<script>
	var button = document.getElementById('go');

	window.addEventListener('beforeunload', function(event) {
		event.returnValue = "Farewell!";
	});

	button.onclick = function() {
		window.location.reload();
	}
</script>
```

Note: I've confirmed this doesn't trigger on iOS/iPadOS.
