### PR TITLE
menus.OnClickedData.srcUrl returned post-redirect URL

### DIFF
--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -454,7 +454,7 @@
                   {
                     "version_added": "59",
                     "version_removed": "94",
-                    "notes": "Returns a post-redirect URL rather than the raw <code>&lt;img src&gt;<code> value."
+                    "notes": "Returns a post-redirect URL rather than the raw value of the <code>src<code> attribute of the clicked element."
                   }
                 ],
                 "firefox_android": {

--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -438,6 +438,37 @@
               }
             }
           },
+          "srcUrl": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": [
+                  {
+                    "version_added": "48"
+                  },
+                  {
+                    "version_added": "59",
+                    "version_removed": "94",
+                    "notes": "Returns a post-redirect URL rather than the raw <code>&lt;img src&gt;<code> value."
+                  }
+                ],
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": "14"
+                }
+              }
+            }
+          },
           "targetElementId": {
             "__compat": {
               "support": {


### PR DESCRIPTION
#### Summary

Add details for the `srcUrl` property to `menus.OnClickedData` including a note that between versions 59 and 94 it incorrectly returned the post-redirect URL rather than the `<img src>` value.

#### Test results and supporting details

`npm test` executed with no errors

#### Related issues

Provide complementary browser compatibility data for [menus.OnClickedData.srcUrl returns <img src> #10214](https://github.com/mdn/content/pull/10214) which addresses the documentation requirements for [Bug 1659155](https://bugzilla.mozilla.org/show_bug.cgi?id=1659155).
