### PR TITLE
Add Safari for iOS WebExtensions browserAction data

### DIFF
--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -23,6 +23,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -48,6 +51,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -73,6 +79,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -98,6 +107,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -125,6 +137,11 @@
                 "version_added": "14",
                 "partial_implementation": true,
                 "notes": "Always returns a red <code>ColorArray</code>."
+              },
+              "safari_ios": {
+                "version_added": "15",
+                "partial_implementation": true,
+                "notes": "Always returns a red <code>ColorArray</code>."
               }
             }
           },
@@ -148,6 +165,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -176,6 +196,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -199,6 +222,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -227,6 +253,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -252,6 +281,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -275,6 +307,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -303,6 +338,11 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15",
+                "partial_implementation": true,
+                "notes": "The API exists, but the title not visible in the UI."
               }
             }
           },
@@ -326,6 +366,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -354,6 +397,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -377,6 +423,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -405,6 +454,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -427,6 +479,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -452,6 +507,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -492,6 +550,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -526,6 +587,11 @@
                 "version_added": "14",
                 "partial_implementation": true,
                 "notes": "The API exists, but has no effect."
+              },
+              "safari_ios": {
+                "version_added": "15",
+                "partial_implementation": true,
+                "notes": "The API exists, but has no effect."
               }
             }
           },
@@ -549,6 +615,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -576,6 +645,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -601,6 +673,9 @@
                   "version_added": true
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -635,6 +710,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -658,6 +736,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -685,6 +766,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -710,6 +794,9 @@
                 "version_added": false
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -749,6 +836,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -772,6 +862,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -798,6 +891,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -823,6 +919,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -863,6 +962,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -886,6 +988,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -913,6 +1018,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -953,6 +1061,11 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15",
+                "partial_implementation": true,
+                "notes": "The API exists, but the title not visible in the UI."
               }
             }
           },
@@ -976,6 +1089,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -1003,6 +1119,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }


### PR DESCRIPTION
#### Summary
Include Safari for iOS support for WebExtensions browserAction API.

#### Test results and supporting details
Reviewed internally with Safari engineers.

See ["Web Extensions" section in the Safari 15 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions).
