### PR TITLE
Correct Opera 83 engine version and update data

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -634,7 +634,7 @@
         "83": {
           "status": "nightly",
           "engine": "Blink",
-          "engine_version": "96"
+          "engine_version": "97"
         }
       }
     }

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -669,7 +669,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "83"
               },
               "opera_android": {
                 "version_added": false
@@ -724,7 +724,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "83"
               },
               "opera_android": {
                 "version_added": false

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -799,7 +799,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "83"
               },
               "opera_android": {
                 "version_added": false
@@ -854,7 +854,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "83"
               },
               "opera_android": {
                 "version_added": false


### PR DESCRIPTION
Also add Opera 83 support for findLast and findLastIndex

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Corrects the engine version for Opera 83, and also sets it as supporting findLast and findLastIndex (same as Chrome 97)

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://blogs.opera.com/desktop/2021/11/opera-83-developer/

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
