### PR TITLE
Add Safari for iOS WebExtensions Cookie API support

### DIFF
--- a/webextensions/api/cookies.json
+++ b/webextensions/api/cookies.json
@@ -23,6 +23,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -45,6 +48,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -69,6 +75,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -96,6 +105,10 @@
                 "safari": {
                   "notes": "Only supports explicit.",
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "notes": "Only supports explicit.",
+                  "version_added": "15"
                 }
               }
             }
@@ -122,6 +135,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -146,6 +162,9 @@
                 "version_added": true
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -174,6 +193,10 @@
               "safari": {
                 "notes": "HTTPOnly cookies are not retrieved.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "notes": "HTTPOnly cookies are not retrieved.",
+                "version_added": "15"
               }
             }
           },
@@ -196,6 +219,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -220,6 +246,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -253,6 +282,13 @@
                   "HTTPOnly cookies are not retrieved."
                 ],
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "notes": [
+                  "Only the cookies in the default cookie store are retrieved.",
+                  "HTTPOnly cookies are not retrieved."
+                ],
+                "version_added": "15"
               }
             }
           },
@@ -275,6 +311,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -299,6 +338,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -329,6 +371,10 @@
               "safari": {
                 "notes": "Always returns the same default cookie store with ID 0.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "notes": "Always returns the same default cookie store with ID 0.",
+                "version_added": "15"
               }
             }
           }
@@ -354,6 +400,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -376,6 +425,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -405,6 +457,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -427,6 +482,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -451,6 +509,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -479,6 +540,10 @@
               "safari": {
                 "notes": "Only supports explicit.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "notes": "Only supports explicit.",
+                "version_added": "15"
               }
             }
           }
@@ -506,6 +571,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -528,6 +596,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -578,6 +649,10 @@
                 "safari": {
                   "notes": "Only supports explicit.",
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "notes": "Only supports explicit.",
+                  "version_added": "15"
                 }
               }
             }


### PR DESCRIPTION
#### Summary
Includes Safari for iOS data for the Cookie API in WebExtensions.

#### Test results and supporting details
Reviewed internally with Safari engineers.

See ["Web Extensions" section in the Safari 15 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions).
