### PR TITLE
Add Edge versions for Geolocation API

### DIFF
--- a/api/Geolocation.json
+++ b/api/Geolocation.json
@@ -158,7 +158,7 @@
               "version_added": "50"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "55"

--- a/api/GeolocationCoordinates.json
+++ b/api/GeolocationCoordinates.json
@@ -490,7 +490,7 @@
               "version_added": "47"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "55"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1166,7 +1166,7 @@
                 "version_added": "47"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "55"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `Geolocation` API, based upon manual testing.

Test Code Used: http://mdn-bcd-collector.appspot.com/tests/api/Navigator/geolocation vs. https://mdn-bcd-collector.appspot.com/tests/api/Navigator/geolocation
