### PR TITLE
Updating firefox versions - release 94 2nd November

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -673,27 +673,28 @@
         "93": {
           "release_date": "2021-10-05",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/93",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "93"
         },
         "94": {
           "release_date": "2021-11-02",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/94",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "94"
         },
         "95": {
           "release_date": "2021-12-07",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/95",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "95"
         },
         "96": {
           "release_date": "2022-01-11",
-          "status": "planned",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/96",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "96"
         },

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -539,27 +539,28 @@
         "93": {
           "release_date": "2021-10-05",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/93",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "93"
         },
         "94": {
           "release_date": "2021-11-02",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/94",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "94"
         },
         "95": {
           "release_date": "2021-12-07",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/95",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "95"
         },
         "96": {
           "release_date": "2022-01-11",
-          "status": "planned",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/96",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "96"
         },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Firefox 94 is released 2nd November - this updates the browser releases

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

Tests pass

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
