### PR TITLE
Add nodejs version for Console.info.substitution_strings

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -1014,7 +1014,7 @@
                 ]
               },
               "nodejs": {
-                "version_added": true
+                "version_added": "0.10.0"
               },
               "opera": {
                 "version_added": "15"


### PR DESCRIPTION
#### Summary
Part of #13170. This fills in the one remaining `true` value for `api.console`.

#### Test results and supporting details
This matches the listed `nodejs` version for all the other `console.*.substitution_strings` values.

Also confirmed locally:

```
$ nvm exec 0.10.0 node -e 'console.info("%s string", "substituted")'
Running node v0.10.0 (npm v1.2.14)
substituted string
```
