### PR TITLE
Update ResizeObserverEntry Firefox support

### DIFF
--- a/api/ResizeObserverEntry.json
+++ b/api/ResizeObserverEntry.json
@@ -111,11 +111,17 @@
             "edge": {
               "version_added": "84"
             },
-            "firefox": {
-              "version_added": "69",
-              "partial_implementation": true,
-              "notes": "Implemented as a single object representing a content box size, rather than an array of content box size objects."
-            },
+            "firefox": [
+              {
+                "version_added": "92"
+              },
+              {
+                "version_added": "69",
+                "version_removed": "92",
+                "partial_implementation": true,
+                "notes": "Implemented as a single object representing a content box size, rather than an array of content box size objects."
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },


### PR DESCRIPTION
In https://github.com/mdn/browser-compat-data/issues/10938 we updated compat data to note that `contentBoxSize` is a single item in Firefox, not an array as per spec. According to https://bugzilla.mozilla.org/show_bug.cgi?id=1599176, and confirmed by manual testing, this is now fixed.

Also see: https://mdn.github.io/dom-examples/resize-observer/resize-observer-border-radius.html - this example is implemented using the old Firefox way (https://github.com/mdn/dom-examples/blob/92687307cb13a922e4a3ef1cc16d36fe64fcec28/resize-observer/resize-observer-border-radius.html#L32-L33) and no longer works.

I've filed https://github.com/mdn/dom-examples/pull/84 to fix that, and you can see that it now works in Firefox (and Chrome): https://wbamberg.github.io/dom-examples/resize-observer/resize-observer-border-radius.html.