### PR TITLE
Add Edge versions for api.HTMLCanvasElement.getContext.webgl2_context.options_alpha_parameter

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -563,7 +563,7 @@
             }
           }
         },
-        "webgl2_context": {
+        "_context": {
           "__compat": {
             "description": "WebGL2 context",
             "support": {
@@ -634,7 +634,7 @@
                   "version_added": "56"
                 },
                 "edge": {
-                  "version_added": "≤79"
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "30"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `getContext.webgl2_context.options_alpha_parameter` member of the `HTMLCanvasElement` API.  This was caught by #8969; the feature is set to "79" exactly.
