### PR TITLE
Add Edge versions for FileEntrySync API

### DIFF
--- a/api/FileEntrySync.json
+++ b/api/FileEntrySync.json
@@ -13,7 +13,7 @@
             "prefix": "webkit"
           },
           "edge": {
-            "version_added": "≤79",
+            "version_added": "79",
             "prefix": "webkit"
           },
           "firefox": {


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `FileEntrySync` API, based upon manual testing.

Test Code Used: `'WebKitFileEntrySync' in self; 'FileEntrySync' in self; 'MSFileEntrySync' in self;`
