### PR TITLE
Switch Edge "≤79" range to non-range when parent is "79" exactly

### DIFF
--- a/api/BroadcastChannel.json
+++ b/api/BroadcastChannel.json
@@ -196,7 +196,7 @@
               "version_added": "1.11"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "38"
@@ -255,7 +255,7 @@
               "version_added": "1.11"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "57"

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -634,7 +634,7 @@
                   "version_added": "56"
                 },
                 "edge": {
-                  "version_added": "≤79"
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "30"

--- a/api/MIDIAccess.json
+++ b/api/MIDIAccess.json
@@ -207,7 +207,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false

--- a/api/MIDIInput.json
+++ b/api/MIDIInput.json
@@ -60,7 +60,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false

--- a/api/MIDIPort.json
+++ b/api/MIDIPort.json
@@ -452,7 +452,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false

--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -123,7 +123,7 @@
               ]
             },
             "edge": {
-              "version_added": "≤79",
+              "version_added": "79",
               "flags": [
                 {
                   "type": "preference",

--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -265,7 +265,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -272,7 +272,7 @@
                 "version_added": "76"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "46",
@@ -336,7 +336,7 @@
                 "version_added": "69"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "44",
@@ -400,7 +400,7 @@
                 "version_added": "69"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "44",
@@ -464,7 +464,7 @@
                 "version_added": "69"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": false

--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -330,7 +330,7 @@
               "version_added": "62"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "57"

--- a/api/PresentationRequest.json
+++ b/api/PresentationRequest.json
@@ -336,7 +336,7 @@
               "version_added": "61"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51",

--- a/api/RTCDTMFSender.json
+++ b/api/RTCDTMFSender.json
@@ -256,7 +256,7 @@
               "version_added": "27"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "52"

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -161,7 +161,7 @@
               "notes": "The default for <code>rtcpMuxPolicy<code> is <code>require<code>."
             },
             "edge": {
-              "version_added": "≤79",
+              "version_added": "79",
               "notes": "The default for <code>rtcpMuxPolicy<code> is <code>require<code>."
             },
             "firefox": {
@@ -314,7 +314,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "22"
@@ -364,7 +364,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "22"
@@ -610,7 +610,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "22"
@@ -1010,7 +1010,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "22"
@@ -1301,7 +1301,7 @@
               "version_added": "58"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "63"
@@ -1398,7 +1398,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR changes everything that's set to Edge ≤79 to simply "79" when the parent feature is exactly "79".  This was caught by #8969.
