### PR TITLE
Firefox for Android permissions.request can't be triggered by browserAction.onClicked

### DIFF
--- a/webextensions/api/permissions.json
+++ b/webextensions/api/permissions.json
@@ -195,7 +195,7 @@
               "firefox_android": {
                 "version_added": true,
                 "partial_implementation": true,
-                "notes": "From version 79, the user interface to approve the permission request is missing. See <a href='https://bugzil.la/1601420'>bug 1601420</a>."
+                "notes": "From version 79, the user interface to approve the permission request is missing (see <a href='https://bugzil.la/1601420'>bug 1601420</a>), and <code>browserAction.onClicked</code> is not recognized as a user action (see <a href='https://github.com/mozilla-mobile/fenix/issues/22348'>fenix bug 22348</a>)"
               },
               "opera": {
                 "version_added": true

--- a/webextensions/api/permissions.json
+++ b/webextensions/api/permissions.json
@@ -195,7 +195,10 @@
               "firefox_android": {
                 "version_added": true,
                 "partial_implementation": true,
-                "notes": "From version 79, the user interface to approve the permission request is missing (see <a href='https://bugzil.la/1601420'>bug 1601420</a>), and <code>browserAction.onClicked</code> is not recognized as a user action (see <a href='https://github.com/mozilla-mobile/fenix/issues/22348'>fenix bug 22348</a>)"
+                "notes": [
+                  "From version 79, the user interface to approve the permission request is missing (see <a href='https://bugzil.la/1601420'>bug 1601420</a>).",
+                  "<code>browserAction.onClicked</code> is not recognized as a user action (see <a href='https://github.com/mozilla-mobile/fenix/issues/22348'>mozilla-mobile/fenix#22348</a>)."
+                ]
               },
               "opera": {
                 "version_added": true


### PR DESCRIPTION
To include additional limitation on triggering `permissions.request()` in Firefox for Android

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Add clarification that trying to call `permissions.request` from a [`browserAction.onClicked`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/onClicked) event in Firefox for Android will throw an error, despite it being a valid user interaction.

#### Test results and supporting details
See https://github.com/mozilla-mobile/fenix/issues/22348 

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
See https://github.com/mozilla-mobile/fenix/issues/22348 

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
