### PR TITLE
Add missing api.HTMLOutputElement.HTMLOutputElement feature

### DIFF
--- a/api/HTMLOutputElement.json
+++ b/api/HTMLOutputElement.json
@@ -48,6 +48,55 @@
           "deprecated": false
         }
       },
+      "HTMLOutputElement": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#htmloutputelement",
+          "description": "<code>HTMLOutputElement()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": {
+              "version_added": "15"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "checkValidity": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLOutputElement/checkValidity",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `HTMLOutputElement` member of the HTMLOutputElement API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLOutputElement/HTMLOutputElement

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
