### PR TITLE
Update Edge versions for RTCRtpSender API

### DIFF
--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -12,7 +12,7 @@
             "version_added": "64"
           },
           "edge": {
-            "version_added": "12"
+            "version_added": "13"
           },
           "firefox": {
             "version_added": "34"
@@ -107,7 +107,7 @@
               "version_added": "66"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "52"
@@ -157,7 +157,7 @@
               "version_added": "69"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "13"
             },
             "firefox": {
               "version_added": false
@@ -207,7 +207,7 @@
               "version_added": "68"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "46"
@@ -257,7 +257,7 @@
               "version_added": "67"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "13"
             },
             "firefox": {
               "version_added": "55"
@@ -307,7 +307,7 @@
               "version_added": "65"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "34"
@@ -355,7 +355,7 @@
               "version_added": "75"
             },
             "edge": {
-              "version_added": "12",
+              "version_added": "13",
               "version_removed": "79"
             },
             "firefox": {
@@ -406,7 +406,7 @@
               "version_added": "68"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -516,7 +516,7 @@
               "version_added": "64"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "13"
             },
             "firefox": {
               "version_added": "34"
@@ -565,7 +565,7 @@
               "version_added": "75"
             },
             "edge": {
-              "version_added": "12",
+              "version_added": "13",
               "version_removed": "79"
             },
             "firefox": {

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -355,8 +355,7 @@
               "version_added": "75"
             },
             "edge": {
-              "version_added": "13",
-              "version_removed": "79"
+              "version_added": "13"
             },
             "firefox": {
               "version_added": "34"
@@ -565,8 +564,7 @@
               "version_added": "75"
             },
             "edge": {
-              "version_added": "13",
-              "version_removed": "79"
+              "version_added": "13"
             },
             "firefox": {
               "version_added": "34"


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `RTCRtpSender` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCRtpSender

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
