### PR TITLE
Update Edge versions for PushSubscription API

### DIFF
--- a/api/PushSubscription.json
+++ b/api/PushSubscription.json
@@ -12,7 +12,7 @@
             "version_added": "42"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "17"
           },
           "firefox": {
             "version_added": "44",
@@ -62,7 +62,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": "16"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "44",
@@ -112,7 +112,7 @@
               "version_added": "60"
             },
             "edge": {
-              "version_added": "16"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": false
@@ -162,7 +162,7 @@
               "version_added": "42"
             },
             "edge": {
-              "version_added": "16"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "44",
@@ -361,7 +361,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": "16"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "44",


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `PushSubscription` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PushSubscription

Additional notes: support for service workers was implemented in Edge 17, so it wouldn't make sense for this interface to have any support before Edge 17.

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
