### PR TITLE
Remove calc()'s "<color> value support" entry

### DIFF
--- a/css/types/calc.json
+++ b/css/types/calc.json
@@ -26,6 +26,7 @@
               {
                 "version_added": "16",
                 "notes": [
+                  "Before Firefox 59 <code>calc()</code> is not supported in <code>rgb()</code> and other color functions.",
                   "Before Firefox 57 <code>calc(1*2*3)</code> is not parsed successfully.",
                   "Firefox 57 increased the number of places <code>calc()</code> could substitute another value. See <a href='https://bugzil.la/1350857'>bug 1350857</a>."
                 ]
@@ -40,6 +41,7 @@
               {
                 "version_added": "16",
                 "notes": [
+                  "Before Firefox 59 <code>calc()</code> is not supported in <code>rgb()</code> and other color functions.",
                   "Before Firefox 57 <code>calc(1*2*3)</code> is not parsed successfully.",
                   "Firefox 57 increased the number of places <code>calc()</code> could substitute another value. See <a href='https://bugzil.la/1350857'>bug 1350857</a>."
                 ]
@@ -94,54 +96,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "color_values": {
-          "__compat": {
-            "description": "<code>&lt;color&gt;</code> value support",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "59"
-              },
-              "firefox_android": {
-                "version_added": "59"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": "6"
-              },
-              "safari_ios": {
-                "version_added": "6"
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         },
         "gradient_color_stops": {


### PR DESCRIPTION
This entry represents support for calc() inside color functions like
rgb(), and can be tested with `rgb(0, calc(64 + 64), 0)`:
http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=9798

The data for Firefox is correct, this didn't work before Firefox 59.

However, the data for Chrome and Edge is wrong, this was supported since
Chrome 16 (with `-webkit-calc()`) and at least since Edge 15.

Since this concerns only Firefox, make it a note instead.
