### PR TITLE
Add Safari for iOS WebExtensions Windows API data

### DIFF
--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -27,6 +27,10 @@
               "safari": {
                 "version_added": "14",
                 "notes": "`panel` and `detached_panel` are not supported."
+              },
+              "safari_ios": {
+                "version_added": "15",
+                "notes": "`panel` and `detached_panel` are not supported."
               }
             }
           }
@@ -52,6 +56,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -77,6 +84,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -102,6 +112,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -125,6 +138,10 @@
                 },
                 "safari": {
                   "version_added": "14",
+                  "notes": "Always returns false."
+                },
+                "safari_ios": {
+                  "version_added": "15",
                   "notes": "Always returns false."
                 }
               }
@@ -150,6 +167,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -174,6 +194,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -198,6 +221,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -223,6 +249,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -247,6 +276,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -270,6 +302,9 @@
                   "version_added": "18"
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -295,6 +330,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -319,6 +357,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -342,6 +383,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -367,6 +411,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -391,6 +438,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -415,6 +465,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -441,6 +494,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -463,6 +519,9 @@
                   "version_added": true
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               },
@@ -493,6 +552,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -517,6 +579,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -541,6 +606,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -567,6 +635,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -589,6 +660,9 @@
                   "version_added": true
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -614,6 +688,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -637,6 +714,9 @@
                   "version_added": true
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -669,6 +749,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -692,6 +775,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -717,6 +803,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -741,6 +830,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -765,6 +857,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -789,6 +884,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -813,6 +911,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -837,6 +938,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -860,6 +964,9 @@
                     "version_added": true
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -885,6 +992,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -909,6 +1019,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -933,6 +1046,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -958,6 +1074,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -982,6 +1101,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -1009,6 +1131,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -1032,6 +1157,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             },
@@ -1055,6 +1183,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": "15"
                   }
                 },
                 "status": {
@@ -1087,6 +1218,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -1110,6 +1244,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -1134,6 +1271,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -1160,6 +1300,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -1183,6 +1326,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             },
@@ -1206,6 +1352,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 },
                 "status": {
@@ -1238,6 +1387,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -1261,6 +1413,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             },
@@ -1284,6 +1439,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 },
                 "status": {
@@ -1316,6 +1474,10 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15",
+                "notes": "Fires a pair of events: one for private browsing, one for regular browsing."
               }
             }
           }
@@ -1341,6 +1503,10 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15",
+                "notes": "Fires when toggling in or out of private browsing mode, leaving Safari to the home screen, and returning to Safari from the home screen."
               }
             }
           }
@@ -1366,6 +1532,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -1391,6 +1560,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -1416,6 +1588,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -1438,6 +1613,9 @@
                   "version_added": true
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -1463,6 +1641,10 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15",
+                  "notes": "`update()` will not switch between side-by-side Safari on iPadOS."
                 }
               }
             }
@@ -1487,6 +1669,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -1511,6 +1696,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -1535,6 +1723,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -1558,6 +1749,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -1583,6 +1777,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -1607,6 +1804,9 @@
                 },
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }

--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -1644,7 +1644,7 @@
                 },
                 "safari_ios": {
                   "version_added": "15",
-                  "notes": "`update()` will not switch between side-by-side Safari on iPadOS."
+                  "notes": "<code>update()</code> will not switch between side-by-side Safari on iPadOS."
                 }
               }
             }


### PR DESCRIPTION
#### Summary
Includes Safari for iOS support of the WebExtensions Windows API.

#### Test results and supporting details
Reviewed internally with Safari engineers.

See ["Web Extensions" section in the Safari 15 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions).