### PR TITLE
Update Edge versions for IDBObjectStore API

### DIFF
--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -146,7 +146,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "10"
@@ -496,7 +496,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "44"
@@ -545,7 +545,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "44"
@@ -594,7 +594,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "51"
@@ -941,7 +941,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "44",


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `IDBObjectStore` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/IDBObjectStore

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
