### PR TITLE
Add WebView versions for api.ServiceWorkerRegistration.paymentManager

### DIFF
--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -506,7 +506,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": true
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for WebView Android for the `paymentManager` member of the `ServiceWorkerRegistration` API.  The Web Payment API isn't supported in WebView, so this doesn't make sense to be supported when everything else isn't.  (Confirmed with the mdn-bcd-collector project.)
