### PR TITLE
Add Chromium versions for api.DataTransfer.items

### DIFF
--- a/api/DataTransfer.json
+++ b/api/DataTransfer.json
@@ -402,7 +402,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -420,7 +420,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12"
             },
             "safari": {
               "version_added": "11.1"
@@ -429,10 +429,10 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `items` member of the `DataTransfer` API by mirroring the data.
