### PR TITLE
Add safari_ios support to webextensions-mobile in linter

### DIFF
--- a/test/linter/test-browsers.js
+++ b/test/linter/test-browsers.js
@@ -20,7 +20,7 @@ const browsers = {
   ],
   server: ['nodejs', 'deno'],
   'webextensions-desktop': ['chrome', 'edge', 'firefox', 'opera', 'safari'],
-  'webextensions-mobile': ['firefox_android'],
+  'webextensions-mobile': ['firefox_android', 'safari_ios'],
 };
 
 /**


### PR DESCRIPTION
#### Summary
Add Safari for iOS support to the linter to validate Safari for iOS 15 entries for Web Extensions on mobile.

#### Test results and supporting details
See the [Web Extensions section from Safari 15 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions).