### PR TITLE
Add Safari versions for ProgressEvent API

### DIFF
--- a/api/ProgressEvent.json
+++ b/api/ProgressEvent.json
@@ -33,10 +33,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "3.1"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "2"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -142,11 +142,11 @@
               "version_removed": "14"
             },
             "safari": {
-              "version_added": "≤4",
+              "version_added": "3.1",
               "version_removed": "6"
             },
             "safari_ios": {
-              "version_added": "≤3",
+              "version_added": "2",
               "version_removed": "6"
             },
             "samsunginternet_android": {
@@ -248,10 +248,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -300,10 +300,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `ProgressEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ProgressEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
