### PR TITLE
Add IE versions for api.IDBIndex.name.renaming_with_name_setter

### DIFF
--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -609,7 +609,7 @@
                 "version_added": null
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "42"


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `name.renaming_with_name_setter` member of the `IDBIndex` API.  Based upon the versions this was implemented in for other browsers, this feature seems too new for Internet Explorer.
