### PR TITLE
Add IE/Edge versions for api.HTMLAnchorElement.toString

### DIFF
--- a/api/_mixins/HTMLHyperlinkElementUtils__HTMLAnchorElement.json
+++ b/api/_mixins/HTMLHyperlinkElementUtils__HTMLAnchorElement.json
@@ -512,7 +512,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "22"
@@ -521,7 +521,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": false
+              "version_added": "5.5"
             },
             "opera": {
               "version_added": true


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `toString` member of the `HTMLAnchorElement` API, based upon manual testing.

Test Code Used:
```js
var el = document.createElement('a');
el.href = 'https://mdn-bcd-collector.appspot.com/';
alert(el.toString() == el.href);
```
