### PR TITLE
Opt out of GitHub fetch in push artifact workflow

### DIFF
--- a/.github/workflows/add-push-artifacts.yml
+++ b/.github/workflows/add-push-artifacts.yml
@@ -16,7 +16,7 @@ jobs:
         node-version: 14.x
     - run: npm install
     - run: node ./scripts/enumerate-features.js features.json
-    - run: node ./scripts/diff-features.js --format=json > features.diff.json
+    - run: node ./scripts/diff-features.js --no-github --format=json > features.diff.json
     - uses: actions/upload-artifact@v2
       with:
         name: enumerate-features


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

This adds an option to `diff-features` to opt out of getting artifacts from GitHub and does so in the workflow that generates the artifacts that you would fetch from GitHub.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

This reduces the noise in the output for the workflow. Because we run this workflow to generate the thing that this would fetch, it won't ever fetch the artifact. The added flag skips ahead to a direct diff.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

The sequel to https://github.com/mdn/browser-compat-data/pull/13695 and https://github.com/mdn/browser-compat-data/pull/13720.

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
