### PR TITLE
Add Edge versions for api.Element.auxclick_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1274,7 +1274,7 @@
               "version_added": "55"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53",
@@ -1609,7 +1609,7 @@
               }
             ],
             "edge": {
-              "version_added": "12"
+              "version_added": "13"
             },
             "firefox": {
               "version_added": "1"
@@ -4345,7 +4345,7 @@
               "notes": "This API was previously available on the <code>Node</code> API."
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "1"
@@ -5763,7 +5763,7 @@
               "notes": "This API was previously available on the <code>Node</code> API."
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "11"

--- a/api/Element.json
+++ b/api/Element.json
@@ -1609,7 +1609,7 @@
               }
             ],
             "edge": {
-              "version_added": "13"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -4345,7 +4345,7 @@
               "notes": "This API was previously available on the <code>Node</code> API."
             },
             "edge": {
-              "version_added": "14"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "1"
@@ -5763,7 +5763,7 @@
               "notes": "This API was previously available on the <code>Node</code> API."
             },
             "edge": {
-              "version_added": "14"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "11"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `auxclick_event` member of the `Element` API.  The data was copied from the corresponding event handler counterpart in `GlobalEventHandlers`.
