### PR TITLE
Add Edge versions for api.performance.worker_support

### DIFF
--- a/api/_globals/performance.json
+++ b/api/_globals/performance.json
@@ -65,7 +65,7 @@
               "version_added": "1.0"
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "34"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `worker_support` member of the `performance` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/performance

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
