### PR TITLE
Add Safari versions for api.Window.webkitConvertPointFrom[NodeToPage/PageToNode]

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -10465,10 +10465,10 @@
               "version_removed": "26"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0",
@@ -10519,10 +10519,10 @@
               "version_removed": "26"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0",


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `webkitConvertPointFromNodeToPage` and `webkitConvertPointFromPageToNode` members of the `Window` API, based upon manual testing.

Test Code Used: `alert("webkitConvertPointFromNodeToPage: " + window.webkitConvertPointFromNodeToPage); alert("webkitConvertPointFromPageToNode: " + window.webkitConvertPointFromPageToNode);`
