### PR TITLE
add Firefox 81 flex-direction fully supported

### DIFF
--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -35,6 +35,9 @@
             ],
             "firefox": [
               {
+                "version_added": "81"
+              },
+              {
                 "version_added": "20",
                 "partial_implementation": true,
                 "notes": [
@@ -48,6 +51,9 @@
               }
             ],
             "firefox_android": [
+              {
+                "version_added": "81"
+              },
               {
                 "version_added": "20",
                 "partial_implementation": true,


### PR DESCRIPTION
Fixes #13735

Data from notes here that links https://bugzilla.mozilla.org/show_bug.cgi?id=1042151
