### PR TITLE
Add Safari versions for api.EventTarget.addEventListener.useCapture_parameter_optional

### DIFF
--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -601,10 +601,10 @@
                 "version_added": "12"
               },
               "safari": {
-                "version_added": "≤4"
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": "≤3"
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -835,10 +835,10 @@
                 "version_added": "12"
               },
               "safari": {
-                "version_added": "≤4"
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": "≤3"
+                "version_added": "1"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `addEventListener.useCapture_parameter_optional` member of the `EventTarget` API, based upon manual testing.

Test Code Used: `document.addEventListener('keydown', function() {} /* no third parameter */);`
