### PR TITLE
Add Edge versions for BroadcastChannel API

### DIFF
--- a/api/BroadcastChannel.json
+++ b/api/BroadcastChannel.json
@@ -196,7 +196,7 @@
               "version_added": "1.11"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "38"
@@ -255,7 +255,7 @@
               "version_added": "1.11"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "57"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `BroadcastChannel` API.  This was caught by #8969; the feature is set to "79" exactly.
