### PR TITLE
Add Safari versions for ResizeObserverEntry API

### DIFF
--- a/api/ResizeObserverEntry.json
+++ b/api/ResizeObserverEntry.json
@@ -30,10 +30,10 @@
             "version_added": true
           },
           "safari": {
-            "version_added": true
+            "version_added": "13.1"
           },
           "safari_ios": {
-            "version_added": true
+            "version_added": "13.4"
           },
           "samsunginternet_android": {
             "version_added": "9.0"
@@ -184,10 +184,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -280,10 +280,10 @@
               "version_added": true
             },
             "safari": {
-              "version_added": true
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "9.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `ResizeObserverEntry` API, based upon manual testing.

Test Code Used:
```js
var observer = new ResizeObserver(function(entries) {
	alert(entries[0]);
	alert(entries[0].borderBoxSize);
	alert(entries[0].contentBoxSize);
	alert(entries[0].contentRect);
	alert(entries[0].devicePixelContentBoxSize);
	alert(entries[0].target);
});
observer.observe(document.body);
```

Note: these versions match that for `ResizeObserver`, which makes sense.

Fixes #12668.
