### PR TITLE
No markdown in notes

### DIFF
--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -808,7 +808,7 @@
             "support": {
               "chrome": {
                 "version_added": true,
-                "notes": "Before Chrome 23, `path` couldn't specify multiple icon files, but had to be a string specifying a single icon path."
+                "notes": "Before Chrome 23, <code>path</code> couldn't specify multiple icon files, but had to be a string specifying a single icon path."
               },
               "edge": {
                 "version_added": "14",

--- a/webextensions/api/pageAction.json
+++ b/webextensions/api/pageAction.json
@@ -261,7 +261,7 @@
             "support": {
               "chrome": {
                 "version_added": true,
-                "notes": "Before Chrome 23, `path` couldn't specify multiple icon files, but had to be a string specifying a single icon path."
+                "notes": "Before Chrome 23, <code>path</code> couldn't specify multiple icon files, but had to be a string specifying a single icon path."
               },
               "edge": {
                 "version_added": "14"

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -93,7 +93,7 @@
                 },
                 "edge": {
                   "version_added": "14",
-                  "notes": "The `url` is missing when the message was sent by an extension view."
+                  "notes": "The <code>url</code> is missing when the message was sent by an extension view."
                 },
                 "firefox": {
                   "version_added": "45"
@@ -1261,7 +1261,7 @@
               },
               "edge": {
                 "version_added": "14",
-                "notes": "`runtime.onMessage` listeners in extension views receive the messages they sent."
+                "notes": "<code>runtime.onMessage</code> listeners in extension views receive the messages they sent."
               },
               "firefox": {
                 "version_added": "45"

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -3731,7 +3731,7 @@
               },
               "edge": {
                 "version_added": "14",
-                "notes": "No response is sent after the receiving tab is refreshed if there is no `runtime.onMessage` listener."
+                "notes": "No response is sent after the receiving tab is refreshed if there is no <code>runtime.onMessage</code> listener."
               },
               "firefox": {
                 "version_added": "45"

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -461,11 +461,11 @@
                 },
                 "firefox": {
                   "version_added": "55",
-                  "notes": "Requests have been reported as `object_subrequest` before, but the type was missing in the `ResourceType` object before Firefox 55."
+                  "notes": "Requests have been reported as <code>object_subrequest</code> before, but the type was missing in the <code>ResourceType</code> object before Firefox 55."
                 },
                 "firefox_android": {
                   "version_added": "55",
-                  "notes": "Requests have been reported as `object_subrequest` before, but the type was missing in the `ResourceType` object before Firefox 55."
+                  "notes": "Requests have been reported as <code>object_subrequest</code>  before, but the type was missing in the <code>ResourceType</code> object before Firefox 55."
                 },
                 "opera": {
                   "version_added": false
@@ -484,7 +484,7 @@
               "support": {
                 "chrome": {
                   "version_added": "49",
-                  "notes": "Requests sent by navigator.sendBeacon(), and CSP reports in Chrome 49-57 (Opera 36-44), are also labeled as `ping`."
+                  "notes": "Requests sent by <code>navigator.sendBeacon()</code>, and CSP reports in Chrome 49-57 (Opera 36-44), are also labeled as <code>ping</code>."
                 },
                 "edge": {
                   "version_added": "79"
@@ -497,7 +497,7 @@
                 },
                 "opera": {
                   "version_added": "36",
-                  "notes": "Requests sent by navigator.sendBeacon(), and CSP reports in Chrome 49-57 (Opera 36-44), are also labeled as `ping`."
+                  "notes": "Requests sent by <code>navigator.sendBeacon()</code>, and CSP reports in Chrome 49-57 (Opera 36-44), are also labeled as <code>ping</code>."
                 },
                 "safari": {
                   "version_added": false

--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -8,11 +8,11 @@
             "support": {
               "chrome": {
                 "version_added": true,
-                "notes": "`detached_panel` is not supported."
+                "notes": "<code>detached_panel</code> is not supported."
               },
               "edge": {
                 "version_added": "14",
-                "notes": "`panel` and `detached_panel` are not supported."
+                "notes": "<code>panel</code> and <code>detached_panel</code> are not supported."
               },
               "firefox": {
                 "version_added": "45"
@@ -22,11 +22,11 @@
               },
               "opera": {
                 "version_added": true,
-                "notes": "`detached_panel` is not supported."
+                "notes": "<code>detached_panel</code> is not supported."
               },
               "safari": {
                 "version_added": "14",
-                "notes": "`panel` and `detached_panel` are not supported."
+                "notes": "<code>panel</code> and <code>detached_panel</code> are not supported."
               }
             }
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

We can discuss if BCD should switch to Markdown for notes but for now it is HTML.


