### PR TITLE
Add Edge versions for api.MediaElementAudioSourceNode.mediaElement

### DIFF
--- a/api/MediaElementAudioSourceNode.json
+++ b/api/MediaElementAudioSourceNode.json
@@ -114,7 +114,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "70"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `mediaElement` member of the `MediaElementAudioSourceNode` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaElementAudioSourceNode/mediaElement

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
