### PR TITLE
Updates Opera to version 81

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -615,16 +615,23 @@
         "80": {
           "release_date": "2021-10-05",
           "release_notes": "https://blogs.opera.com/desktop/2021/10/opera-80-stable/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "94"
         },
         "81": {
-          "status": "beta",
+          "release_date": "2021-11-04",
+          "release_notes": "https://blogs.opera.com/desktop/2021/11/opera-81-stable/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "95"
         },
         "82": {
+          "status": "beta",
+          "engine": "Blink",
+          "engine_version": "96"
+        },
+        "83": {
           "status": "nightly",
           "engine": "Blink",
           "engine_version": "96"


### PR DESCRIPTION
Hello everyone!

The Opera browser has been updated to version 81.

As per the [release notes](https://blogs.opera.com/desktop/2021/11/opera-81-stable/).