### PR TITLE
Add missing api.Device[Motion/Orientation]Event.requestPermission feature

### DIFF
--- a/api/DeviceMotionEvent.json
+++ b/api/DeviceMotionEvent.json
@@ -245,6 +245,54 @@
           }
         }
       },
+      "requestPermission": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/deviceorientation/#dom-devicemotionevent-requestpermission",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "14.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "rotationRate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceMotionEvent/rotationRate",

--- a/api/DeviceOrientationEvent.json
+++ b/api/DeviceOrientationEvent.json
@@ -299,6 +299,54 @@
             "deprecated": false
           }
         }
+      },
+      "requestPermission": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/deviceorientation/#dom-deviceorientationevent-requestpermission",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "14.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `requestPermission` member of the DeviceMotionEvent and DeviceOrientationEvent APIs, populating the results using commit history and date.

Commit: https://github.com/WebKit/WebKit/commit/1978c01a68fb5d4a8d7a0c3becb685f3364150ae#diff-cc63b7286aced27c9467c2e4466e43c0ba3960ee6991e59cefc66b06d30ea2ce ([WebKit 611.1.1](https://github.com/WebKit/WebKit/blob/1978c01a68fb5d4a8d7a0c3becb685f3364150ae/Source/WebCore/Configurations/Version.xcconfig))
