### PR TITLE
Add Chromium versions for api.Element.getElementsByTagName.all_elements_selector

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -3877,7 +3877,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -3904,7 +3904,7 @@
                 "version_added": "≤3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `getElementsByTagName.all_elements_selector` member of the `Element` API by mirroring the data.
