### PR TITLE
Add Safari versions for api.set[Timeout/Interval].supports_parameters_for_callback

### DIFF
--- a/api/_globals/setInterval.json
+++ b/api/_globals/setInterval.json
@@ -94,10 +94,10 @@
               "version_added": "≤14"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/_globals/setTimeout.json
+++ b/api/_globals/setTimeout.json
@@ -94,10 +94,10 @@
               "version_added": "≤14"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `supports_parameters_for_callback` member of the `setTimeout` and `setInterval` globals, based upon manual testing.

Test Code Used: `setTimeout(function(a) { alert(a) }, 1000, "foo!");`
