### PR TITLE
KHR_parallel_shader_compile not supported on Firefox

### DIFF
--- a/api/KHR_parallel_shader_compile.json
+++ b/api/KHR_parallel_shader_compile.json
@@ -15,7 +15,7 @@
             "version_added": "79"
           },
           "firefox": {
-            "version_added": "80"
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false


### PR DESCRIPTION
[KHR_parallel_shader_compile](https://developer.mozilla.org/en-US/docs/Web/API/KHR_parallel_shader_compile) was marked as supported in FF80 in https://github.com/mdn/browser-compat-data/pull/6499 (work done in https://bugzilla.mozilla.org/show_bug.cgi?id=1536674).

However https://bugzilla.mozilla.org/show_bug.cgi?id=1736076 indicates the work was incomplete, so this is not supported.

All this does is set FF support to false.

This is part of work being tracked in https://github.com/mdn/content/issues/10147