### PR TITLE
Add Firefox support for color-scheme property & meta tag

### DIFF
--- a/css/properties/color-scheme.json
+++ b/css/properties/color-scheme.json
@@ -16,10 +16,10 @@
               "version_added": "81"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "96"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "96"
             },
             "ie": {
               "version_added": false

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -497,10 +497,10 @@
                   "version_added": "81"
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "96"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "96"
                 },
                 "ie": {
                   "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Add Firefox support for color-scheme property & meta tag in Firefox 96 onwards

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
Test case: https://color-scheme-demo.glitch.me/
The test case is not working on FF 95 Beta (android & mac), but working on FF 96 Nightly (android & mac)

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Source: https://bugzilla.mozilla.org/show_bug.cgi?id=1576289#c10 (will ride the trains in version 96 branch)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A
<!-- ✅ After submitting, review the results of the "Checks" tab! -->
