### PR TITLE
PermissionStatus items other than name are not experimental

### DIFF
--- a/api/PermissionStatus.json
+++ b/api/PermissionStatus.json
@@ -44,7 +44,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -140,7 +140,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -203,7 +203,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
Other than it's new `name` property, `PermissionStatus` is used by more than 2 major browsers. This marks those as not experimental. As discussed in https://github.com/mdn/browser-compat-data/pull/13466#issuecomment-976016162