### PR TITLE
Add api.AudioDecoder.isConfigSupported to BCD

### DIFF
--- a/api/AudioDecoder.json
+++ b/api/AudioDecoder.json
@@ -343,6 +343,54 @@
           }
         }
       },
+      "isConfigSupported": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webcodecs/#dom-audiodecoder-isconfigsupported",
+          "support": {
+            "chrome": {
+              "version_added": "94"
+            },
+            "chrome_android": {
+              "version_added": "94"
+            },
+            "edge": {
+              "version_added": "94"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "80"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "94"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "reset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioDecoder/reset",

--- a/api/AudioDecoder.json
+++ b/api/AudioDecoder.json
@@ -385,7 +385,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This PR adds the missing `isConfigSupported` member of the `AudioDecoder` API to BCD.  The data was collected using the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AudioDecoder/isConfigSupported

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
