### PR TITLE
IMP: update data for iOS safari for -webkit-scrollbar

### DIFF
--- a/css/selectors/-webkit-scrollbar-button.json
+++ b/css/selectors/-webkit-scrollbar-button.json
@@ -36,7 +36,8 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "14"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/-webkit-scrollbar-button.json
+++ b/css/selectors/-webkit-scrollbar-button.json
@@ -37,7 +37,7 @@
             },
             "safari_ios": {
               "version_added": "3",
-              "version_removed": "14"
+              "version_removed": "13"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/-webkit-scrollbar-corner.json
+++ b/css/selectors/-webkit-scrollbar-corner.json
@@ -36,7 +36,8 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "14"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/-webkit-scrollbar-corner.json
+++ b/css/selectors/-webkit-scrollbar-corner.json
@@ -37,7 +37,7 @@
             },
             "safari_ios": {
               "version_added": "3",
-              "version_removed": "14"
+              "version_removed": "13"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/-webkit-scrollbar-thumb.json
+++ b/css/selectors/-webkit-scrollbar-thumb.json
@@ -36,7 +36,8 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "14"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/-webkit-scrollbar-thumb.json
+++ b/css/selectors/-webkit-scrollbar-thumb.json
@@ -37,7 +37,7 @@
             },
             "safari_ios": {
               "version_added": "3",
-              "version_removed": "14"
+              "version_removed": "13"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/-webkit-scrollbar-track-piece.json
+++ b/css/selectors/-webkit-scrollbar-track-piece.json
@@ -36,7 +36,8 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "14"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/-webkit-scrollbar-track-piece.json
+++ b/css/selectors/-webkit-scrollbar-track-piece.json
@@ -37,7 +37,7 @@
             },
             "safari_ios": {
               "version_added": "3",
-              "version_removed": "14"
+              "version_removed": "13"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/-webkit-scrollbar-track.json
+++ b/css/selectors/-webkit-scrollbar-track.json
@@ -36,7 +36,8 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "14"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/-webkit-scrollbar-track.json
+++ b/css/selectors/-webkit-scrollbar-track.json
@@ -37,7 +37,7 @@
             },
             "safari_ios": {
               "version_added": "3",
-              "version_removed": "14"
+              "version_removed": "13"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/-webkit-scrollbar.json
+++ b/css/selectors/-webkit-scrollbar.json
@@ -37,7 +37,7 @@
             },
             "safari_ios": {
               "version_added": "3",
-              "version_removed": "14"
+              "notes": "As of Safari for iOS 13 only `display: none` will work, any other styles have no effect."
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/-webkit-scrollbar.json
+++ b/css/selectors/-webkit-scrollbar.json
@@ -36,7 +36,8 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "14"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/css/selectors/-webkit-scrollbar.json
+++ b/css/selectors/-webkit-scrollbar.json
@@ -37,7 +37,7 @@
             },
             "safari_ios": {
               "version_added": "3",
-              "notes": "As of Safari for iOS 13 only `display: none` will work, any other styles have no effect."
+              "notes": "From Safari 13, only <code>display: none</code> works with this pseudo-element. Other styles have no effect."
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

This marks the removal of the CSS Selectors for the -webkit-scrollbar from iOS safari 14+
Since this does not work anymore on iOS safari 14+

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

Tested websites using an custom scrollbar like, [css-tricks.com](https://css-tricks.com/) and [fylgja.dev](https://fylgja.dev/components/scrollbar/), on iOS device

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Sadly there is no mention of this in the official release notes for Safari.

Only this https://developer.apple.com/forums/thread/670065
And this issue found here -> https://github.com/mdn/browser-compat-data/issues/9967

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fixes #9967

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
