### PR TITLE
Remove entry for Node.getFeature

### DIFF
--- a/api/Node.json
+++ b/api/Node.json
@@ -402,56 +402,6 @@
           }
         }
       },
-      "getFeature": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/getFeature",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "≤12.1",
-              "version_removed": "15"
-            },
-            "opera_android": {
-              "version_added": "≤12.1",
-              "version_removed": "14"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "getRootNode": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/getRootNode",


### PR DESCRIPTION
This method was only supported by Opera, and removed in… Opera 15.

It will not be mentioned on MDN either (the page doesn't exist, mention in Node is about to be removed)

Time to go…