### PR TITLE
Add Edge versions for api.HTMLElement.focus.options_preventScroll_parameter

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1181,7 +1181,7 @@
                 "version_added": "64"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "17"
               },
               "firefox": {
                 "version_added": "68"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `focus.options_preventScroll_parameter` member of the `HTMLElement` API, based upon manual testing.

Test Code Used:
```js
<div id="test">
	<button type="button" onclick="focusScrollMethod()">Click me to focus on the button!</button>
	<button type="button" onclick="focusNoScrollMethod()">Click me to focus on the button without scrolling!</button>

	<div id="container" style="height: 2000px; width: 1000px;">
	<button type="button" id="myButton" style="margin-top: 1500px;">Click Me!</button>
	</div>
</div>

<script>
	focusScrollMethod = function getFocus() {
	  document.getElementById("myButton").focus({preventScroll:false});
	}
	focusNoScrollMethod = function getFocusWithoutScrolling() {
	  document.getElementById("myButton").focus({preventScroll:true});
	}
</script>
```
