### PR TITLE
Add Safari for iOS WebExtensions clipboard data

### DIFF
--- a/webextensions/api/clipboard.json
+++ b/webextensions/api/clipboard.json
@@ -23,6 +23,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }


### PR DESCRIPTION
#### Summary
Adds no support of clipboard for Safari on iOS.

#### Test results and supporting details
Reviewed internally with Safari engineers.

See ["Web Extensions" section in the Safari 15 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions).
