### PR TITLE
Add Edge versions for api.VTTCue.VTTCue

### DIFF
--- a/api/VTTCue.json
+++ b/api/VTTCue.json
@@ -61,7 +61,7 @@
               "version_added": "33"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "31"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `VTTCue` member of the `VTTCue` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/VTTCue/VTTCue

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
