### PR TITLE
Add Safari versions for MouseEvent API

### DIFF
--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -132,10 +132,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -329,10 +329,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -378,10 +378,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -524,10 +524,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -573,10 +573,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -860,10 +860,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -909,10 +909,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -958,10 +958,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1007,10 +1007,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1153,10 +1153,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1202,10 +1202,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1251,10 +1251,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1300,10 +1300,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1349,10 +1349,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1398,10 +1398,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -34,10 +34,10 @@
             "version_added": "11"
           },
           "safari": {
-            "version_added": "3.1"
+            "version_added": "1"
           },
           "safari_ios": {
-            "version_added": "2"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -132,10 +132,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -181,10 +181,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -280,10 +280,10 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -329,10 +329,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -378,10 +378,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -573,10 +573,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1153,10 +1153,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1202,10 +1202,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1251,10 +1251,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1300,10 +1300,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -524,10 +524,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -860,10 +860,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -909,10 +909,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -958,10 +958,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1007,10 +1007,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `MouseEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MouseEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
