### PR TITLE
Add Edge versions for api.Document.createTreeWalker.whatToShow_filter_parameters_optional

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -2885,7 +2885,7 @@
                 "version_added": "18"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "13"
               },
               "firefox": {
                 "version_added": "12"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `createTreeWalker.whatToShow_filter_parameters_optional` member of the `Document` API, based upon manual testing.

Test Code Used: `document.createTreeWalker(document.body); // Check if it returns an exception`
