### PR TITLE
Add Edge versions for api.CanvasRenderingContext2D.scrollPathIntoView

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -3211,7 +3211,7 @@
               ]
             },
             "edge": {
-              "version_added": "≤79",
+              "version_added": "79",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `scrollPathIntoView` member of the `CanvasRenderingContext2D` API.  The associated flag is a Chrome-only flag, and the only reason this was a range is because Edge was originally `null`.
