### PR TITLE
Add Chromium versions for api.Window.onvrdisplayconnect

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -4889,11 +4889,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": [
-                "Chrome for Android 56 supports only Google Daydream View.",
-                "Chrome for Android 57 adds support for Google Cardboard."
-              ]
+              "version_added": false
             },
             "edge": {
               "version_added": "15",
@@ -10044,11 +10040,7 @@
               ]
             },
             "chrome_android": {
-              "version_added": true,
-              "notes": [
-                "Chrome for Android 56 supports only Google Daydream View.",
-                "Chrome for Android 57 adds support for Google Cardboard."
-              ]
+              "version_added": false
             },
             "edge": {
               "version_added": "15",


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `onvrdisplayconnect` member of the `Window` API, based upon manual testing.

Test Code Used: `window.onvrdisplayconnect !== undefined;`
