### PR TITLE
FF96 supports Navigator.canShare()

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3508,7 +3508,7 @@
                 "notes": "Not supported on macOS, see <a href='https://crbug.com/1144920'>bug 1144920</a>."
               },
               "firefox": {
-                "version_added": "71"
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -3563,7 +3563,7 @@
                 "notes": "Not supported on macOS, see <a href='https://crbug.com/1144920'>bug 1144920</a>."
               },
               "firefox": {
-                "version_added": false
+                "version_added": "71"
               },
               "firefox_android": {
                 "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -552,20 +552,13 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "#dom.webshare.enabled",
-                  "value_to_set": "enabled"
+                  "name": "dom.webshare.enabled",
+                  "value_to_set": "true"
                 }
               ]
             },
             "firefox_android": {
-              "version_added": "96",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#dom.webshare.enabled",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "96"
             },
             "ie": {
               "version_added": false
@@ -3459,8 +3452,8 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "#dom.webshare.enabled",
-                  "value_to_set": "enabled"
+                  "name": "dom.webshare.enabled",
+                  "value_to_set": "true"
                 }
               ]
             },

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -664,7 +664,7 @@
                 "notes": "Not supported on macOS, see <a href='https://crbug.com/1144920'>bug 1144920</a>."
               },
               "firefox": {
-                "version_added": false
+                "version_added": "96"
               },
               "firefox_android": {
                 "version_added": false
@@ -3508,7 +3508,7 @@
                 "notes": "Not supported on macOS, see <a href='https://crbug.com/1144920'>bug 1144920</a>."
               },
               "firefox": {
-                "version_added": false
+                "version_added": "71"
               },
               "firefox_android": {
                 "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -548,10 +548,24 @@
               "notes": "Not supported on macOS, see <a href='https://crbug.com/1144920'>bug 1144920</a>."
             },
             "firefox": {
-              "version_added": false
+              "version_added": "96",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#dom.webshare.enabled",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "96",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#dom.webshare.enabled",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Support added for [Navigator.canShare()](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/canShare) in FF96 according to this bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1666203

- desktop sharing behind preference. Android sharing enabled.
- text shared on desktop, but not on android until this bug fixed https://github.com/mozilla-mobile/fenix/pull/22633
- files still cannot be shared.