### PR TITLE
Add Chromium versions for HTMLMediaElement API

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -403,7 +403,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -453,7 +453,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -1111,7 +1111,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -1161,7 +1161,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -1260,7 +1260,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -1551,7 +1551,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -1601,7 +1601,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -2209,7 +2209,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -2236,10 +2236,10 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -2258,7 +2258,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -2286,10 +2286,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -2474,7 +2474,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -2505,7 +2505,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -2532,10 +2532,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -2670,7 +2670,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -2701,7 +2701,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -2728,10 +2728,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -2749,7 +2749,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -2776,10 +2776,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -2817,7 +2817,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -3021,7 +3021,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -3152,7 +3152,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -3179,10 +3179,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -3220,7 +3220,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -3250,7 +3250,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -3277,10 +3277,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -3318,7 +3318,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -3552,7 +3552,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -3579,10 +3579,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -3701,7 +3701,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -3751,7 +3751,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -3850,7 +3850,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -3985,7 +3985,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -4012,10 +4012,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `HTMLMediaElement` API by mirroring the data.
