### PR TITLE
Update Chrome version for Document's readystatechange event

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -9645,7 +9645,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-readystatechange",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "9"
             },
             "chrome_android": {
               "version_added": "18"


### PR DESCRIPTION
It was implemented at the same time as the `onreadystatechange` event handler property in WebKit:
https://trac.webkit.org/changeset/69710/webkit
https://trac.webkit.org/browser/webkit/trunk/WebCore/Configurations/Version.xcconfig?rev=69710

The Chrome 9 data for `onreadystatechange` looks reliable:
https://github.com/mdn/browser-compat-data/pull/6836