### PR TITLE
Add IE versions for api.HTMLTableRowElement.insertCell.index_parameter_optional

### DIFF
--- a/api/HTMLTableRowElement.json
+++ b/api/HTMLTableRowElement.json
@@ -452,7 +452,7 @@
                 "version_added": "20"
               },
               "ie": {
-                "version_added": true
+                "version_added": "5.5"
               },
               "opera": {
                 "version_added": "15"


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `insertCell.index_parameter_optional` member of the `HTMLTableRowElement` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<button id="add-row">Add row!</button>

	<table id="my-table">
	  <tr><td>Row 1</td></tr>
	  <tr><td>Row 2</td></tr>
	  <tr><td>Row 3</td></tr>
	</table>
</div>

<script>
	var tableRef = document.getElementById('my-table');

	function addRow() {
	  var newRow = tableRef.insertRow(-1);
	  var newCell = newRow.insertCell();

	  var newText = document.createTextNode('New bottom row');
	  newCell.appendChild(newText);
	}

	document.getElementById('add-row').onclick = addRow;
</script>
```
