### PR TITLE
Update Safari versions for api.Document.readystatechange_event

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -9669,10 +9669,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR corrects values for Safari (Desktop and iOS/iPadOS) for the `readystatechange_event` member of the `Document` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<button id="reload" type="button">Reload</button>
</div>

<script>
	var reload = document.getElementById('reload');

	reload.onclick = function() {
		window.location.reload(true);
	}

	document.addEventListener('readystatechange', function(event) {
		alert('readystatechange!');
	});
</script>
```
