### PR TITLE
Add Safari versions for WebKitCSSMatrix API

### DIFF
--- a/api/WebKitCSSMatrix.json
+++ b/api/WebKitCSSMatrix.json
@@ -44,10 +44,10 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "4"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "3"
           },
           "samsunginternet_android": {
             "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `WebKitCSSMatrix` API, based upon manual testing.

Test Code Used: `alert(WebKitCSSMatrix);`
