### PR TITLE
Add Safari iOS versions for Touch API

### DIFF
--- a/api/Touch.json
+++ b/api/Touch.json
@@ -40,7 +40,7 @@
             "version_added": false
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "≤3"
           },
           "samsunginternet_android": {
             "version_added": true
@@ -89,7 +89,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -239,7 +239,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -295,7 +295,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -351,7 +351,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -407,7 +407,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -463,7 +463,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -519,7 +519,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -575,7 +575,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -631,7 +631,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -687,7 +687,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -743,7 +743,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -799,7 +799,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -855,7 +855,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari iOS/iPadOS for the `Touch` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Touch

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
