### PR TITLE
Add Edge versions for api.MediaStreamAudioDestinationNode.MediaStreamAudioDestinationNode

### DIFF
--- a/api/MediaStreamAudioDestinationNode.json
+++ b/api/MediaStreamAudioDestinationNode.json
@@ -63,7 +63,7 @@
               "notes": "Before Chrome 59, the default values were not supported."
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `MediaStreamAudioDestinationNode` member of the `MediaStreamAudioDestinationNode` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaStreamAudioDestinationNode/MediaStreamAudioDestinationNode

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
