### PR TITLE
Update line_breaks Firefox compability

### DIFF
--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -545,8 +545,7 @@
                   "version_added": "12"
                 },
                 "firefox": {
-                  "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/1312897'>bug 1312897</a>."
+                  "version_added": "59"
                 },
                 "firefox_android": {
                   "version_added": false,

--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -548,8 +548,7 @@
                   "version_added": "59"
                 },
                 "firefox_android": {
-                  "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/1312897'>bug 1312897</a>."
+                  "version_added": "59"
                 },
                 "ie": {
                   "version_added": "10"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
line_breaks compability was fixed in firefox 59 ([bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1391044))

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
