### PR TITLE
Complete nodejs data for global timers

### DIFF
--- a/api/_globals/clearInterval.json
+++ b/api/_globals/clearInterval.json
@@ -28,7 +28,7 @@
             "notes": "From Internet Explorer 4 through 8, <code>clearInterval</code> is an Object rather than a Function. This behavior was fixed in Internet Explorer 9."
           },
           "nodejs": {
-            "version_added": true,
+            "version_added": "0.10.0",
             "partial_implementation": true,
             "notes": "Takes a <code>Timeout</code> object instead of the <code>intervalID</code>."
           },
@@ -81,6 +81,9 @@
             },
             "ie": {
               "version_added": "10"
+            },
+            "nodejs": {
+              "version_added": "10.5.0"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/_globals/clearTimeout.json
+++ b/api/_globals/clearTimeout.json
@@ -28,7 +28,7 @@
             "notes": "From Internet Explorer 4 through 8, <code>clearTimeout</code> is an Object rather than a Function. This behavior was fixed in Internet Explorer 9."
           },
           "nodejs": {
-            "version_added": true,
+            "version_added": "0.10.0",
             "partial_implementation": true,
             "notes": "Takes a <code>Timeout</code> object instead of the <code>timeoutID</code>."
           },
@@ -81,6 +81,9 @@
             },
             "ie": {
               "version_added": "10"
+            },
+            "nodejs": {
+              "version_added": "10.5.0"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/_globals/setInterval.json
+++ b/api/_globals/setInterval.json
@@ -27,7 +27,7 @@
             "version_added": "4"
           },
           "nodejs": {
-            "version_added": true,
+            "version_added": "0.10.0",
             "partial_implementation": true,
             "notes": [
               "Returns a <code>Timeout</code> object instead of the <code>intervalID</code>.",
@@ -85,7 +85,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "≤15"
@@ -137,6 +137,9 @@
             },
             "ie": {
               "version_added": "10"
+            },
+            "nodejs": {
+              "version_added": "10.5.0"
             },
             "opera": {
               "version_added": "≤12.1"

--- a/api/_globals/setTimeout.json
+++ b/api/_globals/setTimeout.json
@@ -27,7 +27,7 @@
             "version_added": "4"
           },
           "nodejs": {
-            "version_added": true,
+            "version_added": "0.10.0",
             "partial_implementation": true,
             "notes": [
               "Returns a <code>Timeout</code> object instead of the <code>timeoutID</code>.",
@@ -85,7 +85,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "0.10.0"
             },
             "opera": {
               "version_added": "≤15"
@@ -137,6 +137,9 @@
             },
             "ie": {
               "version_added": "10"
+            },
+            "nodejs": {
+              "version_added": "10.5.0"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
#### Summary

Part of #13170. This fills in `true` and missing `nodejs` entries for global timers (`setTimeout` et al).

#### Test results and supporting details

The basic methods were in the very first version, as listed in the history for each method at https://nodejs.org/dist/latest-v16.x/docs/api/timers.html

Worker threads in general were added to NodeJS in 10.5.0: https://nodejs.org/dist/latest-v16.x/docs/api/worker_threads.html
