### PR TITLE
Add Safari for iOS WebExtensions privacy data

### DIFF
--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -23,6 +23,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -46,6 +49,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -72,6 +78,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -95,6 +104,9 @@
                   "version_added": true
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -122,6 +134,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -145,6 +160,9 @@
                   "version_added": true
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -175,6 +193,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -198,6 +219,9 @@
                   "version_added": true
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -223,6 +247,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -246,6 +273,9 @@
                   "version_added": true
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -271,6 +301,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -294,6 +327,9 @@
                   "version_added": true
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -319,6 +355,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -342,6 +381,9 @@
                   "version_added": true
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -374,6 +416,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -397,6 +442,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -422,6 +470,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -445,6 +496,9 @@
                   "version_added": true
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -470,6 +524,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -493,6 +550,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }
@@ -518,6 +578,9 @@
                 },
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
             }
@@ -541,6 +604,9 @@
                   "version_added": false
                 },
                 "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
                   "version_added": false
                 }
               }


### PR DESCRIPTION
#### Summary
Adds no support of the WebExtensions privacy API for Safari on iOS.

#### Test results and supporting details
Reviewed internally with Safari engineers.

See ["Web Extensions" section in the Safari 15 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions).