### PR TITLE
Add window.open popup feature and BarProp.visible value update

### DIFF
--- a/api/BarProp.json
+++ b/api/BarProp.json
@@ -95,6 +95,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "returns_popup": {
+          "__compat": {
+            "description": "Returns <code>true</code> for non-popup windows",
+            "support": {
+              "chrome": {
+                "version_added": "98"
+              },
+              "chrome_android": {
+                "version_added": "98"
+              },
+              "edge": {
+                "version_added": "98"
+              },
+              "firefox": {
+                "version_added": "96"
+              },
+              "firefox_android": {
+                "version_added": "96"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "98"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/api/Window.json
+++ b/api/Window.json
@@ -5333,6 +5333,54 @@
             "deprecated": false
           }
         },
+        "features_parameter_popup": {
+          "__compat": {
+            "description": "<code>features</code> parameter accepts <code>\"popup\"</code> value",
+            "support": {
+              "chrome": {
+                "version_added": "98"
+              },
+              "chrome_android": {
+                "version_added": "98"
+              },
+              "edge": {
+                "version_added": "98"
+              },
+              "firefox": {
+                "version_added": "96"
+              },
+              "firefox_android": {
+                "version_added": "96"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "98"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "once_per_event": {
           "__compat": {
             "description": "One <code>Window.open()</code> call per event",


### PR DESCRIPTION
for https://github.com/whatwg/html/pull/6530

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Add browser compat data for updated `windowFeatures` parameter behavior for `window.open`, and also `BarProp.visible` behavior, from the spec change in https://github.com/whatwg/html/pull/6530.

#### Test results and supporting details

The behavior is tested by https://github.com/web-platform-tests/wpt/pull/28243

Firefox: fixed in 96 (currently Nightly) https://bugzilla.mozilla.org/show_bug.cgi?id=1701001
Chrome: fixed in 98 (current Canary) https://bugs.chromium.org/p/chromium/issues/detail?id=1192701
Safari: bug is filed https://bugs.webkit.org/show_bug.cgi?id=223751

#### Related issues

* https://github.com/mdn/content/pull/10339

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
