### PR TITLE
Add Chromium versions for api.HTMLBodyElement.onorientationchange

### DIFF
--- a/api/HTMLBodyElement.json
+++ b/api/HTMLBodyElement.json
@@ -247,7 +247,7 @@
               "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": false
@@ -265,7 +265,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": false
@@ -274,10 +274,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `onorientationchange` member of the `HTMLBodyElement` API.  The data comes from mirroring Safari iOS from https://github.com/mdn/browser-compat-data/pull/13295.
