### PR TITLE
Rename api.MediaDevices.getUserMedia.audio-capture-support

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -237,7 +237,7 @@
             "deprecated": false
           }
         },
-        "audio-capture-support": {
+        "audio_capture_support": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/Screen_Capture_API/Using_Screen_Capture#Capturing_shared_audio",
             "description": "Audio capture support",


### PR DESCRIPTION
This PR renames the `api.MediaDevices.getUserMedia.audio-capture-support` feature to `audio_capture_support` to match our typical convention.
