### PR TITLE
Add Safari versions for api.Selection.collapse.node_parameter_nullable

### DIFF
--- a/api/Selection.json
+++ b/api/Selection.json
@@ -274,10 +274,10 @@
                 "version_added": "26"
               },
               "safari": {
-                "version_added": true
+                "version_added": "10"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "10"
               },
               "samsunginternet_android": {
                 "version_added": "4.0"

--- a/api/Selection.json
+++ b/api/Selection.json
@@ -274,10 +274,10 @@
                 "version_added": "26"
               },
               "safari": {
-                "version_added": "10"
+                "version_added": "1.3"
               },
               "safari_ios": {
-                "version_added": "10"
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "4.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `collapse.node_parameter_nullable` member of the `Selection` API, based upon manual testing.

Test Code Used:
```js
try {
	var sel = window.getSelection();
	sel.collapse(null, 0);
} catch(e) {
	alert(e);
}
```