### PR TITLE
Add Safari for iOS extension support data

### DIFF
--- a/webextensions/api/extension.json
+++ b/webextensions/api/extension.json
@@ -208,11 +208,11 @@
                 },
                 "safari": {
                   "version_added": "14",
-                  "notes": "Filtering by `windowId` won't work when a tab is moved from one window to another."
+                  "notes": "Filtering by <code>windowId</code> won't work when a tab is moved from one window to another."
                 },
                 "safari_ios": {
                   "version_added": "15",
-                  "notes": "Filtering by `windowId` won't work when a tab is moved from one window to another."
+                  "notes": "Filtering by <code>windowId</code> won't work when a tab is moved from one window to another."
                 }
               }
             }

--- a/webextensions/api/extension.json
+++ b/webextensions/api/extension.json
@@ -23,6 +23,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -45,6 +48,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -72,6 +78,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -96,6 +105,9 @@
                 "version_added": false
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             },
@@ -127,6 +139,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             },
             "status": {
@@ -159,6 +174,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           },
@@ -189,7 +207,12 @@
                   "version_added": true
                 },
                 "safari": {
-                  "version_added": "14"
+                  "version_added": "14",
+                  "notes": "Filtering by `windowId` won't work when a tab is moved from one window to another."
+                },
+                "safari_ios": {
+                  "version_added": "15",
+                  "notes": "Filtering by `windowId` won't work when a tab is moved from one window to another."
                 }
               }
             }
@@ -218,6 +241,11 @@
                 "notes": "Always returns false.",
                 "partial_implementation": true,
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "notes": "Always returns false.",
+                "partial_implementation": true,
+                "version_added": "15"
               }
             }
           }
@@ -245,6 +273,11 @@
                 "notes": "Always returns false.",
                 "partial_implementation": true,
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "notes": "Always returns false.",
+                "partial_implementation": true,
+                "version_added": "15"
               }
             }
           }
@@ -272,6 +305,11 @@
                 "notes": "Always returns true.",
                 "partial_implementation": true,
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "notes": "Always returns true.",
+                "partial_implementation": true,
+                "version_added": "15"
               }
             }
           }
@@ -297,6 +335,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -321,6 +362,9 @@
                 "version_added": true
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             },
@@ -352,6 +396,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
             "status": {
@@ -382,6 +429,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
             "status": {
@@ -411,6 +461,9 @@
                 "version_added": true
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }


### PR DESCRIPTION
#### Summary
Includes Safari for iOS support of WebExtensions Extension API.

#### Test results and supporting details
Reviewed internally with Safari engineers.

See ["Web Extensions" section in the Safari 15 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions).