### PR TITLE
Add IE versions for api.MouseEvent.getModifierState.accel_support

### DIFF
--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -465,7 +465,7 @@
                 "version_added": "32"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": null


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `getModifierState.accel_support` member of the `MouseEvent` API.  Edge's support is `false`, so it doesn't makes sense that this would be supported in IE.  (Additionally, the same feature for `KeyboardEvent` is `false` for IE.)
