### PR TITLE
Adds Safari for iOS WebExtensions pkcs11 data

### DIFF
--- a/webextensions/api/pkcs11.json
+++ b/webextensions/api/pkcs11.json
@@ -23,6 +23,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
             "status": {
@@ -52,6 +55,9 @@
                 "version_added": false
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             },
@@ -83,6 +89,9 @@
               },
               "safari": {
                 "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
               }
             },
             "status": {
@@ -112,6 +121,9 @@
                 "version_added": false
               },
               "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
                 "version_added": false
               }
             },


### PR DESCRIPTION
#### Summary
Adds no support of pkcs11 for Safari on iOS.

#### Test results and supporting details
Reviewed internally with Safari engineers.

See ["Web Extensions" section in the Safari 15 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions).