### PR TITLE
Complete nodejs data for URL and URLSearchParams

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -143,9 +143,15 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": true
-            },
+            "nodejs": [
+              {
+                "version_added": "10.0.0"
+              },
+              {
+                "version_added": "7.0.0",
+                "notes": "Has to be imported from the URL module."
+              }
+            ],
             "opera": {
               "version_added": "15"
             },
@@ -206,7 +212,7 @@
               "notes": "If the underlying object does not have a content type set, using this URL as the <code>src</code> of an <code>img</code> tag fails intermittently with error DOM7009."
             },
             "nodejs": {
-              "version_added": false
+              "version_added": "16.7.0"
             },
             "opera": {
               "version_added": "15"
@@ -326,7 +332,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "7.0.0"
             },
             "opera": {
               "version_added": "19"
@@ -381,7 +387,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "7.0.0"
             },
             "opera": {
               "version_added": "19"
@@ -436,7 +442,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "7.0.0"
             },
             "opera": {
               "version_added": "19"
@@ -491,7 +497,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "7.0.0"
             },
             "opera": {
               "version_added": "19"
@@ -560,7 +566,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "7.0.0"
             },
             "opera": {
               "version_added": "19"
@@ -615,7 +621,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "7.0.0"
             },
             "opera": {
               "version_added": "19"
@@ -672,7 +678,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "7.0.0"
             },
             "opera": {
               "version_added": "19"
@@ -727,7 +733,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "7.0.0"
             },
             "opera": {
               "version_added": "19"
@@ -782,7 +788,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "7.0.0"
             },
             "opera": {
               "version_added": "19"
@@ -839,7 +845,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": false
+              "version_added": "16.7.0"
             },
             "opera": {
               "version_added": "15"
@@ -896,7 +902,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "7.0.0"
             },
             "opera": {
               "version_added": "19"
@@ -950,9 +956,17 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": "7.5.0"
-            },
+            "nodejs": [
+              {
+                "version_added": "7.5.0"
+              },
+              {
+                "version_added": "7.0.0",
+                "version_removed": "7.5.0",
+                "partial_implementation": true,
+                "notes": "An object matching the <code>URLSearchParams</code> interface is returned, but it contains no data."
+              }
+            ],
             "opera": {
               "version_added": "38"
             },
@@ -1006,7 +1020,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "7.7.0"
             },
             "opera": {
               "version_added": "58"
@@ -1059,6 +1073,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "7.0.0"
             },
             "opera": {
               "version_added": "15"
@@ -1113,7 +1130,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "7.0.0"
             },
             "opera": {
               "version_added": "19"

--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -89,16 +89,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "7.10.0"
-              },
-              {
-                "version_added": "7.5.0",
-                "partial_implementation": true,
-                "notes": "Only string as <code>init</code> object supported."
-              }
-            ],
+            "nodejs": {
+              "version_added": "7.5.0"
+            },
             "opera": {
               "version_added": "36"
             },
@@ -314,7 +307,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "7.5.0"
             },
             "opera": {
               "version_added": "36"
@@ -369,7 +362,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "7.5.0"
             },
             "opera": {
               "version_added": "36"
@@ -427,7 +420,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "7.5.0"
             },
             "opera": {
               "version_added": "36"
@@ -479,6 +472,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "7.5.0"
             },
             "opera": {
               "version_added": "36"
@@ -533,7 +529,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "7.5.0"
             },
             "opera": {
               "version_added": "36"
@@ -588,7 +584,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "7.5.0"
             },
             "opera": {
               "version_added": "36"
@@ -643,7 +639,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "7.5.0"
             },
             "opera": {
               "version_added": "36"
@@ -697,7 +693,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "7.5.0"
             },
             "opera": {
               "version_added": "36"
@@ -752,7 +748,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "7.5.0"
             },
             "opera": {
               "version_added": "36"
@@ -862,7 +858,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "7.5.0"
             },
             "opera": {
               "version_added": "36"
@@ -916,7 +912,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "7.5.0"
             },
             "opera": {
               "version_added": "36"
@@ -967,6 +963,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "7.5.0"
             },
             "opera": {
               "version_added": "36"


### PR DESCRIPTION
#### Summary

Part of #13170. This fills in `true` and missing `nodejs` values for `URL` and `URLSearchParams`.

#### Test results and supporting details

Most of the data came from the "history" section of [the documentation](https://nodejs.org/dist/latest-v16.x/docs/api/url.html#class-url).

Local testing also revealed the oddity of `URL#searchParams` returning a dummy object in `7.0.0` before `URLSearchParams` was properly implemented in `7.5.0`.