### PR TITLE
Add Edge versions for api.TouchEvent.TouchEvent

### DIFF
--- a/api/TouchEvent.json
+++ b/api/TouchEvent.json
@@ -83,7 +83,7 @@
               "notes": "Chrome only supports the following <code>touchEventInit</code> properties: <code>touches</code>, <code>targetTouches</code>, <code>changedTouches</code>."
             },
             "edge": {
-              "version_added": "≤79",
+              "version_added": "79",
               "notes": "Edge only supports the following <code>touchEventInit</code> properties: <code>touches</code>, <code>targetTouches</code>, <code>changedTouches</code>."
             },
             "firefox": {


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `TouchEvent` member of the `TouchEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TouchEvent/TouchEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
