### PR TITLE
Mark HTTP digest and want-digest support as null/unknown

### DIFF
--- a/http/headers/digest.json
+++ b/http/headers/digest.json
@@ -7,40 +7,40 @@
           "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers-05#section-3",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": null
             },
             "edge": {
-              "version_added": "12"
+              "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": null
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": null
             },
             "ie": {
-              "version_added": true
+              "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": null
             },
             "opera_android": {
-              "version_added": true
+              "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": null
             }
           },
           "status": {

--- a/http/headers/want-digest.json
+++ b/http/headers/want-digest.json
@@ -7,40 +7,40 @@
           "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers-05#section-4",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": null
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": null
             },
             "edge": {
-              "version_added": "12"
+              "version_added": null
             },
             "firefox": {
-              "version_added": true
+              "version_added": null
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": null
             },
             "ie": {
-              "version_added": true
+              "version_added": null
             },
             "opera": {
-              "version_added": true
+              "version_added": null
             },
             "opera_android": {
-              "version_added": true
+              "version_added": null
             },
             "safari": {
-              "version_added": true
+              "version_added": null
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": null
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": null
             },
             "webview_android": {
-              "version_added": true
+              "version_added": null
             }
           },
           "status": {


### PR DESCRIPTION
This changes the `Digest` and `Want-Digest` HTTP header support from `true` to `null` for all platforms.

- `true` is incorrect because the browser does nothing with these headers.
- `false` is correct because there are things a browser could do with these headers. However if we used `false` the table would be empty, and we normally don't allow all-false data. 
-  `null` is a compromise, which essentially says "we don't know" (but at least we're not pretending it is supported in some way). It will force us to return to this question in the near future when we start enforcing better data quality on the HTTP section. At that time I am hoping we allow `false` and a note to be added as top level support option for all browsers so this can be explained.

There is a discussion on this in https://github.com/mdn/browser-compat-data/issues/12533 and https://github.com/mdn/content/issues/9139. The decision for now was that we set this as null and perhaps revisit later.