### PR TITLE
Add Safari versions for api.XMLHttpRequestEventTarget.onload

### DIFF
--- a/api/XMLHttpRequestEventTarget.json
+++ b/api/XMLHttpRequestEventTarget.json
@@ -176,10 +176,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": "≤3"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `onload` member of the `XMLHttpRequestEventTarget` API, based upon manual testing.

Test Code Used: `var xhr = new XMLHttpRequest(); xhr.onload;`
