### PR TITLE
Add Safari versions for TransitionEvent API

### DIFF
--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -49,7 +49,7 @@
             },
             {
               "prefix": "WebKit",
-              "version_added": "≤4"
+              "version_added": "4"
             }
           ],
           "safari_ios": [
@@ -58,7 +58,7 @@
             },
             {
               "prefix": "WebKit",
-              "version_added": "≤3"
+              "version_added": "3"
             }
           ],
           "samsunginternet_android": [
@@ -223,12 +223,12 @@
               "version_removed": "14"
             },
             "safari": {
-              "version_added": "≤4",
+              "version_added": "4",
               "version_removed": "6",
               "alternative_name": "initWebKitTransitionEvent"
             },
             "safari_ios": {
-              "version_added": "≤3",
+              "version_added": "3",
               "version_removed": "6",
               "alternative_name": "initWebKitTransitionEvent"
             },


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `TransitionEvent` API, based upon manual testing.

Test Code Used: `alert(WebKitTransitionEvent);`
