### PR TITLE
Add Safari versions for api.XMLHttpRequest.responseXML

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1288,10 +1288,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `responseXML` member of the `XMLHttpRequest` API, based upon manual testing.

Test Code Used:
```js
var instance = new XMLHttpRequest();
alert("api.XMLHttpRequest.responseXML: " + instance.responseXML);
```
