### PR TITLE
Add Edge versions for TextDecoder API

### DIFF
--- a/api/TextDecoder.json
+++ b/api/TextDecoder.json
@@ -15,7 +15,7 @@
             "version_added": "1.0"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": [
             {
@@ -161,7 +161,7 @@
               "notes": "Before Deno 1.11, passing <code>option.stream</code> is not supported and results in an error being thrown."
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -236,7 +236,7 @@
               "version_added": "1.0"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -304,7 +304,7 @@
               "version_added": "1.0"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "36"
@@ -358,7 +358,7 @@
               "version_added": "1.0"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "63"
@@ -412,7 +412,7 @@
               "version_added": "1.0"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "20"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `TextDecoder` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TextDecoder

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
