### PR TITLE
Add Edge versions for api.WindowEventHandlers.onmessageerror.worker_support

### DIFF
--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -403,7 +403,7 @@
                 "version_added": "60"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "18"
               },
               "firefox": {
                 "version_added": "57"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `onmessageerror.worker_support` member of the `WindowEventHandlers` API, based upon manual testing.

Test Code Used: https://mdn-bcd-collector.appspot.com/tests/api/ServiceWorkerGlobalScope/onmessageerror

Note: I'm thinking that this subfeature should be removed, since this is a mixin for the Window API.
