### PR TITLE
Performance.measure() - subfeature for old spec return value

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -741,7 +741,7 @@
                 "version_removed": "95"
               },
               "deno": {
-                "version_added": "1.2"
+                "version_added": false
               },
               "edge": {
                 "version_added": "12",

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -728,9 +728,9 @@
             "deprecated": false
           }
         },
-        "undefined": {
+        "returns_undefined": {
           "__compat": {
-            "description": "Return value <code>undefined</code>",
+            "description": "Returns <code>undefined</code>",
             "support": {
               "chrome": {
                 "version_added": "25",

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -727,6 +727,67 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "undefined": {
+          "__compat": {
+            "description": "Return value <code>undefined</code>",
+            "support": {
+              "chrome": {
+                "version_added": "25",
+                "version_removed": "95"
+              },
+              "chrome_android": {
+                "version_added": "25",
+                "version_removed": "95"
+              },
+              "deno": {
+                "version_added": "1.2"
+              },
+              "edge": {
+                "version_added": "12",
+                "version_removed": "95"
+              },
+              "firefox": {
+                "version_added": "41"
+              },
+              "firefox_android": {
+                "version_added": "42"
+              },
+              "ie": {
+                "version_added": "10"
+              },
+              "nodejs": {
+                "version_added": "8.5.0"
+              },
+              "opera": {
+                "version_added": "33",
+                "version_removed": "81"
+              },
+              "opera_android": {
+                "version_added": "33"
+              },
+              "safari": {
+                "version_added": "11",
+                "version_removed": "15"
+              },
+              "safari_ios": {
+                "version_added": "11",
+                "version_removed": "15"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.5"
+              },
+              "webview_android": {
+                "version_added": "≤37",
+                "version_removed": "95"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
         }
       },
       "measureUserAgentSpecificMemory": {


### PR DESCRIPTION
Fixes #13418

Performance.measure() had a spec change from returning `undefined` to returning a `PerformanceMeasure` object. Firefox still returns old value, Chrome 95 and Safari 15 have been updated - according to #13418.

This handles the case in the same way as  #13236 - it created a subfeature for the deprecated behaviour called `undefined`. Note that Opera for Android and samsunginternet_android are still on version 92 so have not been updated. 
I DO NOT know about deno.