### PR TITLE
Add WebView versions for MouseEvent API

### DIFF
--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -698,7 +698,7 @@
                 "version_added": "37"
               },
               {
-                "version_added": true,
+                "version_added": "4.4",
                 "version_removed": "37",
                 "prefix": "webkit"
               }
@@ -817,7 +817,7 @@
                 "version_added": "37"
               },
               {
-                "version_added": true,
+                "version_added": "4.4",
                 "version_removed": "37",
                 "prefix": "webkit"
               }


### PR DESCRIPTION
This PR adds real values for WebView Android for the `MouseEvent` API.  The data was mirrored from Chrome/Safari and determined based upon the WebKit version.  I'm not able to set the version added to "≤37" because the version removed is "37" -- the linter will fail due to the changes made in #10710.
