### PR TITLE
Add Safari versions for SVGRenderingIntent API

### DIFF
--- a/api/SVGRenderingIntent.json
+++ b/api/SVGRenderingIntent.json
@@ -34,10 +34,10 @@
             "version_removed": "32"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "3.1"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "2"
           },
           "samsunginternet_android": {
             "version_added": "1.0",


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `SVGRenderingIntent` API, based upon manual testing.

Test Code Used: `alert(SVGRenderingIntent);`
