### PR TITLE
Add a note to WebExtension storage sync for Safari error

### DIFF
--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -311,12 +311,18 @@
                 "version_added": false
               },
               "safari": {
-                "notes": "Safari does not sync items saved in the <code>sync</code> storage area, i.e. it behaves the same as the <code>local</code> storage area.",
+                "notes": [
+                  "Safari does not sync items saved in the <code>sync</code> storage area, i.e. it behaves the same as the <code>local</code> storage area.",
+                  "Safari 15 and 15.1 erroneously store sync items in the <code>local</code> storage area. If unable to locate sync items, check for sync items in the <code>local</code> storage area and do a one-time migration to the <code>sync</code> storage area."
+                ],
                 "partial_implementation": true,
                 "version_added": "14"
               },
               "safari_ios": {
-                "notes": "Safari does not sync items saved in the <code>sync</code> storage area, i.e. it behaves the same as the <code>local</code> storage area.",
+                "notes": [
+                  "Safari does not sync items saved in the <code>sync</code> storage area, i.e. it behaves the same as the <code>local</code> storage area.",
+                  "Safari 15 and 15.1 erroneously store sync items in the <code>local</code> storage area. If unable to locate sync items, check for sync items in the <code>local</code> storage area and do a one-time migration to the <code>sync</code> storage area."
+                ],
                 "partial_implementation": true,
                 "version_added": "15"
               }


### PR DESCRIPTION
#### Summary
Add a note to Web Extension sync storage area describing an error in Safari 15 and 15.1 for both Safari and Safari iOS.

#### Test results and supporting details
Behavioral note provided by the Safari engineering team.