### PR TITLE
SpeechSynthesisEvent.elapsedTime spec change ms to s

### DIFF
--- a/api/SpeechSynthesisEvent.json
+++ b/api/SpeechSynthesisEvent.json
@@ -44,7 +44,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -141,7 +141,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -238,9 +238,62 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "milliseconds": {
+          "__compat": {
+            "description": "<code>elapsedTime</code> in milliseconds",
+            "support": {
+              "chrome": {
+                "version_added": "33"
+              },
+              "chrome_android": {
+                "version_added": "33"
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "49",
+                "version_removed": "95",
+                "partial_implementation": true,
+                "notes": "Windows and macOS only."
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "21"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "7",
+                "version_removed": "14.1"
+              },
+              "safari_ios": {
+                "version_added": "7",
+                "version_removed": "14.5"
+              },
+              "samsunginternet_android": {
+                "version_added": "3.0"
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
           }
         }
       },
@@ -287,7 +340,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -336,7 +389,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
The Web Speech API spec recently changed the event property [`SpeechSynthesisEvent.elapsedTime`](https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesisEvent/elapsedTime) from milliseconds to seconds:
- FF95 has made this change in https://bugzilla.mozilla.org/show_bug.cgi?id=1732498
- Chromium issue (not fixed) is https://bugs.chromium.org/p/chromium/issues/detail?id=1253036
- Safari 14.1.2 on macOS appears to do the right thing (seconds) according to this https://bugzilla.mozilla.org/show_bug.cgi?id=1732498#c0 . I have no information on when it changed but I've used 14.1 because it coincides fairly well with spec change and also mentions the [API in release notes](https://developer.apple.com/documentation/safari-release-notes/safari-14_1-release-notes)

There is a demo fiddle here https://jsfiddle.net/ybe1c6ot/ ([comes from this issue](https://github.com/mdn/content/pull/10179)).

To update this I have followed @ddbeck suggestion of having a subfeature for the deprecated behaviour named milliseconds, which has a version-removed matching the version in which browsers update. I also will not update the handlers and specific instances.

I also set the experimental flag `false`.

P.S.- Docs tracking: https://github.com/mdn/content/issues/10221

Fixes #12595