### PR TITLE
Add Safari for iOS WebExtensions permissions data

### DIFF
--- a/webextensions/api/permissions.json
+++ b/webextensions/api/permissions.json
@@ -23,6 +23,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -48,6 +51,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -74,6 +80,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -100,6 +109,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -125,6 +137,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -150,6 +165,10 @@
               },
               "safari": {
                 "version_added": "14",
+                "notes": "Removing <code>&lt;all_urls&gt;</code> or <code>*://*/*</code> origins will remove previously granted permission to request specific origin patterns and will stop automatically prompting the user for access to any visited website via the extension's access popover in the toolbar."
+              },
+              "safari_ios": {
+                "version_added": "15",
                 "notes": "Removing <code>&lt;all_urls&gt;</code> or <code>*://*/*</code> origins will remove previously granted permission to request specific origin patterns and will stop automatically prompting the user for access to any visited website via the extension's access popover in the toolbar."
               }
             }
@@ -183,6 +202,14 @@
                 "version_added": "14",
                 "notes": [
                   "Requesting <code>&lt;all_urls&gt;</code> or <code>*://*/*</code> origins will grant permission to request specific origin patterns and automatically prompt the user for access to any visited website via the extension's access popover in the toolbar.",
+                  "The user will be prompted again for permissions that have been previously granted and then removed.",
+                  "Supported permissions will be granted without prompting the user. Only specific origin patterns will prompt the user."
+                ]
+              },
+              "safari_ios": {
+                "version_added": "15",
+                "notes": [
+                  "Requesting <code>&lt;all_urls&gt;</code> or <code>*://*/*</code> origins will grant permission to request specific origin patterns and automatically prompt the user for access to any visited website via the extension's banner.",
                   "The user will be prompted again for permissions that have been previously granted and then removed.",
                   "Supported permissions will be granted without prompting the user. Only specific origin patterns will prompt the user."
                 ]


### PR DESCRIPTION
#### Summary
Includes WebExtensions permissions support data for Safari on iOS 15

#### Test results and supporting details
Reviewed internally with Safari engineers.

See ["Web Extensions" section in the Safari 15 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions).