### PR TITLE
Add Edge versions for api.ServiceWorkerGlobalScope.onabortpayment

### DIFF
--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -362,7 +362,7 @@
               "version_added": "70"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `onabortpayment` member of the `ServiceWorkerGlobalScope` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ServiceWorkerGlobalScope/onabortpayment (will be added in collector v4.1)

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
