### PR TITLE
Add Chromium versions for DeviceOrientationEvent API

### DIFF
--- a/api/DeviceOrientationEvent.json
+++ b/api/DeviceOrientationEvent.json
@@ -79,10 +79,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "46"
             },
             "safari": {
               "version_added": false
@@ -113,7 +113,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -128,10 +128,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -140,7 +140,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -162,7 +162,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -177,10 +177,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -189,7 +189,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -211,7 +211,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -226,10 +226,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -238,7 +238,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -260,7 +260,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -275,10 +275,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -287,7 +287,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `DeviceOrientationEvent` API by mirroring the data.
