### PR TITLE
Add Chromium versions for api.DataTransferItem.webkitGetAsEntry

### DIFF
--- a/api/DataTransferItem.json
+++ b/api/DataTransferItem.json
@@ -302,7 +302,7 @@
               "version_added": "13"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "14"
@@ -329,7 +329,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `webkitGetAsEntry` member of the `DataTransferItem` API by mirroring the data.
