### PR TITLE
Add Edge versions for InstallEvent API

### DIFF
--- a/api/InstallEvent.json
+++ b/api/InstallEvent.json
@@ -11,7 +11,7 @@
             "version_added": "40"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "17"
           },
           "firefox": {
             "version_added": "44",
@@ -60,7 +60,7 @@
               "version_added": "40"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "44",
@@ -109,7 +109,7 @@
               "version_added": "40"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "44",


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `InstallEvent` API.  The data was copied from the event handler, api.ServiceWorkerGlobalScope.oninstall, and the constructor was tested using the mdn-bcd-collector project.
