### PR TITLE
Add shadowroot attribute to template element.

### DIFF
--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -50,48 +50,50 @@
           }
         },
         "shadowroot": {
-          "support": {
-            "chrome": {
-              "version_added": "90"
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "90"
+              },
+              "chrome_android": {
+                "version_added": "90"
+              },
+              "edge": {
+                "version_added": "90"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "90"
+              }
             },
-            "chrome_android": {
-              "version_added": "90"
-            },
-            "edge": {
-              "version_added": "90"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": "90"
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
           }
         }
       }

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -48,6 +48,51 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "shadowroot": {
+          "support": {
+            "chrome": {
+              "version_added": "90"
+            },
+            "chrome_android": {
+              "version_added": "90"
+            },
+            "edge": {
+              "version_added": "90"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "90"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Adds `shadowroot` attribute to `<template>` element.

#### Test results and supporting details
https://www.chromestatus.com/features/5191745052606464

#### Related issues
Part 1 of fixing https://github.com/mdn/content/issues/9559

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
