### PR TITLE
Add Safari for iOS WebExtensions Storage API data

### DIFF
--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -23,6 +23,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -47,6 +50,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -72,6 +78,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -98,6 +107,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -123,6 +135,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -149,6 +164,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -175,6 +193,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -201,6 +222,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -231,6 +255,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -256,6 +283,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -284,6 +314,11 @@
                 "notes": "Safari does not sync items saved in the <code>sync</code> storage area, i.e. it behaves the same as the <code>local</code> storage area.",
                 "partial_implementation": true,
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "notes": "Safari does not sync items saved in the <code>sync</code> storage area, i.e. it behaves the same as the <code>local</code> storage area.",
+                "partial_implementation": true,
+                "version_added": "15"
               }
             }
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Includes WebExtensions Storage API data for Safari on iOS 15.

#### Test results and supporting details
Reviewed internally with Safari engineers.

See ["Web Extensions" section in the Safari 15 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions).
