### PR TITLE
CSP strict-dynamic added in Safari 15.4

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1514,10 +1514,10 @@
                   "version_added": "41"
                 },
                 "safari": {
-                  "version_added": "15.4"
+                  "version_added": "preview"
                 },
                 "safari_ios": {
-                  "version_added": "15.4"
+                  "version_added": "preview"
                 },
                 "samsunginternet_android": {
                   "version_added": "6.0"

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1514,10 +1514,10 @@
                   "version_added": "41"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "15.4"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "15.4"
                 },
                 "samsunginternet_android": {
                   "version_added": "6.0"

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1517,7 +1517,7 @@
                   "version_added": "preview"
                 },
                 "safari_ios": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "samsunginternet_android": {
                   "version_added": "6.0"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Content-Security-Policy: strict-dynamic has been added to Safari 15.4 (now in Technical Preview)

#### Test results and supporting details

[Bug 184031 - CSP: Implement 'strict-dynamic' source expression](https://bugs.webkit.org/show_bug.cgi?id=184031)
