### PR TITLE
Diff features by fetching from GitHub Actions

### DIFF
--- a/scripts/diff-features.js
+++ b/scripts/diff-features.js
@@ -20,8 +20,8 @@ function main({ ref1, ref2, format }) {
     refB = `${ref1}`;
   }
 
-  const aSide = new Set(enumerateFeatures(refA));
-  const bSide = new Set(enumerateFeatures(refB));
+  let aSide = enumerate(refA);
+  let bSide = enumerate(refB);
 
   const results = {
     added: [...bSide].filter(feature => !aSide.has(feature)),
@@ -32,6 +32,57 @@ function main({ ref1, ref2, format }) {
     printMarkdown(results);
   } else {
     console.log(JSON.stringify(results, undefined, 2));
+  }
+}
+
+function enumerate(ref) {
+  try {
+    return new Set(getEnumerationFromGithub(ref));
+  } catch {
+    console.error('Fetching artifact from GitHub failed. Using fallback.');
+    return new Set(enumerateFeatures(ref));
+  }
+}
+
+function getEnumerationFromGithub(ref) {
+  const ENUMERATE_WORKFLOW = '15595228';
+  const ENUMERATE_WORKFLOW_ARTIFACT = 'enumerate-features';
+  const ENUMERATE_WORKFLOW_FILE = 'features.json';
+
+  const unlinkFile = () => {
+    try {
+      fs.unlinkSync(ENUMERATE_WORKFLOW_FILE);
+    } catch (err) {
+      if (err.code == 'ENOENT') {
+        return;
+      } else {
+        throw err;
+      }
+    }
+  };
+
+  const hash = execSync(`git rev-parse ${ref}`, {
+    encoding: 'utf-8',
+  }).trim();
+  const workflowRun = execSync(
+    `gh api /repos/:owner/:repo/actions/workflows/${ENUMERATE_WORKFLOW}/runs --jq '.workflow_runs[] | select(.head_sha=="${hash}") | .id'`,
+    {
+      encoding: 'utf-8',
+    },
+  ).trim();
+
+  if (!workflowRun) throw Error('No workflow run found for commit.');
+
+  try {
+    unlinkFile();
+    execSync(
+      `gh run download ${workflowRun} -n ${ENUMERATE_WORKFLOW_ARTIFACT}`,
+    );
+    return JSON.parse(
+      fs.readFileSync(ENUMERATE_WORKFLOW_FILE, { encoding: 'utf-8' }),
+    );
+  } finally {
+    unlinkFile();
   }
 }
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

This substantially speeds up feature diffing, where the enumeration has already been done in GitHub Actions. Where possible, it tries to fetch from GitHub Actions, or falls back to using a worktree to enumerate directly.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

You can see this in action with these examples:

- `node ./scripts/diff-features.js --format=json 80d976fb46e5ca453856adcab9bcf0b36a4bf140`, for a fallback case. This is typical for commits older than about 24 hours. On my machine, runs in about 10 seconds (with a full npm cache).
- `node ./scripts/diff-features.js --format=json 1409a8c6d17e7d420404bb1a0561cca431cba1b5`, for a GitHub-facilitated case. Runs in about 5 seconds.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

See https://github.com/mdn/browser-compat-data/pull/13695 for background.

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
