### PR TITLE
Fix Chrome data for Gamepad APIs

### DIFF
--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -8,26 +8,12 @@
           "https://w3c.github.io/gamepad/extensions.html#partial-gamepad-interface"
         ],
         "support": {
-          "chrome": [
-            {
-              "version_added": "35"
-            },
-            {
-              "prefix": "webkit",
-              "version_added": "21",
-              "version_removed": "34"
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_added": "35"
-            },
-            {
-              "prefix": "webkit",
-              "version_added": "25",
-              "version_removed": "34"
-            }
-          ],
+          "chrome": {
+            "version_added": "21"
+          },
+          "chrome_android": {
+            "version_added": "25"
+          },
           "edge": {
             "version_added": "12"
           },
@@ -40,44 +26,23 @@
           "ie": {
             "version_added": false
           },
-          "opera": [
-            {
-              "version_added": "22"
-            },
-            {
-              "prefix": "webkit",
-              "version_added": "15",
-              "version_removed": "21"
-            }
-          ],
-          "opera_android": [
-            {
-              "version_added": "22"
-            },
-            {
-              "prefix": "webkit",
-              "version_added": "14",
-              "version_removed": "21"
-            }
-          ],
+          "opera": {
+            "version_added": "15"
+          },
+          "opera_android": {
+            "version_added": "14"
+          },
           "safari": {
             "version_added": "10.1"
           },
           "safari_ios": {
             "version_added": "10.3"
           },
-          "samsunginternet_android": [
-            {
-              "version_added": "4.0"
-            },
-            {
-              "prefix": "webkit",
-              "version_added": "2.0",
-              "version_removed": "3.0"
-            }
-          ],
+          "samsunginternet_android": {
+            "version_added": "1.5"
+          },
           "webview_android": {
-            "version_added": false
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -91,26 +56,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Gamepad/axes",
           "spec_url": "https://w3c.github.io/gamepad/#dom-gamepad-axes",
           "support": {
-            "chrome": [
-              {
-                "version_added": "35"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "21",
-                "version_removed": "34"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "35"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "25",
-                "version_removed": "34"
-              }
-            ],
+            "chrome": {
+              "version_added": "21"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -123,44 +74,23 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "15",
-                "version_removed": "21"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "14",
-                "version_removed": "21"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "10.1"
             },
             "safari_ios": {
               "version_added": "10.3"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "4.0"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "2.0",
-                "version_removed": "3.0"
-              }
-            ],
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
             "webview_android": {
-              "version_added": false
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -175,26 +105,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Gamepad/buttons",
           "spec_url": "https://w3c.github.io/gamepad/#dom-gamepad-buttons",
           "support": {
-            "chrome": [
-              {
-                "version_added": "35"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "21",
-                "version_removed": "34"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "35"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "25",
-                "version_removed": "34"
-              }
-            ],
+            "chrome": {
+              "version_added": "21"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -207,44 +123,23 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "15",
-                "version_removed": "21"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "14",
-                "version_removed": "21"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "10.1"
             },
             "safari_ios": {
               "version_added": "10.3"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "4.0"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "2.0",
-                "version_removed": "3.0"
-              }
-            ],
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
             "webview_android": {
-              "version_added": false
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -259,26 +154,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Gamepad/connected",
           "spec_url": "https://w3c.github.io/gamepad/#dom-gamepad-connected",
           "support": {
-            "chrome": [
-              {
-                "version_added": "35"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "25",
-                "version_removed": "34"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "35"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "25",
-                "version_removed": "34"
-              }
-            ],
+            "chrome": {
+              "version_added": "25"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -291,44 +172,23 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "15",
-                "version_removed": "21"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "14",
-                "version_removed": "21"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "10.1"
             },
             "safari_ios": {
               "version_added": "10.3"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "4.0"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "2.0",
-                "version_removed": "3.0"
-              }
-            ],
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
             "webview_android": {
-              "version_added": false
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -520,26 +380,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Gamepad/id",
           "spec_url": "https://w3c.github.io/gamepad/#dom-gamepad-id",
           "support": {
-            "chrome": [
-              {
-                "version_added": "35"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "21",
-                "version_removed": "34"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "35"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "25",
-                "version_removed": "34"
-              }
-            ],
+            "chrome": {
+              "version_added": "21"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -552,44 +398,23 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "15",
-                "version_removed": "21"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "14",
-                "version_removed": "21"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "4.0"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "2.0",
-                "version_removed": "3.0"
-              }
-            ],
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
             "webview_android": {
-              "version_added": false
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -604,26 +429,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Gamepad/index",
           "spec_url": "https://w3c.github.io/gamepad/#dom-gamepad-index",
           "support": {
-            "chrome": [
-              {
-                "version_added": "35"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "21",
-                "version_removed": "34"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "35"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "25",
-                "version_removed": "34"
-              }
-            ],
+            "chrome": {
+              "version_added": "21"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -636,44 +447,23 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "15",
-                "version_removed": "21"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "14",
-                "version_removed": "21"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "10.1"
             },
             "safari_ios": {
               "version_added": "10.3"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "4.0"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "2.0",
-                "version_removed": "3.0"
-              }
-            ],
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
             "webview_android": {
-              "version_added": false
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -688,26 +478,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Gamepad/mapping",
           "spec_url": "https://w3c.github.io/gamepad/#dom-gamepad-mapping",
           "support": {
-            "chrome": [
-              {
-                "version_added": "35"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "21",
-                "version_removed": "34"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "35"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "25",
-                "version_removed": "34"
-              }
-            ],
+            "chrome": {
+              "version_added": "21"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -720,44 +496,23 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "15",
-                "version_removed": "21"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "14",
-                "version_removed": "21"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "10.1"
             },
             "safari_ios": {
               "version_added": "10.3"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "4.0"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "2.0",
-                "version_removed": "3.0"
-              }
-            ],
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
             "webview_android": {
-              "version_added": false
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -905,26 +660,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Gamepad/timestamp",
           "spec_url": "https://w3c.github.io/gamepad/#dom-gamepad-timestamp",
           "support": {
-            "chrome": [
-              {
-                "version_added": "35"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "21",
-                "version_removed": "34"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "35"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "25",
-                "version_removed": "34"
-              }
-            ],
+            "chrome": {
+              "version_added": "21"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -937,44 +678,23 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "15",
-                "version_removed": "21"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "14",
-                "version_removed": "21"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "10.1"
             },
             "safari_ios": {
               "version_added": "10.3"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "4.0"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "2.0",
-                "version_removed": "3.0"
-              }
-            ],
+            "samsunginternet_android": {
+              "version_added": "1.5"
+            },
             "webview_android": {
-              "version_added": false
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -5,18 +5,11 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GamepadButton",
         "spec_url": "https://w3c.github.io/gamepad/#gamepadbutton-interface",
         "support": {
-          "chrome": [
-            {
-              "version_added": "35"
-            },
-            {
-              "prefix": "webkit",
-              "version_added": "21",
-              "version_removed": "34"
-            }
-          ],
+          "chrome": {
+            "version_added": "21"
+          },
           "chrome_android": {
-            "version_added": true
+            "version_added": "25"
           },
           "edge": {
             "version_added": "12"
@@ -30,26 +23,12 @@
           "ie": {
             "version_added": false
           },
-          "opera": [
-            {
-              "version_added": "22"
-            },
-            {
-              "prefix": "webkit",
-              "version_added": "15",
-              "version_removed": "21"
-            }
-          ],
-          "opera_android": [
-            {
-              "version_added": "22"
-            },
-            {
-              "prefix": "webkit",
-              "version_added": "14",
-              "version_removed": "21"
-            }
-          ],
+          "opera": {
+            "version_added": "15"
+          },
+          "opera_android": {
+            "version_added": "14"
+          },
           "safari": {
             "version_added": "10.1"
           },
@@ -57,10 +36,10 @@
             "version_added": "10.3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -74,18 +53,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GamepadButton/pressed",
           "spec_url": "https://w3c.github.io/gamepad/#dom-gamepadbutton-pressed",
           "support": {
-            "chrome": [
-              {
-                "version_added": "35"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "21",
-                "version_removed": "34"
-              }
-            ],
+            "chrome": {
+              "version_added": "21"
+            },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -99,26 +71,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "15",
-                "version_removed": "21"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "14",
-                "version_removed": "21"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "10.1"
             },
@@ -126,10 +84,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -275,18 +233,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GamepadButton/value",
           "spec_url": "https://w3c.github.io/gamepad/#dom-gamepadbutton-value",
           "support": {
-            "chrome": [
-              {
-                "version_added": "35"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "21",
-                "version_removed": "34"
-              }
-            ],
+            "chrome": {
+              "version_added": "21"
+            },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -300,26 +251,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "15",
-                "version_removed": "21"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "14",
-                "version_removed": "21"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "10.1"
             },
@@ -327,10 +264,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/GamepadEvent.json
+++ b/api/GamepadEvent.json
@@ -5,26 +5,12 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GamepadEvent",
         "spec_url": "https://w3c.github.io/gamepad/#gamepadevent-interface",
         "support": {
-          "chrome": [
-            {
-              "version_added": "35"
-            },
-            {
-              "prefix": "webkit",
-              "version_added": "21",
-              "version_removed": "34"
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_added": "35"
-            },
-            {
-              "prefix": "webkit",
-              "version_added": "25",
-              "version_removed": "34"
-            }
-          ],
+          "chrome": {
+            "version_added": "21"
+          },
+          "chrome_android": {
+            "version_added": "25"
+          },
           "edge": {
             "version_added": "12"
           },
@@ -37,26 +23,12 @@
           "ie": {
             "version_added": false
           },
-          "opera": [
-            {
-              "version_added": "22"
-            },
-            {
-              "prefix": "webkit",
-              "version_added": "15",
-              "version_removed": "21"
-            }
-          ],
-          "opera_android": [
-            {
-              "version_added": "22"
-            },
-            {
-              "prefix": "webkit",
-              "version_added": "14",
-              "version_removed": "21"
-            }
-          ],
+          "opera": {
+            "version_added": "15"
+          },
+          "opera_android": {
+            "version_added": "14"
+          },
           "safari": {
             "version_added": "10.1"
           },
@@ -64,10 +36,10 @@
             "version_added": "10.3"
           },
           "samsunginternet_android": {
-            "version_added": true
+            "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": "37"
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -131,26 +103,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GamepadEvent/gamepad",
           "spec_url": "https://w3c.github.io/gamepad/#dom-gamepadevent-gamepad",
           "support": {
-            "chrome": [
-              {
-                "version_added": "35"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "21",
-                "version_removed": "34"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "35"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "25",
-                "version_removed": "34"
-              }
-            ],
+            "chrome": {
+              "version_added": "21"
+            },
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
               "version_added": "12"
             },
@@ -163,26 +121,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "15",
-                "version_removed": "21"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "14",
-                "version_removed": "21"
-              }
-            ],
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
             "safari": {
               "version_added": "10.1"
             },
@@ -190,10 +134,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR fixes up the data for three Gamepad-related APIs (`Gamepad`, `GamepadButton`, `GamepadEvent`) in a few ways:

- These APIs had prefix data applied to the basic support.  This doesn't make sense as these interfaces aren't to be directly accessed; they are accessed via `navigator.getGamepads()`.  Additionally, these ranges left a gap that implied support was removed in 34 and re-added in 35 -- I've confirmed this isn't the case -- so I have removed them and flattened the ranges.
- The prefix data was propogated to the children of these interfaces.  This doesn't make sense; the propogated prefix data has been removed.
