### PR TITLE
Add Edge versions for IDBDatabaseException API

### DIFF
--- a/api/IDBDatabaseException.json
+++ b/api/IDBDatabaseException.json
@@ -12,7 +12,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": "≤79",
+            "version_added": "79",
             "prefix": "webkit"
           },
           "firefox": {


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `IDBDatabaseException` API, based upon manual testing.

Test Code Used: `'WebKitIDBDatabaseException' in self; 'IDBDatabaseException' in self; 'MSIDBDatabaseException' in self;`
