### PR TITLE
FF93 supports image-rendering: pixelated

### DIFF
--- a/css/properties/image-rendering.json
+++ b/css/properties/image-rendering.json
@@ -224,10 +224,10 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "93"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "93"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Firefox supports `image-rendering: pixelated` since recently.

#### Test results and supporting details
Tested by me on a canvas and (not by me) on images in #13148.

Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=856337

#### Related issues
Fixes #13148 

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
