### PR TITLE
Mirror Chromium to Opera (true to false) for api/

### DIFF
--- a/api/ContactsManager.json
+++ b/api/ContactsManager.json
@@ -72,7 +72,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": false
             },
             "opera_android": {
               "version_added": "57"
@@ -121,7 +121,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": false
             },
             "opera_android": {
               "version_added": "57"

--- a/api/Document.json
+++ b/api/Document.json
@@ -4276,10 +4276,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": false
               },
               "opera_android": {
-                "version_added": true
+                "version_added": false
               },
               "safari": {
                 "version_added": false

--- a/api/MediaTrackConstraints.json
+++ b/api/MediaTrackConstraints.json
@@ -231,7 +231,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": false
             },
             "opera_android": {
               "version_added": null
@@ -331,7 +331,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": false
             },
             "opera_android": {
               "version_added": null
@@ -674,7 +674,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": false
             },
             "opera_android": {
               "version_added": null

--- a/api/MediaTrackSupportedConstraints.json
+++ b/api/MediaTrackSupportedConstraints.json
@@ -233,7 +233,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": false
             },
             "opera_android": {
               "version_added": null
@@ -331,7 +331,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": false
             },
             "opera_android": {
               "version_added": null
@@ -674,7 +674,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": false
             },
             "opera_android": {
               "version_added": null

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -494,7 +494,7 @@
               "version_added": true
             },
             "opera_android": {
-              "version_added": true
+              "version_added": false
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR mirrors the data from Chrome and Chrome Android to Opera and Opera Android respectively for the API data.  This PR focuses solely on changes where Opera is marked as `true`, but Chrome is `false` (or the result will otherwise be `false`).  All of these values were double-checked for support using the mdn-bcd-collector project.
