### PR TITLE
Add Edge versions for api.ClipboardEvent.ClipboardEvent

### DIFF
--- a/api/ClipboardEvent.json
+++ b/api/ClipboardEvent.json
@@ -61,7 +61,7 @@
               "version_added": "58"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "22"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `ClipboardEvent` member of the `ClipboardEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ClipboardEvent/ClipboardEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
