### PR TITLE
Add IE versions for api.HTMLCanvasElement.getContext.webgl_context.options_failIfMajorPerformanceCaveat_parameter

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -483,7 +483,7 @@
                   "version_added": "41"
                 },
                 "ie": {
-                  "version_added": true
+                  "version_added": "11"
                 },
                 "opera": {
                   "version_added": "20"


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `getContext.webgl_context.options_failIfMajorPerformanceCaveat_parameter` member of the `HTMLCanvasElement` API.  This PR simply sets the value to "11", because honestly, I have no idea how I'd be able to create a test for this.  I don't think anyone would care about data before IE 11 nowadays as it is, and if anyone does, I feel that they could make the corrections themselves.
