### PR TITLE
Add Chromium versions for api.Window.orientation

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -5539,7 +5539,7 @@
               "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "edge": {
               "version_added": false
@@ -5557,7 +5557,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": false
@@ -5566,10 +5566,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `orientation` member of the `Window` API.  The data was mirrored from Safari iOS from https://github.com/mdn/browser-compat-data/pull/13297.
