### PR TITLE
Add IE/Edge versions for api.XMLHttpRequest.send.URLSearchParams

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1667,7 +1667,7 @@
                 "version_added": "59"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "17"
               },
               "firefox": {
                 "version_added": "44"
@@ -1676,7 +1676,7 @@
                 "version_added": "44"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "12"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `send.URLSearchParams` member of the `XMLHttpRequest` API, based upon manual testing.

Test Code Used:
```js
try {
	var params = new URLSearchParams('q=hello&world=here');

	var xhr = new XMLHttpRequest();
	xhr.open('GET', '/queengooborg/test', true);

	xhr.send(params);
	alert("Send successful!");
} catch(e) {
	alert(e);
}
```
