### PR TITLE
Add Safari versions for ProcessingInstruction API

### DIFF
--- a/api/ProcessingInstruction.json
+++ b/api/ProcessingInstruction.json
@@ -30,10 +30,10 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "3"
           },
           "safari_ios": {
-            "version_added": "≤3"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -78,10 +78,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `ProcessingInstruction` API, based upon manual testing.

Test Code Used:
```js
var doc = new DOMParser().parseFromString('<foo />', 'application/xml');
var instance = doc.createProcessingInstruction('xml-stylesheet', 'href="mycss.css" type="text/css"');
alert("api.ProcessingInstruction: " + instance);
alert("api.ProcessingInstruction.data: " + instance.data);
alert("api.ProcessingInstruction.target: " + instance.target);
```
