### PR TITLE
Add Safari iOS versions for api.Element.touch*_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -8605,7 +8605,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -8655,7 +8655,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -8705,7 +8705,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -8755,7 +8755,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "≤3"
             },
             "samsunginternet_android": {
               "version_added": "1.5"


### PR DESCRIPTION
This PR adds real values for Safari iOS/iPadOS for the `touch*_event` members of the `Element` API.  The data for these events was copied from their event handler counterparts (from `GlobalEventHandlers`).
