### PR TITLE
Add IE versions for api.XMLHttpRequest.send.ArrayBufferView

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1520,7 +1520,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "20"
@@ -1529,7 +1529,7 @@
                 "version_added": "20"
               },
               "ie": {
-                "version_added": null
+                "version_added": "10"
               },
               "opera": {
                 "version_added": true


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `send.ArrayBufferView` member of the `XMLHttpRequest` API, based upon manual testing.

Test Code Used:
```js
try {
	var buffer = new Uint8Array(10);
	for(var i = 0; i < 10; i++) {
		buffer[i] = 32 + i;
	}

	var xhr = new XMLHttpRequest();
	xhr.open('GET', '/queengooborg/test', true);

	xhr.send(buffer);
	alert("Send successful!");
} catch(e) {
	alert(e);
}
```