### PR TITLE
FF95: Add CSS cursor support on Android

### DIFF
--- a/css/properties/cursor.json
+++ b/css/properties/cursor.json
@@ -20,7 +20,7 @@
               "notes": "Starting in Firefox 67, the maximum size allowed for custom cursors is 32x32 pixels due to cursors being misused by certain malicious sites."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "95"
             },
             "ie": {
               "version_added": "4",
@@ -68,7 +68,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": "10"
@@ -116,7 +116,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": "6"
@@ -164,7 +164,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": "4"
@@ -212,7 +212,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": "10"
@@ -260,7 +260,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": "10"
@@ -308,7 +308,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": "6"
@@ -359,7 +359,7 @@
                 "notes": "This cursor is only supported on macOS and Linux."
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": "10"
@@ -409,7 +409,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": "10"
@@ -457,7 +457,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": "4"
@@ -505,7 +505,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": "4"
@@ -575,7 +575,7 @@
                 }
               ],
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": false
@@ -651,7 +651,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": "4"
@@ -699,7 +699,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": "8"
@@ -747,7 +747,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": "4"
@@ -795,7 +795,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": "6"
@@ -843,7 +843,7 @@
                 "version_added": "3"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": "9"
@@ -891,7 +891,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": "6"
@@ -939,7 +939,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": "6"
@@ -987,7 +987,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": "6"
@@ -1035,7 +1035,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": "6"
@@ -1083,7 +1083,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": "4"
@@ -1131,7 +1131,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": "4"
@@ -1180,7 +1180,7 @@
                 "notes": "Firefox 4 added macOS support."
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": "6"
@@ -1229,7 +1229,7 @@
                 "notes": "Firefox 4 added macOS support."
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": false
@@ -1277,7 +1277,7 @@
                 "version_added": "1.5"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": false
@@ -1325,7 +1325,7 @@
                 "version_added": "1"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": "4"
@@ -1391,7 +1391,7 @@
                 }
               ],
               "firefox_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
FF95 adds support for CSS [cursor](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#browser_compatibility) on android. I've simply marked all of the FF for android fields as "95" rather than false.

The associated bug is https://bugzilla.mozilla.org/show_bug.cgi?id=1672609

Docs work tracked in https://github.com/mdn/content/issues/10145
