### PR TITLE
Add Edge versions for api.PerformanceResourceTiming.serverTiming

### DIFF
--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -795,7 +795,7 @@
               "version_added": "65"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "61"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `serverTiming` member of the `PerformanceResourceTiming` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PerformanceResourceTiming/serverTiming (will be added in collector v4.1)

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
