### PR TITLE
Add Edge versions for FontFaceSet API

### DIFF
--- a/api/FontFaceSet.json
+++ b/api/FontFaceSet.json
@@ -12,7 +12,7 @@
             "version_added": "35"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "41"
@@ -886,7 +886,7 @@
               "version_added": "69"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `FontFaceSet` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FontFaceSet

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
