### PR TITLE
Remove api.Range.insertNode.collapsed_ranges

### DIFF
--- a/api/Range.json
+++ b/api/Range.json
@@ -1002,54 +1002,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "collapsed_ranges": {
-          "__compat": {
-            "description": "Collapsed ranges",
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "14"
-              },
-              "firefox_android": {
-                "version_added": "14"
-              },
-              "ie": {
-                "version_added": "9"
-              },
-              "opera": {
-                "version_added": "9"
-              },
-              "opera_android": {
-                "version_added": "10.1"
-              },
-              "safari": {
-                "version_added": "4"
-              },
-              "safari_ios": {
-                "version_added": "3"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0"
-              },
-              "webview_android": {
-                "version_added": "≤37"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "intersectsNode": {


### PR DESCRIPTION
It's not clear what this sub-feature means from just the description,
and all we have is a guess:
https://github.com/mdn/browser-compat-data/pull/13075#issuecomment-954756548

The data matches the parent feature except for Firefox and Safari. This
probably means there's *something* that doesn't work the same before
Firefox 14 and Safari 4. This is far enough in the past that it's not
worth trying to salvage this sub-feature with more research.