### PR TITLE
structuredClone supported by node 17.0.0

### DIFF
--- a/api/_globals/structuredClone.json
+++ b/api/_globals/structuredClone.json
@@ -39,7 +39,7 @@
             "version_added": false
           },
           "nodejs": {
-            "version_added": false
+            "version_added": "17.0.0"
           },
           "opera": {
             "version_added": false


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/10378 - Nodejs supports structuredClone in v17.0.0. This is in the release blog: https://nodejs.org/en/blog/release/v17.0.0/

Note that node v17.0.0 isn't available yet as a browser choice. That is addressed in PR #13381

