### PR TITLE
Add missing features for MediaSession API

### DIFF
--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -252,6 +252,102 @@
           }
         }
       },
+      "setCameraActive": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediasession-setcameraactive",
+          "support": {
+            "chrome": {
+              "version_added": "93"
+            },
+            "chrome_android": {
+              "version_added": "93"
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "79"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "setMicrophoneActive": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediasession/#dom-mediasession-setmicrophoneactive",
+          "support": {
+            "chrome": {
+              "version_added": "93"
+            },
+            "chrome_android": {
+              "version_added": "93"
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "79"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "setPositionState": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSession/setPositionState",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing features of the MediaSession API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaSession

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
