### PR TITLE
Add Chromium versions for api.HTMLInputElement.capture

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -244,7 +244,7 @@
               "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "edge": {
               "version_added": false
@@ -271,10 +271,10 @@
               "version_added": true
             },
             "samsunginternet_android": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `capture` member of the `HTMLInputElement` API, based upon commit history and date.

Commit: https://source.chromium.org/chromium/chromium/src/+/13bfc68b02ee2fe60514db8cb340b5aea49d8c8e
