### PR TITLE
Add Safari for iOS WebExtensions browserSettings data

### DIFF
--- a/webextensions/api/browserSettings.json
+++ b/webextensions/api/browserSettings.json
@@ -23,6 +23,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -47,6 +50,9 @@
                 "version_added": false
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -73,6 +79,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -98,6 +107,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -122,6 +134,9 @@
                 "version_added": false
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -149,6 +164,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -173,6 +191,9 @@
                 "version_added": false
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -199,6 +220,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -223,6 +247,9 @@
                 "version_added": false
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -250,6 +277,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -274,6 +304,9 @@
                 "version_added": false
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -300,6 +333,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -324,6 +360,9 @@
                 "version_added": false
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -350,6 +389,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -374,6 +416,9 @@
                 "version_added": false
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -400,6 +445,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -424,6 +472,9 @@
                 "version_added": false
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -450,6 +501,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -474,6 +528,9 @@
                 "version_added": false
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }


### PR DESCRIPTION
#### Summary
Adds no support of browserSettings API for Safari on iOS.

#### Test results and supporting details
Reviewed internally with Safari engineers.

See ["Web Extensions" section in the Safari 15 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions).
