### PR TITLE
Note Firefox scroll snap problem on macOS 12

### DIFF
--- a/css/properties/scroll-snap-type.json
+++ b/css/properties/scroll-snap-type.json
@@ -25,7 +25,8 @@
             ],
             "firefox": [
               {
-                "version_added": "68"
+                "version_added": "68",
+                "notes": "On macOS 12, scroll snapping does not complete reliably. See <a href='https://bugzil.la/1737820'>bug 1737820</a>"
               },
               {
                 "version_added": "39",


### PR DESCRIPTION
This PR notes a problem with scroll snapping on Firefox on macOS 12 (Monterey).

This was originally reported at https://github.com/mdn/content/issues/10562 and has also been filed as a Firefox bug at https://bugzilla.mozilla.org/show_bug.cgi?id=1737820.

Since at least three people have reported this issue it seems worth documenting: however I'm a little uncertain about documenting it in case Mozilla fixes it quickly and we miss the update.