### PR TITLE
Add Safari for iOS WebExtensions topSites data

### DIFF
--- a/webextensions/api/topSites.json
+++ b/webextensions/api/topSites.json
@@ -24,6 +24,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -47,6 +50,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -81,6 +87,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -105,6 +114,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             },
@@ -128,6 +140,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -154,6 +169,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -178,6 +196,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -201,6 +222,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -227,6 +251,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -252,6 +279,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -276,6 +306,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }


### PR DESCRIPTION
#### Summary
Adds no support of topSites for Safari on iOS.

#### Test results and supporting details
Reviewed internally with Safari engineers.

See ["Web Extensions" section in the Safari 15 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions).