### PR TITLE
Add Chromium versions for api.DOMParser.parseFromString

### DIFF
--- a/api/DOMParser.json
+++ b/api/DOMParser.json
@@ -107,7 +107,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -125,7 +125,7 @@
               "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1.3"
@@ -134,7 +134,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "1"


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `parseFromString` member of the `DOMParser` API by mirroring the data.
