### PR TITLE
Add Safari for iOS WebExtensions runtime data

### DIFF
--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -25,6 +25,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -47,7 +50,10 @@
                   "version_added": "28"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -71,6 +77,9 @@
                   "version_added": "19"
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -97,6 +106,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -127,6 +139,10 @@
               "safari": {
                 "version_added": "14",
                 "notes": "Only supports 'install' and 'update'."
+              },
+              "safari_ios": {
+                "version_added": "15",
+                "notes": "Only supports 'install' and 'update'."
               }
             }
           }
@@ -151,6 +167,9 @@
                 "version_added": true
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -177,6 +196,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -202,6 +224,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -224,6 +249,9 @@
                   "version_added": true
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -251,6 +279,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -276,6 +307,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -301,6 +335,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -323,6 +360,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -350,6 +390,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -375,6 +418,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -401,6 +447,10 @@
               "safari": {
                 "notes": "See the documentation on developer.apple.com about native messaging in Safari.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "notes": "See the documentation on developer.apple.com about native messaging in Safari.",
+                "version_added": "15"
               }
             }
           }
@@ -428,6 +478,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -452,6 +505,9 @@
                 "version_added": false
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -478,6 +534,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -502,6 +561,9 @@
                 "version_added": "16"
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -528,6 +590,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -553,6 +618,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -578,6 +646,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -606,6 +677,10 @@
               "safari": {
                 "notes": "<code>lastError</code> is only set if a callback is used. <code>Promise</code> results that fail will be rejected with an <code>Error</code> object.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "notes": "<code>lastError</code> is only set if a callback is used. <code>Promise</code> results that fail will be rejected with an <code>Error</code> object.",
+                "version_added": "15"
               }
             }
           }
@@ -630,6 +705,9 @@
                 "version_added": "15"
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             },
@@ -661,6 +739,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -685,6 +766,9 @@
                 "version_added": "15"
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -713,6 +797,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -737,6 +824,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": "15"
                   }
                 }
               }
@@ -761,6 +851,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": "15"
                   }
                 }
               }
@@ -785,6 +878,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": "15"
                   }
                 }
               }
@@ -808,6 +904,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -836,6 +935,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -859,6 +961,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -885,7 +990,12 @@
                 "version_added": "15"
               },
               "safari": {
+                "notes": "Only fired in response to a message from an extension's containing app.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "notes": "Only fired in response to a message from an extension's containing app.",
+                "version_added": "15"
               }
             }
           },
@@ -909,6 +1019,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -936,6 +1049,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -961,6 +1077,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -985,6 +1104,9 @@
                 "version_added": "15"
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -1011,6 +1133,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -1035,6 +1160,9 @@
                 "version_added": "15"
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -1061,6 +1189,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -1086,6 +1217,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -1110,6 +1244,9 @@
                 "version_added": "15"
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -1137,6 +1274,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -1161,6 +1301,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1184,6 +1327,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -1213,6 +1359,10 @@
               "safari": {
                 "notes": "See the documentation on developer.apple.com about native messaging in Safari.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "notes": "See the documentation on developer.apple.com about native messaging in Safari.",
+                "version_added": "15"
               }
             }
           }
@@ -1240,6 +1390,11 @@
                 "notes": "API exists, but has no effect.",
                 "partial_implementation": true,
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "notes": "API exists, but has no effect.",
+                "partial_implementation": true,
+                "version_added": "15"
               }
             }
           }


### PR DESCRIPTION
#### Summary
Includes Safari for iOS support data for WebExtensions runtime. Corrects Safari 14 for macOS support data.

#### Test results and supporting details
Reviewed internally with Safari engineers.

See ["Web Extensions" section in the Safari 15 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions).