### PR TITLE
Add Edge versions for ImageCapture API

### DIFF
--- a/api/ImageCapture.json
+++ b/api/ImageCapture.json
@@ -12,7 +12,7 @@
             "version_added": "59"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false,
@@ -63,7 +63,7 @@
               "version_added": "59"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,
@@ -114,7 +114,7 @@
               "version_added": "59"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,
@@ -165,7 +165,7 @@
               "version_added": "61"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,
@@ -216,7 +216,7 @@
               "version_added": "59"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,
@@ -283,7 +283,7 @@
               }
             ],
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,
@@ -366,7 +366,7 @@
               "version_added": "59"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false,


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `ImageCapture` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ImageCapture/ImageCapture (constructor needed to use this interface)

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
