### PR TITLE
Mirror Chromium to Opera (nonreal to version number) for api/

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -405,10 +405,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "30"
             },
             "safari": {
               "version_added": "9"
@@ -750,10 +750,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "28"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "28"
             },
             "safari": {
               "version_added": "9"
@@ -799,10 +799,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "30"
             },
             "safari": {
               "version_added": "9"

--- a/api/AudioNode.json
+++ b/api/AudioNode.json
@@ -367,10 +367,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "30"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "30"
               },
               "safari": {
                 "version_added": false
@@ -415,10 +415,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "30"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "30"
               },
               "safari": {
                 "version_added": false

--- a/api/AudioWorklet.json
+++ b/api/AudioWorklet.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "53"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "47"
           },
           "safari": {
             "version_added": "14.1"

--- a/api/AudioWorkletNode.json
+++ b/api/AudioWorkletNode.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "53"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "47"
           },
           "safari": {
             "version_added": "14.1"
@@ -73,10 +73,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "53"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
               "version_added": "14.1"
@@ -122,10 +122,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "54"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "safari": {
               "version_added": "14.1"
@@ -171,10 +171,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "54"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "48"
             },
             "safari": {
               "version_added": "14.1"
@@ -220,10 +220,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "54"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "48"
             },
             "safari": {
               "version_added": "14.1"
@@ -269,10 +269,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "53"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
               "version_added": false

--- a/api/AudioWorkletProcessor.json
+++ b/api/AudioWorkletProcessor.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "51"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "47"
           },
           "safari": {
             "version_added": "14.1"
@@ -73,10 +73,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "51"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
               "version_added": false
@@ -122,10 +122,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "51"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
               "version_added": false

--- a/api/BarcodeDetector.json
+++ b/api/BarcodeDetector.json
@@ -28,12 +28,12 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true,
+            "version_added": "69",
             "partial_implementation": true,
             "notes": "Supported on macOS only."
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "59"
           },
           "safari": {
             "version_added": false
@@ -83,12 +83,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "69",
               "partial_implementation": true,
               "notes": "Supported on macOS only."
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "safari": {
               "version_added": false
@@ -138,12 +138,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "69",
               "partial_implementation": true,
               "notes": "Supported on macOS only."
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "safari": {
               "version_added": false
@@ -193,12 +193,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "69",
               "partial_implementation": true,
               "notes": "Supported on macOS only."
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "59"
             },
             "safari": {
               "version_added": false

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -160,10 +160,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "53"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "safari": {
               "version_added": "14.1"
@@ -748,10 +748,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "36"
             },
             "safari": {
               "version_added": "14.1"
@@ -1259,10 +1259,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "36"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "36"
               },
               "safari": {
                 "version_added": "14.1"

--- a/api/ClipboardItem.json
+++ b/api/ClipboardItem.json
@@ -38,10 +38,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "53"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "47"
           },
           "safari": {
             "version_added": "13.1"
@@ -107,14 +107,14 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "53",
               "partial_implementation": true,
               "notes": "The <code>ClipboardItem</code> constructor only accepts a blob as the item data, but not strings or Promises that resolve to strings or blobs. See <a href='https://crbug.com/1014310'>bug 1014310</a>."
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "47",
               "partial_implementation": true,
-              "notes": "The <code>ClipboardItem</code> constructor only accepts a blob as the item data, but not strings or Promises that resolve to strings or blobs. See <a href='https://crbug.com/1014310'>bug 1014310</a>."
+              "notes": "The <code>ClipboardItem</code> constructor only accepts a blob as the item data. Full implementation would also allow for a string or a Promise which resolves with either a string or blob. See <a href='https://crbug.com/1014310'>bug 1014310</a>."
             },
             "safari": {
               "version_added": "13.1"
@@ -178,10 +178,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "53"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "safari": {
               "version_added": "13.1"
@@ -304,10 +304,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "53"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "safari": {
               "version_added": "13.1"

--- a/api/ContactsManager.json
+++ b/api/ContactsManager.json
@@ -27,7 +27,7 @@
             "version_added": "57"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "57"
           },
           "safari": {
             "version_added": false

--- a/api/DOMParser.json
+++ b/api/DOMParser.json
@@ -172,7 +172,7 @@
                 "version_added": "17"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "18"
               },
               "safari": {
                 "version_added": "9.1"

--- a/api/DeviceMotionEvent.json
+++ b/api/DeviceMotionEvent.json
@@ -73,10 +73,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": false

--- a/api/Document.json
+++ b/api/Document.json
@@ -4547,10 +4547,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "56"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "48"
               },
               "safari": {
                 "version_added": false

--- a/api/DragEvent.json
+++ b/api/DragEvent.json
@@ -125,7 +125,7 @@
               "notes": "The value is always <code>null</code>."
             },
             "opera": {
-              "version_added": true
+              "version_added": "33"
             },
             "opera_android": {
               "version_added": false

--- a/api/EXT_color_buffer_float.json
+++ b/api/EXT_color_buffer_float.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "50"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "46"
           },
           "safari": {
             "version_added": false

--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -213,10 +213,10 @@
                 "version_added": "14.5.0"
               },
               "opera": {
-                "version_added": true
+                "version_added": "36"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "36"
               },
               "safari": {
                 "version_added": "10"
@@ -267,10 +267,10 @@
                   "version_added": "14.5.0"
                 },
                 "opera": {
-                  "version_added": true
+                  "version_added": "39"
                 },
                 "opera_android": {
-                  "version_added": true
+                  "version_added": "41"
                 },
                 "safari": {
                   "version_added": "10"
@@ -377,10 +377,10 @@
                   "version_added": "14.5.0"
                 },
                 "opera": {
-                  "version_added": true
+                  "version_added": "38"
                 },
                 "opera_android": {
-                  "version_added": true
+                  "version_added": "41"
                 },
                 "safari": {
                   "version_added": "10"
@@ -431,10 +431,10 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "42"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "42"
                 },
                 "safari": {
                   "version_added": false
@@ -485,10 +485,10 @@
                   "version_added": null
                 },
                 "opera": {
-                  "version_added": null
+                  "version_added": "60"
                 },
                 "opera_android": {
-                  "version_added": null
+                  "version_added": "52"
                 },
                 "safari": {
                   "version_added": false
@@ -775,10 +775,10 @@
                 "version_added": "14.5.0"
               },
               "opera": {
-                "version_added": true
+                "version_added": "36"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "36"
               },
               "safari": {
                 "version_added": "10"

--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -269,10 +269,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "safari": {
               "version_added": "10"
@@ -318,10 +318,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "safari": {
               "version_added": "10"
@@ -431,12 +431,28 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "32"
+              },
+              {
+                "version_added": "22",
+                "version_removed": "32",
+                "partial_implementation": true,
+                "notes": "Before Opera 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification."
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "32"
+              },
+              {
+                "version_added": "22",
+                "version_removed": "32",
+                "partial_implementation": true,
+                "notes": "Before Opera 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification."
+              }
+            ],
             "safari": {
               "version_added": "10"
             },
@@ -512,12 +528,28 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "32"
+              },
+              {
+                "version_added": "22",
+                "version_removed": "32",
+                "partial_implementation": true,
+                "notes": "Before Opera 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification."
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "32"
+              },
+              {
+                "version_added": "22",
+                "version_removed": "32",
+                "partial_implementation": true,
+                "notes": "Before Opera 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification."
+              }
+            ],
             "safari": {
               "version_added": "10"
             },
@@ -578,10 +610,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "safari": {
               "version_added": "10"
@@ -627,10 +659,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "safari": {
               "version_added": "10"
@@ -676,10 +708,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "safari": {
               "version_added": "10"
@@ -725,10 +757,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "safari": {
               "version_added": "10"
@@ -774,10 +806,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "safari": {
               "version_added": false
@@ -872,10 +904,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "safari": {
               "version_added": "10"
@@ -920,10 +952,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "safari": {
               "version_added": false

--- a/api/FormData.json
+++ b/api/FormData.json
@@ -241,10 +241,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "37"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "37"
             },
             "safari": {
               "version_added": "11.1"
@@ -498,10 +498,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "37"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "37"
             },
             "safari": {
               "version_added": "11.1"
@@ -549,10 +549,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "37"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "37"
             },
             "safari": {
               "version_added": "11.1"

--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -253,6 +253,11 @@
             "opera": {
               "version_added": false
             },
+            "opera_android": {
+              "version_added": "42",
+              "version_removed": "57",
+              "notes": "Currently supported only by Google Daydream."
+            },
             "safari": {
               "version_added": false
             },

--- a/api/GeolocationCoordinates.json
+++ b/api/GeolocationCoordinates.json
@@ -502,10 +502,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "34"
             },
             "safari": {
               "version_added": "10"

--- a/api/GeolocationPosition.json
+++ b/api/GeolocationPosition.json
@@ -180,10 +180,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "34"
             },
             "safari": {
               "version_added": "10"

--- a/api/GeolocationPositionError.json
+++ b/api/GeolocationPositionError.json
@@ -217,10 +217,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "34"
             },
             "safari": {
               "version_added": "10"

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -1260,7 +1260,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "37"
               },
               "opera_android": {
                 "version_added": false

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -3329,6 +3329,9 @@
             "opera": {
               "version_added": "36"
             },
+            "opera_android": {
+              "version_added": "36"
+            },
             "safari": {
               "version_added": false
             },

--- a/api/HTMLShadowElement.json
+++ b/api/HTMLShadowElement.json
@@ -32,7 +32,8 @@
             "version_removed": "75"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "22",
+            "version_removed": "63"
           },
           "safari": {
             "version_added": false
@@ -84,7 +85,8 @@
               "version_removed": "75"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "22",
+              "version_removed": "63"
             },
             "safari": {
               "version_added": false

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -71,10 +71,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "30"
             },
             "safari": {
               "version_added": false

--- a/api/IDBDatabase.json
+++ b/api/IDBDatabase.json
@@ -210,10 +210,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "18"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "safari": {
               "version_added": "10.1"
@@ -561,10 +561,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "18"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "18"
             },
             "safari": {
               "version_added": "10.1"

--- a/api/IDBFactory.json
+++ b/api/IDBFactory.json
@@ -163,7 +163,7 @@
               "version_added": "58"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "50"
             },
             "safari": {
               "version_added": "14"

--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -456,10 +456,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "35"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "35"
               },
               "safari": {
                 "version_added": false

--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -76,7 +76,7 @@
               "version_added": "29"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "29"
             },
             "safari": {
               "version_added": "7"

--- a/api/InputDeviceCapabilities.json
+++ b/api/InputDeviceCapabilities.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "34"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "34"
           },
           "safari": {
             "version_added": false
@@ -73,10 +73,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "34"
             },
             "safari": {
               "version_added": false
@@ -122,10 +122,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "34"
             },
             "safari": {
               "version_added": false

--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -75,6 +75,9 @@
             "opera": {
               "version_added": "38"
             },
+            "opera_android": {
+              "version_added": "41"
+            },
             "safari": {
               "version_added": "12.1"
             },
@@ -168,7 +171,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "38"
+            },
+            "opera_android": {
+              "version_added": "41"
             },
             "safari": {
               "version_added": "12.1"
@@ -214,7 +220,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "38"
+            },
+            "opera_android": {
+              "version_added": "41"
             },
             "safari": {
               "version_added": "12.1"
@@ -260,7 +269,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "38"
+            },
+            "opera_android": {
+              "version_added": "41"
             },
             "safari": {
               "version_added": "12.1"
@@ -306,7 +318,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "38"
+            },
+            "opera_android": {
+              "version_added": "41"
             },
             "safari": {
               "version_added": "12.1",
@@ -355,7 +370,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "38"
+            },
+            "opera_android": {
+              "version_added": "41"
             },
             "safari": {
               "version_added": "12.1"
@@ -401,7 +419,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "38"
+            },
+            "opera_android": {
+              "version_added": "41"
             },
             "safari": {
               "version_added": "12.1"
@@ -448,7 +469,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "38"
+            },
+            "opera_android": {
+              "version_added": "41"
             },
             "safari": {
               "version_added": "12.1"

--- a/api/IntersectionObserverEntry.json
+++ b/api/IntersectionObserverEntry.json
@@ -24,7 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "38"
+          },
+          "opera_android": {
+            "version_added": "41"
           },
           "safari": {
             "version_added": "12.1"
@@ -118,7 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "38"
+            },
+            "opera_android": {
+              "version_added": "41"
             },
             "safari": {
               "version_added": "12.1"
@@ -164,7 +170,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "38"
+            },
+            "opera_android": {
+              "version_added": "41"
             },
             "safari": {
               "version_added": "12.1"
@@ -210,7 +219,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "38"
+            },
+            "opera_android": {
+              "version_added": "41"
             },
             "safari": {
               "version_added": "12.1"
@@ -256,7 +268,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "38"
+            },
+            "opera_android": {
+              "version_added": "41"
             },
             "safari": {
               "version_added": "12.1"
@@ -302,7 +317,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "38"
+            },
+            "opera_android": {
+              "version_added": "41"
             },
             "safari": {
               "version_added": "12.1"
@@ -348,7 +366,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "38"
+            },
+            "opera_android": {
+              "version_added": "41"
             },
             "safari": {
               "version_added": "12.1"
@@ -394,7 +415,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "38"
+            },
+            "opera_android": {
+              "version_added": "41"
             },
             "safari": {
               "version_added": "12.1"

--- a/api/KHR_parallel_shader_compile.json
+++ b/api/KHR_parallel_shader_compile.json
@@ -27,7 +27,7 @@
             "version_added": "63"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "54"
           },
           "safari": {
             "version_added": "14.1"

--- a/api/LargestContentfulPaint.json
+++ b/api/LargestContentfulPaint.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "64"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "55"
           },
           "safari": {
             "version_added": false
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -170,10 +170,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -219,10 +219,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -268,10 +268,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -317,10 +317,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -366,10 +366,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "55"
             },
             "safari": {
               "version_added": false

--- a/api/LayoutShift.json
+++ b/api/LayoutShift.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "64"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "55"
           },
           "safari": {
             "version_added": false
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -219,10 +219,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -268,10 +268,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "55"
             },
             "safari": {
               "version_added": false

--- a/api/LayoutShiftAttribution.json
+++ b/api/LayoutShiftAttribution.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "64"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "55"
           },
           "safari": {
             "version_added": false
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -170,10 +170,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -219,10 +219,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "55"
             },
             "safari": {
               "version_added": false

--- a/api/Location.json
+++ b/api/Location.json
@@ -818,10 +818,10 @@
               "notes": "Intranet sites are set to Compatibility View, which will emulate IE7 and omit <code>window.location.toString</code>."
             },
             "opera": {
-              "version_added": null
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "41"
             },
             "safari": {
               "version_added": "1"

--- a/api/MIDIAccess.json
+++ b/api/MIDIAccess.json
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "30"
             },
             "safari": {
               "version_added": false
@@ -170,10 +170,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "30"
             },
             "safari": {
               "version_added": false
@@ -219,10 +219,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "30"
             },
             "safari": {
               "version_added": false
@@ -268,10 +268,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "32"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "safari": {
               "version_added": false

--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -142,7 +142,14 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "54",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "chrome://flags/#enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "opera_android": {
               "version_added": null

--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -24,7 +24,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "55"
+            "version_added": "53"
           },
           "opera_android": {
             "version_added": "48"
@@ -72,7 +72,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "55"
+              "version_added": "53"
             },
             "opera_android": {
               "version_added": "48"

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -263,7 +263,8 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "62",
+                "notes": "On Windows and Opera OS the entire system audio can be captured, but on Linux and Mac only the audio of a tab can be captured."
               },
               "opera_android": {
                 "version_added": false

--- a/api/MediaKeyMessageEvent.json
+++ b/api/MediaKeyMessageEvent.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "29"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "29"
           },
           "safari": {
             "version_added": "12.1"
@@ -73,10 +73,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "29"
             },
             "safari": {
               "version_added": "12.1"
@@ -122,10 +122,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "safari": {
               "version_added": "12.1"
@@ -171,10 +171,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "safari": {
               "version_added": "12.1"

--- a/api/MediaKeySession.json
+++ b/api/MediaKeySession.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "29"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "29"
           },
           "safari": {
             "version_added": "12.1"
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "safari": {
               "version_added": "12.1"
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "safari": {
               "version_added": "12.1"
@@ -170,10 +170,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "safari": {
               "version_added": "12.1"
@@ -219,10 +219,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "safari": {
               "version_added": "12.1"
@@ -268,10 +268,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "safari": {
               "version_added": "12.1"
@@ -317,10 +317,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "safari": {
               "version_added": "12.1"
@@ -464,10 +464,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "safari": {
               "version_added": "12.1"
@@ -513,10 +513,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "safari": {
               "version_added": "12.1"
@@ -562,10 +562,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "safari": {
               "version_added": "12.1"

--- a/api/MediaKeySystemAccess.json
+++ b/api/MediaKeySystemAccess.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "29"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "29"
           },
           "safari": {
             "version_added": "12.1"
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "safari": {
               "version_added": "12.1"
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "safari": {
               "version_added": "12.1"
@@ -170,10 +170,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "safari": {
               "version_added": "12.1"

--- a/api/MediaKeySystemConfiguration.json
+++ b/api/MediaKeySystemConfiguration.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "29"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "29"
           },
           "safari": {
             "version_added": "12.1"
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "29"
             },
             "safari": {
               "version_added": "12.1"
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "29"
             },
             "safari": {
               "version_added": "12.1"
@@ -170,10 +170,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "29"
             },
             "safari": {
               "version_added": "12.1"
@@ -219,10 +219,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "29"
             },
             "safari": {
               "version_added": "12.1"
@@ -268,10 +268,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "29"
             },
             "safari": {
               "version_added": "12.1"

--- a/api/MediaKeys.json
+++ b/api/MediaKeys.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "29"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "29"
           },
           "safari": {
             "version_added": "12.1"
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "safari": {
               "version_added": "12.1"
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "29"
             },
             "safari": {
               "version_added": "12.1"

--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "44"
           },
           "opera_android": {
             "version_added": false
@@ -87,7 +87,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "44"
             },
             "opera_android": {
               "version_added": false
@@ -136,7 +136,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "44"
             },
             "opera_android": {
               "version_added": false
@@ -185,7 +185,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "44"
             },
             "opera_android": {
               "version_added": false
@@ -234,7 +234,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "44"
             },
             "opera_android": {
               "version_added": false
@@ -283,7 +283,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "44"
             },
             "opera_android": {
               "version_added": false

--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "32"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "safari": {
               "version_added": "14"
@@ -320,10 +320,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "32"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "32"
             },
             "safari": {
               "version_added": "14"

--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -38,7 +38,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "60"
           },
           "opera_android": {
             "version_added": false
@@ -100,7 +100,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "60"
             },
             "opera_android": {
               "version_added": false
@@ -163,7 +163,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "60"
             },
             "opera_android": {
               "version_added": false
@@ -227,7 +227,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "60"
             },
             "opera_android": {
               "version_added": false
@@ -387,7 +387,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "60"
             },
             "opera_android": {
               "version_added": false

--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -255,7 +255,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "32"
             },
             "opera_android": {
               "version_added": false
@@ -552,7 +552,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "32"
             },
             "opera_android": {
               "version_added": false
@@ -701,7 +701,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "32"
             },
             "opera_android": {
               "version_added": false
@@ -749,7 +749,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "32"
             },
             "opera_android": {
               "version_added": false
@@ -846,7 +846,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "32"
             },
             "opera_android": {
               "version_added": false

--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -366,10 +366,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "40"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": "11"

--- a/api/MediaTrackConstraints.json
+++ b/api/MediaTrackConstraints.json
@@ -182,10 +182,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -282,10 +282,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -380,10 +380,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -429,10 +429,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -478,10 +478,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -527,10 +527,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -576,10 +576,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -625,10 +625,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -784,10 +784,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -833,10 +833,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -881,10 +881,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -930,10 +930,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"

--- a/api/MediaTrackSettings.json
+++ b/api/MediaTrackSettings.json
@@ -236,10 +236,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "58"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "50"
             },
             "safari": {
               "version_added": false
@@ -334,10 +334,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "58"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "50"
             },
             "safari": {
               "version_added": "11.1"
@@ -677,10 +677,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "58"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "50"
             },
             "safari": {
               "version_added": "11.1"

--- a/api/MediaTrackSupportedConstraints.json
+++ b/api/MediaTrackSupportedConstraints.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "39"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "41"
           },
           "safari": {
             "version_added": "11"
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": "11"
@@ -135,10 +135,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "48"
             },
             "safari": {
               "version_added": false
@@ -184,10 +184,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": "11"
@@ -282,10 +282,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": "11"
@@ -380,10 +380,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": "11"
@@ -429,10 +429,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": "11"
@@ -478,10 +478,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": "11"
@@ -527,10 +527,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": "11"
@@ -576,10 +576,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": "11"
@@ -625,10 +625,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": "11"
@@ -737,10 +737,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "48"
             },
             "safari": {
               "version_added": false
@@ -834,10 +834,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": "11"
@@ -883,10 +883,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": "11"
@@ -931,10 +931,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": "11"
@@ -980,10 +980,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": "11"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -351,10 +351,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "54",
+              "flags": [
+                {
+                  "name": "WebAuth",
+                  "type": "preference"
+                }
+              ]
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "48",
+              "flags": [
+                {
+                  "name": "WebAuth",
+                  "type": "preference"
+                }
+              ]
             },
             "safari": {
               "version_added": false
@@ -826,7 +838,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "37"
@@ -1178,10 +1190,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "34"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "34"
               },
               "safari": {
                 "version_added": "10"
@@ -2122,10 +2134,10 @@
               }
             ],
             "opera": {
-              "version_added": true
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "22"
             },
             "safari": {
               "version_added": "13"
@@ -2632,10 +2644,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "30"
             },
             "safari": {
               "version_added": false
@@ -4097,8 +4109,11 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": true,
-              "notes": "Beginning in Opera 47, this method requires a user gesture. Otherwise it returns <code>false</code>."
+              "version_added": "19",
+              "notes": [
+                "Beginning in Opera 42, this is not supported in cross-origin iframes.",
+                "Beginning in Opera 47, this method requires a user gesture. Otherwise it returns <code>false</code>."
+              ]
             },
             "safari": {
               "version_added": false
@@ -4200,10 +4215,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "70"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "60"
             },
             "safari": {
               "version_added": false

--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -280,7 +280,7 @@
               "version_added": null
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "25"
             },
             "safari": {
               "version_added": false
@@ -382,10 +382,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "52"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "safari": {
               "version_added": false

--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -27,7 +27,7 @@
             "version_added": "48"
           },
           "opera_android": {
-            "version_added": "45"
+            "version_added": "25"
           },
           "safari": {
             "version_added": false
@@ -79,7 +79,7 @@
               "notes": "The value is never greater than 10 Mbps, as a non-standard anti-fingerprinting measure."
             },
             "opera_android": {
-              "version_added": "45",
+              "version_added": "25",
               "notes": "The value is never greater than 10 Mbps, as a non-standard anti-fingerprinting measure."
             },
             "safari": {
@@ -333,7 +333,7 @@
               "notes": "The value is never greater than 3000 ms, as a non-standard anti-fingerprinting measure."
             },
             "opera_android": {
-              "version_added": "45",
+              "version_added": "25",
               "notes": "The value is never greater than 3000 ms, as a non-standard anti-fingerprinting measure."
             },
             "safari": {

--- a/api/NodeList.json
+++ b/api/NodeList.json
@@ -74,7 +74,7 @@
               "version_added": "38"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "41"
             },
             "safari": {
               "version_added": "10"
@@ -219,7 +219,7 @@
               "version_added": "38"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "41"
             },
             "safari": {
               "version_added": "10"
@@ -316,7 +316,7 @@
               "version_added": "38"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "41"
             },
             "safari": {
               "version_added": "10"

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -108,7 +108,7 @@
               "version_added": "56"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "48"
             },
             "safari": {
               "version_added": false

--- a/api/PaintSize.json
+++ b/api/PaintSize.json
@@ -23,10 +23,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "52"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "47"
           },
           "safari": {
             "version_added": false
@@ -70,10 +70,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "52"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
               "version_added": false
@@ -118,10 +118,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "52"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
               "version_added": false

--- a/api/PaintWorkletGlobalScope.json
+++ b/api/PaintWorkletGlobalScope.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "52"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "47"
           },
           "safari": {
             "version_added": false
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "52"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
               "version_added": false
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "52"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
               "version_added": false

--- a/api/PerformanceEventTiming.json
+++ b/api/PerformanceEventTiming.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "64"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "55"
           },
           "safari": {
             "version_added": false
@@ -71,10 +71,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -119,10 +119,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -167,10 +167,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "55"
             },
             "safari": {
               "version_added": false
@@ -263,10 +263,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "64"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "55"
             },
             "safari": {
               "version_added": false

--- a/api/PerformanceLongTaskTiming.json
+++ b/api/PerformanceLongTaskTiming.json
@@ -26,10 +26,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "45"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "43"
           },
           "safari": {
             "version_added": false
@@ -74,10 +74,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "45"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": false

--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -242,10 +242,10 @@
               "version_added": "8.5.0"
             },
             "opera": {
-              "version_added": true
+              "version_added": "60"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "52"
             },
             "safari": {
               "version_added": "12.1"
@@ -294,10 +294,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "52"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "safari": {
               "version_added": "15"

--- a/api/PermissionStatus.json
+++ b/api/PermissionStatus.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "30"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "30"
           },
           "safari": {
             "version_added": false
@@ -122,10 +122,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "30"
             },
             "safari": {
               "version_added": false
@@ -184,12 +184,26 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "31"
+              },
+              {
+                "alternative_name": "status",
+                "version_added": "30",
+                "version_removed": "31"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "32"
+              },
+              {
+                "alternative_name": "status",
+                "version_added": "30",
+                "version_removed": "32"
+              }
+            ],
             "safari": {
               "version_added": false
             },

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "30"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "30"
           },
           "safari": {
             "version_added": false
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "49"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "46"
             },
             "safari": {
               "version_added": false
@@ -120,10 +120,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "49"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "46"
             },
             "safari": {
               "version_added": false
@@ -168,10 +168,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "49"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "46"
             },
             "safari": {
               "version_added": false
@@ -216,10 +216,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "49"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "46"
             },
             "safari": {
               "version_added": false
@@ -264,10 +264,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "51"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
               "version_added": false
@@ -312,10 +312,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "51"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
               "version_added": false
@@ -360,10 +360,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "51"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
               "version_added": false
@@ -456,10 +456,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "38"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "41"
             },
             "safari": {
               "version_added": false
@@ -504,10 +504,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "49"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "46"
             },
             "safari": {
               "version_added": false
@@ -552,10 +552,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "51"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
               "version_added": false
@@ -696,10 +696,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "53"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "47"
             },
             "safari": {
               "version_added": false
@@ -841,10 +841,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "30"
             },
             "safari": {
               "version_added": false

--- a/api/Presentation.json
+++ b/api/Presentation.json
@@ -40,10 +40,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "35"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "35"
           },
           "safari": {
             "version_added": false
@@ -104,10 +104,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "35"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "35"
             },
             "safari": {
               "version_added": false
@@ -169,10 +169,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "35"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "35"
             },
             "safari": {
               "version_added": false

--- a/api/PresentationAvailability.json
+++ b/api/PresentationAvailability.json
@@ -40,10 +40,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "35"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "35"
           },
           "safari": {
             "version_added": false
@@ -104,10 +104,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "35"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "35"
             },
             "safari": {
               "version_added": false
@@ -169,10 +169,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "35"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "35"
             },
             "safari": {
               "version_added": false

--- a/api/PresentationConnectionAvailableEvent.json
+++ b/api/PresentationConnectionAvailableEvent.json
@@ -40,10 +40,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "35"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "35"
           },
           "safari": {
             "version_added": false
@@ -105,10 +105,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "35"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "35"
             },
             "safari": {
               "version_added": false
@@ -170,10 +170,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "35"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "35"
             },
             "safari": {
               "version_added": false

--- a/api/PresentationConnectionCloseEvent.json
+++ b/api/PresentationConnectionCloseEvent.json
@@ -40,10 +40,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "37"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "37"
           },
           "safari": {
             "version_added": false
@@ -104,10 +104,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "37"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "37"
             },
             "safari": {
               "version_added": false
@@ -168,10 +168,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "37"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "37"
             },
             "safari": {
               "version_added": false
@@ -232,10 +232,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "37"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "37"
             },
             "safari": {
               "version_added": false

--- a/api/PresentationConnectionList.json
+++ b/api/PresentationConnectionList.json
@@ -40,10 +40,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "38"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "41"
           },
           "safari": {
             "version_added": false
@@ -103,10 +103,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "38"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": false
@@ -167,10 +167,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "38"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": false

--- a/api/PresentationReceiver.json
+++ b/api/PresentationReceiver.json
@@ -40,10 +40,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "42"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "42"
           },
           "safari": {
             "version_added": false
@@ -103,10 +103,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "42"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "42"
             },
             "safari": {
               "version_added": false

--- a/api/PushSubscription.json
+++ b/api/PushSubscription.json
@@ -323,10 +323,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "37"
             },
             "safari": {
               "version_added": false
@@ -374,10 +374,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "37"
             },
             "safari": {
               "version_added": false

--- a/api/RTCConfiguration.json
+++ b/api/RTCConfiguration.json
@@ -27,7 +27,7 @@
             "version_added": true
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "43"
           },
           "safari": {
             "version_added": "11"
@@ -75,7 +75,7 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -124,7 +124,7 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": "12.1"
@@ -172,7 +172,7 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -221,7 +221,7 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -270,7 +270,7 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -318,7 +318,7 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": "12.1"
@@ -369,7 +369,7 @@
               "notes": "Default for <code>rtcpMuxPolicy</code> is <code>require</code>"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": "12.1"

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -1313,10 +1313,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "45"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": false

--- a/api/RTCIceCandidatePairStats.json
+++ b/api/RTCIceCandidatePairStats.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "43"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "43"
           },
           "safari": {
             "version_added": "11"
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -170,10 +170,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -219,10 +219,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -432,12 +432,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "58"
+              },
+              {
+                "version_added": "43",
+                "alternative_name": "currentRtt"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "version_added": "43",
+                "alternative_name": "currentRtt"
+              }
+            ],
             "safari": {
               "version_added": "11"
             },
@@ -739,10 +751,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -788,10 +800,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -947,10 +959,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -1044,10 +1056,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -1093,10 +1105,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -1142,10 +1154,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -1191,10 +1203,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -1240,10 +1252,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -1387,10 +1399,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -1453,12 +1465,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "58"
+              },
+              {
+                "version_added": "43",
+                "alternative_name": "totalRtt"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "50"
+              },
+              {
+                "version_added": "43",
+                "alternative_name": "totalRtt"
+              }
+            ],
             "safari": {
               "version_added": "11"
             },
@@ -1521,10 +1545,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43"
             },
             "safari": {
               "version_added": "11"
@@ -1572,10 +1596,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "43",
+              "notes": "Opera does not currently use the specification's algorithm to determine the value of <code>writable</code>; it may not match the behavior of other browsers."
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "43",
+              "notes": "Opera does not currently use the specification's algorithm to determine the value of <code>writable</code>; it may not match the behavior of other browsers."
             },
             "safari": {
               "version_added": "11"

--- a/api/RTCPeerConnectionIceEvent.json
+++ b/api/RTCPeerConnectionIceEvent.json
@@ -101,10 +101,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": "12"

--- a/api/RTCRtpEncodingParameters.json
+++ b/api/RTCRtpEncodingParameters.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "54"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "48"
           },
           "safari": {
             "version_added": "11"
@@ -71,10 +71,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "54"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "safari": {
               "version_added": "11"
@@ -263,10 +263,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "54"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "safari": {
               "version_added": "11"
@@ -363,10 +363,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "54",
+              "notes": "The standard version of this property is <a href='https://developer.mozilla.org/docs/Web/API/RTCRtpSendParameters/priority'><code>RTCRtpSendParameters.priority</code></a>."
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "48",
+              "notes": "The standard version of this property is <a href='https://developer.mozilla.org/docs/Web/API/RTCRtpSendParameters/priority'><code>RTCRtpSendParameters.priority</code></a>."
             },
             "safari": {
               "version_added": "11"
@@ -558,10 +560,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "53"
             },
             "safari": {
               "version_added": "11"

--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -284,10 +284,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "60"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "52"
               },
               "safari": {
                 "version_added": "12.1"

--- a/api/RTCRtpSendParameters.json
+++ b/api/RTCRtpSendParameters.json
@@ -26,10 +26,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "56"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "48"
           },
           "safari": {
             "version_added": "12.1"
@@ -124,10 +124,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "safari": {
               "version_added": "12.1"
@@ -220,10 +220,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "48"
             },
             "safari": {
               "version_added": "12.1"

--- a/api/Request.json
+++ b/api/Request.json
@@ -282,7 +282,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "36"
               },
               "opera_android": {
                 "version_added": false
@@ -384,7 +384,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "30"
               },
               "opera_android": {
                 "version_added": false
@@ -1055,7 +1055,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": "36"
               },
               "opera_android": {
                 "version_added": false

--- a/api/ResizeObserverEntry.json
+++ b/api/ResizeObserverEntry.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "51"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "47"
           },
           "safari": {
             "version_added": "13.1"
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "70"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "60"
             },
             "safari": {
               "version_added": "preview"
@@ -129,10 +129,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "70"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "60"
             },
             "safari": {
               "version_added": "preview"
@@ -178,10 +178,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "51"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "safari": {
               "version_added": "13.1"
@@ -274,10 +274,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "51"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "safari": {
               "version_added": "13.1"

--- a/api/ResizeObserverSize.json
+++ b/api/ResizeObserverSize.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "70"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "60"
           },
           "safari": {
             "version_added": false
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "70"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "60"
             },
             "safari": {
               "version_added": false
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "70"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "60"
             },
             "safari": {
               "version_added": false

--- a/api/Screen.json
+++ b/api/Screen.json
@@ -422,10 +422,10 @@
               "prefix": "ms"
             },
             "opera": {
-              "version_added": true
+              "version_added": "25"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "safari": {
               "version_added": false
@@ -821,10 +821,10 @@
               "prefix": "ms"
             },
             "opera": {
-              "version_added": true
+              "version_added": "25"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "safari": {
               "version_added": false

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -374,10 +374,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -1111,10 +1111,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "safari": {
               "version_added": false

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -491,7 +491,14 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "43",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#service-worker-payment-apps",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "opera_android": {
               "version_added": true
@@ -1243,10 +1250,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "55"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "48"
             },
             "safari": {
               "version_added": "11.1"

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -567,10 +567,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "49"
             },
             "safari": {
               "version_added": "12.1"

--- a/api/SubmitEvent.json
+++ b/api/SubmitEvent.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "68"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "58"
           },
           "safari": {
             "version_added": "15"
@@ -73,10 +73,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "68"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "58"
             },
             "safari": {
               "version_added": "15"
@@ -122,10 +122,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "68"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "58"
             },
             "safari": [
               {

--- a/api/SyncEvent.json
+++ b/api/SyncEvent.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "36"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "36"
           },
           "safari": {
             "version_added": false
@@ -73,10 +73,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": false
@@ -122,10 +122,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": false
@@ -171,10 +171,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": false

--- a/api/TaskAttributionTiming.json
+++ b/api/TaskAttributionTiming.json
@@ -26,10 +26,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "45"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "43"
           },
           "safari": {
             "version_added": false
@@ -74,10 +74,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "45"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -123,10 +123,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "45"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -172,10 +172,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "45"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -221,10 +221,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "45"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": false

--- a/api/TextDecoder.json
+++ b/api/TextDecoder.json
@@ -430,7 +430,7 @@
               "version_added": "25"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "25"
             },
             "safari": {
               "version_added": "10.1"

--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -40,7 +40,7 @@
             "version_added": "25"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "25"
           },
           "safari": {
             "version_added": "10.1"
@@ -101,7 +101,7 @@
               "version_added": "25"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "25"
             },
             "safari": {
               "version_added": "10.1"
@@ -156,7 +156,7 @@
               "version_added": "25"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "safari": {
               "version_added": "10.1"
@@ -266,7 +266,7 @@
               "version_added": "25"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "25"
             },
             "safari": {
               "version_added": "10.1"
@@ -320,7 +320,7 @@
               "version_added": "25"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "25"
             },
             "safari": {
               "version_added": "10.1"

--- a/api/Touch.json
+++ b/api/Touch.json
@@ -83,7 +83,7 @@
               "version_added": "35"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "35"
             },
             "safari": {
               "version_added": false

--- a/api/TouchEvent.json
+++ b/api/TouchEvent.json
@@ -96,10 +96,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "35",
+              "notes": "Opera only supports the following <code>touchEventInit</code> properties: <code>touches</code>, <code>targetTouches</code>, <code>changedTouches</code>."
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "35",
+              "notes": "Opera only supports the following <code>touchEventInit</code> properties: <code>touches</code>, <code>targetTouches</code>, <code>changedTouches</code>."
             },
             "safari": {
               "version_added": false

--- a/api/WEBGL_compressed_texture_astc.json
+++ b/api/WEBGL_compressed_texture_astc.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "34"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "34"
           },
           "safari": {
             "version_added": false
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "34"
             },
             "safari": {
               "version_added": false

--- a/api/WEBGL_debug_renderer_info.json
+++ b/api/WEBGL_debug_renderer_info.json
@@ -24,10 +24,10 @@
             "version_added": "11"
           },
           "opera": {
-            "version_added": true
+            "version_added": "20"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "20"
           },
           "safari": {
             "version_added": "9.1"

--- a/api/WEBGL_debug_shaders.json
+++ b/api/WEBGL_debug_shaders.json
@@ -32,10 +32,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "34"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "34"
           },
           "safari": {
             "version_added": "14"
@@ -88,10 +88,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "34"
             },
             "safari": {
               "version_added": "14"

--- a/api/WakeLock.json
+++ b/api/WakeLock.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "70"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "60"
           },
           "safari": {
             "version_added": false
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "70"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "60"
             },
             "safari": {
               "version_added": false

--- a/api/WakeLockSentinel.json
+++ b/api/WakeLockSentinel.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "70"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "60"
           },
           "safari": {
             "version_added": false
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "70"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "60"
             },
             "safari": {
               "version_added": false
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "70"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "60"
             },
             "safari": {
               "version_added": false
@@ -170,10 +170,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "73"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "62"
             },
             "safari": {
               "version_added": false
@@ -219,10 +219,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "70"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "60"
             },
             "safari": {
               "version_added": false

--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -320,10 +320,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "18"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "18"
             },
             "safari": {
               "version_added": "15"

--- a/api/Window.json
+++ b/api/Window.json
@@ -763,10 +763,10 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": null
+                "version_added": "17"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "18"
               },
               "safari": {
                 "version_added": "8"
@@ -1094,10 +1094,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "34"
             },
             "safari": {
               "version_added": false
@@ -1609,7 +1609,7 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": true
+              "version_added": "18"
             },
             "opera_android": {
               "version_added": false
@@ -2341,7 +2341,7 @@
               }
             ],
             "opera_android": {
-              "version_added": true
+              "version_added": "24"
             },
             "safari": {
               "version_added": "10.1"
@@ -2405,7 +2405,7 @@
               }
             ],
             "opera_android": {
-              "version_added": true
+              "version_added": "24"
             },
             "safari": {
               "version_added": "10.1"
@@ -9041,7 +9041,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "20"
             },
             "opera_android": {
               "version_added": false

--- a/api/WindowClient.json
+++ b/api/WindowClient.json
@@ -25,10 +25,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": "29"
           },
           "opera_android": {
-            "version_added": null
+            "version_added": "29"
           },
           "safari": {
             "version_added": "11.1"
@@ -74,10 +74,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "29"
             },
             "safari": {
               "version_added": "11.1"
@@ -124,10 +124,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "29"
             },
             "safari": {
               "version_added": "11.1"
@@ -174,10 +174,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "36"
             },
             "safari": {
               "version_added": "11.1"
@@ -224,10 +224,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "29"
             },
             "safari": {
               "version_added": "11.1"

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -236,7 +236,7 @@
               "version_added": "11.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "27"
             },
             "safari": {
               "version_added": "4"
@@ -288,7 +288,7 @@
               "version_added": "11.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "27"
             },
             "safari": {
               "version_added": "4"
@@ -340,7 +340,7 @@
               "version_added": "11.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "27"
             },
             "safari": {
               "version_added": "4"
@@ -392,7 +392,7 @@
               "version_added": "11.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "27"
             },
             "safari": {
               "version_added": "4"
@@ -444,7 +444,7 @@
               "version_added": "11.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "27"
             },
             "safari": {
               "version_added": "4"
@@ -496,7 +496,7 @@
               "version_added": null
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "27"
             },
             "safari": {
               "version_added": "8"
@@ -548,7 +548,7 @@
               "version_added": null
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "27"
             },
             "safari": {
               "version_added": "8"
@@ -600,7 +600,7 @@
               "version_added": "11.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "27"
             },
             "safari": {
               "version_added": "4"

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -225,7 +225,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "48"
             },
             "opera_android": {
               "version_added": "37"

--- a/api/_globals/createImageBitmap.json
+++ b/api/_globals/createImageBitmap.json
@@ -27,10 +27,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "37"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "37"
           },
           "safari": {
             "version_added": "15",
@@ -130,10 +130,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "41"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": false
@@ -181,10 +181,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "43"
             },
             "safari": {
               "version_added": false

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -78,10 +78,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "35"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "35"
             },
             "safari": {
               "version_added": "10.1"

--- a/api/_mixins/HTMLHyperlinkElementUtils__HTMLAnchorElement.json
+++ b/api/_mixins/HTMLHyperlinkElementUtils__HTMLAnchorElement.json
@@ -524,10 +524,10 @@
               "version_added": "5.5"
             },
             "opera": {
-              "version_added": true
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": "3"

--- a/api/_mixins/HTMLHyperlinkElementUtils__HTMLAreaElement.json
+++ b/api/_mixins/HTMLHyperlinkElementUtils__HTMLAreaElement.json
@@ -524,10 +524,10 @@
               "version_added": "5.5"
             },
             "opera": {
-              "version_added": true
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "41"
             },
             "safari": {
               "version_added": "10.1"


### PR DESCRIPTION
This PR mirrors the data from Chrome and Chrome Android to Opera and Opera Android respectively for the API data.  This PR focuses solely on changes from a nonreal value (true or null) to a version number newer than 14/15.
