### PR TITLE
Add Edge versions for api.Window.onappinstalled

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3861,7 +3861,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "49",


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `onappinstalled` member of the `Window` API, based upon manual testing.

Test Code Used: `window.onappinstalled`
