### PR TITLE
Add Edge versions for api.IDBVersionChangeEvent.version

### DIFF
--- a/api/IDBVersionChangeEvent.json
+++ b/api/IDBVersionChangeEvent.json
@@ -253,7 +253,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "10"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `version` member of the `IDBVersionChangeEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/IDBVersionChangeEvent/version (will be added in collector v4.1)

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
