### PR TITLE
Add Edge versions for api.BaseAudioContext.decodeAudioData.returns_promise

### DIFF
--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -1247,7 +1247,7 @@
                 "version_added": "49"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "16"
               },
               "firefox": {
                 "version_added": "36"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `decodeAudioData.returns_promise` member of the `BaseAudioContext` API, based upon manual testing.

Test Code Used: https://mdn-bcd-collector.appspot.com/tests/api/BaseAudioContext/decodeAudioData/promise_syntax (will be renamed to https://mdn-bcd-collector.appspot.com/tests/api/BaseAudioContext/decodeAudioData/returns_promise in collector v4.1)
