### PR TITLE
Add Safari versions for api.KeyboardEvent.key

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -1110,10 +1110,10 @@
                 "version_added": "41"
               },
               "safari": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -1159,10 +1159,10 @@
                 "version_added": "41"
               },
               "safari": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"
@@ -1208,10 +1208,10 @@
                 "version_added": "41"
               },
               "safari": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "10.3"
               },
               "samsunginternet_android": {
                 "version_added": "5.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `key` member of the `KeyboardEvent` API, based upon manual testing.  See #12849 for more details.

Closes #12849.
