### PR TITLE
Rename api.IDBIndex.name.renaming_with_name_setter (with -> through)

### DIFF
--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -589,9 +589,9 @@
             "deprecated": false
           }
         },
-        "renaming_with_name_setter": {
+        "renaming_through_name_setter": {
           "__compat": {
-            "description": "Renaming with name setter",
+            "description": "Renaming through <code>name</code> setter",
             "support": {
               "chrome": {
                 "version_added": "55"


### PR DESCRIPTION
This PR renames the `api.IDBIndex.name.renaming_with_name_setter` feature to `api.IDBIndex.name.renaming_through_name_setter` to maintain consistency with the matching feature in `IDBObjectStore`.
