### PR TITLE
Add no Safari on iOS support for WebExtensions Notifications API

### DIFF
--- a/webextensions/api/notifications.json
+++ b/webextensions/api/notifications.json
@@ -22,7 +22,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": "14"
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -47,7 +50,10 @@
                   "version_added": true
                 },
                 "safari": {
-                  "version_added": "14"
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               },
               "status": {
@@ -77,7 +83,10 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": "14"
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -105,6 +114,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -130,7 +142,10 @@
                   "version_added": true
                 },
                 "safari": {
-                  "version_added": "14"
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -157,7 +172,10 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": "14"
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               },
               "status": {
@@ -190,6 +208,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -218,8 +239,10 @@
                   "version_added": false
                 },
                 "safari": {
-                  "notes": "On macOS only the first item is shown.",
-                  "version_added": "14"
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -245,7 +268,10 @@
                   "version_added": true
                 },
                 "safari": {
-                  "version_added": "14"
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -273,6 +299,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -297,6 +326,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -326,7 +358,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": "14"
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -351,6 +386,9 @@
                 "version_added": "25"
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -377,6 +415,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -401,6 +442,9 @@
                 "version_added": "25"
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -427,6 +471,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -451,6 +498,9 @@
                 "version_added": "25"
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -477,6 +527,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -499,6 +552,9 @@
                   "version_added": true
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -526,6 +582,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -551,6 +610,9 @@
                 "version_added": "25"
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }


### PR DESCRIPTION
#### Summary
Updates that remove Safari support for WebExtensions Notifications API.

#### Test results and supporting details
Reviewed internally with Safari engineers.

See ["Web Extensions" section in the Safari 15 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions).