### PR TITLE
Add Safari versions for SVGStringList API

### DIFF
--- a/api/SVGStringList.json
+++ b/api/SVGStringList.json
@@ -32,10 +32,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "3"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -78,10 +78,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -125,10 +125,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -172,10 +172,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -219,10 +219,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -266,10 +266,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -360,10 +360,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -407,10 +407,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -454,10 +454,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `SVGStringList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGStringList

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
