### PR TITLE
Add Chromium versions for api.CustomEvent.detail

### DIFF
--- a/api/CustomEvent.json
+++ b/api/CustomEvent.json
@@ -113,7 +113,7 @@
               "version_added": "15"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "deno": {
               "version_added": "1.0"
@@ -134,7 +134,7 @@
               "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12"
             },
             "safari": {
               "version_added": "5"
@@ -143,7 +143,7 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `detail` member of the `CustomEvent` API by mirroring the data.
