### PR TITLE
Add Safari versions for api.HTMLMediaElement.volumechange_event

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -4062,10 +4062,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "2"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `volumechange_event` member of the `HTMLMediaElement` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<video id="video" controls width="250"></video>
</div>

<script>
	var video = document.getElementById('video');
	var videoSrc = '/queengooborg/static/rabbit320.mp4';
	// https://mdn.github.io/learning-area/html/multimedia-and-embedding/video-and-audio-content/rabbit320.mp4

	video.addEventListener('volumechange', function() {
	  alert('Volume change!');
	});

	var source = document.createElement('source');
	source.setAttribute('src', videoSrc);
	source.setAttribute('type', 'video/mp4');

	video.appendChild(source);
</script>
```
