### PR TITLE
Add Safari versions for Plugin API

### DIFF
--- a/api/Plugin.json
+++ b/api/Plugin.json
@@ -77,10 +77,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -125,10 +125,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -272,10 +272,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `Plugin` API, based upon manual testing.

Test Code Used:
```js
var plugin = navigator.plugins[0];
alert("api.Plugin: " + plugin);
alert("api.Plugin.description: " + plugin.description);
alert("api.Plugin.filename: " + plugin.filename);
alert("api.Plugin.name: " + plugin.name);
```
