### PR TITLE
Add Edge versions for RTCDTMFToneChangeEvent API

### DIFF
--- a/api/RTCDTMFToneChangeEvent.json
+++ b/api/RTCDTMFToneChangeEvent.json
@@ -61,7 +61,7 @@
               "version_added": "27"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "13"
             },
             "firefox": {
               "version_added": "52"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `RTCDTMFToneChangeEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCDTMFToneChangeEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
