### PR TITLE
Update supported platforms for BarcodeDetector in Chrome

### DIFF
--- a/api/BarcodeDetector.json
+++ b/api/BarcodeDetector.json
@@ -5,10 +5,19 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/BarcodeDetector",
         "spec_url": "https://wicg.github.io/shape-detection-api/#barcode-detection-api",
         "support": {
-          "chrome": {
-            "version_added": "83",
-            "notes": "Before Chrome 98, this feature was only supported on macOS. In Chrome 98, support was added for Linux and Windows."
-          },
+          "chrome": [
+            {
+              "version_added": "88",
+              "partial_implementation": true,
+              "notes": "Supported on Chrome OS and macOS only."
+            },
+            {
+              "version_added": "83",
+              "version_removed": "88",
+              "partial_implementation": true,
+              "notes": "Supported on macOS only."
+            }
+          ],
           "chrome_android": {
             "version_added": "83"
           },
@@ -59,10 +68,19 @@
           "spec_url": "https://wicg.github.io/shape-detection-api/#dom-barcodedetector-barcodedetector",
           "description": "<code>BarcodeDetector()</code> constructor",
           "support": {
-            "chrome": {
-              "version_added": "83",
-              "notes": "Before Chrome 98, this feature was only supported on macOS. In Chrome 98, support was added for Linux and Windows."
-            },
+            "chrome": [
+              {
+                "version_added": "88",
+                "partial_implementation": true,
+                "notes": "Supported on Chrome OS and macOS only."
+              },
+              {
+                "version_added": "83",
+                "version_removed": "88",
+                "partial_implementation": true,
+                "notes": "Supported on macOS only."
+              }
+            ],
             "chrome_android": {
               "version_added": "83"
             },
@@ -113,10 +131,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BarcodeDetector/detect",
           "spec_url": "https://wicg.github.io/shape-detection-api/#dom-barcodedetector-detect",
           "support": {
-            "chrome": {
-              "version_added": "83",
-              "notes": "Before Chrome 98, this feature was only supported on macOS. In Chrome 98, support was added for Linux and Windows."
-            },
+            "chrome": [
+              {
+                "version_added": "88",
+                "partial_implementation": true,
+                "notes": "Supported on Chrome OS and macOS only."
+              },
+              {
+                "version_added": "83",
+                "version_removed": "88",
+                "partial_implementation": true,
+                "notes": "Supported on macOS only."
+              }
+            ],
             "chrome_android": {
               "version_added": "83"
             },
@@ -167,10 +194,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BarcodeDetector/getSupportedFormats",
           "spec_url": "https://wicg.github.io/shape-detection-api/#dom-barcodedetector-getsupportedformats",
           "support": {
-            "chrome": {
-              "version_added": "83",
-              "notes": "Before Chrome 98, this feature was only supported on macOS. In Chrome 98, support was added for Linux and Windows."
-            },
+            "chrome": [
+              {
+                "version_added": "88",
+                "partial_implementation": true,
+                "notes": "Supported on Chrome OS and macOS only."
+              },
+              {
+                "version_added": "83",
+                "version_removed": "88",
+                "partial_implementation": true,
+                "notes": "Supported on macOS only."
+              }
+            ],
             "chrome_android": {
               "version_added": "83"
             },

--- a/api/BarcodeDetector.json
+++ b/api/BarcodeDetector.json
@@ -7,8 +7,7 @@
         "support": {
           "chrome": {
             "version_added": "83",
-            "partial_implementation": true,
-            "notes": "Supported on macOS only."
+            "notes": "Before Chrome 98, this feature was only supported on macOS. In Chrome 98, support was added for Linux and Windows."
           },
           "chrome_android": {
             "version_added": "83"
@@ -62,8 +61,7 @@
           "support": {
             "chrome": {
               "version_added": "83",
-              "partial_implementation": true,
-              "notes": "Supported on macOS only."
+              "notes": "Before Chrome 98, this feature was only supported on macOS. In Chrome 98, support was added for Linux and Windows."
             },
             "chrome_android": {
               "version_added": "83"
@@ -117,8 +115,7 @@
           "support": {
             "chrome": {
               "version_added": "83",
-              "partial_implementation": true,
-              "notes": "Supported on macOS only."
+              "notes": "Before Chrome 98, this feature was only supported on macOS. In Chrome 98, support was added for Linux and Windows."
             },
             "chrome_android": {
               "version_added": "83"
@@ -172,8 +169,7 @@
           "support": {
             "chrome": {
               "version_added": "83",
-              "partial_implementation": true,
-              "notes": "Supported on macOS only."
+              "notes": "Before Chrome 98, this feature was only supported on macOS. In Chrome 98, support was added for Linux and Windows."
             },
             "chrome_android": {
               "version_added": "83"


### PR DESCRIPTION
#### Summary
The BarcodeDetector interface has been supported on Chrome OS since Chrome 88.

#### Test results and supporting details
https://groups.google.com/a/chromium.org/g/blink-dev/c/j-PLtssE5fo/m/Tj9HoFOIDAAJ

#### Related issues
Fixes #13752.
