### PR TITLE
Add Safari versions for WindowEventHandlers API

### DIFF
--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "3"
+            "version_added": "1"
           },
           "safari_ios": {
             "version_added": "1"
@@ -470,10 +470,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -518,10 +518,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -853,10 +853,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `WindowEventHandlers` API, based upon manual testing.

Test Code Used:
```js
alert("api.WindowEventHandlers.onoffline: " + window.onoffline);
alert("api.WindowEventHandlers.ononline: " + window.ononline);
alert("api.WindowEventHandlers.onunload: " + window.onunload);
```
