### PR TITLE
Add spec URL for ContactAddress API

### DIFF
--- a/api/ContactAddress.json
+++ b/api/ContactAddress.json
@@ -2,6 +2,7 @@
   "api": {
     "ContactAddress": {
       "__compat": {
+        "spec_url": "https://wicg.github.io/contact-api/spec/#contactaddress",
         "support": {
           "chrome": {
             "version_added": false


### PR DESCRIPTION
This PR adds the spec URL for the ContactAddress API.
