### PR TITLE
Add Safari for iOS data for context menus

### DIFF
--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -33,6 +33,9 @@
               "safari": {
                 "alternative_name": "contextMenus.ACTION_MENU_TOP_LEVEL_LIMIT",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -69,6 +72,9 @@
               "safari": {
                 "alternative_name": "contextMenus.ContextType",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -93,6 +99,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -119,6 +128,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -142,6 +154,9 @@
                   "version_added": true
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -167,6 +182,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -190,6 +208,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -215,6 +236,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -239,6 +263,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -276,6 +303,9 @@
               "safari": {
                 "alternative_name": "contextMenus.ItemType",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -311,6 +341,9 @@
               "safari": {
                 "alternative_name": "contextMenus.OnClickData",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -333,6 +366,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -357,6 +393,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -386,6 +425,9 @@
                 "safari": {
                   "alternative_name": "contextMenus.OnClickData.frameId",
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -410,6 +452,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -433,6 +478,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -465,6 +513,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -488,6 +539,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -530,6 +584,9 @@
                 "alternative_name": "contextMenus.create",
                 "notes": "Items that don't specify 'contexts' do not inherit contexts from their parents.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -556,6 +613,9 @@
                   "notes": "Safari removes <code>&</code> from menu items' displayed titles, but does not support invoking menu items via access keys.",
                   "partial_implementation": true,
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -579,6 +639,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -604,6 +667,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -628,6 +694,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -653,6 +722,9 @@
                 "version_added": false
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -689,6 +761,9 @@
               "safari": {
                 "alternative_name": "contextMenus.onClicked",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -719,6 +794,9 @@
                 "version_added": false
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -751,6 +829,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -781,6 +862,9 @@
                 "version_added": false
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -817,6 +901,9 @@
               "safari": {
                 "alternative_name": "contextMenus.remove",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -852,6 +939,9 @@
               "safari": {
                 "alternative_name": "contextMenus.removeAll",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -887,6 +977,9 @@
               "safari": {
                 "alternative_name": "contextMenus.update",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }


### PR DESCRIPTION
#### Summary
Includes Safari for iOS data for WebExtensions contextual menus.

#### Test results and supporting details
Reviewed internally with Safari engineers.

See ["Web Extensions" section in the Safari 15 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions).