### PR TITLE
Add Edge versions for api.RTCIceCandidate.address

### DIFF
--- a/api/RTCIceCandidate.json
+++ b/api/RTCIceCandidate.json
@@ -137,16 +137,9 @@
             "chrome_android": {
               "version_added": "74"
             },
-            "edge": [
-              {
-                "version_added": "79"
-              },
-              {
-                "version_added": "≤18",
-                "version_removed": "79",
-                "alternative_name": "ip"
-              }
-            ],
+            "edge": {
+              "version_added": "79"
+            },
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `address` member of the `RTCIceCandidate` API, based upon manual testing.

Test Code Used: `var rtcic = new RTCIceCandidate(); rtcic.ip;`
