### PR TITLE
Add a note of URL Constructor in old Edge

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -124,7 +124,8 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": "Before Edge 79, query arguments in the base URL argument are removed when calling the <code>URL</code> constructor."
             },
             "firefox": {
               "version_added": "26"


### PR DESCRIPTION
#### Summary

Add a note of URL Constructor in old Edge to specify a special behaviour.

#### Test results and supporting details

```js
// Chrome, Firefox, Node, New Edge
new URL('', 'http://www.test.com?sid=1').searchParams.get('sid'); // => "1"
// Old Edge
new URL('', 'http://www.test.com?sid=1').searchParams.get('sid'); // => null
```
