### PR TITLE
Add Safari versions for api.XSLTProcessor.XSLTProcessor

### DIFF
--- a/api/XSLTProcessor.json
+++ b/api/XSLTProcessor.json
@@ -77,10 +77,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `XSLTProcessor` member of the `XSLTProcessor` API, based upon manual testing.

Test Code Used: `alert("api.XSLTProcessor.XSLTProcessor: " + new XSLTProcessor());`
