### PR TITLE
Add Edge versions for FileSystemDirectoryReader API

### DIFF
--- a/api/FileSystemDirectoryReader.json
+++ b/api/FileSystemDirectoryReader.json
@@ -13,10 +13,17 @@
             "version_added": "18",
             "alternative_name": "DirectoryReader"
           },
-          "edge": {
-            "version_added": "≤18",
-            "alternative_name": "WebKitDirectoryReader"
-          },
+          "edge": [
+            {
+              "version_added": "79",
+              "alternative_name": "DirectoryReader"
+            },
+            {
+              "version_added": "14",
+              "version_removed": "79",
+              "alternative_name": "WebKitDirectoryReader"
+            }
+          ],
           "firefox": {
             "version_added": "50"
           },
@@ -66,7 +73,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "50"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `FileSystemDirectoryReader` API, based upon manual testing.

Test Code Used: `'FileSystemDirectoryReader' in self; 'DirectoryReader' in self; 'WebKitDirectoryReReader' in self;`
