### PR TITLE
Add Safari versions for api.Element.mouseout_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -5145,10 +5145,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `mouseout_event` member of the `Element` API, based upon manual testing.

Test Code Used:
```js
var test = document.getElementById('test');
test.addEventListener("mouseout", function() {
	alert("mouseout");
});
```
