### PR TITLE
Add Edge versions for api.Window.animation*_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -318,7 +318,7 @@
                 "version_added": "18"
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "prefix": "webkit"
               }
             ],
@@ -398,7 +398,7 @@
                 "version_added": "18"
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "prefix": "webkit"
               }
             ],
@@ -478,7 +478,7 @@
                 "version_added": "18"
               },
               {
-                "version_added": "≤79",
+                "version_added": "79",
                 "prefix": "webkit"
               }
             ],


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `animation*_event` members of the `Window` API, based upon manual testing.

Test Code Used:
```js
<div id="test">
    <div id="container">
        <p id="animation">You chose a cold night to visit our planet.</p>
    </div>
    <button id="activate" type="button">Activate animation</button>
    <div id="event-log"></div>
</div>

<script>
	var animation = document.getElementById('animation');
	var animationEventLog = document.getElementById('event-log');
	var applyAnimation = document.getElementById('activate');
	var iterationCount = 0;

	animation.addEventListener('webkitanimationstart', function() {
	  animationEventLog.textContent = `${animationEventLog.textContent}'animation started' `;
	});

	animation.addEventListener('webkitanimationiteration', function() {
	  iterationCount++;
	  animationEventLog.textContent = `${animationEventLog.textContent}'animation iterations: ${iterationCount}' `;
	});

	animation.addEventListener('webkitanimationend', function() {
	  animationEventLog.textContent = `${animationEventLog.textContent}'animation ended'`;
	  animation.classList.remove('active');
	  applyAnimation.textContent = "Activate animation";
	});

	animation.addEventListener('webkitanimationcancel', function() {
	  animationEventLog.textContent = `${animationEventLog.textContent}'animation canceled'`;
	});

	applyAnimation.addEventListener('click', function() {
	  animation.classList.toggle('active');
	  animationEventLog.textContent = '';
	  iterationCount = 0;
	  let active = animation.classList.contains('active');
	  if (active) {
	    applyAnimation.textContent = "Cancel animation";
	  } else {
	    applyAnimation.textContent = "Activate animation";
	  }
	});
</script>
```
