### PR TITLE
WakeLockSentinel: onrelease -> release_event

### DIFF
--- a/api/WakeLockSentinel.json
+++ b/api/WakeLockSentinel.json
@@ -48,11 +48,10 @@
           "deprecated": false
         }
       },
-      "release_event": {
+      "release": {
         "__compat": {
-          "description": "<code>release</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WakeLockSentinel/release_event",
-          "spec_url": "https://w3c.github.io/screen-wake-lock/#the-onrelease-attribute",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WakeLockSentinel/release",
+          "spec_url": "https://w3c.github.io/screen-wake-lock/#the-release-method",
           "support": {
             "chrome": {
               "version_added": "84"
@@ -98,10 +97,11 @@
           }
         }
       },
-      "release": {
+      "release_event": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WakeLockSentinel/release",
-          "spec_url": "https://w3c.github.io/screen-wake-lock/#the-release-method",
+          "description": "<code>release</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WakeLockSentinel/release_event",
+          "spec_url": "https://w3c.github.io/screen-wake-lock/#the-onrelease-attribute",
           "support": {
             "chrome": {
               "version_added": "84"

--- a/api/WakeLockSentinel.json
+++ b/api/WakeLockSentinel.json
@@ -48,9 +48,10 @@
           "deprecated": false
         }
       },
-      "onrelease": {
+      "release_event": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WakeLockSentinel/onrelease",
+          "description": "<code>release</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WakeLockSentinel/release_event",
           "spec_url": "https://w3c.github.io/screen-wake-lock/#the-onrelease-attribute",
           "support": {
             "chrome": {


### PR DESCRIPTION
Update per new events guideline: https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#dom-events-eventname_event