### PR TITLE
Add Edge versions for FileSystem API

### DIFF
--- a/api/FileSystem.json
+++ b/api/FileSystem.json
@@ -13,11 +13,18 @@
             "version_added": "18",
             "alternative_name": "DOMFileSystem"
           },
-          "edge": {
-            "version_added": "14",
-            "prefix": "WebKit",
-            "notes": "Edge only supports this API in drag-and-drop scenarios using the the <code><a href='https://developer.mozilla.org/docs/Web/API/DataTransferItem/webkitGetAsEntry'>DataTransferItem.webkitGetAsEntry()</a></code> method. It's not available for use in file or folder picker panels (such as when you use an <code><a href='https://developer.mozilla.org/docs/Web/HTML/Element/input'>&lt;input&gt;</a></code> element with the <code><a href='https://developer.mozilla.org/docs/Web/API/HTMLInputElement/webkitdirectory'>HTMLInputElement.webkitdirectory</a></code> attribute."
-          },
+          "edge": [
+            {
+              "version_added": "79",
+              "alternative_name": "DOMFileSystem"
+            },
+            {
+              "version_added": "14",
+              "version_removed": "79",
+              "prefix": "WebKit",
+              "notes": "Edge only supports this API in drag-and-drop scenarios using the the <code><a href='https://developer.mozilla.org/docs/Web/API/DataTransferItem/webkitGetAsEntry'>DataTransferItem.webkitGetAsEntry()</a></code> method. It's not available for use in file or folder picker panels (such as when you use an <code><a href='https://developer.mozilla.org/docs/Web/HTML/Element/input'>&lt;input&gt;</a></code> element with the <code><a href='https://developer.mozilla.org/docs/Web/API/HTMLInputElement/webkitdirectory'>HTMLInputElement.webkitdirectory</a></code> attribute."
+            }
+          ],
           "firefox": {
             "version_added": "50"
           },

--- a/api/FileSystem.json
+++ b/api/FileSystem.json
@@ -14,7 +14,7 @@
             "alternative_name": "DOMFileSystem"
           },
           "edge": {
-            "version_added": "≤18",
+            "version_added": "14",
             "prefix": "WebKit",
             "notes": "Edge only supports this API in drag-and-drop scenarios using the the <code><a href='https://developer.mozilla.org/docs/Web/API/DataTransferItem/webkitGetAsEntry'>DataTransferItem.webkitGetAsEntry()</a></code> method. It's not available for use in file or folder picker panels (such as when you use an <code><a href='https://developer.mozilla.org/docs/Web/HTML/Element/input'>&lt;input&gt;</a></code> element with the <code><a href='https://developer.mozilla.org/docs/Web/API/HTMLInputElement/webkitdirectory'>HTMLInputElement.webkitdirectory</a></code> attribute."
           },
@@ -68,7 +68,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "50"
@@ -117,7 +117,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "50"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `FileSystem` API, based upon manual testing.

Test Code Used: `'FileSystem' in self; 'WebKitFileSystem' in self;`
