### PR TITLE
Add Safari for iOS WebExtensions webNavigation data

### DIFF
--- a/webextensions/api/webNavigation.json
+++ b/webextensions/api/webNavigation.json
@@ -25,6 +25,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -47,6 +50,9 @@
                   "version_added": "17"
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -74,6 +80,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -96,6 +105,9 @@
                   "version_added": "17"
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -123,6 +135,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -146,6 +161,9 @@
                   "version_added": "17"
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -171,6 +189,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -195,6 +216,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -218,6 +242,9 @@
                   "version_added": "17"
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -245,6 +272,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -268,6 +298,9 @@
                   "version_added": "17"
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -293,6 +326,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -317,6 +353,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -340,6 +379,9 @@
                   "version_added": "17"
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -369,6 +411,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -394,6 +439,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -431,6 +479,10 @@
               "safari": {
                 "notes": "If the filter parameter is empty, Safari matches all URLs.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "notes": "If the filter parameter is empty, Safari matches all URLs.",
+                "version_added": "15"
               }
             }
           }
@@ -468,6 +520,10 @@
               "safari": {
                 "notes": "If the filter parameter is empty, Safari matches all URLs.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "notes": "If the filter parameter is empty, Safari matches all URLs.",
+                "version_added": "15"
               }
             }
           },
@@ -490,6 +546,9 @@
                   "version_added": "17"
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -514,6 +573,9 @@
                   "version_added": "17"
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -553,6 +615,10 @@
               "safari": {
                 "notes": "If the filter parameter is empty, Safari matches all URLs.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "notes": "If the filter parameter is empty, Safari matches all URLs.",
+                "version_added": "15"
               }
             }
           }
@@ -589,6 +655,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -611,6 +680,9 @@
                   "version_added": "17"
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -636,6 +708,9 @@
                   "version_added": "17"
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -675,6 +750,10 @@
               "safari": {
                 "notes": "If the filter parameter is empty, Safari matches all URLs.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "notes": "If the filter parameter is empty, Safari matches all URLs.",
+                "version_added": "15"
               }
             }
           }
@@ -712,6 +791,10 @@
               "safari": {
                 "notes": "If the filter parameter is empty, Safari matches all URLs.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "notes": "If the filter parameter is empty, Safari matches all URLs.",
+                "version_added": "15"
               }
             }
           },
@@ -735,6 +818,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -762,6 +848,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -784,6 +873,9 @@
                   "version_added": "17"
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -808,6 +900,9 @@
                   "version_added": "17"
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -846,6 +941,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -868,6 +966,9 @@
                   "version_added": "17"
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -892,6 +993,9 @@
                   "version_added": "17"
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -920,6 +1024,9 @@
                 "version_added": "17"
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }


### PR DESCRIPTION
#### Summary
Includes Safari for iOS 15 data for WebExtensions webNavigation API.

#### Test results and supporting details
Reviewed internally with Safari engineers.

See ["Web Extensions" section in the Safari 15 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions).
