### PR TITLE
Add Safari versions for api.HTMLFormElement.reset_event

### DIFF
--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -813,10 +813,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `reset_event` member of the `HTMLFormElement` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<form id="form">
	  <label>Test field: <input type="text"></label>
	  <br><br>
	  <button type="reset">Reset form</button>
	</form>
</div>

<script>
	var form = document.getElementById('form');
	form.addEventListener('reset', function() {
		alert('reset');
	});
</script>
```
