### PR TITLE
Add Safari for iOS WebExtensions omnibox data

### DIFF
--- a/webextensions/manifest/omnibox.json
+++ b/webextensions/manifest/omnibox.json
@@ -22,6 +22,9 @@
             },
             "safari": {
               "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
             }
           }
         },
@@ -44,6 +47,9 @@
                 "version_added": true
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             }


### PR DESCRIPTION
#### Summary
Adds no support of omnibus for Safari on iOS.

#### Test results and supporting details
Reviewed internally with Safari engineers.

See ["Web Extensions" section in the Safari 15 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions).