### PR TITLE
Add Edge versions for api.Window.resolveLocalFileSystemURL

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -6977,7 +6977,7 @@
               "prefix": "webkit"
             },
             "edge": {
-              "version_added": "≤79",
+              "version_added": "79",
               "prefix": "webkit"
             },
             "firefox": {


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `resolveLocalFileSystemURL` member of the `Window` API, based upon manual testing.

Test Code Used: `window.webkitResolveLocalFileSystemURL || window.resolveLocalFileSystemURL;`
