### PR TITLE
Add Safari versions for Selection API

### DIFF
--- a/api/Selection.json
+++ b/api/Selection.json
@@ -765,10 +765,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1316,10 +1316,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `Selection` API, based upon manual testing.

Test Code Used:
```js
var selection = window.getSelection();
alert("api.Selection.focusNode: " + selection.focusNode);
alert("api.Selection.toString: " + selection.toString);
```
