### PR TITLE
Add Safari versions for KeyboardEvent API

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -30,10 +30,10 @@
             "version_added": "12.1"
           },
           "safari": {
-            "version_added": "3.1"
+            "version_added": "1"
           },
           "safari_ios": {
-            "version_added": "2"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -128,10 +128,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -177,10 +177,10 @@
               "version_added": "12.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -275,10 +275,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -964,10 +964,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1258,10 +1258,10 @@
               "version_added": "12.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1410,10 +1410,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1508,10 +1508,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -128,10 +128,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -177,10 +177,10 @@
               "version_added": "12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -275,10 +275,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -964,10 +964,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1258,10 +1258,10 @@
               "version_added": "12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1410,10 +1410,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1508,10 +1508,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -30,7 +30,7 @@
             "version_added": "12.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "1.2"
           },
           "safari_ios": {
             "version_added": "1"
@@ -964,7 +964,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "1"
+              "version_added": "1.2"
             },
             "safari_ios": {
               "version_added": "1"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `KeyboardEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/KeyboardEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
