### PR TITLE
compat-data-scheme: spec data clarification

### DIFF
--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -103,7 +103,9 @@ The `__compat` object consists of the following:
 - An optional `mdn_url` property which **points to an MDN reference page documenting the feature**.
   It needs to be a valid URL, and should be the language-neutral URL (e.g. use `https://developer.mozilla.org/docs/Web/CSS/text-align` instead of `https://developer.mozilla.org/en-US/docs/Web/CSS/text-align`).
 
-- An optional `spec_url` property as a URL or an array of URLs, each of which is for a specific part of a specification in which this feature is defined. Each URL must either contain a fragment identifier (e.g. `https://tc39.es/proposal-promise-allSettled/#sec-promise.allsettled`), or else must match the regular-expression pattern `^https://www.khronos.org/registry/webgl/extensions/[^/]+/` (e.g. `https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/`).
+- An optional `spec_url` property as a URL or an array of URLs, each of which is for a specific part of a specification in which this feature is defined.
+  - Each URL must either contain a fragment identifier (e.g. `https://tc39.es/proposal-promise-allSettled/#sec-promise.allsettled`), or else must match the regular-expression pattern `^https://www.khronos.org/registry/webgl/extensions/[^/]+/` (e.g. `https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/`).
+  - This property may only contain specifications published by standards bodies, or formal proposals that may lead to such standards).
 
 ### The `support` object
 


### PR DESCRIPTION
This adds the information about what specs can be added, as a follow on to the discussion here: https://github.com/mdn/browser-compat-data/pull/13383#issuecomment-971825712 

This might not be the right place - e.g. it could be 
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md or somewhere else.

However it would be good if it was somewhere.