### PR TITLE
Add Edge versions for api.Window.onbeforeinstallprompt

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3924,7 +3924,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `onbeforeinstallprompt` member of the `Window` API, based upon manual testing.

Test Code Used: `window.onbeforeinstallprompt`
