### PR TITLE
Add Edge versions for MediaStream API

### DIFF
--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -243,7 +243,7 @@
               "version_added": "45"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": false
@@ -689,7 +689,7 @@
               "version_added": "45"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `MediaStream` API.  The data was copied from their event handler counterparts.
