### PR TITLE
Add IE versions for api.IDBCursor.key.binary_keys

### DIFF
--- a/api/IDBCursor.json
+++ b/api/IDBCursor.json
@@ -416,7 +416,7 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "45"


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `key.binary_keys` member of the `IDBCursor` API.  Based upon the versions this was implemented in for other browsers, this feature seems too new for Internet Explorer.
