### PR TITLE
Fixes #13299 - Firefox for Android doesn't support permissions.request()

### DIFF
--- a/webextensions/api/permissions.json
+++ b/webextensions/api/permissions.json
@@ -174,7 +174,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": false
               },
               "opera": {
                 "version_added": true

--- a/webextensions/api/permissions.json
+++ b/webextensions/api/permissions.json
@@ -174,7 +174,9 @@
                 ]
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": true,
+                "partial_implementation": true,
+                "notes": "Since version 79, the UI to approve the permission request is missing (<a href='https://bugzil.la/1601420'>bug 1601420</a>)."
               },
               "opera": {
                 "version_added": true

--- a/webextensions/api/permissions.json
+++ b/webextensions/api/permissions.json
@@ -176,7 +176,7 @@
               "firefox_android": {
                 "version_added": true,
                 "partial_implementation": true,
-                "notes": "Since version 79, the UI to approve the permission request is missing (<a href='https://bugzil.la/1601420'>bug 1601420</a>)."
+                "notes": "From version 79, the user interface to approve the permission request is missing. See <a href='https://bugzil.la/1601420'>bug 1601420</a>."
               },
               "opera": {
                 "version_added": true


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Correctly say that Firefox for Android doesn't support `browser.permissions.request()` (see #13299)

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

[permissions.request()](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/permissions/request) says that it can be used in Firefox for Android. However, according to [Bugzilla #1601420](https://bugzilla.mozilla.org/show_bug.cgi?id=1601420) and [Fenix #16912](https://github.com/mozilla-mobile/fenix/issues/16912), `permissions.request()` is not implemented.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fixes #13299

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
