### PR TITLE
Update Safari versions for api.HTMLAreaElement.toString

### DIFF
--- a/api/_mixins/HTMLHyperlinkElementUtils__HTMLAreaElement.json
+++ b/api/_mixins/HTMLHyperlinkElementUtils__HTMLAreaElement.json
@@ -530,10 +530,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"


### PR DESCRIPTION
This PR corrects real values for Safari (Desktop and iOS/iPadOS) for the `toString` member of the `HTMLAreaElement` API, based upon manual testing.

Test Code Used:
```js
var el = document.createElement('area');
el.href = 'https://mdn-bcd-collector.appspot.com/';
alert(el.toString() == el.href);
```
