### PR TITLE
Add Edge versions for api.CanvasRenderingContext2D.drawFocusIfNeeded.path_parameter

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1021,7 +1021,7 @@
                 "version_added": "37"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": false


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `drawFocusIfNeeded.path_parameter` member of the `CanvasRenderingContext2D` API, based upon manual testing.

Test Code Used:
```js
var canvas = document.createElement('canvas');
if (!canvas) {
  return false;
}
var instance = canvas.getContext('2d');
var path = new Path2D();
var el = document.createElement('p');
instance.drawFocusIfNeeded(path, el); // Check if it doesn't throw an error
```
