### PR TITLE
Remove api.WindowEventHandlers.onmessageerror.worker_support from BCD

### DIFF
--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -391,54 +391,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "worker_support": {
-          "__compat": {
-            "description": "Available in workers",
-            "support": {
-              "chrome": {
-                "version_added": "60"
-              },
-              "chrome_android": {
-                "version_added": "60"
-              },
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": {
-                "version_added": "57"
-              },
-              "firefox_android": {
-                "version_added": "57"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "47"
-              },
-              "opera_android": {
-                "version_added": "44"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": "8.0"
-              },
-              "webview_android": {
-                "version_added": "60"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "onoffline": {


### PR DESCRIPTION
This PR removes the `onmessageerror.worker_support` member of the `WindowEventHandlers` API from BCD.  Worker support is already represented in the dedicated worker global scopes, and it doesn't make sense to have a `worker_support` feature in this context.
