### PR TITLE
Add Chromium versions for api.ServiceWorkerGlobalScope.oncontentdelete

### DIFF
--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -748,7 +748,7 @@
               "version_added": false
             },
             "chrome_android": {
-              "version_added": true
+              "version_added": "77"
             },
             "edge": {
               "version_added": false
@@ -766,7 +766,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -775,10 +775,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": true
+              "version_added": "77"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `oncontentdelete` member of the `ServiceWorkerGlobalScope` API, based upon commit history and date.

Commit: https://storage.googleapis.com/chromium-find-releases-static/c36.html#c366ff18d371e047a60bb0932a63e20bec4cceed
