### PR TITLE
Add Safari versions for api.Window.[online/offline]_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3838,10 +3838,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -4634,10 +4634,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `online_event` and `offline_event` members of the `Window` API, based upon manual testing.

Test Code Used:
```js
window.addEventListener('online', function() {
	alert('online');
});
window.addEventListener('offline', function() {
	alert('offline');
});
```
