### PR TITLE
Data for Safari 15.2 Beta 1 on macOS

### DIFF
--- a/api/FileSystemDirectoryHandle.json
+++ b/api/FileSystemDirectoryHandle.json
@@ -33,7 +33,7 @@
             "version_added": false
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "15.2"
           },
           "samsunginternet_android": {
             "version_added": "14.0"
@@ -80,7 +80,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "samsunginternet_android": {
               "version_added": "14.0"
@@ -129,7 +129,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "samsunginternet_android": {
               "version_added": "14.0"
@@ -178,7 +178,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "samsunginternet_android": {
               "version_added": "14.0"
@@ -226,7 +226,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "samsunginternet_android": {
               "version_added": "14.0"
@@ -275,7 +275,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "samsunginternet_android": {
               "version_added": "14.0"
@@ -324,7 +324,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "samsunginternet_android": {
               "version_added": "14.0"
@@ -372,7 +372,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "samsunginternet_android": {
               "version_added": "14.0"

--- a/api/FileSystemDirectoryHandle.json
+++ b/api/FileSystemDirectoryHandle.json
@@ -30,7 +30,7 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "15.2"
           },
           "safari_ios": {
             "version_added": "15.2"
@@ -77,7 +77,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "safari_ios": {
               "version_added": "15.2"
@@ -126,7 +126,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "safari_ios": {
               "version_added": "15.2"
@@ -175,7 +175,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "safari_ios": {
               "version_added": "15.2"
@@ -223,7 +223,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "safari_ios": {
               "version_added": "15.2"
@@ -272,7 +272,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "safari_ios": {
               "version_added": "15.2"
@@ -321,7 +321,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "safari_ios": {
               "version_added": "15.2"
@@ -369,7 +369,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "safari_ios": {
               "version_added": "15.2"

--- a/api/FileSystemFileHandle.json
+++ b/api/FileSystemFileHandle.json
@@ -30,7 +30,7 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "15.2"
           },
           "safari_ios": {
             "version_added": "15.2"
@@ -127,7 +127,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "safari_ios": {
               "version_added": "15.2"

--- a/api/FileSystemFileHandle.json
+++ b/api/FileSystemFileHandle.json
@@ -33,7 +33,7 @@
             "version_added": false
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "15.2"
           },
           "samsunginternet_android": {
             "version_added": "14.0"
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "samsunginternet_android": {
               "version_added": "14.0"

--- a/api/FileSystemHandle.json
+++ b/api/FileSystemHandle.json
@@ -33,7 +33,7 @@
             "version_added": false
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "15.2"
           },
           "samsunginternet_android": {
             "version_added": "14.0"
@@ -81,7 +81,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "samsunginternet_android": {
               "version_added": "14.0"
@@ -130,7 +130,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "samsunginternet_android": {
               "version_added": "14.0"
@@ -179,7 +179,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "samsunginternet_android": {
               "version_added": "14.0"

--- a/api/FileSystemHandle.json
+++ b/api/FileSystemHandle.json
@@ -30,7 +30,7 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "15.2"
           },
           "safari_ios": {
             "version_added": "15.2"
@@ -78,7 +78,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "safari_ios": {
               "version_added": "15.2"
@@ -127,7 +127,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "safari_ios": {
               "version_added": "15.2"
@@ -176,7 +176,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "safari_ios": {
               "version_added": "15.2"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3527,7 +3527,7 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "safari_ios": {
               "version_added": "15.2"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3530,7 +3530,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/StorageManager.json
+++ b/api/StorageManager.json
@@ -33,7 +33,7 @@
             "version_added": false
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "15.2"
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -128,7 +128,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -177,7 +177,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -226,7 +226,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/StorageManager.json
+++ b/api/StorageManager.json
@@ -30,7 +30,7 @@
             "version_added": "42"
           },
           "safari": {
-            "version_added": false
+            "version_added": "15.2"
           },
           "safari_ios": {
             "version_added": "15.2"
@@ -125,7 +125,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "safari_ios": {
               "version_added": "15.2"
@@ -174,7 +174,7 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "safari_ios": {
               "version_added": "15.2"
@@ -223,7 +223,7 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "safari_ios": {
               "version_added": "15.2"

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -894,7 +894,7 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "safari_ios": {
               "version_added": "15.2"

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -897,7 +897,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/_globals/crossOriginIsolated.json
+++ b/api/_globals/crossOriginIsolated.json
@@ -39,7 +39,7 @@
             "version_added": false
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "15.2"
           },
           "samsunginternet_android": {
             "version_added": "14.0"

--- a/api/_globals/crossOriginIsolated.json
+++ b/api/_globals/crossOriginIsolated.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "15.2"
           },
           "safari_ios": {
             "version_added": "15.2"

--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -188,6 +188,11 @@
           "status": "current",
           "engine": "WebKit",
           "engine_version": "612.2.9"
+        },
+        "15.2": {
+          "status": "beta",
+          "engine": "WebKit",
+          "engine_version": "612.3.2"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -159,6 +159,11 @@
           "status": "current",
           "engine": "WebKit",
           "engine_version": "612.2.9"
+        },
+        "15.2": {
+          "status": "beta",
+          "engine": "WebKit",
+          "engine_version": "612.3.2"
         }
       }
     }


### PR DESCRIPTION
#### Summary
Adds support data for Safari 15.2 Beta 1 on macOS.

#### Test results and supporting details
Data collected from results of the mdn-bcd-collector