### PR TITLE
Add findLast and findLastIndex methods

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -639,6 +639,116 @@
             }
           }
         },
+        "findLast": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/findLast",
+            "spec_url": "https://tc39.es/proposal-array-find-from-last/index.html#sec-array.prototype.findlast",
+            "support": {
+              "chrome": {
+                "version_added": "97"
+              },
+              "chrome_android": {
+                "version_added": "97"
+              },
+              "deno": {
+                "version_added": "1.16"
+              },
+              "edge": {
+                "version_added": "97"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": {
+                "version_added": "preview"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "97"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "findLastIndex": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/findLastIndex",
+            "spec_url": "https://tc39.es/proposal-array-find-from-last/index.html#sec-array.prototype.findlastindex",
+            "support": {
+              "chrome": {
+                "version_added": "97"
+              },
+              "chrome_android": {
+                "version_added": "97"
+              },
+              "deno": {
+                "version_added": "1.16"
+              },
+              "edge": {
+                "version_added": "97"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "97"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "flat": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/flat",

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -675,10 +675,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "preview"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "preview"
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -769,6 +769,116 @@
             }
           }
         },
+        "findLast": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/findLast",
+            "spec_url": "https://tc39.es/proposal-array-find-from-last/index.html#sec-%typedarray%.prototype.findlast",
+            "support": {
+              "chrome": {
+                "version_added": "97"
+              },
+              "chrome_android": {
+                "version_added": "97"
+              },
+              "deno": {
+                "version_added": "1.16"
+              },
+              "edge": {
+                "version_added": "97"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "97"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "findLastIndex": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/findLastIndex",
+            "spec_url": "https://tc39.es/proposal-array-find-from-last/index.html#sec-%typedarray%.prototype.findlastindex",
+            "support": {
+              "chrome": {
+                "version_added": "97"
+              },
+              "chrome_android": {
+                "version_added": "97"
+              },
+              "deno": {
+                "version_added": "1.16"
+              },
+              "edge": {
+                "version_added": "97"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "97"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "forEach": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/forEach",


### PR DESCRIPTION
Implemented in V8 9.7 (thus Chrome 97 and Deno 1.16): https://v8.dev/blog/v8-release-97

Merged in WebKit behind a flag, but not yet in Safari: https://trac.webkit.org/changeset/279937/webkit/
