### PR TITLE
Add Edge versions for Metadata API

### DIFF
--- a/api/Metadata.json
+++ b/api/Metadata.json
@@ -13,7 +13,7 @@
             "prefix": "webkit"
           },
           "edge": {
-            "version_added": "≤79",
+            "version_added": "79",
             "prefix": "webkit"
           },
           "firefox": {
@@ -62,7 +62,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -110,7 +110,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `Metadata` API, based upon manual testing.

Test Code Used: `'Metadata' in self; 'WebKitMetadata' in self; 'webkitMetadata' in self; 'MSMetadata' in self;`
