### PR TITLE
Add Edge versions for api.CanvasRenderingContext2D.currentTransform

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -794,8 +794,7 @@
               ]
             },
             "edge": {
-              "version_added": "≤18",
-              "version_removed": "79"
+              "version_added": false
             },
             "firefox": {
               "version_added": false,


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `currentTransform` member of the `CanvasRenderingContext2D` API, based upon manual testing.

Test Code Used:
```js
var canvas = document.createElement('canvas');
var instance = canvas.getContext('2d');
alert(instance.currentTransform);
```
