### PR TITLE
add exception for NTLM spec (microsoft)

### DIFF
--- a/test/spec-urls.test.js
+++ b/test/spec-urls.test.js
@@ -52,7 +52,7 @@ describe('spec_url data', () => {
 
       // Remove if https://github.com/w3c/mathml/issues/216 is resolved
       'https://w3c.github.io/mathml/',
-      
+
       // Discussed in https://github.com/w3c/browser-specs/pull/421
       // This is a private spec so can't go in w3c
       'https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-ntht/',

--- a/test/spec-urls.test.js
+++ b/test/spec-urls.test.js
@@ -52,6 +52,10 @@ describe('spec_url data', () => {
 
       // Remove if https://github.com/w3c/mathml/issues/216 is resolved
       'https://w3c.github.io/mathml/',
+      
+      // Discussed in https://github.com/w3c/browser-specs/pull/421
+      // This is a private spec so can't go in w3c
+      'https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-ntht/',
     ];
 
     const allowList = new Set([...specsFromBrowserSpecs, ...specsExceptions]);


### PR DESCRIPTION
https://github.com/mdn/browser-compat-data/pull/12446 references the NTLM spec. I tried to get this into the w3c list in  https://github.com/w3c/browser-specs/pull/421 but as they pointed out, it is a "private" spec maintained by a particular vendor and does not comply with formatting rules expected by their tooling.

The other option is simply to remove the spec and people can search for it.