### PR TITLE
Add Safari versions for SVGPoint API

### DIFF
--- a/api/SVGPoint.json
+++ b/api/SVGPoint.json
@@ -30,10 +30,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "3"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -78,10 +78,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -127,10 +127,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -176,10 +176,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `SVGPoint` API, based upon manual testing.

Test Code Used:
```js
var el = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
var instance = el.createSVGPoint();
alert("api.SVGPoint: " + instance);
alert("api.SVGPoint.matrixTransform: " + instance.matrixTransform);
alert("api.SVGPoint.x: " + instance.x);
alert("api.SVGPoint.y: " + instance.y);
```
