### PR TITLE
Add Safari versions for api.HTMLAnchorElement.toString

### DIFF
--- a/api/_mixins/HTMLHyperlinkElementUtils__HTMLAnchorElement.json
+++ b/api/_mixins/HTMLHyperlinkElementUtils__HTMLAnchorElement.json
@@ -530,10 +530,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "6.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `toString` member of the `HTMLAnchorElement` API, based upon manual testing.

Test Code Used:
```js
var el = document.createElement('a');
el.href = 'https://mdn-bcd-collector.appspot.com/';
alert("api.HTMLAnchorElement.toString: " + el.toString() == el.href);
```