### PR TITLE
Correct tag reference when uploading a release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     - name: Add JSON as a release asset
-      run: gh release upload $GITHUB_REF build/data.json
+      run: gh release upload ${GITHUB_REF#refs/*/} build/data.json
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Uploading a release asset fails in the new release workflow because GitHub uses the `refs/tags/vX.Y.Z` reference, not the tag name alone. This PR tries to correct for that when uploading release assets.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

The failure is demonstrated here: https://github.com/mdn/browser-compat-data/runs/4315784952

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

See https://github.com/mdn/browser-compat-data/pull/13714 for background.

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
