### PR TITLE
Add Edge versions for api.WindowEventHandlers.onlanguagechange

### DIFF
--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -256,7 +256,7 @@
               "version_added": "37"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "32"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `onlanguagechange` member of the `WindowEventHandlers` mixin, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Window/onlanguagechange

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
