### PR TITLE
Correct Safari versions for HTML[Audio/Video/Media]Element API + audio/video elements

### DIFF
--- a/api/HTMLAudioElement.json
+++ b/api/HTMLAudioElement.json
@@ -33,7 +33,7 @@
             "version_added": "3.1"
           },
           "safari_ios": {
-            "version_added": "2"
+            "version_added": "3"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -82,7 +82,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -30,10 +30,10 @@
             "version_added": "11"
           },
           "safari": {
-            "version_added": "1.3"
+            "version_added": "3.1"
           },
           "safari_ios": {
-            "version_added": "1"
+            "version_added": "3"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -79,10 +79,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -409,7 +409,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -459,7 +459,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -968,7 +968,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1117,7 +1117,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1167,7 +1167,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1266,7 +1266,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1362,10 +1362,10 @@
               "version_added": "12"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1560,7 +1560,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1610,7 +1610,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2086,7 +2086,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2233,7 +2233,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2283,7 +2283,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2332,7 +2332,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2381,7 +2381,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2479,7 +2479,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2528,7 +2528,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2576,7 +2576,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2626,7 +2626,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2777,10 +2777,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "1.3"
+              "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2830,7 +2830,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2879,7 +2879,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -2979,7 +2979,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -3029,7 +3029,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -3077,7 +3077,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -3127,7 +3127,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -3382,7 +3382,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -3513,7 +3513,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -3563,7 +3563,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -3662,7 +3662,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -3815,7 +3815,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -3865,7 +3865,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -33,7 +33,7 @@
             "version_added": "3.1"
           },
           "safari_ios": {
-            "version_added": "2"
+            "version_added": "3"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -325,7 +325,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -905,7 +905,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1050,7 +1050,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1099,7 +1099,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1147,7 +1147,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/html/elements/audio.json
+++ b/html/elements/audio.json
@@ -36,7 +36,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -82,7 +82,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "3"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -176,7 +176,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "3"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -223,7 +223,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "3"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"
@@ -436,7 +436,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "3"
               },
               "samsunginternet_android": {
                 "version_added": "1.0",
@@ -485,7 +485,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "3"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"

--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -34,7 +34,7 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -189,7 +189,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -299,7 +299,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -562,7 +562,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -613,7 +613,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "version_added": true,
@@ -662,7 +662,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -709,7 +709,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "2"
               },
               "samsunginternet_android": {
                 "version_added": true

--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -189,7 +189,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": "2"
+                "version_added": "3"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -299,7 +299,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": "2"
+                "version_added": "3"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -562,7 +562,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": "2"
+                "version_added": "3"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -613,7 +613,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": "2"
+                "version_added": "3"
               },
               "samsunginternet_android": {
                 "version_added": true,
@@ -662,7 +662,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": "2"
+                "version_added": "3"
               },
               "samsunginternet_android": {
                 "version_added": true
@@ -709,7 +709,7 @@
                 "version_added": "3.1"
               },
               "safari_ios": {
-                "version_added": "2"
+                "version_added": "3"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
This PR updates the values for Safari (Desktop and iOS/iPadOS) for the `HTMLMediaElement`, `HTMLAudioElement`, and `HTMLVideoElement` APIs, as well as the `<audio>` and `<video>`.  In an [Apple Developer document](https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/Using_HTML5_Audio_Video/Introduction/Introduction.html), it is stated that audio and video support were added in Safari 3.1 and iOS 3.0.
