### PR TITLE
Add Safari for iOS WebExtensions sidebarAction data

### DIFF
--- a/webextensions/api/sidebarAction.json
+++ b/webextensions/api/sidebarAction.json
@@ -23,6 +23,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -48,6 +51,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -72,6 +78,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -95,6 +104,9 @@
                 "version_added": "30"
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -121,6 +133,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -144,6 +159,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -172,6 +190,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -195,6 +216,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -223,6 +247,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -247,6 +274,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -270,6 +300,9 @@
                 "version_added": "30"
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -296,6 +329,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -320,6 +356,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -343,6 +382,9 @@
                 "version_added": "30"
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -369,6 +411,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -392,6 +437,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -419,6 +467,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -445,6 +496,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -468,6 +522,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -495,6 +552,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -521,6 +581,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -544,6 +607,9 @@
                     "version_added": false
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -571,6 +637,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -596,6 +665,9 @@
                 "version_added": false
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }


### PR DESCRIPTION
#### Summary
Adds no support of sidebarAction for Safari on iOS.

#### Test results and supporting details
Reviewed internally with Safari engineers.

See ["Web Extensions" section in the Safari 15 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions).
