### PR TITLE
Add Edge versions for api.Window.languagechange_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -2870,7 +2870,7 @@
               "version_added": "37"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "32"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `languagechange_event` member of the `Window` API.  The data was copied from its event handler counterpart.
