### PR TITLE
Add Safari for iOS WebExtensions contentScripts data

### DIFF
--- a/webextensions/api/contentScripts.json
+++ b/webextensions/api/contentScripts.json
@@ -26,6 +26,9 @@
               "safari": {
                 "version_added": false,
                 "notes": "There is a <a href='https://github.com/bfred-it/content-scripts-register-polyfill'>polyfill available</a>."
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -53,6 +56,9 @@
                 "safari": {
                   "version_added": false,
                   "notes": "There is a <a href='https://github.com/bfred-it/content-scripts-register-polyfill'>polyfill available</a>."
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -82,6 +88,9 @@
               "safari": {
                 "version_added": false,
                 "notes": "There is a <a href='https://github.com/bfred-it/content-scripts-register-polyfill'>polyfill available</a>."
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }


### PR DESCRIPTION
#### Summary
Adds no support of contentScripts for Safari on iOS.

#### Test results and supporting details
Reviewed internally with Safari engineers.

See ["Web Extensions" section in the Safari 15 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions).