### PR TITLE
Deno 1.16 supports BYOB WHATWG streams

### DIFF
--- a/api/ReadableStreamBYOBReader.json
+++ b/api/ReadableStreamBYOBReader.json
@@ -12,7 +12,7 @@
             "version_added": "89"
           },
           "deno": {
-            "version_added": false
+            "version_added": "1.16"
           },
           "edge": {
             "version_added": "89"
@@ -65,7 +65,7 @@
               "version_added": "89"
             },
             "deno": {
-              "version_added": false
+              "version_added": "1.16"
             },
             "edge": {
               "version_added": "89"
@@ -118,7 +118,7 @@
               "version_added": "89"
             },
             "deno": {
-              "version_added": false
+              "version_added": "1.16"
             },
             "edge": {
               "version_added": "89"
@@ -171,7 +171,7 @@
               "version_added": "89"
             },
             "deno": {
-              "version_added": false
+              "version_added": "1.16"
             },
             "edge": {
               "version_added": "89"
@@ -224,7 +224,7 @@
               "version_added": "89"
             },
             "deno": {
-              "version_added": false
+              "version_added": "1.16"
             },
             "edge": {
               "version_added": "89"
@@ -277,7 +277,7 @@
               "version_added": "89"
             },
             "deno": {
-              "version_added": false
+              "version_added": "1.16"
             },
             "edge": {
               "version_added": "89"

--- a/api/ReadableStreamBYOBRequest.json
+++ b/api/ReadableStreamBYOBRequest.json
@@ -12,7 +12,7 @@
             "version_added": "89"
           },
           "deno": {
-            "version_added": false
+            "version_added": "1.16"
           },
           "edge": {
             "version_added": "89"
@@ -63,7 +63,7 @@
               "version_added": "89"
             },
             "deno": {
-              "version_added": false
+              "version_added": "1.16"
             },
             "edge": {
               "version_added": "89"
@@ -115,7 +115,7 @@
               "version_added": "89"
             },
             "deno": {
-              "version_added": false
+              "version_added": "1.16"
             },
             "edge": {
               "version_added": "89"
@@ -167,7 +167,7 @@
               "version_added": "89"
             },
             "deno": {
-              "version_added": false
+              "version_added": "1.16"
             },
             "edge": {
               "version_added": "89"


### PR DESCRIPTION
#### Summary

Deno 1.16 adds support for the BYOB features of WHATWG readable streams.

#### Test results and supporting details

https://github.com/denoland/deno/commit/95b2955712b0daae3c8e8f7bb0eccf341b5c8fa3
