### PR TITLE
Eyedropper API requires secure context

### DIFF
--- a/api/EyeDropper.json
+++ b/api/EyeDropper.json
@@ -146,6 +146,54 @@
             "deprecated": false
           }
         }
+      },
+      "secure_context_required": {
+        "__compat": {
+          "description": "Secure context required",
+          "support": {
+            "chrome": {
+              "version_added": "96"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "96"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "82"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
They Eyedropper API requires a secure context, as documented in the spec: https://wicg.github.io/eyedropper-api/#idl-index

Anecdotally, this requirement was added in Chrome 96: https://github.com/mdn/content/pull/10837. Hence this PR. I can't find confirmation online so have requested verification.