### PR TITLE
Update HPKP Firefox Android data

### DIFF
--- a/http/headers/public-key-pins.json
+++ b/http/headers/public-key-pins.json
@@ -34,7 +34,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "35"
+              "version_added": "35",
+              "version_removed": "79"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Formally, Firefox codebase disabled HPKP in version 72, but this change arrived in Firefox Android version 79.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Update `version_added` for HPKP in Firefox Android.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
 - Tested with [HPKP test](https://projects.dm.id.lv/Public-Key-Pins_test)
 - [The commit implementing this change](https://hg.mozilla.org/mozilla-central/rev/d791bfa31f08) notes milestone 72.0a1, but this corresponds to Firefox Android 79.
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
