### PR TITLE
Add Safari for iOS WebExtensions management data

### DIFF
--- a/webextensions/api/management.json
+++ b/webextensions/api/management.json
@@ -23,6 +23,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -45,6 +48,9 @@
                   "version_added": true
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -70,6 +76,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -94,6 +103,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -117,6 +129,9 @@
                   "version_added": true
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -143,6 +158,9 @@
                 "version_added": true
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -171,6 +189,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -195,6 +216,9 @@
                 "version_added": true
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -221,6 +245,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -245,6 +272,9 @@
                 "version_added": false
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -273,6 +303,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -299,6 +332,9 @@
                 "version_added": true
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -327,6 +363,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -353,6 +392,9 @@
                 "version_added": true
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -387,6 +429,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -414,6 +459,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -438,6 +486,9 @@
                 "version_added": true
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }
@@ -464,6 +515,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           },
@@ -486,6 +540,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }


### PR DESCRIPTION
#### Summary
Adds no support of management for Safari on iOS.

#### Test results and supporting details
Reviewed internally with Safari engineers.

See ["Web Extensions" section in the Safari 15 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions).