### PR TITLE
Add Edge versions for WebGLObject API

### DIFF
--- a/api/WebGLObject.json
+++ b/api/WebGLObject.json
@@ -11,7 +11,8 @@
             "version_added": false
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "12",
+            "version_removed": "79"
           },
           "firefox": {
             "version_added": false


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `WebGLObject` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WebGLObject

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
