### PR TITLE
Add Safari for iOS WebExtensions extensionTypes data

### DIFF
--- a/webextensions/api/extensionTypes.json
+++ b/webextensions/api/extensionTypes.json
@@ -23,6 +23,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -45,6 +48,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -69,6 +75,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -101,7 +110,12 @@
                 "notes": "This feature is supported but not exposed through the 'extensionTypes' object."
               },
               "safari": {
-                "version_added": false,
+                "version_added": "14",
+                "partial_implementation": true,
+                "notes": "This feature is supported but not exposed through the 'extensionTypes' object."
+              },
+              "safari_ios": {
+                "version_added": "15",
                 "partial_implementation": true,
                 "notes": "This feature is supported but not exposed through the 'extensionTypes' object."
               }
@@ -134,9 +148,20 @@
                 "notes": "This feature is supported but not exposed through the 'extensionTypes' object."
               },
               "safari": {
-                "version_added": false,
+                "version_added": "14",
                 "partial_implementation": true,
-                "notes": "This feature is supported but not exposed through the 'extensionTypes' object."
+                "notes": [
+                  "This feature is supported but not exposed through the 'extensionTypes' object.",
+                  "'document_idle' and 'document_end' are treated the same."
+                ]
+              },
+              "safari_ios": {
+                "version_added": "15",
+                "partial_implementation": true,
+                "notes": [
+                  "This feature is supported but not exposed through the 'extensionTypes' object.",
+                  "'document_idle' and 'document_end' are treated the same."
+                ]
               }
             }
           }
@@ -160,6 +185,9 @@
                 "version_added": false
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }


### PR DESCRIPTION
#### Summary
Includes extensionType support data for Safari on iOS.

#### Test results and supporting details
Reviewed internally with Safari engineers.

See ["Web Extensions" section in the Safari 15 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions).