### PR TITLE
Add Safari iOS versions for TouchEvent API

### DIFF
--- a/api/TouchEvent.json
+++ b/api/TouchEvent.json
@@ -53,7 +53,7 @@
             "version_added": false
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "3.2"
           },
           "samsunginternet_android": {
             "version_added": "1.5"
@@ -219,7 +219,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -275,7 +275,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -331,7 +331,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -387,7 +387,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -443,7 +443,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -499,7 +499,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari iOS/iPadOS for the `TouchEvent` API, based upon commit history and date.

Commit: https://github.com/WebKit/WebKit/commit/ce64d715f62fe76b229b937dcf95f7b39baa6cc7 / https://github.com/WebKit/WebKit/commit/5f9e450ef87e941d63891f08a6ff986ea92e889e

The "3.2" came from the initial data for `api.TouchEvent.TouchEvent`.  `TouchEvent` was undefined in Safari iOS 3 but defined in Safari iOS 4, so this checks out.
