### PR TITLE
Add IE versions for api.Window.postMessage.transfer_parameter

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -6279,7 +6279,7 @@
                 "version_added": "20"
               },
               "ie": {
-                "version_added": true
+                "version_added": "11"
               },
               "opera": {
                 "version_added": "≤15"


### PR DESCRIPTION
This PR adds real values for Internet Explorer for the `postMessage.transfer_parameter` member of the `Window` API, based upon manual testing.

Test Code Used (based upon https://developer.mozilla.org/en-US/docs/Glossary/Transferable_objects#transferring_objects_between_threads):
```js
var myWorker = new Worker('/link/to/worker.js'); // Tested using setup on mdn-bcd-collector

var buffer = new ArrayBuffer(8);

myWorker.postMessage(buffer, [buffer]);
console.log(buffer.byteLength == 0);
```
