### PR TITLE
Note that Firefox-for-Android supports ::part since v72

### DIFF
--- a/css/selectors/part.json
+++ b/css/selectors/part.json
@@ -33,7 +33,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "72"
             },
             "ie": {
               "version_added": false

--- a/css/selectors/part.json
+++ b/css/selectors/part.json
@@ -33,7 +33,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": "72"
+              "version_added": "79"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
::part shipped in Firefox (all platforms) in version 72, in https://bugzilla.mozilla.org/show_bug.cgi?id=1559074

It looks like Firefox-for-Android was missed when this json file was updated to reflect that.  This commit addresses that and marks it as supported.

(Note: the Firefox-for-Desktop "behind-a-pref" snippet for versions 69-72 is likely accurate for Firefox-for-Android, too, but I'm not bothering to copy that over, for brevity & because it's unlikely to matter at this point.)


#### Summary
Mark Firefox-for-Android as supporting ::part since v72

#### Test results and supporting details
This shipped in Firefox (all versions) in https://bugzilla.mozilla.org/show_bug.cgi?id=1559074 . The implementor @emilio confirms that Android is expected to be supported in https://twitter.com/ecbos_/status/1461484762158321666

#### Related issues
This completes #5327. (It looks like that pull request didn't intentionally exclude Android due to it being specially-unsupported; it was likely just left out by accident.)