### PR TITLE
Add Chromium versions for RTCIceCandidatePairStats API

### DIFF
--- a/api/RTCIceCandidatePairStats.json
+++ b/api/RTCIceCandidatePairStats.json
@@ -103,10 +103,10 @@
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcicecandidatepairstats-availableoutgoingbitrate",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "56"
             },
             "edge": {
               "version_added": "≤79"
@@ -133,10 +133,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "56"
             }
           },
           "status": {
@@ -152,10 +152,10 @@
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcicecandidatepairstats-bytesreceived",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "56"
             },
             "edge": {
               "version_added": "≤79"
@@ -182,10 +182,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "56"
             }
           },
           "status": {
@@ -201,10 +201,10 @@
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcicecandidatepairstats-bytessent",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "56"
             },
             "edge": {
               "version_added": "≤79"
@@ -231,10 +231,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "56"
             }
           },
           "status": {
@@ -401,7 +401,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": true,
+                "version_added": "56",
                 "alternative_name": "currentRtt"
               }
             ],
@@ -410,7 +410,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": true,
+                "version_added": "56",
                 "alternative_name": "currentRtt"
               }
             ],
@@ -449,7 +449,7 @@
                 "version_added": "10.0"
               },
               {
-                "version_added": true,
+                "version_added": "6.0",
                 "alternative_name": "currentRtt"
               }
             ],
@@ -458,7 +458,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": true,
+                "version_added": "56",
                 "alternative_name": "currentRtt"
               }
             ]
@@ -721,10 +721,10 @@
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcicecandidatepairstats-localcandidateid",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "edge": {
               "version_added": false
@@ -751,10 +751,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -770,10 +770,10 @@
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcicecandidatepairstats-nominated",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "edge": {
               "version_added": false
@@ -800,10 +800,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -917,10 +917,10 @@
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcicecandidatepairstats-priority",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "edge": {
               "version_added": false
@@ -959,10 +959,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -1026,10 +1026,10 @@
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcicecandidatepairstats-remotecandidateid",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "edge": {
               "version_added": false
@@ -1056,10 +1056,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -1075,10 +1075,10 @@
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcicecandidatepairstats-requestsreceived",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "56"
             },
             "edge": {
               "version_added": "≤79"
@@ -1105,10 +1105,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "56"
             }
           },
           "status": {
@@ -1124,10 +1124,10 @@
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcicecandidatepairstats-requestssent",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "56"
             },
             "edge": {
               "version_added": "≤79"
@@ -1154,10 +1154,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "56"
             }
           },
           "status": {
@@ -1173,10 +1173,10 @@
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcicecandidatepairstats-responsesreceived",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "56"
             },
             "edge": {
               "version_added": "≤79"
@@ -1203,10 +1203,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "56"
             }
           },
           "status": {
@@ -1222,10 +1222,10 @@
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcicecandidatepairstats-responsessent",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "56"
             },
             "edge": {
               "version_added": "≤79"
@@ -1252,10 +1252,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "56"
             }
           },
           "status": {
@@ -1369,10 +1369,10 @@
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcicecandidatepairstats-state",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "edge": {
               "version_added": false
@@ -1399,10 +1399,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -1422,7 +1422,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": true,
+                "version_added": "56",
                 "alternative_name": "totalRtt"
               }
             ],
@@ -1431,7 +1431,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": true,
+                "version_added": "56",
                 "alternative_name": "totalRtt"
               }
             ],
@@ -1470,7 +1470,7 @@
                 "version_added": "10.0"
               },
               {
-                "version_added": true,
+                "version_added": "6.0",
                 "alternative_name": "totalRtt"
               }
             ],
@@ -1491,10 +1491,10 @@
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcicecandidatepairstats-transportid",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "edge": {
               "version_added": false
@@ -1533,10 +1533,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {
@@ -1551,11 +1551,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidatePairStats/writable",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "56",
               "notes": "Chrome does not currently use the specification's algorithm to determine the value of <code>writable</code>; it may not match the behavior of other browsers."
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "56",
               "notes": "Chrome does not currently use the specification's algorithm to determine the value of <code>writable</code>; it may not match the behavior of other browsers."
             },
             "edge": {
@@ -1584,11 +1584,11 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "6.0",
               "notes": "Samsung Internet does not currently use the specification's algorithm to determine the value of <code>writable</code>; it may not match the behavior of other browsers."
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "56"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `RTCIceCandidatePairStats` API, based upon commit history and date, as well as correcting the existing data for some features set to `false`.

Commit: https://source.chromium.org/chromium/_/webrtc/src.git/+/c47a0c3ac42ba4a5582187acc3ad3a762c323e33

Note: there are some properties added in this commit that I have not set to a truthy value.  There are comments in the [current commit](https://source.chromium.org/chromium/chromium/src/+/main:third_party/webrtc/api/stats/rtcstats_objects.h;l=150;drc=7af7400d03766f76cdc34b9ffee27178dc9430c6) that imply that the values are not populated, so I left them as `false`.
