### PR TITLE
Update Edge versions for IDBIndex API

### DIFF
--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -196,7 +196,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "44"
@@ -245,7 +245,7 @@
               "version_added": "48"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "44",


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `IDBIndex` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/IDBIndex

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
