### PR TITLE
Add Edge versions for MediaStreamAudioDestinationNode API

### DIFF
--- a/api/MediaStreamAudioDestinationNode.json
+++ b/api/MediaStreamAudioDestinationNode.json
@@ -12,7 +12,7 @@
             "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "18"
           },
           "firefox": {
             "version_added": "25"
@@ -114,7 +114,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "18"
             },
             "firefox": {
               "version_added": "25"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `MediaStreamAudioDestinationNode` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaStreamAudioDestinationNode

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
