### PR TITLE
Copy edit spec_url documentation additions

### DIFF
--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -104,8 +104,8 @@ The `__compat` object consists of the following:
   It needs to be a valid URL, and should be the language-neutral URL (e.g. use `https://developer.mozilla.org/docs/Web/CSS/text-align` instead of `https://developer.mozilla.org/en-US/docs/Web/CSS/text-align`).
 
 - An optional `spec_url` property as a URL or an array of URLs, each of which is for a specific part of a specification in which this feature is defined.
-  - Each URL must either contain a fragment identifier (e.g. `https://tc39.es/proposal-promise-allSettled/#sec-promise.allsettled`), or else must match the regular-expression pattern `^https://www.khronos.org/registry/webgl/extensions/[^/]+/` (e.g. `https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/`).
-  - This property may only contain specifications published by standards bodies, or formal proposals that may lead to such standards).
+  Each URL must either contain a fragment identifier (e.g. `https://tc39.es/proposal-promise-allSettled/#sec-promise.allsettled`), or else must match the regular-expression pattern `^https://www.khronos.org/registry/webgl/extensions/[^/]+/` (e.g. `https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/`).
+  Each URL must link to a specification published by a standards body or a formal proposal that may lead to such publication.
 
 ### The `support` object
 


### PR DESCRIPTION

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Some copyediting to the changes introduced in #13629. This improves symmetry, accuracy (specifying the URLs, not the property of the object), and removes a spurious parenthesis.

#### Related issues

#13629
