### PR TITLE
Wheel + ctrl key added in Safari 15

### DIFF
--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -326,8 +326,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": "15",
-              "notes": "Pinch-to-zoom gestures produce <code>WheelEvent</code>s in addition to non-standard <a href='https://developer.mozilla.org/docs/Web/API/GestureEvent'><code>GestureEvent</code></a>s. In prior versions, only <code>GestureEvent</code>s were emitted."
+              "version_added": "15"
             },
             "safari_ios": {
               "version_added": false

--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -326,7 +326,8 @@
               "version_added": null
             },
             "safari": {
-              "version_added": false
+              "version_added": "15",
+              "notes": "Pinch-to-zoom gestures produce <code>WheelEvent</code>s in addition to non-standard <a href='https://developer.mozilla.org/docs/Web/API/GestureEvent'><code>GestureEvent</code></a>s. In prior versions, only <code>GestureEvent</code>s were emitted."
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Mapping of the pinch-zoom gesture to `wheel + ctrlKey` on macOS Safari has been added in version 15. Also added note on fallback for prior versions.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

* [Tracking WebKit issue](https://bugs.webkit.org/show_bug.cgi?id=225788)
* https://twitter.com/smfr/status/1460338156914425857

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
