### PR TITLE
Deno version for javascript.builtins.Error.cause

### DIFF
--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -122,7 +122,7 @@
                   "version_added": "93"
                 },
                 "deno": {
-                  "version_added": false
+                  "version_added": "1.13"
                 },
                 "edge": {
                   "version_added": false
@@ -177,7 +177,7 @@
                 "version_added": "93"
               },
               "deno": {
-                "version_added": false
+                "version_added": "1.13"
               },
               "edge": {
                 "version_added": false


### PR DESCRIPTION
Was added in Deno 1.13 (in V8 9.3), see
https://v8.dev/blog/v8-release-93#error-cause.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
