### PR TITLE
Add Safari versions for UIEvent API

### DIFF
--- a/api/UIEvent.json
+++ b/api/UIEvent.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "3"
+            "version_added": "1"
           },
           "safari_ios": {
             "version_added": "1"
@@ -130,7 +130,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -179,7 +179,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -385,7 +385,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"

--- a/api/UIEvent.json
+++ b/api/UIEvent.json
@@ -30,10 +30,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "3"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -130,10 +130,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -179,10 +179,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -231,10 +231,10 @@
               "version_removed": "32"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0",
@@ -285,10 +285,10 @@
               "version_removed": "32"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0",
@@ -385,10 +385,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -462,10 +462,10 @@
               }
             ],
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/UIEvent.json
+++ b/api/UIEvent.json
@@ -231,7 +231,7 @@
               "version_removed": "32"
             },
             "safari": {
-              "version_added": "3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -285,7 +285,7 @@
               "version_removed": "32"
             },
             "safari": {
-              "version_added": "3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -462,7 +462,7 @@
               }
             ],
             "safari": {
-              "version_added": "3"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `UIEvent` API, based upon commit history and date.

Commit: https://github.com/WebKit/WebKit/commit/fc2d793ffd1757f56a254b3c48f86accb2c3a422#diff-121634aea0006c7adb6b1512abc7c9c3f9cb8def4d8c1c9ff0cb5298d3da78f2
