### PR TITLE
Add Chromium versions for api.BaseAudioContext.createStereoPanner

### DIFF
--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -1050,7 +1050,7 @@
               "version_added": "42"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "42"
             },
             "edge": {
               "version_added": "12"
@@ -1065,10 +1065,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "29"
             },
             "safari": {
               "version_added": "14.1"
@@ -1077,10 +1077,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "42"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `createStereoPanner` member of the `BaseAudioContext` API by mirroring the data.
