### PR TITLE
Set Chrome 96 as current

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -659,21 +659,28 @@
         "95": {
           "release_date": "2021-10-19",
           "release_notes": "https://chromereleases.googleblog.com/2021/10/stable-channel-update-for-desktop_19.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "95"
         },
         "96": {
-          "release_date": "2021-11-16",
-          "status": "beta",
+          "release_date": "2021-11-15",
+          "release_notes": "https://chromereleases.googleblog.com/2021/11/stable-channel-update-for-desktop.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "96"
         },
         "97": {
           "release_date": "2022-01-04",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "97"
+        },
+        "98": {
+          "release_date": "2022-02-01",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "98"
         }
       }
     }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -495,21 +495,28 @@
         "95": {
           "release_date": "2021-10-19",
           "release_notes": "https://chromereleases.googleblog.com/2021/10/chrome-for-android-update_01703513036.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "95"
         },
         "96": {
-          "release_date": "2021-11-16",
-          "status": "beta",
+          "release_date": "2021-11-15",
+          "release_notes": "https://chromereleases.googleblog.com/2021/11/chrome-for-android-update.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "96"
         },
         "97": {
           "release_date": "2022-01-04",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "97"
+        },
+        "98": {
+          "release_date": "2022-02-01",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "98"
         }
       }
     }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -460,21 +460,28 @@
         "95": {
           "release_date": "2021-10-19",
           "release_notes": "https://chromereleases.googleblog.com/2021/10/chrome-for-android-update_01703513036.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "95"
         },
         "96": {
-          "release_date": "2021-11-16",
-          "status": "beta",
+          "release_date": "2021-11-15",
+          "release_notes": "https://chromereleases.googleblog.com/2021/11/chrome-for-android-update.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "96"
         },
         "97": {
           "release_date": "2022-01-04",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "97"
+        },
+        "98": {
+          "release_date": "2022-02-01",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "98"
         }
       }
     }


### PR DESCRIPTION
In this PR, set Chrome to version 96. 

According to: 

https://chromereleases.googleblog.com/2021/11/chrome-for-android-update.html
https://chromereleases.googleblog.com/2021/11/stable-channel-update-for-desktop.html

For future versions: 

https://www.chromestatus.com/features/schedule