### PR TITLE
Add Edge versions for api.CacheStorage.secure_context_required

### DIFF
--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -357,7 +357,7 @@
               "version_added": "65"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "44"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `secure_context_required` member of the `CacheStorage` API, based upon manual testing.

Test Code Used: http://mdn-bcd-collector.appspot.com/tests/api/CacheStorage vs. https://mdn-bcd-collector.appspot.com/tests/api/CacheStorage
