### PR TITLE
Firefox 95 adds `ElementInternals` support for `.labels`, `.form`,  and `.setFormValue()`

### DIFF
--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -112,10 +112,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "95"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "95"
             },
             "ie": {
               "version_added": false
@@ -161,10 +161,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "95"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "95"
             },
             "ie": {
               "version_added": false
@@ -259,10 +259,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "95"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "95"
             },
             "ie": {
               "version_added": false

--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -112,10 +112,17 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "95"
+              "version_added": "95",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.formAssociatedCustomElement.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": "95"
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -161,10 +168,17 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "95"
+              "version_added": "95",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.formAssociatedCustomElement.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": "95"
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -259,10 +273,17 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "95"
+              "version_added": "95",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.formAssociatedCustomElement.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": "95"
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
FF95 adds support for the [ElementInternals.form](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/form), [ElementInternals.labels](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/labels), [ElementInternals.setFormValue()](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/setFormValue). See these bugs:
- [Custom elements: implement form attribute of ElementInternals](https://bugzilla.mozilla.org/show_bug.cgi?id=1556362)
- [Custom elements: implement labels for ElementInternals](https://bugzilla.mozilla.org/show_bug.cgi?id=1556373)
- [Custom elements: implement setFormValue() for ElementInternals](https://bugzilla.mozilla.org/show_bug.cgi?id=1556449)

