### PR TITLE
Add Safari versions for api.Element.getElementsByTagName.all_elements_selector

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -3898,10 +3898,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": "≤4"
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": "≤3"
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -4008,10 +4008,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": "≤4"
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": "≤3"
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `getElementsByTagName.all_elements_selector` member of the `Element` API, based upon manual testing.

Test Code Used: `document.getElementsByTagName('*'); document.getElementsByTagNameNS('https://www.w3.org/1999/xhtml', "*");`
