### PR TITLE
Add Chromium versions for CanMakePaymentEvent API

### DIFF
--- a/api/CanMakePaymentEvent.json
+++ b/api/CanMakePaymentEvent.json
@@ -5,34 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanMakePaymentEvent",
         "support": {
           "chrome": {
-            "version_added": "61",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#service-worker-payment-apps",
-                "value_to_set": "Enabled"
-              }
-            ]
+            "version_added": "70"
           },
           "chrome_android": {
-            "version_added": "61",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#service-worker-payment-apps",
-                "value_to_set": "Enabled"
-              }
-            ]
+            "version_added": "70"
           },
           "edge": {
-            "version_added": "≤79",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#service-worker-payment-apps",
-                "value_to_set": "Enabled"
-              }
-            ]
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false
@@ -44,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "57"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "49"
           },
           "safari": {
             "version_added": false
@@ -56,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "10.0"
           },
           "webview_android": {
             "version_added": false
@@ -74,34 +53,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanMakePaymentEvent/CanMakePaymentEvent",
           "support": {
             "chrome": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "70"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -113,10 +71,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -125,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -143,34 +101,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanMakePaymentEvent/methodData",
           "support": {
             "chrome": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "70"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -182,10 +119,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -194,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -212,34 +149,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanMakePaymentEvent/modifiers",
           "support": {
             "chrome": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": false
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -281,34 +197,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanMakePaymentEvent/paymentRequestOrigin",
           "support": {
             "chrome": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "70"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -320,10 +215,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -332,7 +227,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -350,34 +245,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanMakePaymentEvent/respondWith",
           "support": {
             "chrome": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "70"
             },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -389,10 +263,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -401,7 +275,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -418,49 +292,14 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanMakePaymentEvent/topOrigin",
           "support": {
-            "chrome": [
-              {
-                "version_added": "68",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#service-worker-payment-apps",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "61",
-                "version_removed": "67",
-                "alternative_name": "topLevelOrigin"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "68",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#service-worker-payment-apps",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "61",
-                "version_removed": "67",
-                "alternative_name": "topLevelOrigin"
-              }
-            ],
+            "chrome": {
+              "version_added": "70"
+            },
+            "chrome_android": {
+              "version_added": "70"
+            },
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -472,10 +311,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -484,7 +323,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `CanMakePaymentEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CanMakePaymentEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
