### PR TITLE
Update Edge versions for api.IDBKeyRange.includes

### DIFF
--- a/api/IDBKeyRange.json
+++ b/api/IDBKeyRange.json
@@ -160,7 +160,7 @@
               "version_added": "52"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "47"


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `includes` member of the `IDBKeyRange` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/IDBKeyRange/includes

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
