### PR TITLE
Add Safari versions for api.[clear/set][Interval/Timeout].worker_support

### DIFF
--- a/api/_globals/clearInterval.json
+++ b/api/_globals/clearInterval.json
@@ -92,10 +92,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/_globals/clearTimeout.json
+++ b/api/_globals/clearTimeout.json
@@ -92,10 +92,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/_globals/setInterval.json
+++ b/api/_globals/setInterval.json
@@ -148,10 +148,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/_globals/setTimeout.json
+++ b/api/_globals/setTimeout.json
@@ -148,10 +148,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `worker_support` member of the `clearInterval`, `clearTimeout`, `setInterval` and `setTimeout` globals, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used:
https://mdn-bcd-collector.appspot.com/tests/api/clearInterval?exposure=Worker
https://mdn-bcd-collector.appspot.com/tests/api/clearTimeout?exposure=Worker
https://mdn-bcd-collector.appspot.com/tests/api/setInterval?exposure=Worker
https://mdn-bcd-collector.appspot.com/tests/api/setTimeout?exposure=Worker

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
