### PR TITLE
Add Edge versions for api.HTMLCanvasElement.getContext.bitmaprenderer_context

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -156,7 +156,7 @@
                 "version_added": "56"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "46"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `getContext.bitmaprenderer_context` member of the `HTMLCanvasElement` API, based upon manual testing.

Test Code Used: `var canvas = document.createElement('canvas'); canvas.getContext('bitmaprenderer');`
