### PR TITLE
Add spec URLs for HTMLMetaElement API

### DIFF
--- a/api/HTMLMetaElement.json
+++ b/api/HTMLMetaElement.json
@@ -50,6 +50,7 @@
       },
       "content": {
         "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#dom-meta-content",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -97,6 +98,7 @@
       },
       "httpEquiv": {
         "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#dom-meta-httpequiv",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -144,6 +146,7 @@
       },
       "name": {
         "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#dom-meta-name",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -191,6 +194,7 @@
       },
       "scheme": {
         "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#dom-meta-scheme",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
This PR adds spec URLs for the members of the HTMLMetaElement API.
