### PR TITLE
Add Edge versions for api.ServiceWorkerContainer.startMessages

### DIFF
--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -566,7 +566,7 @@
               "version_added": "74"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "64"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `startMessages` member of the `ServiceWorkerContainer` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ServiceWorkerContainer/startMessages

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
