### PR TITLE
Add WritableStreamDefaultController.signal data

### DIFF
--- a/api/WritableStreamDefaultController.json
+++ b/api/WritableStreamDefaultController.json
@@ -102,6 +102,58 @@
             "deprecated": false
           }
         }
+      },
+      "signal": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WritableStreamDefaultController/signal",
+          "spec_url": "https://streams.spec.whatwg.org/#ref-for-ws-default-controller-signal①",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": "1.16"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
#### Summary

The streams spec recently added a `signal` proprety to the spec: https://streams.spec.whatwg.org/#ws-default-controller-class

#### Test results and supporting details

Not yet implemented in browsers:
- Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1215992
- Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1714341
- Safari: https://bugs.webkit.org/show_bug.cgi?id=226575

It is implemented in Deno however:
- https://github.com/denoland/deno/pull/12654 (merging imminently)

Marked as experimental because there are not 2 implementations yet.
