### PR TITLE
Remove ProcessingInstruction.data

### DIFF
--- a/api/ProcessingInstruction.json
+++ b/api/ProcessingInstruction.json
@@ -48,57 +48,10 @@
           "deprecated": false
         }
       },
-      "data": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ProcessingInstruction/data",
-          "support": {
-            "chrome": {
-              "version_added": "1"
-            },
-            "chrome_android": {
-              "version_added": "18"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "1"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
-            "ie": {
-              "version_added": "9"
-            },
-            "opera": {
-              "version_added": "≤12.1"
-            },
-            "opera_android": {
-              "version_added": "≤12.1"
-            },
-            "safari": {
-              "version_added": "≤4"
-            },
-            "safari_ios": {
-              "version_added": "≤3"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.0"
-            },
-            "webview_android": {
-              "version_added": "1"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
-      },
       "target": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ProcessingInstruction/target",
+          "spec_url": "https://dom.spec.whatwg.org/#dom-processinginstruction-target",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
`ProcessingInstruction.data` doesn't exist.  There is a `data` attribute on its parent interface, `CharacterData`. This removes it from bcd (there is no associated page in mdn/content).

It also add `spec_url` to `ProcessingInstruction.target` that was missing.