### PR TITLE
Add Safari versions for api.Window.scroll[X/Y].subpixel_precision

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -8234,10 +8234,10 @@
                 "version_added": "27"
               },
               "safari": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "4.0"
@@ -8398,10 +8398,10 @@
                 "version_added": "27"
               },
               "safari": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "4.0"

--- a/api/Window.json
+++ b/api/Window.json
@@ -8234,10 +8234,10 @@
                 "version_added": "27"
               },
               "safari": {
-                "version_added": "10.1"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "10.3"
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "4.0"
@@ -8398,10 +8398,10 @@
                 "version_added": "27"
               },
               "safari": {
-                "version_added": "10.1"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "10.3"
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "4.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `scroll[X/Y].subpixel_precision` member of the `Window` API, based upon commit history and date.

Commit: https://github.com/WebKit/WebKit/commit/d056b5f4dc07e1f653d0965fb478840395fc5087#diff-d3e96b972e2af1057b7c16b83a6a78798de67f5f8a811662d4d2e9a0fc1c492e ([WebKit 603.1.0](https://github.com/WebKit/WebKit/blob/d056b5f4dc07e1f653d0965fb478840395fc5087/Source/WebCore/Configurations/Version.xcconfig))
