### PR TITLE
Update deno version to 1.16

### DIFF
--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -90,36 +90,42 @@
         "1.12": {
           "release_date": "2021-07-13",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.12.0",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "9.2"
         },
         "1.13": {
           "release_date": "2021-08-10",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.13.0",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "9.3"
         },
         "1.14": {
           "release_date": "2021-09-14",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.14.0",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "9.4"
         },
         "1.15": {
           "release_date": "2021-10-12",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.15.0",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "9.5"
         },
         "1.16": {
-          "release_date": "2021-11-16",
-          "status": "nightly",
+          "release_date": "2021-11-09",
+          "release_notes": "https://github.com/denoland/deno/releases/tag/v1.16.0",
+          "status": "current",
           "engine": "V8",
           "engine_version": "9.6"
+        },
+        "1.17": {
+          "status": "nightly",
+          "engine": "V8",
+          "engine_version": "9.7"
         }
       }
     }


### PR DESCRIPTION
Hello everyone!

I updated the Deno version to 1.16.

It doesn't include a version date for 1.17 as I haven't found any site commenting on it.