### PR TITLE
Add Edge versions for api.Notification.secure_context_required

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -1036,7 +1036,7 @@
               "version_added": "62"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "67"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `secure_context_required` member of the `Notification` API, based upon manual testing.

Test Code Used: http://mdn-bcd-collector.appspot.com/tests/api/Notification vs. https://mdn-bcd-collector.appspot.com/tests/api/Notification
