### PR TITLE
Remove prefix claims about the Metadata interface

### DIFF
--- a/api/Metadata.json
+++ b/api/Metadata.json
@@ -5,16 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Metadata",
         "support": {
           "chrome": {
-            "version_added": "13",
-            "prefix": "webkit"
+            "version_added": "13"
           },
           "chrome_android": {
-            "version_added": "18",
-            "prefix": "webkit"
+            "version_added": "18"
           },
           "edge": {
-            "version_added": "79",
-            "prefix": "webkit"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false
@@ -38,8 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "1.0",
-            "prefix": "webkit"
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": false


### PR DESCRIPTION
The interface itself isn't prefixed in Chromium:
https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/filesystem/metadata.idl;l=34;drc=f5eccec110f06a006f4ec2b249b3c4b92e7dac35

Additionally, the string "webkitMetadata" has never appeared in a
Chromium commit message.
