### PR TITLE
Add IE versions for api.Window.beforeunload_event.return_string_activation

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -809,7 +809,7 @@
                 "version_added": true
               },
               "ie": {
-                "version_added": true
+                "version_added": "9"
               },
               "opera": {
                 "version_added": "12"


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `beforeunload_event.return_string_activation` member of the `Window` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<button id="go">Click me!</button>
</div>

<script>
	var button = document.getElementById('go');

	window.addEventListener('beforeunload', function(event) {
		event.returnValue = "Farewell!";
	});

	button.onclick = function() {
		window.location.reload();
	}
</script>
```
