### PR TITLE
Link Chromium bugs for font-variant-alternates/position

### DIFF
--- a/css/properties/font-variant-alternates.json
+++ b/css/properties/font-variant-alternates.json
@@ -6,10 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/716567'>bug 716567</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/716567'>bug 716567</a>."
             },
             "edge": {
               "version_added": false

--- a/css/properties/font-variant-position.json
+++ b/css/properties/font-variant-position.json
@@ -7,10 +7,12 @@
           "spec_url": "https://drafts.csswg.org/css-fonts/#font-variant-position-prop",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/1212668'>bug 1212668</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/1212668'>bug 1212668</a>."
             },
             "edge": {
               "version_added": false


### PR DESCRIPTION
These are in Firefox and Safari but not in Chrome, and the subject of an
Interop 2022 proposal:
https://github.com/web-platform-tests/interop-2022/issues/13
