### PR TITLE
Add Edge versions for RTCRtpReceiver API

### DIFF
--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -322,7 +322,7 @@
               "version_added": "59"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -371,7 +371,7 @@
               "version_added": "67"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "13"
             },
             "firefox": {
               "version_added": "55"
@@ -420,7 +420,7 @@
               "version_added": "73"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "59"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `RTCRtpReceiver` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCRtpReceiver

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
