### PR TITLE
Add Edge versions for api.Window.appinstalled_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -541,7 +541,7 @@
               "version_added": "57"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "49",


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `appinstalled_event` member of the `Window` API.  The data was copied from the event handler counterpart.
