### PR TITLE
Add Safari iOS versions for api.Document.touch*_event

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -10655,7 +10655,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -10705,7 +10705,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -10755,7 +10755,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -10805,7 +10805,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.5"


### PR DESCRIPTION
This PR adds real values for Safari iOS/iPadOS for the `touch*_event` members of the `Document` API.  The data for these events was copied from their event handler counterparts (from `GlobalEventHandlers`).
