### PR TITLE
Updates edge to version 96

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -161,19 +161,26 @@
         "95": {
           "release_date": "2021-10-21",
           "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-950102030-october-21",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "95"
         },
         "96": {
-          "status": "beta",
+          "release_date": "2021-11-19",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-960105429-november-19",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "96"
         },
         "97": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "97"
+        },
+        "98": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "98"
         }
       }
     }


### PR DESCRIPTION
Hello everyone!

I updated Edge browser to version 96, according to [this release note](https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-960105429-november-19).

Fixes #13701.

:)