### PR TITLE
Add IE versions for api.IDBObjectStore.name.renaming_through_name_setter

### DIFF
--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -850,7 +850,7 @@
                 "version_added": "49"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "42"


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `name.renaming_through_name_setter` member of the `IDBObjectStore` API.  Based upon the versions this was implemented in for other browsers, this feature seems too new for Internet Explorer.
