### PR TITLE
Add Safari versions for WheelEvent API

### DIFF
--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -30,10 +30,10 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "3"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -373,10 +373,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -420,10 +420,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -467,10 +467,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `WheelEvent` API, based upon commit history and date.

Commits:
https://github.com/WebKit/WebKit/commit/69c2badd4978c45bfb905a0d71fbebfaadc51765
https://github.com/WebKit/WebKit/commit/7c3e7ab965ccdb34426db45e8b960b78590ca3ce
