### PR TITLE
Add Chromium versions for api.Window.onorientationchange

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -4653,7 +4653,7 @@
               "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": false
@@ -4671,7 +4671,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": false
@@ -4680,10 +4680,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -5589,7 +5589,7 @@
               "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": false
@@ -5607,7 +5607,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": false
@@ -5616,10 +5616,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `onorientationchange` member of the `Window` API.  The data was mirrored from Safari iOS from https://github.com/mdn/browser-compat-data/pull/13296.
