### PR TITLE
Add Safari versions for RTCRtpReceiver API

### DIFF
--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -235,10 +235,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": null
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"
@@ -290,10 +290,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": null
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": "11.0"
@@ -499,10 +499,10 @@
                 "version_added": "52"
               },
               "safari": {
-                "version_added": null
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": "11.0"
@@ -554,10 +554,10 @@
                 "version_added": "52"
               },
               "safari": {
-                "version_added": null
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": "11.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `RTCRtpReceiver` API.  Honestly speaking, I have no clue how to test support for these features, and they're the last ones remaining that have true/null values.  This PR is simply filling in version numbers for the sake of completing the version numbers, and rely on the community to make changes if needed.
