### PR TITLE
Add Safari iOS versions for api.Window.orientation

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -5563,7 +5563,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari iOS/iPadOS for the `orientation` member of the `Window` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Window/orientation

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
