### PR TITLE
Add Safari versions for api.Range.createContextualFragment

### DIFF
--- a/api/Range.json
+++ b/api/Range.json
@@ -581,10 +581,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `createContextualFragment` member of the `Range` API, based upon manual testing.

Test Code Used:
```js
var range = document.createRange();
alert("api.Range.createContextualFragment: " + range.createContextualFragment);
```
