### PR TITLE
Add Edge versions for SVGAltGlyphElement API

### DIFF
--- a/api/SVGAltGlyphElement.json
+++ b/api/SVGAltGlyphElement.json
@@ -12,7 +12,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "4",
@@ -62,7 +62,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "4"
@@ -111,7 +111,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "4"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `SVGAltGlyphElement` API, based upon manual testing.

Test Code Used: `var instance = document.createElementNS('http://www.w3.org/2000/svg', 'altglyph'); instance.constructor.name === 'SVGAltGlyphElement';`
