### PR TITLE
Add api.AudioData.timestamp to BCD

### DIFF
--- a/api/AudioData.json
+++ b/api/AudioData.json
@@ -582,7 +582,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/AudioData.json
+++ b/api/AudioData.json
@@ -538,6 +538,55 @@
             "deprecated": false
           }
         }
+      },
+      "timestamp": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioData/timestamp",
+          "spec_url": "https://w3c.github.io/webcodecs/#dom-audiodata-timestamp",
+          "support": {
+            "chrome": {
+              "version_added": "94"
+            },
+            "chrome_android": {
+              "version_added": "94"
+            },
+            "edge": {
+              "version_added": "94"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "80"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "94"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This PR adds the missing `timestamp` member of the `AudioData` API to BCD.  The data was collected using the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AudioData/timestamp

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
