### PR TITLE
Add Chromium versions for SourceBuffer API

### DIFF
--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -198,7 +198,7 @@
               "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -232,7 +232,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -961,7 +961,7 @@
               "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -995,7 +995,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": false
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `SourceBuffer` API, based upon manual testing.

Test Code Used: `SourceBuffer.prototype.appendBufferAsync; SourceBuffer.prototype.removeAsync; // Confirmed this shows the other properties`
