### PR TITLE
Add missing api.ImageData.colorSpace feature

### DIFF
--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -98,6 +98,54 @@
           }
         }
       },
+      "colorSpace": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-imagedata-colorspace",
+          "support": {
+            "chrome": {
+              "version_added": "92"
+            },
+            "chrome_android": {
+              "version_added": "92"
+            },
+            "edge": {
+              "version_added": "92"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "78"
+            },
+            "opera_android": {
+              "version_added": "65"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "92"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "data": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageData/data",

--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -140,7 +140,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `colorSpace` member of the ImageData API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ImageData/colorSpace

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
