### PR TITLE
Firefox Android supports <input type=month> and <input type=week> on 18+

### DIFF
--- a/html/elements/input/month.json
+++ b/html/elements/input/month.json
@@ -22,7 +22,7 @@
                 "notes": "See <a href='https://bugzil.la/888320'>bug 888320</a>."
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "18"
               },
               "ie": {
                 "version_added": false

--- a/html/elements/input/week.json
+++ b/html/elements/input/week.json
@@ -22,7 +22,7 @@
                 "notes": "See <a href='https://bugzil.la/888320'>bug 888320</a>."
               },
               "firefox_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
#### Summary
These controls are implemented by https://bugzilla.mozilla.org/show_bug.cgi?id=730330

#### Test results and supporting details
Tested on Firefox 18.

#### Related issues
https://bugzilla.mozilla.org/show_bug.cgi?id=730330