### PR TITLE
Add Safari versions for api.HTMLImageElement.Image

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -76,7 +76,7 @@
               "version_added": "8"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `Image` member of the `HTMLImageElement` API, based upon manual testing.

Test Code Used: `new Image();`
