### PR TITLE
Add Safari versions for Selection API

### DIFF
--- a/api/Selection.json
+++ b/api/Selection.json
@@ -32,7 +32,7 @@
             "version_added": "10.1"
           },
           "safari": {
-            "version_added": "1"
+            "version_added": "1.3"
           },
           "safari_ios": {
             "version_added": "1"
@@ -1316,7 +1316,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "1"
+              "version_added": "1.3"
             },
             "safari_ios": {
               "version_added": "1"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `Selection` API, based upon manual testing.

Test Code Used:
```js
var sel = window.getSelection();
alert(typeof sel);
```

Before Safari 1.3, `window.getSelection()` returned a `string`, not an `object`.
