### PR TITLE
Add Edge versions for FileSystemSync API

### DIFF
--- a/api/FileSystemSync.json
+++ b/api/FileSystemSync.json
@@ -13,7 +13,7 @@
             "prefix": "webkit"
           },
           "edge": {
-            "version_added": "≤79",
+            "version_added": "79",
             "prefix": "webkit"
           },
           "firefox": {
@@ -66,7 +66,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -113,7 +113,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `FileSystemSync` API, based upon manual testing.

Test Code Used: `'WebKitFileSystemSync' in self; 'FileSystemSync' in self; 'MSFileSystemSync' in self;`
