### PR TITLE
Update spec URLs for Document API

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -8,7 +8,6 @@
           "https://html.spec.whatwg.org/multipage/dom.html#the-document-object",
           "https://drafts.csswg.org/cssom-view/#extensions-to-the-document-interface",
           "https://w3c.github.io/pointerlock/#extensions-to-the-document-interface",
-          "https://w3c.github.io/page-visibility/#extensions-to-the-document-interface",
           "https://w3c.github.io/selection-api/#extensions-to-document-interface"
         ],
         "support": {
@@ -6194,7 +6193,7 @@
       "hidden": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/hidden",
-          "spec_url": "https://w3c.github.io/page-visibility/#dom-document-hidden",
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-document-hidden",
           "support": {
             "chrome": [
               {
@@ -7839,7 +7838,7 @@
       "onvisibilitychange": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/onvisibilitychange",
-          "spec_url": "https://w3c.github.io/page-visibility/#dom-document-onvisibilitychange",
+          "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onvisibilitychange",
           "support": {
             "chrome": {
               "version_added": "62",
@@ -11117,7 +11116,7 @@
       "visibilitychange_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/visibilitychange_event",
-          "spec_url": "https://w3c.github.io/page-visibility/#reacting-to-visibilitychange",
+          "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onvisibilitychange",
           "description": "<code>visibilitychange</code> event",
           "support": {
             "chrome": [
@@ -11231,7 +11230,7 @@
       "visibilityState": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/visibilityState",
-          "spec_url": "https://w3c.github.io/page-visibility/#visibilitystate-attribute",
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-document-visibilitystate",
           "support": {
             "chrome": [
               {


### PR DESCRIPTION
This PR updates the spec URLs for the Document API.  The Page Visibility spec has been merged into the WHATWG HTML spec, see https://github.com/w3c/browser-specs/pull/425 for more details.

This fixes the linter issue with the `browser-specs` update in #13395.
