### PR TITLE
Add Safari for iOS WebExtensions devtools data

### DIFF
--- a/webextensions/api/devtools.json
+++ b/webextensions/api/devtools.json
@@ -24,6 +24,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             },
@@ -46,6 +49,9 @@
                     "version_added": true
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -71,6 +77,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -94,6 +103,9 @@
                     "version_added": true
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -121,6 +133,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -145,6 +160,9 @@
                   "version_added": true
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -174,6 +192,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -198,6 +219,9 @@
                   "version_added": true
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -231,6 +255,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -259,6 +286,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -283,6 +313,9 @@
                     "version_added": true
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -310,6 +343,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -334,6 +370,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -357,6 +396,9 @@
                     "version_added": true
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -386,6 +428,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -411,6 +456,9 @@
                     "version_added": true
                   },
                   "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
                     "version_added": false
                   }
                 }
@@ -440,6 +488,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -468,6 +519,9 @@
                   },
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -494,6 +548,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -518,6 +575,9 @@
                   "version_added": true
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -544,6 +604,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -568,6 +631,9 @@
                   "version_added": "41"
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }


### PR DESCRIPTION
#### Summary
Adds no support of dev tools for Safari on iOS.

#### Test results and supporting details
Reviewed internally with Safari engineers.

See ["Web Extensions" section in the Safari 15 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions).
