### PR TITLE
Update Blob support on Opera

### DIFF
--- a/api/Blob.json
+++ b/api/Blob.json
@@ -134,7 +134,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "63"
             },
             "opera_android": {
               "version_added": "54"
@@ -335,7 +335,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "63"
             },
             "opera_android": {
               "version_added": "54"


### PR DESCRIPTION
#### Summary
Adds support for arrayBuffer() et stream') for Opera in the File API.

#### Test results and supporting details
Being tested manually by installing differents versions of Opera until the version 63 who was the first to execute arrayBuffer() and stream().

#### Related issues
None