### PR TITLE
Safari 15: import supported in workers

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1866,10 +1866,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "15"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15"
               },
               "samsunginternet_android": {
                 "version_added": "13.0"


### PR DESCRIPTION
According to https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes

> Added support for ES6 Modules in Workers and ServiceWorkers.

So this just adds the version to the import statement. Will fix up the table in the last row here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#import

Fixes https://github.com/mdn/browser-compat-data/pull/13670