### PR TITLE
Add Safari versions for DOMRectList API

### DIFF
--- a/api/DOMRectList.json
+++ b/api/DOMRectList.json
@@ -84,7 +84,7 @@
             },
             {
               "alternative_name": "ClientRectList",
-              "version_added": "≤4",
+              "version_added": "4",
               "version_removed": "11"
             }
           ],
@@ -94,7 +94,7 @@
             },
             {
               "alternative_name": "ClientRectList",
-              "version_added": "≤3",
+              "version_added": "3",
               "version_removed": "11"
             }
           ],
@@ -154,10 +154,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -202,10 +202,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `DOMRectList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DOMRectList

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
