### PR TITLE
Add Edge versions for IIRFilterNode API

### DIFF
--- a/api/IIRFilterNode.json
+++ b/api/IIRFilterNode.json
@@ -12,7 +12,7 @@
             "version_added": "49"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "14"
           },
           "firefox": {
             "version_added": "50"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `IIRFilterNode` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/IIRFilterNode

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
