### PR TITLE
Add Safari for iOS WebExtensions webRequest data

### DIFF
--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -23,6 +23,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -46,6 +49,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -73,6 +79,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -98,6 +107,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -122,6 +134,9 @@
                 "version_added": true
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -156,6 +171,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -179,6 +197,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -205,6 +226,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -228,6 +252,9 @@
                   "version_added": true
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -253,6 +280,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -279,6 +309,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -301,6 +334,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -326,6 +362,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -349,6 +388,9 @@
                   "version_added": "36"
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -374,6 +416,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -397,6 +442,9 @@
                   "version_added": "45"
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -424,6 +472,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -449,8 +500,10 @@
                   "notes": "Requests sent by navigator.sendBeacon(), and CSP reports in Chrome 49-57 (Opera 36-44), are also labeled as `ping`."
                 },
                 "safari": {
-                  "version_added": false,
-                  "notes": "Requests sent by navigator.sendBeacon(), and CSP reports in Chrome 49-57 (Opera 36-44), are also labeled as `ping`."
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -474,6 +527,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -499,6 +555,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -522,6 +581,9 @@
                   "version_added": "45"
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -548,6 +610,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -572,6 +637,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -595,6 +663,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -622,6 +693,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -647,6 +721,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -670,6 +747,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -696,6 +776,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -720,6 +803,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -746,6 +832,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -770,6 +859,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -796,6 +888,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -820,6 +915,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -846,6 +944,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -870,6 +971,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -896,6 +1000,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -920,6 +1027,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -947,6 +1057,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -971,6 +1084,9 @@
                 "version_added": false
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -997,6 +1113,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -1021,6 +1140,9 @@
                 "version_added": true
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -1050,6 +1172,9 @@
               "safari": {
                 "notes": "extraInfoSpec options are not supported.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -1072,6 +1197,9 @@
                   "version_added": true
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -1100,6 +1228,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1123,6 +1254,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -1148,6 +1282,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1172,6 +1309,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1195,6 +1335,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -1220,6 +1363,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1244,6 +1390,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1267,6 +1416,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -1292,6 +1444,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1315,6 +1470,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -1340,6 +1498,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1364,6 +1525,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1388,6 +1552,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1412,6 +1579,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1436,6 +1606,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1460,6 +1633,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1484,6 +1660,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1507,6 +1686,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -1532,6 +1714,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1556,6 +1741,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1580,6 +1768,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1603,6 +1794,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -1632,6 +1826,9 @@
               "safari": {
                 "notes": "extraInfoSpec options are not supported.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -1655,6 +1852,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -1680,6 +1880,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1704,6 +1907,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1752,6 +1958,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1776,6 +1985,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1800,6 +2012,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1823,6 +2038,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -1848,6 +2066,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1871,6 +2092,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -1896,6 +2120,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1920,6 +2147,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1944,6 +2174,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1968,6 +2201,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1992,6 +2228,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2016,6 +2255,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2039,6 +2281,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -2064,6 +2309,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2088,6 +2336,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2112,6 +2363,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2135,6 +2389,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -2169,6 +2426,9 @@
               "safari": {
                 "notes": "extraInfoSpec options are not supported.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -2192,6 +2452,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -2217,6 +2480,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2240,6 +2506,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -2265,6 +2534,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2288,6 +2560,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -2313,6 +2588,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2336,6 +2614,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -2361,6 +2642,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2384,6 +2668,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -2409,6 +2696,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2433,6 +2723,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2457,6 +2750,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2480,6 +2776,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -2505,6 +2804,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2529,6 +2831,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2553,6 +2858,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2576,6 +2884,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -2610,6 +2921,9 @@
               "safari": {
                 "notes": "extraInfoSpec options are not supported.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -2633,6 +2947,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -2658,6 +2975,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2682,6 +3002,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2705,6 +3028,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -2730,6 +3056,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2753,6 +3082,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -2778,6 +3110,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2801,6 +3136,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -2826,6 +3164,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2850,6 +3191,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2874,6 +3218,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2897,6 +3244,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -2922,6 +3272,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2946,6 +3299,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2970,6 +3326,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -2993,6 +3352,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -3022,6 +3384,9 @@
               "safari": {
                 "notes": "extraInfoSpec options are not supported.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -3045,6 +3410,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -3070,6 +3438,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3094,6 +3465,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3118,6 +3492,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3141,6 +3518,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -3166,6 +3546,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3190,6 +3573,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3213,6 +3599,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -3238,6 +3627,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3261,6 +3653,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -3286,6 +3681,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3310,6 +3708,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3334,6 +3735,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3358,6 +3762,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3382,6 +3789,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3405,6 +3815,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -3430,6 +3843,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3454,6 +3870,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3478,6 +3897,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3501,6 +3923,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -3530,6 +3955,9 @@
               "safari": {
                 "notes": "extraInfoSpec options are not supported.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -3553,6 +3981,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -3578,6 +4009,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3602,6 +4036,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3626,6 +4063,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3674,6 +4114,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3698,6 +4141,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3722,6 +4168,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3745,6 +4194,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -3770,6 +4222,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3793,6 +4248,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -3818,6 +4276,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3842,6 +4303,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3865,6 +4329,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -3890,6 +4357,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3914,6 +4384,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3938,6 +4411,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -3961,6 +4437,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -4001,6 +4480,9 @@
               "safari": {
                 "notes": "extraInfoSpec options are not supported.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -4024,6 +4506,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -4049,6 +4534,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4072,6 +4560,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -4097,6 +4588,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4120,6 +4614,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -4145,6 +4642,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4168,6 +4668,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -4193,6 +4696,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4216,6 +4722,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -4241,6 +4750,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4264,6 +4776,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -4289,6 +4804,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4313,6 +4831,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4337,6 +4858,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4361,6 +4885,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4385,6 +4912,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4408,6 +4938,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -4433,6 +4966,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4457,6 +4993,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4481,6 +5020,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4504,6 +5046,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -4533,6 +5078,9 @@
               "safari": {
                 "notes": "extraInfoSpec options are not supported.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -4556,6 +5104,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -4581,6 +5132,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4605,6 +5159,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4629,6 +5186,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4652,6 +5212,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -4677,6 +5240,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4701,6 +5267,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4724,6 +5293,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -4749,6 +5321,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4772,6 +5347,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -4797,6 +5375,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4821,6 +5402,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4845,6 +5429,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4869,6 +5456,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4893,6 +5483,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4916,6 +5509,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -4941,6 +5537,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4965,6 +5564,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4989,6 +5591,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -5012,6 +5617,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -5041,6 +5649,9 @@
               "safari": {
                 "notes": "extraInfoSpec options are not supported.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -5064,6 +5675,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -5089,6 +5703,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -5113,6 +5730,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -5136,6 +5756,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -5161,6 +5784,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -5184,6 +5810,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -5209,6 +5838,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -5232,6 +5864,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -5257,6 +5892,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -5281,6 +5919,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -5305,6 +5946,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -5328,6 +5972,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -5353,6 +6000,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -5377,6 +6027,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -5401,6 +6054,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -5424,6 +6080,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }


### PR DESCRIPTION
#### Summary
Includes lack of Safari for iOS support of WebExtensions webRequest.
 
#### Test results and supporting details
Reviewed internally with Safari engineers.

See ["Web Extensions" section in the Safari 15 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions).