### PR TITLE
Add IE/Edge versions for api.WheelEvent.pinch-to-zoom_support

### DIFF
--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -308,7 +308,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "55"
@@ -317,7 +317,7 @@
               "version_added": "55"
             },
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "opera": {
               "version_added": null


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `pinch-to-zoom_support` member of the `WheelEvent` API, based upon manual testing.

Test Code Used:
```js
document.addEventListener('wheel', function(event) {
	event.preventDefault();
	var newEl = document.createElement('p');
	newEl.textContent = event.ctrlKey;
	document.getElementById('test').appendChild(newEl);
});
```

For this one, I grabbed my touchscreen monitor and connected it directly to my VMs for testing.  Obligatory photo to show off the testing environment:
![IMG_0548](https://user-images.githubusercontent.com/5179191/140670169-3632ac4a-e772-454a-b6c5-f1e46357ba23.jpeg)
