### PR TITLE
MouseEvent - pageX, pageY, x, y not experimental

### DIFF
--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -971,7 +971,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -1020,7 +1020,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -1362,7 +1362,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -1411,7 +1411,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
Follows on from #13206 - if the offsetX and offsetY are not experimental, neither are pageX, pageY, x, y. These are widely supported across many browsers in many versions.

The associated MDN docs were update in https://github.com/mdn/content/pull/10220