### PR TITLE
Add Edge versions for api.PerformanceResourceTiming.toJSON

### DIFF
--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -844,7 +844,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "16"
             },
             "firefox": {
               "version_added": "40"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `toJSON` member of the `PerformanceResourceTiming` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PerformanceResourceTiming/toJSON

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
