### PR TITLE
Remove the requestAnimationFrame() "Return value" subfeature

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -6660,54 +6660,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "return_value": {
-          "__compat": {
-            "description": "Return value",
-            "support": {
-              "chrome": {
-                "version_added": "23"
-              },
-              "chrome_android": {
-                "version_added": "25"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "11"
-              },
-              "firefox_android": {
-                "version_added": "14"
-              },
-              "ie": {
-                "version_added": "10"
-              },
-              "opera": {
-                "version_added": "15"
-              },
-              "opera_android": {
-                "version_added": "14"
-              },
-              "safari": {
-                "version_added": "6.1"
-              },
-              "safari_ios": {
-                "version_added": "6.1"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.5"
-              },
-              "webview_android": {
-                "version_added": "≤37"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "requestFileSystem": {


### PR DESCRIPTION
This is already captured by the cancelAnimationFrame() entry.

The return value of requestAnimationFrame() is an integer which can be
used to cancel the callback with cancelAnimationFrame(). Judging by the
data, this entry must have been added to capture that
mozRequestAnimationFrame() returned undefined in Firefox 4-10, but this
by itself is not useful information.

Also, most readers could probably not decipher what this entry means.