### PR TITLE
Add Edge versions for Speech* API

### DIFF
--- a/api/SpeechGrammarList.json
+++ b/api/SpeechGrammarList.json
@@ -15,7 +15,7 @@
           },
           "edge": {
             "prefix": "webkit",
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false
@@ -69,7 +69,7 @@
             },
             "edge": {
               "prefix": "webkit",
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -120,7 +120,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -169,7 +169,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -218,7 +218,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -267,7 +267,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false

--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -17,7 +17,7 @@
           },
           "edge": {
             "prefix": "webkit",
-            "version_added": "≤79",
+            "version_added": "79",
             "notes": "You'll need to serve your code through a web server for recognition to work."
           },
           "firefox": {
@@ -76,7 +76,7 @@
             },
             "edge": {
               "prefix": "webkit",
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -129,7 +129,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -278,7 +278,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -427,7 +427,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -476,7 +476,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -525,7 +525,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -574,7 +574,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -673,7 +673,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -722,7 +722,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -771,7 +771,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -820,7 +820,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -869,7 +869,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -918,7 +918,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -967,7 +967,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -1016,7 +1016,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -1065,7 +1065,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -1114,7 +1114,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -1163,7 +1163,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -1261,7 +1261,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -1510,7 +1510,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -1609,7 +1609,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false

--- a/api/SpeechRecognitionAlternative.json
+++ b/api/SpeechRecognitionAlternative.json
@@ -12,7 +12,7 @@
             "version_added": "33"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false
@@ -60,7 +60,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -109,7 +109,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false

--- a/api/SpeechRecognitionEvent.json
+++ b/api/SpeechRecognitionEvent.json
@@ -15,7 +15,7 @@
           },
           "edge": {
             "prefix": "webkit",
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false
@@ -67,7 +67,7 @@
             },
             "edge": {
               "prefix": "webkit",
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -117,7 +117,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -165,7 +165,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -214,7 +214,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -263,7 +263,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false

--- a/api/SpeechRecognitionResult.json
+++ b/api/SpeechRecognitionResult.json
@@ -12,7 +12,7 @@
             "version_added": "33"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false
@@ -60,7 +60,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -109,7 +109,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -158,7 +158,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false

--- a/api/SpeechRecognitionResultList.json
+++ b/api/SpeechRecognitionResultList.json
@@ -12,7 +12,7 @@
             "version_added": "33"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false
@@ -60,7 +60,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -109,7 +109,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `Speech*` API, based upon manual testing.

Test Code Used: `'WebKitSpeech*' in self; 'Speech*' in self;`
