### PR TITLE
Limit main eight browsers to real values for api/

### DIFF
--- a/test/linter/test-real-values.js
+++ b/test/linter/test-real-values.js
@@ -28,7 +28,16 @@ const blockMany = [
 
 /** @type {Record<string, string[]>} */
 const blockList = {
-  api: [],
+  api: [
+    'chrome',
+    'chrome_android',
+    'edge',
+    'firefox',
+    'ie',
+    'safari',
+    'safari_ios',
+    'webview_android',
+  ],
   css: blockMany,
   html: [],
   http: [],


### PR DESCRIPTION
We finally did it!  We reached 100% real+ranged values for the main eight browsers for the API data!

This PR prevents us from regressing and adding true/null values.  Closes #6369.
