### PR TITLE
Add Safari versions for api.KeyboardEvent.keyIdentifier

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -1310,10 +1310,10 @@
               "version_removed": "41"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1.2"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.5",


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `keyIdentifier` member of the `KeyboardEvent` API, based upon commit history and date.

Commit: https://github.com/WebKit/WebKit/commit/27e30f576b5e09574c28ef8c04c3ea2de4442a37
