### PR TITLE
Mirror Chrome to Opera + Chrome/Samsung Internet/WebView Android

### DIFF
--- a/api/DataTransferItem.json
+++ b/api/DataTransferItem.json
@@ -302,7 +302,7 @@
               "version_added": "13"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "14"
@@ -329,7 +329,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/DedicatedWorkerGlobalScope.json
+++ b/api/DedicatedWorkerGlobalScope.json
@@ -161,7 +161,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "deno": {
               "version_added": "1.0"
@@ -191,7 +191,7 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -320,7 +320,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "deno": {
               "version_added": "1.0"
@@ -350,7 +350,7 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -426,7 +426,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "deno": [
               {
@@ -486,7 +486,7 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"

--- a/api/DeviceOrientationEvent.json
+++ b/api/DeviceOrientationEvent.json
@@ -79,10 +79,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -113,7 +113,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -128,10 +128,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -140,7 +140,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -162,7 +162,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -177,10 +177,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -189,7 +189,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -211,7 +211,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -226,10 +226,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -238,7 +238,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -260,7 +260,7 @@
               "version_added": "7"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -275,10 +275,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -287,7 +287,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"

--- a/api/Document.json
+++ b/api/Document.json
@@ -2883,7 +2883,7 @@
                 "version_added": "4"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "≤79"
@@ -2898,10 +2898,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "≤15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "≤14"
               },
               "safari": {
                 "version_added": "3"
@@ -2910,7 +2910,7 @@
                 "version_added": "3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "≤37"
@@ -5431,7 +5431,7 @@
                 "version_added": "71"
               },
               {
-                "version_added": true,
+                "version_added": "≤37",
                 "prefix": "webkit"
               }
             ]
@@ -6093,7 +6093,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -6111,7 +6111,7 @@
               "version_added": "11"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "5"
@@ -6120,7 +6120,7 @@
               "version_added": "4"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -6210,7 +6210,7 @@
                 "version_added": "33"
               },
               {
-                "version_added": true,
+                "version_added": "18",
                 "prefix": "webkit"
               }
             ],

--- a/api/Element.json
+++ b/api/Element.json
@@ -3877,7 +3877,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -3904,7 +3904,7 @@
                 "version_added": "≤3"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "1"

--- a/api/File.json
+++ b/api/File.json
@@ -127,7 +127,7 @@
               "version_added": "13"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "deno": {
               "version_added": "1.0"
@@ -157,7 +157,7 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -178,7 +178,7 @@
               "version_added": "13"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "deno": {
               "version_added": false
@@ -211,7 +211,7 @@
               "version_removed": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -233,7 +233,7 @@
               "version_added": "13"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "deno": {
               "version_added": "1.0"
@@ -263,7 +263,7 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -285,7 +285,7 @@
               "version_added": "13"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "deno": {
               "version_added": "1.0"
@@ -315,7 +315,7 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"

--- a/api/FileReader.json
+++ b/api/FileReader.json
@@ -261,7 +261,7 @@
               "notes": "The <code>error</code> property returns a <code>DOMError</code> object."
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"

--- a/api/FileSystemFlags.json
+++ b/api/FileSystemFlags.json
@@ -10,7 +10,7 @@
             "prefix": "webkit"
           },
           "chrome_android": {
-            "version_added": true,
+            "version_added": "18",
             "prefix": "webkit"
           },
           "edge": {
@@ -39,7 +39,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true,
+            "version_added": "1.0",
             "prefix": "webkit"
           },
           "webview_android": {
@@ -63,7 +63,7 @@
               "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "prefix": "webkit"
             },
             "edge": {
@@ -96,7 +96,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "prefix": "webkit"
             },
             "webview_android": {
@@ -121,7 +121,7 @@
               "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "prefix": "webkit"
             },
             "edge": {
@@ -154,7 +154,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "prefix": "webkit"
             },
             "webview_android": {

--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -15,9 +15,16 @@
               "version_removed": "34"
             }
           ],
-          "chrome_android": {
-            "version_added": true
-          },
+          "chrome_android": [
+            {
+              "version_added": "35"
+            },
+            {
+              "prefix": "webkit",
+              "version_added": "25",
+              "version_removed": "34"
+            }
+          ],
           "edge": {
             "version_added": "12"
           },
@@ -56,9 +63,16 @@
           "safari_ios": {
             "version_added": "10.3"
           },
-          "samsunginternet_android": {
-            "version_added": true
-          },
+          "samsunginternet_android": [
+            {
+              "version_added": "3.0"
+            },
+            {
+              "prefix": "webkit",
+              "version_added": "1.5",
+              "version_removed": "2.0"
+            }
+          ],
           "webview_android": {
             "version_added": false
           }
@@ -84,9 +98,16 @@
                 "version_removed": "34"
               }
             ],
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": [
+              {
+                "version_added": "35"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "25",
+                "version_removed": "34"
+              }
+            ],
             "edge": {
               "version_added": "12"
             },
@@ -125,9 +146,16 @@
             "safari_ios": {
               "version_added": "10.3"
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5",
+                "version_removed": "2.0"
+              }
+            ],
             "webview_android": {
               "version_added": false
             }
@@ -285,9 +313,16 @@
                 "version_removed": "34"
               }
             ],
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": [
+              {
+                "version_added": "35"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "25",
+                "version_removed": "34"
+              }
+            ],
             "edge": {
               "version_added": "12"
             },
@@ -326,9 +361,16 @@
             "safari_ios": {
               "version_added": "10.3"
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5",
+                "version_removed": "2.0"
+              }
+            ],
             "webview_android": {
               "version_added": false
             }

--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -15,16 +15,9 @@
               "version_removed": "34"
             }
           ],
-          "chrome_android": [
-            {
-              "version_added": "35"
-            },
-            {
-              "prefix": "webkit",
-              "version_added": "25",
-              "version_removed": "34"
-            }
-          ],
+          "chrome_android": {
+            "version_added": true
+          },
           "edge": {
             "version_added": "12"
           },
@@ -63,16 +56,9 @@
           "safari_ios": {
             "version_added": "10.3"
           },
-          "samsunginternet_android": [
-            {
-              "version_added": "3.0"
-            },
-            {
-              "prefix": "webkit",
-              "version_added": "1.5",
-              "version_removed": "2.0"
-            }
-          ],
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": false
           }
@@ -98,16 +84,9 @@
                 "version_removed": "34"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "35"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "25",
-                "version_removed": "34"
-              }
-            ],
+            "chrome_android": {
+              "version_added": true
+            },
             "edge": {
               "version_added": "12"
             },
@@ -146,16 +125,9 @@
             "safari_ios": {
               "version_added": "10.3"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "3.0"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "1.5",
-                "version_removed": "2.0"
-              }
-            ],
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": false
             }
@@ -313,16 +285,9 @@
                 "version_removed": "34"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "35"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "25",
-                "version_removed": "34"
-              }
-            ],
+            "chrome_android": {
+              "version_added": true
+            },
             "edge": {
               "version_added": "12"
             },
@@ -361,16 +326,9 @@
             "safari_ios": {
               "version_added": "10.3"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "3.0"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "1.5",
-                "version_removed": "2.0"
-              }
-            ],
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": false
             }

--- a/api/GamepadEvent.json
+++ b/api/GamepadEvent.json
@@ -63,16 +63,9 @@
           "safari_ios": {
             "version_added": "10.3"
           },
-          "samsunginternet_android": [
-            {
-              "version_added": "3.0"
-            },
-            {
-              "prefix": "webkit",
-              "version_added": "1.5",
-              "version_removed": "2.0"
-            }
-          ],
+          "samsunginternet_android": {
+            "version_added": true
+          },
           "webview_android": {
             "version_added": "37"
           }
@@ -196,16 +189,9 @@
             "safari_ios": {
               "version_added": "10.3"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "3.0"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "1.5",
-                "version_removed": "2.0"
-              }
-            ],
+            "samsunginternet_android": {
+              "version_added": true
+            },
             "webview_android": {
               "version_added": "37"
             }

--- a/api/GamepadEvent.json
+++ b/api/GamepadEvent.json
@@ -63,9 +63,16 @@
           "safari_ios": {
             "version_added": "10.3"
           },
-          "samsunginternet_android": {
-            "version_added": true
-          },
+          "samsunginternet_android": [
+            {
+              "version_added": "3.0"
+            },
+            {
+              "prefix": "webkit",
+              "version_added": "1.5",
+              "version_removed": "2.0"
+            }
+          ],
           "webview_android": {
             "version_added": "37"
           }
@@ -189,9 +196,16 @@
             "safari_ios": {
               "version_added": "10.3"
             },
-            "samsunginternet_android": {
-              "version_added": true
-            },
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0"
+              },
+              {
+                "prefix": "webkit",
+                "version_added": "1.5",
+                "version_removed": "2.0"
+              }
+            ],
             "webview_android": {
               "version_added": "37"
             }

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -403,7 +403,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -453,7 +453,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -1111,7 +1111,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -1161,7 +1161,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -1260,7 +1260,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -1416,6 +1416,9 @@
             "safari_ios": {
               "version_added": "8"
             },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -1551,7 +1554,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -1601,7 +1604,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -2209,7 +2212,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -2236,10 +2239,10 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -2258,7 +2261,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -2286,10 +2289,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -2474,7 +2477,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -2505,7 +2508,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -2532,10 +2535,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -2670,7 +2673,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -2701,7 +2704,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -2728,10 +2731,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -2749,7 +2752,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -2776,10 +2779,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -2817,7 +2820,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -3021,7 +3024,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -3152,7 +3155,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -3179,10 +3182,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -3220,7 +3223,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -3250,7 +3253,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -3277,10 +3280,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -3318,7 +3321,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -3369,6 +3372,9 @@
               "version_added": false
             },
             "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
               "version_added": false
             },
             "webview_android": {
@@ -3552,7 +3558,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -3579,10 +3585,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {
@@ -3701,7 +3707,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -3751,7 +3757,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -3850,7 +3856,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -3985,7 +3991,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "edge": {
               "version_added": "12"
@@ -4012,10 +4018,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "43"
             }
           },
           "status": {

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2212,7 +2212,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -2239,10 +2239,10 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": true
             }
           },
           "status": {
@@ -2261,7 +2261,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -2289,10 +2289,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": true
             }
           },
           "status": {
@@ -2508,7 +2508,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -2535,10 +2535,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": true
             }
           },
           "status": {
@@ -2704,7 +2704,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -2731,10 +2731,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": true
             }
           },
           "status": {
@@ -2752,7 +2752,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -2779,10 +2779,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": true
             }
           },
           "status": {
@@ -3155,7 +3155,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -3182,10 +3182,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": true
             }
           },
           "status": {
@@ -3253,7 +3253,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -3280,10 +3280,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": true
             }
           },
           "status": {
@@ -3558,7 +3558,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -3585,10 +3585,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": true
             }
           },
           "status": {
@@ -3991,7 +3991,7 @@
               "version_added": "43"
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": true
             },
             "edge": {
               "version_added": "12"
@@ -4018,10 +4018,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": true
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": true
             }
           },
           "status": {

--- a/api/HTMLOListElement.json
+++ b/api/HTMLOListElement.json
@@ -104,7 +104,7 @@
               "version_added": "18"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -131,7 +131,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"

--- a/api/IDBCursor.json
+++ b/api/IDBCursor.json
@@ -107,7 +107,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -135,7 +135,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -157,7 +157,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -185,7 +185,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -256,7 +256,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -284,7 +284,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -306,7 +306,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -334,7 +334,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -356,7 +356,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -384,7 +384,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -454,7 +454,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -482,7 +482,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -553,7 +553,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -581,7 +581,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -603,7 +603,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -631,7 +631,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"

--- a/api/IDBCursorWithValue.json
+++ b/api/IDBCursorWithValue.json
@@ -93,7 +93,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -121,10 +121,10 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/IDBKeyRange.json
+++ b/api/IDBKeyRange.json
@@ -45,12 +45,26 @@
             "version_added": "10",
             "partial_implementation": true
           },
-          "opera": {
-            "version_added": "15"
-          },
-          "opera_android": {
-            "version_added": "14"
-          },
+          "opera": [
+            {
+              "version_added": "15"
+            },
+            {
+              "version_added": "15",
+              "version_removed": "44",
+              "prefix": "webkit"
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "14"
+            },
+            {
+              "version_added": "14",
+              "version_removed": "44",
+              "prefix": "webkit"
+            }
+          ],
           "safari": {
             "version_added": "7"
           },

--- a/api/IDBKeyRange.json
+++ b/api/IDBKeyRange.json
@@ -15,9 +15,16 @@
               "prefix": "webkit"
             }
           ],
-          "chrome_android": {
-            "version_added": true
-          },
+          "chrome_android": [
+            {
+              "version_added": "25"
+            },
+            {
+              "version_added": "25",
+              "version_removed": "57",
+              "prefix": "webkit"
+            }
+          ],
           "edge": {
             "version_added": "12"
           },
@@ -50,12 +57,26 @@
           "safari_ios": {
             "version_added": "8"
           },
-          "samsunginternet_android": {
-            "version_added": true
-          },
-          "webview_android": {
-            "version_added": true
-          }
+          "samsunginternet_android": [
+            {
+              "version_added": "1.5"
+            },
+            {
+              "version_added": "1.5",
+              "version_removed": "7.0",
+              "prefix": "webkit"
+            }
+          ],
+          "webview_android": [
+            {
+              "version_added": "≤37"
+            },
+            {
+              "version_added": "≤37",
+              "version_removed": "57",
+              "prefix": "webkit"
+            }
+          ]
         },
         "status": {
           "experimental": false,
@@ -72,7 +93,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -100,10 +121,10 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -171,7 +192,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -199,10 +220,10 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -221,7 +242,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -249,10 +270,10 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -271,7 +292,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -299,10 +320,10 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -321,7 +342,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -349,10 +370,10 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -371,7 +392,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -399,10 +420,10 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -421,7 +442,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -449,10 +470,10 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -471,7 +492,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -499,10 +520,10 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/IDBRequest.json
+++ b/api/IDBRequest.json
@@ -156,10 +156,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "35"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "35"
               },
               "safari": {
                 "version_added": false
@@ -192,7 +192,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -220,10 +220,10 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -242,7 +242,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -270,7 +270,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -292,7 +292,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -320,7 +320,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -342,7 +342,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -370,7 +370,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -392,7 +392,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -420,7 +420,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -442,7 +442,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -470,7 +470,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -493,7 +493,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -521,10 +521,10 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -543,7 +543,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -571,7 +571,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"

--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -93,7 +93,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -121,7 +121,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -144,7 +144,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -172,10 +172,10 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -244,7 +244,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -272,10 +272,10 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -492,7 +492,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -520,10 +520,10 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -542,7 +542,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -570,7 +570,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -592,7 +592,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -620,7 +620,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -691,7 +691,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -719,7 +719,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -741,7 +741,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -769,7 +769,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -791,7 +791,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -819,7 +819,7 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"

--- a/api/IDBVersionChangeEvent.json
+++ b/api/IDBVersionChangeEvent.json
@@ -14,9 +14,15 @@
               "prefix": "webkit"
             }
           ],
-          "chrome_android": {
-            "version_added": true
-          },
+          "chrome_android": [
+            {
+              "version_added": "25"
+            },
+            {
+              "version_added": "18",
+              "prefix": "webkit"
+            }
+          ],
           "edge": {
             "version_added": "12"
           },
@@ -49,9 +55,15 @@
           "safari_ios": {
             "version_added": "8"
           },
-          "samsunginternet_android": {
-            "version_added": true
-          },
+          "samsunginternet_android": [
+            {
+              "version_added": "1.5"
+            },
+            {
+              "version_added": "1.0",
+              "prefix": "webkit"
+            }
+          ],
           "webview_android": [
             {
               "version_added": "≤37"

--- a/api/IDBVersionChangeEvent.json
+++ b/api/IDBVersionChangeEvent.json
@@ -43,12 +43,24 @@
             "version_added": "10",
             "partial_implementation": true
           },
-          "opera": {
-            "version_added": "15"
-          },
-          "opera_android": {
-            "version_added": true
-          },
+          "opera": [
+            {
+              "version_added": "15"
+            },
+            {
+              "version_added": "15",
+              "prefix": "webkit"
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "14"
+            },
+            {
+              "version_added": "14",
+              "prefix": "webkit"
+            }
+          ],
           "safari": {
             "version_added": "7"
           },

--- a/api/MediaStreamAudioSourceNode.json
+++ b/api/MediaStreamAudioSourceNode.json
@@ -9,7 +9,7 @@
             "version_added": "23"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "25"
           },
           "edge": {
             "version_added": "12"
@@ -36,7 +36,7 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
             "version_added": "≤37"
@@ -111,7 +111,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤79"
@@ -126,10 +126,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"
@@ -138,7 +138,7 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"

--- a/api/MediaTrackConstraints.json
+++ b/api/MediaTrackConstraints.json
@@ -9,7 +9,7 @@
             "version_added": "59"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "59"
           },
           "edge": {
             "version_added": "≤18"
@@ -36,7 +36,7 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "7.0"
           },
           "webview_android": {
             "version_added": "59"
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -119,7 +119,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "deno": {
               "version_added": "1.4"
@@ -149,7 +149,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -171,7 +171,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "deno": {
               "version_added": false
@@ -201,7 +201,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -223,7 +223,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "deno": {
               "version_added": "1.4"
@@ -253,7 +253,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -275,7 +275,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "deno": {
               "version_added": "1.4"
@@ -305,7 +305,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -327,7 +327,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "deno": {
               "version_added": "1.12"
@@ -357,7 +357,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"

--- a/api/Metadata.json
+++ b/api/Metadata.json
@@ -9,7 +9,7 @@
             "prefix": "webkit"
           },
           "chrome_android": {
-            "version_added": true,
+            "version_added": "18",
             "prefix": "webkit"
           },
           "edge": {
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true,
+            "version_added": "1.0",
             "prefix": "webkit"
           },
           "webview_android": {
@@ -59,7 +59,7 @@
               "version_added": "13"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤79"
@@ -86,7 +86,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": false
@@ -107,7 +107,7 @@
               "version_added": "13"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤79"
@@ -134,7 +134,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1059,7 +1059,7 @@
               "version_added": "23"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "17",
@@ -1083,7 +1083,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari": {
               "version_added": "5.1",
@@ -1094,7 +1094,7 @@
               "version_removed": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -1611,7 +1611,7 @@
               "notes": "Available on all platforms behind a flag, but currently only works on desktop in an <a href='https://webvr.info/get-chrome/'>experimental version of Chrome</a> (other builds won't return any devices when <code>Navigator.getVRDisplays()</code> is invoked)."
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "79",
               "version_removed": "80",
               "notes": "Currently supported only by Google Daydream."
             },
@@ -1648,7 +1648,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "12.0",
               "version_removed": "13.0",
               "notes": "Currently supported only by Google Daydream."
             },

--- a/api/NodeList.json
+++ b/api/NodeList.json
@@ -153,7 +153,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -168,10 +168,10 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "1"
@@ -180,10 +180,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -250,7 +250,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -265,10 +265,10 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "1"
@@ -277,10 +277,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/PaymentAddress.json
+++ b/api/PaymentAddress.json
@@ -35,7 +35,7 @@
             "version_added": "11.3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "6.0"
           },
           "webview_android": {
             "version_added": false
@@ -82,7 +82,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -130,7 +130,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -178,7 +178,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -226,7 +226,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -278,7 +278,7 @@
               "version_removed": "12.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -326,7 +326,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -374,7 +374,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -422,7 +422,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -470,7 +470,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -518,7 +518,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -566,7 +566,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false
@@ -615,7 +615,7 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PaymentInstruments.json
+++ b/api/PaymentInstruments.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "10.0"
           },
           "webview_android": {
             "version_added": false
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -132,7 +132,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -181,7 +181,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -230,7 +230,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -279,7 +279,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -328,7 +328,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PaymentManager.json
+++ b/api/PaymentManager.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "10.0"
           },
           "webview_android": {
             "version_added": false
@@ -129,7 +129,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -177,7 +177,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PaymentMethodChangeEvent.json
+++ b/api/PaymentMethodChangeEvent.json
@@ -38,7 +38,7 @@
             "version_added": "12.2"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "12.0"
           },
           "webview_android": {
             "version_added": false
@@ -87,7 +87,7 @@
               "version_added": "12.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "12.0"
             },
             "webview_android": {
               "version_added": false
@@ -136,7 +136,7 @@
               "version_added": "12.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "12.0"
             },
             "webview_android": {
               "version_added": false
@@ -185,7 +185,7 @@
               "version_added": "12.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "12.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -367,7 +367,7 @@
               "version_added": "76"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "76"
             },
             "edge": {
               "version_added": "79"
@@ -396,7 +396,7 @@
               "version_added": "12.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "12.0"
             },
             "webview_android": {
               "version_added": false
@@ -519,7 +519,7 @@
               "version_added": "76"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "76"
             },
             "edge": {
               "version_added": "79"
@@ -548,7 +548,7 @@
               "version_added": "12.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "12.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PaymentRequestEvent.json
+++ b/api/PaymentRequestEvent.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "10.0"
           },
           "webview_android": {
             "version_added": false
@@ -85,7 +85,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -181,7 +181,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -230,7 +230,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -279,7 +279,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -329,7 +329,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -378,7 +378,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -427,7 +427,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -477,7 +477,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -526,7 +526,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -575,7 +575,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -212,7 +212,7 @@
               "version_added": "78"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "78"
             },
             "edge": {
               "version_added": "79"
@@ -241,7 +241,7 @@
               "version_added": "12.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "12.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/RTCDTMFSender.json
+++ b/api/RTCDTMFSender.json
@@ -283,7 +283,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/RadioNodeList.json
+++ b/api/RadioNodeList.json
@@ -9,7 +9,7 @@
             "version_added": "34"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "34"
           },
           "edge": {
             "version_added": "12"
@@ -24,10 +24,10 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "21"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "21"
           },
           "safari": {
             "version_added": "10"
@@ -36,7 +36,7 @@
             "version_added": "9"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "2.0"
           },
           "webview_android": {
             "version_added": "≤37"
@@ -57,7 +57,7 @@
               "version_added": "34"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "34"
             },
             "edge": {
               "version_added": "12"
@@ -72,10 +72,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "21"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "21"
             },
             "safari": {
               "version_added": "10"
@@ -84,7 +84,7 @@
               "version_added": "9"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "≤37"

--- a/api/ScriptProcessorNode.json
+++ b/api/ScriptProcessorNode.json
@@ -8,7 +8,7 @@
             "version_added": "14"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -35,7 +35,7 @@
             "version_added": "6"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": "≤37"
@@ -56,7 +56,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -83,7 +83,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -104,7 +104,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -131,7 +131,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -152,7 +152,7 @@
               "version_added": "14"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -179,7 +179,7 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "≤37"

--- a/api/SharedWorkerGlobalScope.json
+++ b/api/SharedWorkerGlobalScope.json
@@ -9,7 +9,7 @@
             "version_added": "4"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "79"
@@ -36,10 +36,10 @@
             "version_added": "7"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -56,7 +56,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -74,7 +74,7 @@
               "version_added": "10.6"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": false
@@ -83,10 +83,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -175,7 +175,7 @@
               "version_added": "10.6"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": false
@@ -187,7 +187,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -206,7 +206,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": "40"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "79"
@@ -233,10 +233,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -273,7 +273,7 @@
               "version_added": "10.6"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": false
@@ -285,7 +285,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/SpeechGrammarList.json
+++ b/api/SpeechGrammarList.json
@@ -11,7 +11,7 @@
           },
           "chrome_android": {
             "prefix": "webkit",
-            "version_added": true
+            "version_added": "33"
           },
           "edge": {
             "prefix": "webkit",
@@ -40,11 +40,11 @@
           },
           "samsunginternet_android": {
             "prefix": "webkit",
-            "version_added": true
+            "version_added": "2.0"
           },
           "webview_android": {
             "prefix": "webkit",
-            "version_added": true
+            "version_added": "4.4.3"
           }
         },
         "status": {
@@ -64,7 +64,8 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "prefix": "webkit",
+              "version_added": "33"
             },
             "edge": {
               "prefix": "webkit",
@@ -92,11 +93,12 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "prefix": "webkit",
+              "version_added": "2.0"
             },
             "webview_android": {
               "prefix": "webkit",
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -115,7 +117,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -142,10 +144,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -164,7 +166,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -191,10 +193,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -213,7 +215,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -240,10 +242,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -262,7 +264,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -289,10 +291,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -72,7 +72,7 @@
             },
             "chrome_android": {
               "prefix": "webkit",
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "prefix": "webkit",
@@ -103,7 +103,7 @@
             },
             "samsunginternet_android": {
               "prefix": "webkit",
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "prefix": "webkit",
@@ -126,7 +126,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -153,10 +153,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -176,7 +176,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "79"
@@ -203,10 +203,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -226,7 +226,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "79"
@@ -253,10 +253,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -275,7 +275,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -302,10 +302,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -325,7 +325,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "79"
@@ -352,10 +352,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -375,7 +375,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "79"
@@ -402,10 +402,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -424,7 +424,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -451,10 +451,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -473,7 +473,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -500,10 +500,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -522,7 +522,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -549,10 +549,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -571,7 +571,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -598,10 +598,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -621,7 +621,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "79"
@@ -648,10 +648,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -670,7 +670,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -697,10 +697,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -719,7 +719,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -746,10 +746,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -768,7 +768,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -795,10 +795,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -817,7 +817,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -844,10 +844,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -866,7 +866,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -893,10 +893,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -915,7 +915,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -942,10 +942,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -964,7 +964,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -991,10 +991,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1013,7 +1013,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -1040,10 +1040,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1062,7 +1062,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -1089,10 +1089,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1111,7 +1111,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -1138,10 +1138,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1160,7 +1160,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -1187,10 +1187,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1210,7 +1210,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "79"
@@ -1237,10 +1237,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1258,7 +1258,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -1285,10 +1285,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1308,7 +1308,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "79"
@@ -1335,10 +1335,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1358,7 +1358,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "79"
@@ -1385,10 +1385,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1408,7 +1408,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "79"
@@ -1435,10 +1435,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1458,7 +1458,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "79"
@@ -1485,10 +1485,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1507,7 +1507,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -1534,10 +1534,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1557,7 +1557,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "79"
@@ -1584,10 +1584,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1606,7 +1606,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -1633,10 +1633,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/SpeechRecognitionAlternative.json
+++ b/api/SpeechRecognitionAlternative.json
@@ -9,7 +9,7 @@
             "version_added": "33"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "33"
           },
           "edge": {
             "version_added": "≤79"
@@ -36,10 +36,10 @@
             "version_added": "14.5"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "2.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "4.4.3"
           }
         },
         "status": {
@@ -57,7 +57,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -84,10 +84,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -106,7 +106,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -133,10 +133,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/SpeechRecognitionEvent.json
+++ b/api/SpeechRecognitionEvent.json
@@ -11,7 +11,7 @@
           },
           "chrome_android": {
             "prefix": "webkit",
-            "version_added": true
+            "version_added": "33"
           },
           "edge": {
             "prefix": "webkit",
@@ -40,7 +40,7 @@
           },
           "samsunginternet_android": {
             "prefix": "webkit",
-            "version_added": true
+            "version_added": "2.0"
           },
           "webview_android": {
             "prefix": "webkit",
@@ -63,7 +63,7 @@
             },
             "chrome_android": {
               "prefix": "webkit",
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "prefix": "webkit",
@@ -92,7 +92,7 @@
             },
             "samsunginternet_android": {
               "prefix": "webkit",
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "prefix": "webkit",
@@ -114,7 +114,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -141,7 +141,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -162,7 +162,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -189,7 +189,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -211,7 +211,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -238,7 +238,7 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -260,7 +260,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -287,7 +287,7 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "≤37"

--- a/api/SpeechRecognitionResult.json
+++ b/api/SpeechRecognitionResult.json
@@ -9,7 +9,7 @@
             "version_added": "33"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "33"
           },
           "edge": {
             "version_added": "≤79"
@@ -36,10 +36,10 @@
             "version_added": "14.5"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "2.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "4.4.3"
           }
         },
         "status": {
@@ -57,7 +57,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -84,10 +84,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -106,7 +106,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -133,10 +133,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -155,7 +155,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -182,10 +182,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/SpeechRecognitionResultList.json
+++ b/api/SpeechRecognitionResultList.json
@@ -9,7 +9,7 @@
             "version_added": "33"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "33"
           },
           "edge": {
             "version_added": "≤79"
@@ -36,10 +36,10 @@
             "version_added": "14.5"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "2.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "4.4.3"
           }
         },
         "status": {
@@ -57,7 +57,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -84,10 +84,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -106,7 +106,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "≤79"
@@ -133,10 +133,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/StyleSheet.json
+++ b/api/StyleSheet.json
@@ -9,7 +9,7 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -36,10 +36,10 @@
             "version_added": "1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -57,7 +57,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -84,10 +84,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -106,7 +106,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -133,10 +133,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -155,7 +155,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -182,10 +182,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -204,7 +204,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -231,10 +231,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -253,7 +253,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -280,10 +280,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -302,7 +302,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -329,10 +329,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -351,7 +351,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -378,10 +378,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/StyleSheetList.json
+++ b/api/StyleSheetList.json
@@ -9,7 +9,7 @@
             "version_added": "1"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -36,10 +36,10 @@
             "version_added": "1"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -57,7 +57,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -84,10 +84,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -106,7 +106,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -133,10 +133,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/Text.json
+++ b/api/Text.json
@@ -39,7 +39,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -88,7 +88,7 @@
               "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -252,7 +252,7 @@
               "notes": "Before Samsung Internet 2.0, the <code>offset</code> parameter was optional."
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Before version 4.4, the <code>offset</code> parameter was optional."
             }
           },
@@ -302,7 +302,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -779,7 +779,7 @@
               "version_added": "4"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -806,10 +806,10 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/Touch.json
+++ b/api/Touch.json
@@ -9,7 +9,7 @@
             "version_added": "22"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "25"
           },
           "edge": {
             "version_added": "≤18"
@@ -43,10 +43,10 @@
             "version_added": true
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -208,7 +208,7 @@
               "version_added": "22"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤18"
@@ -242,10 +242,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -264,7 +264,7 @@
               "version_added": "22"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤18"
@@ -298,10 +298,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -376,7 +376,7 @@
               "version_added": "22"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤18"
@@ -410,10 +410,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -432,7 +432,7 @@
               "version_added": "22"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤18"
@@ -466,10 +466,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -488,7 +488,7 @@
               "version_added": "22"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤18"
@@ -522,10 +522,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -712,7 +712,7 @@
               "version_added": "22"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤18"
@@ -746,10 +746,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -768,7 +768,7 @@
               "version_added": "22"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤18"
@@ -802,10 +802,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -824,7 +824,7 @@
               "version_added": "22"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤18"
@@ -858,10 +858,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/TouchEvent.json
+++ b/api/TouchEvent.json
@@ -132,7 +132,7 @@
               "version_added": "22"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤18"
@@ -166,7 +166,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -188,7 +188,7 @@
               "version_added": "22"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤18"
@@ -222,7 +222,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -244,7 +244,7 @@
               "version_added": "22"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤18"
@@ -278,7 +278,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -300,7 +300,7 @@
               "version_added": "22"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤18"
@@ -334,7 +334,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -356,7 +356,7 @@
               "version_added": "22"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤18"
@@ -390,7 +390,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -412,7 +412,7 @@
               "version_added": "22"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤18"
@@ -446,7 +446,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -468,7 +468,7 @@
               "version_added": "22"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "≤18"
@@ -502,7 +502,7 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "≤37"

--- a/api/TouchList.json
+++ b/api/TouchList.json
@@ -9,7 +9,7 @@
             "version_added": "18"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "≤18"
@@ -43,10 +43,10 @@
             "version_added": "2"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -64,7 +64,7 @@
               "version_added": "18"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤18"
@@ -98,10 +98,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -120,7 +120,7 @@
               "version_added": "18"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "≤18"
@@ -154,10 +154,10 @@
               "version_added": "2"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/ValidityState.json
+++ b/api/ValidityState.json
@@ -9,7 +9,7 @@
             "version_added": "15"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -36,7 +36,7 @@
             "version_added": "5"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": "4"
@@ -57,7 +57,7 @@
               "version_added": "25"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "14"
@@ -84,7 +84,7 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4"
@@ -349,7 +349,7 @@
               "version_added": "15"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12",
@@ -378,7 +378,7 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "4"
@@ -400,7 +400,7 @@
               "version_added": "40"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "40"
             },
             "edge": {
               "version_added": "17"
@@ -427,7 +427,7 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": "67"

--- a/api/WebGLShader.json
+++ b/api/WebGLShader.json
@@ -39,7 +39,7 @@
             "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/WebGLTexture.json
+++ b/api/WebGLTexture.json
@@ -39,7 +39,7 @@
             "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/WebGLUniformLocation.json
+++ b/api/WebGLUniformLocation.json
@@ -39,7 +39,7 @@
             "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -305,7 +305,7 @@
               "version_added": "31"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "31"
             },
             "edge": {
               "version_added": "≤79"
@@ -332,7 +332,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "≤37"

--- a/api/Window.json
+++ b/api/Window.json
@@ -700,7 +700,7 @@
                 "version_added": "30"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "30"
               },
               "edge": {
                 "version_added": "12"
@@ -727,10 +727,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "4.4"
               }
             },
             "status": {
@@ -797,7 +797,7 @@
                 "version_added": "1"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -824,10 +824,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -5686,7 +5686,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -5713,10 +5713,10 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -5735,7 +5735,7 @@
               "version_added": "1"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -5762,10 +5762,10 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -6716,7 +6716,7 @@
               "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "prefix": "webkit"
             },
             "edge": {
@@ -6745,7 +6745,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "prefix": "webkit"
             },
             "webview_android": {
@@ -6977,7 +6977,7 @@
               "prefix": "webkit"
             },
             "chrome_android": {
-              "version_added": true,
+              "version_added": "18",
               "prefix": "webkit"
             },
             "edge": {
@@ -7006,11 +7006,11 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "1.0",
               "prefix": "webkit"
             },
             "webview_android": {
-              "version_added": true,
+              "version_added": "1",
               "prefix": "webkit"
             }
           },
@@ -8975,7 +8975,7 @@
               "version_added": "33"
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "33"
             },
             "edge": {
               "version_added": "14"
@@ -9002,7 +9002,7 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": false,

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -9,7 +9,7 @@
             "version_added": "4"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "deno": {
             "version_added": "1.0"
@@ -39,7 +39,7 @@
             "version_added": "5"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": "≤37"

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -9,7 +9,7 @@
             "version_added": "4"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "deno": {
             "version_added": "1.8"
@@ -39,10 +39,10 @@
             "version_added": "5"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "1"
           }
         },
         "status": {
@@ -87,10 +87,10 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -136,10 +136,10 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -185,10 +185,10 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -393,10 +393,10 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -704,10 +704,10 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -753,10 +753,10 @@
               "version_added": "10"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {
@@ -997,10 +997,10 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -843,7 +843,7 @@
                 "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": true
+                "version_added": "1"
               }
             },
             "status": {
@@ -962,7 +962,7 @@
               "version_added": "31"
             },
             "chrome_android": {
-              "version_added": "55"
+              "version_added": "31"
             },
             "edge": {
               "version_added": "12"
@@ -995,10 +995,10 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "55"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1015,7 +1015,7 @@
                 "version_added": "31"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "31"
               },
               "edge": {
                 "version_added": "12"
@@ -1048,10 +1048,10 @@
                 "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
-                "version_added": "55"
+                "version_added": "4.4.3"
               }
             },
             "status": {
@@ -1069,7 +1069,7 @@
                 "version_added": "31"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "31"
               },
               "edge": {
                 "version_added": "12"
@@ -1096,10 +1096,10 @@
                 "version_added": "5"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
-                "version_added": "55"
+                "version_added": "4.4.3"
               }
             },
             "status": {
@@ -1117,7 +1117,7 @@
                 "version_added": "31"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "31"
               },
               "edge": {
                 "version_added": "12"
@@ -1144,10 +1144,10 @@
                 "version_added": "7"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
-                "version_added": "55"
+                "version_added": "4.4.3"
               }
             },
             "status": {
@@ -1165,7 +1165,7 @@
                 "version_added": "31"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "31"
               },
               "edge": {
                 "version_added": "79"
@@ -1198,10 +1198,10 @@
                 "version_added": "7"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "2.0"
               },
               "webview_android": {
-                "version_added": "55"
+                "version_added": "4.4.3"
               }
             },
             "status": {
@@ -1369,7 +1369,7 @@
                 "version_added": "9"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1396,7 +1396,7 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "≤37"
@@ -1418,7 +1418,7 @@
                 "version_added": "22"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "12"
@@ -1445,7 +1445,7 @@
                 "version_added": "7"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": "≤37"
@@ -1467,7 +1467,7 @@
                 "version_added": "22"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "25"
               },
               "edge": {
                 "version_added": "12"
@@ -1494,7 +1494,7 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.5"
               },
               "webview_android": {
                 "version_added": "≤37"
@@ -1516,7 +1516,7 @@
                 "version_added": "6"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "edge": {
                 "version_added": "12"
@@ -1543,7 +1543,7 @@
                 "version_added": "6"
               },
               "samsunginternet_android": {
-                "version_added": true
+                "version_added": "1.0"
               },
               "webview_android": {
                 "version_added": "≤37"

--- a/api/_globals/performance.json
+++ b/api/_globals/performance.json
@@ -9,7 +9,7 @@
             "version_added": "6"
           },
           "chrome_android": {
-            "version_added": true
+            "version_added": "18"
           },
           "deno": {
             "version_added": "1.0"
@@ -39,10 +39,10 @@
             "version_added": "9"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": true
+            "version_added": "≤37"
           }
         },
         "status": {


### PR DESCRIPTION
This PR mirrors the data from Chrome Desktop to the other Chrome derivatives (particularly Chrome Android, Samsung Internet, and WebView Android), as well as some Opera data.  This PR focuses solely on changes that are straightforward and easy to review.
