### PR TITLE
Complete nodejs data for MessageEvent

### DIFF
--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -136,6 +136,9 @@
             "ie": {
               "version_added": "9"
             },
+            "nodejs": {
+              "version_added": "15.0.0"
+            },
             "opera": {
               "version_added": true
             },
@@ -187,6 +190,9 @@
             },
             "ie": {
               "version_added": "9"
+            },
+            "nodejs": {
+              "version_added": false
             },
             "opera": {
               "version_added": true
@@ -240,6 +246,9 @@
             "ie": {
               "version_added": "9"
             },
+            "nodejs": {
+              "version_added": "15.0.0"
+            },
             "opera": {
               "version_added": true
             },
@@ -291,6 +300,9 @@
             },
             "ie": {
               "version_added": "9"
+            },
+            "nodejs": {
+              "version_added": "15.0.0"
             },
             "opera": {
               "version_added": true
@@ -344,6 +356,9 @@
             "ie": {
               "version_added": "9"
             },
+            "nodejs": {
+              "version_added": "15.0.0"
+            },
             "opera": {
               "version_added": true
             },
@@ -396,6 +411,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "15.0.0"
+            },
             "opera": {
               "version_added": "≤12.1"
             },
@@ -444,6 +462,9 @@
                 "version_added": "55"
               },
               "ie": {
+                "version_added": false
+              },
+              "nodejs": {
                 "version_added": false
               },
               "opera": {


### PR DESCRIPTION
#### Summary

Part of #13170. This fills in the missing entries for `nodejs` in the `MessageEvent` APIs.

#### Test results and supporting details

Support for each property was added in the same version as the constructor (`15.0.0`); they just didn't have `nodejs` entries in the data. The two entries marked as `false` were verified via manual testing.
