### PR TITLE
Samesite lax

### DIFF
--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -485,6 +485,7 @@
                   },
                   {
                     "version_added": "86",
+                    "version_removed": "89",
                     "flags": [
                       {
                         "type": "preference",
@@ -500,6 +501,7 @@
                   },
                   {
                     "version_added": "86",
+                    "version_removed": "89",
                     "flags": [
                       {
                         "type": "preference",
@@ -515,6 +517,7 @@
                   },
                   {
                     "version_added": "86",
+                    "version_removed": "89",
                     "flags": [
                       {
                         "type": "preference",
@@ -559,16 +562,22 @@
                 "ie": {
                   "version_added": false
                 },
-                "opera": {
-                  "version_added": "72",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#schemeful-same-site",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
-                },
+                "opera": [
+                  {
+                    "version_added": "75"
+                  },
+                  {
+                    "version_added": "72",
+                    "version_removed": "75",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#schemeful-same-site",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "opera_android": {
                   "version_added": false
                 },

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -509,16 +509,21 @@
                     ]
                   }
                 ],
-                "edge": {
-                  "version_added": "86",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#schemeful-same-site",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
-                },
+                "edge": [
+                  {
+                    "version_added": "89"
+                  },
+                  {
+                    "version_added": "86",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#schemeful-same-site",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "firefox": [
                   {
                     "version_added": "96"

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -588,26 +588,38 @@
                 "edge": {
                   "version_added": "86"
                 },
-                "firefox": {
-                  "version_added": "69",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "network.cookie.sameSite.noneRequiresSecure",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                "firefox_android": {
-                  "version_added": "79",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "network.cookie.sameSite.noneRequiresSecure",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
+                "firefox": [
+                  {
+                    "version_added": "96"
+                  },
+                  {
+                    "version_added": "69",
+                    "version_removed": "96",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "network.cookie.sameSite.noneRequiresSecure",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
+                "firefox_android": [
+                  {
+                    "version_added": "96"
+                  },
+                  {
+                    "version_added": "79",
+                    "version_removed": "96",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "network.cookie.sameSite.noneRequiresSecure",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
                 "ie": {
                   "version_added": false
                 },

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -269,26 +269,38 @@
                 "edge": {
                   "version_added": "86"
                 },
-                "firefox": {
-                  "version_added": "69",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "network.cookie.sameSite.laxByDefault",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                "firefox_android": {
-                  "version_added": "79",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "network.cookie.sameSite.laxByDefault",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
+                "firefox": [
+                  {
+                    "version_added": "96"
+                  },
+                  {
+                    "version_added": "69",
+                    "version_removed": "96",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "network.cookie.sameSite.laxByDefault",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
+                "firefox_android": [
+                  {
+                    "version_added": "96"
+                  },
+                  {
+                    "version_added": "79",
+                    "version_removed": "96",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "network.cookie.sameSite.laxByDefault",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
                 "ie": {
                   "version_added": false
                 },

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -579,7 +579,7 @@
                   }
                 ],
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "63"
                 },
                 "safari": {
                   "version_added": false

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -519,26 +519,38 @@
                     }
                   ]
                 },
-                "firefox": {
-                  "version_added": "79",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "network.cookie.sameSite.schemeful",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                "firefox_android": {
-                  "version_added": "79",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "network.cookie.sameSite.schemeful",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
+                "firefox": [
+                  {
+                    "version_added": "96"
+                  },
+                  {
+                    "version_added": "79",
+                    "version_removed": "96",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "network.cookie.sameSite.schemeful",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
+                "firefox_android": [
+                  {
+                    "version_added": "96"
+                  },
+                  {
+                    "version_added": "79",
+                    "version_removed": "96",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "network.cookie.sameSite.schemeful",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
                 "ie": {
                   "version_added": false
                 },


### PR DESCRIPTION
FF96 sets a number of preferences true by default in https://bugzilla.mozilla.org/show_bug.cgi?id=1617609
- network.cookie.sameSite.laxByDefault
- network.cookie.sameSite.noneRequiresSecure
- network.cookie.sameSite.schemeful

This updates BCD to reflect the changes.

Other docs work for this is in https://github.com/mdn/content/issues/10857