### PR TITLE
Update Deno version to 1.16

### DIFF
--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -90,36 +90,43 @@
         "1.12": {
           "release_date": "2021-07-13",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.12.0",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "9.2"
         },
         "1.13": {
           "release_date": "2021-08-10",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.13.0",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "9.3"
         },
         "1.14": {
           "release_date": "2021-09-14",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.14.0",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "9.4"
         },
         "1.15": {
           "release_date": "2021-10-12",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.15.0",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "9.5"
         },
         "1.16": {
-          "release_date": "2021-11-16",
+          "release_date": "2021-11-08",
+          "release_notes": "https://github.com/denoland/deno/releases/tag/v1.16.0",
+          "status": "current",
+          "engine": "V8",
+          "engine_version": "9.7"
+        },
+        "1.17": {
+          "release_date": "2021-12-21",
           "status": "nightly",
           "engine": "V8",
-          "engine_version": "9.6"
+          "engine_version": "9.7"
         }
       }
     }


### PR DESCRIPTION
We are releasing 1.16 tomorrow. We skipped V8 9.6, so we are updating to 9.7 right away.

I also realized I didn't mark old versions as "retired" last time around. Fixed that now.
