### PR TITLE
Add missing api.ImageDecoder.isTypeSupported feature

### DIFF
--- a/api/ImageDecoder.json
+++ b/api/ImageDecoder.json
@@ -245,6 +245,54 @@
           }
         }
       },
+      "isTypeSupported": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webcodecs/#dom-imagedecoder-istypesupported",
+          "support": {
+            "chrome": {
+              "version_added": "94"
+            },
+            "chrome_android": {
+              "version_added": "94"
+            },
+            "edge": {
+              "version_added": "94"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "80"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "94"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "reset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageDecoder/reset",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `isTypeSupported` member of the ImageDecoder API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ImageDecoder/isTypeSupported

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
