### PR TITLE
SubtleCrypto - match Edge to Chrome from v79

### DIFF
--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -92,11 +92,17 @@
                 "notes": "Not supported: AES-CTR, AES-CBC, AES-GCM."
               }
             ],
-            "edge": {
-              "version_added": "12",
-              "partial_implementation": true,
-              "notes": "Not supported: AES-CTR."
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Not supported: AES-CTR."
+              }
+            ],
             "firefox": {
               "version_added": "34"
             },
@@ -159,14 +165,20 @@
                 "notes": "Not supported: ECDH."
               }
             ],
-            "edge": {
-              "version_added": "12",
-              "partial_implementation": true,
-              "notes": [
-                "Not supported: ECDH.",
-                "Not supported: HKDF, PBKDF2."
-              ]
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": [
+                  "Not supported: ECDH.",
+                  "Not supported: HKDF, PBKDF2."
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "34"
             },
@@ -223,14 +235,20 @@
             "deno": {
               "version_added": "1.15"
             },
-            "edge": {
-              "version_added": "12",
-              "partial_implementation": true,
-              "notes": [
-                "Not supported: ECDH.",
-                "Not supported: HKDF, PBKDF2."
-              ]
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": [
+                  "Not supported: ECDH.",
+                  "Not supported: HKDF, PBKDF2."
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "34"
             },
@@ -287,11 +305,17 @@
             "deno": {
               "version_added": "1.11"
             },
-            "edge": {
-              "version_added": "12",
-              "partial_implementation": true,
-              "notes": "Not supported: SHA-1."
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Not supported: SHA-1."
+              }
+            ],
             "firefox": {
               "version_added": "34"
             },
@@ -356,11 +380,17 @@
                 "notes": "Not supported: AES-CTR, AES-CBC, AES-GCM."
               }
             ],
-            "edge": {
-              "version_added": "12",
-              "partial_implementation": true,
-              "notes": "Not supported: AES-CTR."
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Not supported: AES-CTR."
+              }
+            ],
             "firefox": {
               "version_added": "34"
             },
@@ -425,14 +455,20 @@
                 "notes": "Not supported: ECDSA, ECDH, AES-CTR, AES-CBC, AES-GCM, AES-KW."
               }
             ],
-            "edge": {
-              "version_added": "12",
-              "partial_implementation": true,
-              "notes": [
-                "Not supported: RSA-PSS, ECDSA, ECDH.",
-                "Not supported: AES-CTR."
-              ]
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": [
+                  "Not supported: RSA-PSS, ECDSA, ECDH.",
+                  "Not supported: AES-CTR."
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "34"
             },
@@ -502,14 +538,20 @@
                 "notes": "Not supported: RSA-OAEP, ECDSA P-521, ECDH, AES-CTR, AES-CBC, AES-GCM, AES-KW."
               }
             ],
-            "edge": {
-              "version_added": "12",
-              "partial_implementation": true,
-              "notes": [
-                "Not supported: RSA-PSS, ECDSA, ECDH.",
-                "Not supported: AES-CTR."
-              ]
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": [
+                  "Not supported: RSA-PSS, ECDSA, ECDH.",
+                  "Not supported: AES-CTR."
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "34"
             },
@@ -578,14 +620,20 @@
                 "notes": "Not supported: ECDSA, ECDH, AES-CTR, AES-CBC, AES-GCM, AES-KW."
               }
             ],
-            "edge": {
-              "version_added": "12",
-              "partial_implementation": true,
-              "notes": [
-                "Not supported: RSA-PSS, ECDSA, ECDH.",
-                "Not supported: AES-CTR, HKDF, PBKDF2."
-              ]
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": [
+                  "Not supported: RSA-PSS, ECDSA, ECDH.",
+                  "Not supported: AES-CTR, HKDF, PBKDF2."
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "34"
             },
@@ -701,11 +749,17 @@
               "partial_implementation": true,
               "notes": "Not supported: ECDSA P-521."
             },
-            "edge": {
-              "version_added": "12",
-              "partial_implementation": true,
-              "notes": "Not supported: RSA-PSS, ECDSA."
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Not supported: RSA-PSS, ECDSA."
+              }
+            ],
             "firefox": {
               "version_added": "34"
             },
@@ -761,11 +815,17 @@
             "deno": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "12",
-              "partial_implementation": true,
-              "notes": "Not supported: AES-CTR."
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Not supported: AES-CTR."
+              }
+            ],
             "firefox": {
               "version_added": "34"
             },
@@ -832,11 +892,17 @@
                 "notes": "Not supported: ECDSA, HMAC."
               }
             ],
-            "edge": {
-              "version_added": "12",
-              "partial_implementation": true,
-              "notes": "Not supported: RSA-PSS, ECDSA."
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Not supported: RSA-PSS, ECDSA."
+              }
+            ],
             "firefox": {
               "version_added": "34"
             },
@@ -946,11 +1012,17 @@
             "deno": {
               "version_added": "1.15"
             },
-            "edge": {
-              "version_added": "12",
-              "partial_implementation": true,
-              "notes": "Not supported: AES-CTR."
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Not supported: AES-CTR."
+              }
+            ],
             "firefox": {
               "version_added": "34"
             },


### PR DESCRIPTION
SubtleCrypto was present on Edge 12 but had a partial implementation on many methods. Since Edge updated to Blink on Edge 79 my ASSUMPTION is that at that point the methods match chromium. I have not tested that, but just updated edge to match chromium from v79.