### PR TITLE
update samsunginternet_android to 16.0

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -204,12 +204,13 @@
         },
         "15.0": {
           "release_date": "2021-08-13",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "90"
         },
         "16.0": {
-          "status": "beta",
+          "release_date": "2021-11-25",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "92"
         }


### PR DESCRIPTION
Hello from South Korea!

Samsung Internet 16 was released on Thursday (`2021-11-25`).

- https://www.sammyfans.com/2021/11/25/samsung-internet-browser-update-tracker/
- also installed on my phone (screenshot below)