### PR TITLE
Add Safari versions for SVGRect API

### DIFF
--- a/api/SVGRect.json
+++ b/api/SVGRect.json
@@ -30,10 +30,10 @@
             "version_added": "10.1"
           },
           "safari": {
-            "version_added": "3.1"
+            "version_added": "3"
           },
           "safari_ios": {
-            "version_added": "2"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -76,10 +76,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -123,10 +123,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -170,10 +170,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -217,10 +217,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `SVGRect` API, based upon manual testing.

Test Code Used:
```js
var el = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
var instance = el.createSVGRect();
alert("api.SVGRect: " + instance);
alert("api.SVGRect.height: " + instance.height);
alert("api.SVGRect.width: " + instance.width);
alert("api.SVGRect.x: " + instance.x);
alert("api.SVGRect.y: " + instance.y);
```