### PR TITLE
Add Safari versions for MessageEvent API

### DIFF
--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -39,7 +39,7 @@
             "version_added": "4"
           },
           "safari_ios": {
-            "version_added": "3"
+            "version_added": "3.2"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -94,7 +94,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -146,7 +146,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -198,7 +198,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -250,7 +250,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -302,7 +302,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -354,7 +354,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -406,7 +406,7 @@
               "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -403,10 +403,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `MessageEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MessageEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
