### PR TITLE
Complete nodejs data for MessagePort

### DIFF
--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -26,10 +26,16 @@
           "ie": {
             "version_added": "10"
           },
-          "nodejs": {
-            "version_added": "10.5.0",
-            "notes": "Is a Node <code>EventEmitter</code> instead of DOM <code>EventTarget</code>."
-          },
+          "nodejs": [
+            {
+              "version_added": "14.7.0"
+            },
+            {
+              "version_added": "10.5.0",
+              "version_removed": "14.7.0",
+              "notes": "Is a Node <code>EventEmitter</code> instead of DOM <code>EventTarget</code>."
+            }
+          ],
           "opera": {
             "version_added": "10.6"
           },
@@ -81,9 +87,17 @@
             "ie": {
               "version_added": "10"
             },
-            "nodejs": {
-              "version_added": "10.5.0"
-            },
+            "nodejs": [
+              {
+                "version_added": "14.7.0"
+              },
+              {
+                "version_added": "10.5.0",
+                "version_removed": "14.7.0",
+                "partial_implementation": true,
+                "notes": "Supports the event, but only via Node <code>EventEmitter</code>."
+              }
+            ],
             "opera": {
               "version_added": "10.6"
             },
@@ -137,11 +151,17 @@
             "ie": {
               "version_added": "10"
             },
-            "nodejs": {
-              "version_added": "10.5.0",
-              "partial_implementation": true,
-              "notes": "Supports the event, but only via Node <code>EventEmitter</code>."
-            },
+            "nodejs": [
+              {
+                "version_added": "14.7.0"
+              },
+              {
+                "version_added": "10.5.0",
+                "version_removed": "14.7.0",
+                "partial_implementation": true,
+                "notes": "Supports the event, but only via Node <code>EventEmitter</code>."
+              }
+            ],
             "opera": {
               "version_added": "10.6"
             },
@@ -195,11 +215,17 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": "14.5.0",
-              "partial_implementation": true,
-              "notes": "Supports the event, but only via Node <code>EventEmitter</code>."
-            },
+            "nodejs": [
+              {
+                "version_added": "14.7.0"
+              },
+              {
+                "version_added": "14.5.0",
+                "version_removed": "14.7.0",
+                "partial_implementation": true,
+                "notes": "Supports the event, but only via Node <code>EventEmitter</code>."
+              }
+            ],
             "opera": {
               "version_added": "47"
             },
@@ -488,7 +514,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": true
+              "version_added": "10.5.0"
             },
             "opera": {
               "version_added": "≤15"

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -248,6 +248,13 @@
           "engine": "V8",
           "engine_version": "8.4"
         },
+        "14.7.0": {
+          "release_date": "2020-07-29",
+          "release_notes": "https://nodejs.org/en/blog/release/v14.7.0/",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "8.4"
+        },
         "14.8.0": {
           "release_date": "2020-08-11",
           "release_notes": "https://nodejs.org/en/blog/release/v14.8.0/",


### PR DESCRIPTION
#### Summary

Part of #13170. This fills in a `true` value for `nodejs` in `MessagePort`, but also updates some partially-supported APIs to full support.

#### Test results and supporting details

History section in the documentation: https://nodejs.org/dist/latest-v16.x/docs/api/worker_threads.html#class-messageport

Changelog entry for full support in `14.7.0`: https://nodejs.org/en/blog/release/v14.7.0/

> (SEMVER-MINOR) make MessagePort inherit from EventTarget

This required adding the `14.7.0` release to the `nodejs.json` file. Let me know if that should be split out to a separate PR.