### PR TITLE
Add AbortSignal.reason data

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -107,6 +107,61 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "reason_parameter": {
+          "__compat": {
+            "description": "<code>reason</code> parameter",
+            "spec_url": "https://dom.spec.whatwg.org/#abortsignal-abort-reason",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "deno": {
+                "version_added": "1.16"
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "abort_event": {
@@ -270,6 +325,61 @@
           },
           "status": {
             "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "reason": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortSignal/reason",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-abortsignal-reason①",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": "1.16"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This was just landed in the DOM spec:
https://github.com/whatwg/dom/pull/1027

#### Summary

Deno support added in https://github.com/denoland/deno/pull/12697

