### PR TITLE
Add Safari iOS versions for api.TouchEvent.altKey

### DIFF
--- a/api/TouchEvent.json
+++ b/api/TouchEvent.json
@@ -163,7 +163,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": true
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
               "version_added": "1.5"


### PR DESCRIPTION
This PR adds real values for Safari iOS/iPadOS for the `altKey` member of the `TouchEvent` API by mirroring the data.  Since this feature was available in the first version of Chrome this API was introduced in, this property would most likely be around in the first Safari iOS version of the API as well.

Note: even though iOS didn't have the same level of keyboard support back then as it does now, the properties were still around.  This matches the data for the other keyboard properties (Ctrl, meta, shift).

**This PR is the VERY last PR that we need to achieve our 100% real values goal for the API data!**  🎉