### PR TITLE
Add flagless Deno 1.16 support for local storage

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3026,7 +3026,7 @@
             "deno": [
               {
                 "version_added": "1.16",
-                "notes": "The key used for the Web Storage bucket is based on various factors. See <a href='https://deno.land/manual/runtime/web_storage_api'>the Deno manual</a>"
+                "notes": "The key used for the Web Storage bucket is based on various factors. See <a href='https://deno.land/manual/runtime/web_storage_api'>the Deno manual</a>."
               },
               {
                 "version_added": "1.10",

--- a/api/Window.json
+++ b/api/Window.json
@@ -3026,7 +3026,7 @@
             "deno": [
               {
                 "version_added": "1.16",
-                "notes": "The key used for the Web Storage bucket is based on various factors. See <a href=\"https://deno.land/manual/runtime/web_storage_api\">the Deno manual</a>"
+                "notes": "The key used for the Web Storage bucket is based on various factors. See <a href='https://deno.land/manual/runtime/web_storage_api'>the Deno manual</a>"
               },
               {
                 "version_added": "1.10",

--- a/api/Window.json
+++ b/api/Window.json
@@ -3025,13 +3025,7 @@
             },
             "deno": {
               "version_added": "1.10",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--location",
-                  "value_to_set": "<desired origin>"
-                }
-              ]
+              "notes": "Before Deno 1.16, a `--location <desired location>` flag is required. See <a href='https://deno.com/blog/v1.16#localstorage-does-not-require---location-anymore'>the release post</a>."
             },
             "edge": {
               "version_added": "12"

--- a/api/Window.json
+++ b/api/Window.json
@@ -3023,10 +3023,23 @@
             "chrome_android": {
               "version_added": "18"
             },
-            "deno": {
-              "version_added": "1.10",
-              "notes": "Before Deno 1.16, a `--location <desired location>` flag is required. See <a href='https://deno.com/blog/v1.16#localstorage-does-not-require---location-anymore'>the release post</a>."
-            },
+            "deno": [
+              {
+                "version_added": "1.16",
+                "notes": "The key used for the Web Storage bucket is based on various factors. See <a href=\"https://deno.land/manual/runtime/web_storage_api\">the Deno manual</a>"
+              },
+              {
+                "version_added": "1.10",
+                "version_removed": "1.16",
+                "flags": [
+                  {
+                    "type": "runtime_flag",
+                    "name": "--location",
+                    "value_to_set": "<desired origin>"
+                  }
+                ]
+              }
+            ],
             "edge": {
               "version_added": "12"
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

This updates the support for `localStorage` with the release of Deno 1.16.  The `--location` flag is no longer required.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

- Official Release Post: https://deno.com/blog/v1.16#localstorage-does-not-require---location-anymore

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
