### PR TITLE
FF95 ships inputmode global attribute

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1540,16 +1540,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "77",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.forms.inputmode",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "95",
+              },
+              {
+                "version_added": "77",
+                "version_removed": "95",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.forms.inputmode",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": "79"
             },

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1542,7 +1542,7 @@
             },
             "firefox": [
               {
-                "version_added": "95",
+                "version_added": "95"
               },
               {
                 "version_added": "77",

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1116,7 +1116,11 @@
             },
             "firefox": [
               {
+                "version_added": "95"
+              },
+              {
                 "version_added": "23",
+                "version_removed": "95"
                 "flags": [
                   {
                     "type": "preference",
@@ -1140,6 +1144,7 @@
               },
               {
                 "version_added": "68",
+                "version_removed": "79",
                 "flags": [
                   {
                     "type": "preference",

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1120,7 +1120,7 @@
               },
               {
                 "version_added": "23",
-                "version_removed": "95"
+                "version_removed": "95",
                 "flags": [
                   {
                     "type": "preference",


### PR DESCRIPTION
FF95 ships the [input mode global attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode) in bug https://bugzilla.mozilla.org/show_bug.cgi?id=1205133 by making the `dom.forms.inputmode` always true.

This updates BCD data for affected elements against that key.
