### PR TITLE
Add Edge versions for api.HTMLElement.contextMenu

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -849,8 +849,7 @@
               "version_removed": "61"
             },
             "edge": {
-              "version_added": "≤18",
-              "version_removed": "79"
+              "version_added": false
             },
             "firefox": [
               {


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `contextMenu` member of the `HTMLElement` API, based upon manual testing.

Test Code Used: `document.createElement('p').contextMenu;`
