### PR TITLE
Add Edge versions for api.HTMLTrackElement.cuechange_event

### DIFF
--- a/api/HTMLTrackElement.json
+++ b/api/HTMLTrackElement.json
@@ -63,7 +63,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "18"
             },
             "firefox": {
               "version_added": "68"

--- a/api/HTMLTrackElement.json
+++ b/api/HTMLTrackElement.json
@@ -63,7 +63,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "18"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "68"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `cuechange_event` member of the `HTMLTrackElement` API based upon manual testing.  See https://github.com/mdn/browser-compat-data/pull/13042 for the test code.
