### PR TITLE
Add Edge versions for api.Window.rejectionhandled_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -6439,7 +6439,7 @@
               "version_added": "49"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": [
               {


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `rejectionhandled_event` member of the `Window` API.  The data was copied from its event handler counterpart.
