### PR TITLE
Mirror Chromium to Opera (null to false) for api/

### DIFF
--- a/api/CSSValue.json
+++ b/api/CSSValue.json
@@ -28,7 +28,7 @@
             "version_added": false
           },
           "opera_android": {
-            "version_added": null
+            "version_added": false
           },
           "safari": {
             "version_added": "3"
@@ -77,7 +77,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "7"
@@ -127,7 +127,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "7"

--- a/api/CSSValueList.json
+++ b/api/CSSValueList.json
@@ -28,7 +28,7 @@
             "version_added": false
           },
           "opera_android": {
-            "version_added": null
+            "version_added": false
           },
           "safari": {
             "version_added": "3"
@@ -77,7 +77,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "3"
@@ -127,7 +127,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "10"

--- a/api/Console.json
+++ b/api/Console.json
@@ -683,6 +683,9 @@
             "opera": {
               "version_added": false
             },
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
@@ -732,6 +735,9 @@
                 "version_added": false
               },
               "opera": {
+                "version_added": false
+              },
+              "opera_android": {
                 "version_added": false
               },
               "safari": {

--- a/api/DeviceMotionEventAcceleration.json
+++ b/api/DeviceMotionEventAcceleration.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": false
           },
           "opera_android": {
             "version_added": null
@@ -101,7 +101,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
               "version_added": null
@@ -155,7 +155,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
               "version_added": null
@@ -209,7 +209,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
               "version_added": null
@@ -263,7 +263,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
               "version_added": null

--- a/api/DeviceMotionEventRotationRate.json
+++ b/api/DeviceMotionEventRotationRate.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": false
           },
           "opera_android": {
             "version_added": null
@@ -103,7 +103,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
               "version_added": null
@@ -157,7 +157,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
               "version_added": null
@@ -211,7 +211,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
               "version_added": null
@@ -263,7 +263,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
               "version_added": null

--- a/api/Document.json
+++ b/api/Document.json
@@ -10832,10 +10832,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": [
               {
@@ -10913,10 +10913,10 @@
               "notes": "The <code>ontransitionend</code> attribute is not supported in IE. To listen to this event, use <code>document.addEventListener('transitionend', function() {});</code>."
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "11"
@@ -10964,10 +10964,10 @@
               "notes": "The <code>ontransitionrun</code> attribute is not supported in IE. To listen to this event, use <code>document.addEventListener('transitionrun', function() {});</code>."
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": [
               {
@@ -11045,10 +11045,10 @@
               "notes": "The <code>ontransitionstart</code> attribute is not supported in IE. To listen to this event, use <code>document.addEventListener('transitionstart', function() {});</code>."
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": [
               {

--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -481,10 +481,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": false

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": [
               {
@@ -4444,10 +4444,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -1750,7 +1750,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": "6"
@@ -1845,6 +1848,9 @@
             "opera": {
               "version_added": false
             },
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
@@ -1890,6 +1896,9 @@
             "opera": {
               "version_added": false
             },
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
@@ -1933,6 +1942,9 @@
               "version_added": false
             },
             "opera": {
+              "version_added": false
+            },
+            "opera_android": {
               "version_added": false
             },
             "safari": {
@@ -3166,6 +3178,9 @@
               "version_added": false
             },
             "opera": {
+              "version_added": false
+            },
+            "opera_android": {
               "version_added": false
             },
             "safari": {

--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -145,7 +145,7 @@
               "version_added": null
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false

--- a/api/MediaTrackConstraints.json
+++ b/api/MediaTrackConstraints.json
@@ -234,7 +234,7 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -334,7 +334,7 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "11.1"
@@ -677,7 +677,7 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "11.1"

--- a/api/MediaTrackSupportedConstraints.json
+++ b/api/MediaTrackSupportedConstraints.json
@@ -236,7 +236,7 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -334,7 +334,7 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "11.1"
@@ -677,7 +677,7 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "11.1"

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -468,10 +468,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
-                "version_added": null
+                "version_added": false
               },
               "safari": {
                 "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -504,10 +504,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false

--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -277,7 +277,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
               "version_added": null

--- a/api/RTCIceCandidatePairStats.json
+++ b/api/RTCIceCandidatePairStats.json
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "11"
@@ -268,10 +268,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -317,10 +317,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -366,10 +366,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -494,10 +494,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -543,10 +543,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -592,10 +592,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -641,10 +641,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -690,10 +690,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -837,10 +837,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -886,10 +886,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -995,10 +995,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "11"
@@ -1289,10 +1289,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -1338,10 +1338,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false

--- a/api/RTCIceCandidateStats.json
+++ b/api/RTCIceCandidateStats.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": false
           },
           "opera_android": {
-            "version_added": null
+            "version_added": false
           },
           "safari": {
             "version_added": "12.1"
@@ -84,10 +84,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "12.1"
@@ -133,10 +133,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "12.1"
@@ -183,10 +183,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -232,10 +232,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "12.1"
@@ -280,10 +280,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -331,10 +331,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "12.1"
@@ -380,10 +380,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "12.1"
@@ -441,10 +441,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "12.1"
@@ -502,10 +502,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -553,10 +553,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "12.1"
@@ -602,10 +602,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "12.1"

--- a/api/RTCIdentityAssertion.json
+++ b/api/RTCIdentityAssertion.json
@@ -28,10 +28,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": false
           },
           "opera_android": {
-            "version_added": null
+            "version_added": false
           },
           "safari": {
             "version_added": false
@@ -76,10 +76,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -125,10 +125,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false

--- a/api/RTCPeerConnectionIceEvent.json
+++ b/api/RTCPeerConnectionIceEvent.json
@@ -198,10 +198,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "12"

--- a/api/RTCRtpEncodingParameters.json
+++ b/api/RTCRtpEncodingParameters.json
@@ -119,10 +119,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -167,10 +167,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "11"
@@ -311,10 +311,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "11"
@@ -413,10 +413,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false

--- a/api/RTCRtpSendParameters.json
+++ b/api/RTCRtpSendParameters.json
@@ -73,10 +73,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "12.1"
@@ -172,10 +172,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false

--- a/api/Request.json
+++ b/api/Request.json
@@ -333,7 +333,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": null
+                "version_added": false
               },
               "opera_android": {
                 "version_added": false

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -425,10 +425,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": "11.1",

--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -43,7 +43,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
           },
           "safari": {
             "version_added": false
@@ -108,7 +111,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -174,7 +180,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -240,7 +249,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -306,7 +318,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -372,7 +387,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -438,7 +456,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -504,7 +525,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -570,7 +594,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -636,7 +663,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -689,7 +719,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -754,7 +787,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -820,7 +856,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -863,7 +902,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -928,7 +970,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -994,7 +1039,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -1060,7 +1108,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -1126,7 +1177,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -1192,7 +1246,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -1258,7 +1315,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -1324,7 +1384,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false

--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -43,7 +43,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
           },
           "safari": {
             "version_added": false
@@ -108,7 +111,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -174,7 +180,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -240,7 +249,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -306,7 +318,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -372,7 +387,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -43,7 +43,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
           },
           "safari": {
             "version_added": false
@@ -109,7 +112,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -175,7 +181,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -241,7 +250,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -43,7 +43,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
           },
           "safari": {
             "version_added": false
@@ -108,7 +111,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -161,7 +167,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -213,7 +222,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -278,7 +290,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -321,7 +336,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -386,7 +404,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -429,7 +450,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -494,7 +518,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -43,7 +43,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
           },
           "safari": {
             "version_added": false
@@ -86,7 +89,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -151,7 +157,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -217,7 +226,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -283,7 +295,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -349,7 +364,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -43,7 +43,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
           },
           "safari": {
             "version_added": false
@@ -109,7 +112,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -175,7 +181,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -241,7 +250,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -307,7 +319,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -373,7 +388,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -439,7 +457,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -505,7 +526,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -43,7 +43,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
           },
           "safari": {
             "version_added": false
@@ -108,7 +111,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -174,7 +180,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -217,7 +226,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -259,7 +271,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -324,7 +339,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -390,7 +408,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -456,7 +477,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -522,7 +546,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -566,7 +593,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -43,7 +43,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": null
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
           },
           "safari": {
             "version_added": false
@@ -108,7 +111,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -174,7 +180,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -240,7 +249,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
             },
             "safari": {
               "version_added": false

--- a/api/Window.json
+++ b/api/Window.json
@@ -5555,10 +5555,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -7779,10 +7779,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -7827,10 +7827,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -7875,10 +7875,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -7923,10 +7923,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -8593,10 +8593,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -8696,10 +8696,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -8943,10 +8943,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -8992,10 +8992,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -9435,10 +9435,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": [
               {
@@ -9515,10 +9515,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": [
               {
@@ -9595,10 +9595,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": [
               {
@@ -9675,10 +9675,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": [
               {
@@ -9875,10 +9875,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": false
             },
             "opera_android": {
-              "version_added": null
+              "version_added": false
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR mirrors the data from Chrome and Chrome Android to Opera and Opera Android respectively for the API data.  This PR focuses solely on changes where Opera is set to `null` and it becomes `false` after mirroring, including setting Opera Android to `false` when the feature is behind a flag (Opera Android doesn't have flags).
