### PR TITLE
Mention the existing Chromium attempt for certificate API in WebExtension

### DIFF
--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -64,7 +64,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "There was <a href='https://crrev.com/c/644858'>an attempt</a> to implement this."
+                "notes": "See <a href='https://crbug.com/628819'>bug 628819</a>."
               },
               "edge": {
                 "version_added": false

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -1099,7 +1099,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "There was <a href='https://crrev.com/c/644858'>an attempt</a> to implement this."
+                "notes": "See <a href='https://crbug.com/628819'>bug 628819</a>."
               },
               "edge": {
                 "version_added": false

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -63,7 +63,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/CertificateInfo",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "notes": "There was <a href='https://crrev.com/c/644858'>an attempt</a> to implement this."
               },
               "edge": {
                 "version_added": false
@@ -1097,7 +1098,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/getSecurityInfo",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "notes": "There was <a href='https://crrev.com/c/644858'>an attempt</a> to implement this."
               },
               "edge": {
                 "version_added": false


### PR DESCRIPTION
#### Summary
Add a note to mention the existing attempt, of implementing the [certificate API for WebExtension](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest#accessing_security_information) in Chromium.

#### Test results and supporting details
Not applicable, since this is only adding a note.

#### Related issues
N/A