### PR TITLE
Add real values for early Opera versions for api/

### DIFF
--- a/api/Blob.json
+++ b/api/Blob.json
@@ -264,7 +264,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12"
             },
             "safari": [
               {

--- a/api/CloseEvent.json
+++ b/api/CloseEvent.json
@@ -83,10 +83,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"

--- a/api/DOMParser.json
+++ b/api/DOMParser.json
@@ -76,7 +76,7 @@
               "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "1.3"
@@ -220,7 +220,7 @@
                 "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
                 "version_added": "3"
@@ -268,7 +268,7 @@
                 "version_added": "8"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1.3"

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -72,10 +72,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -169,10 +169,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -314,10 +314,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -411,10 +411,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -460,10 +460,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -752,10 +752,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"

--- a/api/DeviceMotionEventAcceleration.json
+++ b/api/DeviceMotionEventAcceleration.json
@@ -38,9 +38,16 @@
           "opera": {
             "version_added": null
           },
-          "opera_android": {
-            "version_added": null
-          },
+          "opera_android": [
+            {
+              "version_added": "53"
+            },
+            {
+              "alternative_name": "DeviceAcceleration",
+              "version_added": "15",
+              "version_removed": "52"
+            }
+          ],
           "safari": {
             "version_added": "5.1",
             "partial_implementation": true,
@@ -104,7 +111,7 @@
               "version_added": null
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "15"
             },
             "safari": {
               "version_added": "5.1",
@@ -158,7 +165,7 @@
               "version_added": null
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "15"
             },
             "safari": {
               "version_added": "5.1",
@@ -212,7 +219,7 @@
               "version_added": null
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "15"
             },
             "safari": {
               "version_added": "5.1",
@@ -266,7 +273,7 @@
               "version_added": null
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "15"
             },
             "safari": {
               "version_added": "5.1",

--- a/api/DeviceMotionEventRotationRate.json
+++ b/api/DeviceMotionEventRotationRate.json
@@ -38,9 +38,16 @@
           "opera": {
             "version_added": null
           },
-          "opera_android": {
-            "version_added": null
-          },
+          "opera_android": [
+            {
+              "version_added": "53"
+            },
+            {
+              "alternative_name": "DeviceRotation",
+              "version_added": "15",
+              "version_removed": "52"
+            }
+          ],
           "safari": {
             "version_added": "5.1",
             "partial_implementation": true,
@@ -106,7 +113,7 @@
               "version_added": null
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "15"
             },
             "safari": {
               "version_added": "5.1",
@@ -160,7 +167,7 @@
               "version_added": null
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "15"
             },
             "safari": {
               "version_added": "5.1",
@@ -214,7 +221,7 @@
               "version_added": null
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "15"
             },
             "safari": {
               "version_added": "5.1",
@@ -266,7 +273,7 @@
               "version_added": null
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "15"
             },
             "safari": {
               "version_added": "5.1",

--- a/api/Document.json
+++ b/api/Document.json
@@ -1282,24 +1282,26 @@
               },
               {
                 "alternative_name": "charset",
-                "version_added": null
+                "version_added": "15",
+                "notes": "<code>charset</code> alias was made read-only in Opera 45."
               },
               {
                 "alternative_name": "inputEncoding",
-                "version_added": null
+                "version_added": "15"
               }
             ],
             "opera_android": [
               {
-                "version_added": true
+                "version_added": "≤12.1"
               },
               {
                 "alternative_name": "charset",
-                "version_added": null
+                "version_added": "14",
+                "notes": "<code>charset</code> alias was made read-only in Opera 45."
               },
               {
                 "alternative_name": "inputEncoding",
-                "version_added": null
+                "version_added": "14"
               }
             ],
             "safari": [
@@ -2441,7 +2443,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -2742,11 +2744,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true,
+              "version_added": "15",
               "version_removed": "56"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "14",
               "version_removed": "48"
             },
             "safari": {
@@ -8671,12 +8673,26 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "32"
+              },
+              {
+                "version_added": "15",
+                "version_removed": "32",
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "32"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "32",
+                "prefix": "webkit"
+              }
+            ],
             "safari": {
               "version_added": "10.1"
             },
@@ -8763,12 +8779,26 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "32"
+              },
+              {
+                "version_added": "15",
+                "version_removed": "32",
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "32"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "32",
+                "prefix": "webkit"
+              }
+            ],
             "safari": {
               "version_added": "10.1"
             },
@@ -10635,7 +10665,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -10685,7 +10715,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -10735,7 +10765,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -10785,7 +10815,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false

--- a/api/Element.json
+++ b/api/Element.json
@@ -2083,10 +2083,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "14"
             },
             "safari": {
               "version_added": "5"
@@ -3894,10 +3894,10 @@
                 "version_added": "6"
               },
               "opera": {
-                "version_added": true
+                "version_added": "≤15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "≤14"
               },
               "safari": {
                 "version_added": "1"
@@ -4004,10 +4004,10 @@
                 "version_added": "9"
               },
               "opera": {
-                "version_added": true
+                "version_added": "≤15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "≤14"
               },
               "safari": {
                 "version_added": "1"
@@ -4593,10 +4593,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "1.2"
@@ -4647,10 +4647,12 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1",
+              "notes": "Opera does not fire the <code>keypress</code> event for <a href='https://crbug.com/13891#c50'>known keyboard shortcuts</a>. Which keyboard shortcuts are known depends on the user's system. Use the <code>keydown</code> event to implement keyboard shortcuts."
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1",
+              "notes": "Opera does not fire the <code>keypress</code> event for <a href='https://crbug.com/13891#c50'>known keyboard shortcuts</a>. Which keyboard shortcuts are known depends on the user's system. Use the <code>keydown</code> event to implement keyboard shortcuts."
             },
             "safari": {
               "version_added": "1.3"
@@ -4699,10 +4701,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "1.2"
@@ -5141,10 +5143,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "1"
@@ -6884,10 +6886,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "1.3"
@@ -8604,7 +8606,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -8654,7 +8656,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -8704,7 +8706,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -8754,7 +8756,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false

--- a/api/EventSource.json
+++ b/api/EventSource.json
@@ -182,7 +182,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "12"
             },
             "opera_android": {
               "version_added": "12"
@@ -235,7 +235,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "12"
             },
             "opera_android": {
               "version_added": "12"
@@ -288,7 +288,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "12"
             },
             "opera_android": {
               "version_added": "12"
@@ -340,7 +340,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "12"
             },
             "opera_android": {
               "version_added": "12"
@@ -392,7 +392,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "12"
             },
             "opera_android": {
               "version_added": "12"
@@ -444,7 +444,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "12"
             },
             "opera_android": {
               "version_added": "12"
@@ -497,7 +497,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "12"
             },
             "opera_android": {
               "version_added": "12"
@@ -549,7 +549,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "12"
             },
             "opera_android": {
               "version_added": "12"
@@ -601,7 +601,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "12"
             },
             "opera_android": {
               "version_added": "12"
@@ -653,7 +653,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "12"
             },
             "opera_android": {
               "version_added": "12"

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -24,10 +24,10 @@
             "version_added": "4"
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": "1"

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -75,6 +75,9 @@
             "opera": {
               "version_added": "8"
             },
+            "opera_android": {
+              "version_added": "10.1"
+            },
             "safari": {
               "version_added": "1"
             },
@@ -758,7 +761,10 @@
               "version_added": "6"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "3"

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -262,7 +262,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false

--- a/api/HTMLOptionsCollection.json
+++ b/api/HTMLOptionsCollection.json
@@ -24,10 +24,10 @@
             "version_added": "≤6"
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": "3"
@@ -71,10 +71,10 @@
               "version_added": "≤6"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "3"
@@ -119,10 +119,10 @@
               "version_added": "≤6"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "3"
@@ -167,10 +167,10 @@
               "version_added": "≤6"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "3.1"
@@ -215,10 +215,10 @@
               "version_added": "≤6"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "3"

--- a/api/HTMLTemplateElement.json
+++ b/api/HTMLTemplateElement.json
@@ -27,7 +27,7 @@
             "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": "8"
@@ -75,7 +75,7 @@
               "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "8"

--- a/api/IDBDatabase.json
+++ b/api/IDBDatabase.json
@@ -860,10 +860,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "10"

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -1306,7 +1306,7 @@
               "version_removed": "41"
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "14",
               "version_removed": "41"
             },
             "safari": {

--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -27,7 +27,7 @@
             "version_added": "12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "12.1"
           },
           "safari": {
             "version_added": "5.1",
@@ -174,7 +174,7 @@
               "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
               "version_added": "5.1",
@@ -225,7 +225,7 @@
               "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
               "version_added": "5.1"
@@ -274,7 +274,7 @@
               "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
               "version_added": "5.1"
@@ -373,7 +373,7 @@
               "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "12.1"
             },
             "safari": {
               "version_added": "5.1",

--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -454,7 +454,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": false
@@ -603,7 +603,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": false
@@ -943,7 +943,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": false

--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -857,10 +857,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11"

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -85,10 +85,10 @@
               "version_added": "15.0.0"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "4"
@@ -140,10 +140,10 @@
               "version_added": "15.0.0"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "4"
@@ -195,10 +195,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "4"
@@ -250,10 +250,10 @@
               "version_added": "15.0.0"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "4"
@@ -305,10 +305,10 @@
               "version_added": "15.0.0"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "4"
@@ -360,10 +360,10 @@
               "version_added": "15.0.0"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "4"

--- a/api/NodeIterator.json
+++ b/api/NodeIterator.json
@@ -280,10 +280,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": "3"
@@ -378,10 +378,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": "3"

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -259,12 +259,26 @@
             "nodejs": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "33"
+              },
+              {
+                "version_added": "15",
+                "version_removed": "44",
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "33"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "43",
+                "prefix": "webkit"
+              }
+            ],
             "safari": {
               "version_added": "11"
             },
@@ -870,10 +884,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -1067,9 +1081,16 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera_android": [
+              {
+                "version_added": "33"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "43",
+                "alternative_name": "onwebkitresourcetimingbufferfull"
+              }
+            ],
             "safari": {
               "version_added": "11"
             },
@@ -1151,9 +1172,16 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera_android": [
+              {
+                "version_added": "33"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "43",
+                "alternative_name": "webkitresourcetimingbufferfull"
+              }
+            ],
             "safari": {
               "version_added": "11"
             },
@@ -1231,12 +1259,26 @@
             "nodejs": {
               "version_added": false
             },
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": [
+              {
+                "version_added": "33"
+              },
+              {
+                "version_added": "15",
+                "version_removed": "44",
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "33"
+              },
+              {
+                "version_added": "14",
+                "version_removed": "43",
+                "prefix": "webkit"
+              }
+            ],
             "safari": {
               "version_added": "11"
             },

--- a/api/RTCConfiguration.json
+++ b/api/RTCConfiguration.json
@@ -24,7 +24,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
             "version_added": true
@@ -72,7 +72,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true
@@ -121,7 +121,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true
@@ -169,7 +169,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true
@@ -218,7 +218,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true
@@ -267,7 +267,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true
@@ -315,7 +315,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": true

--- a/api/RTCDTMFSender.json
+++ b/api/RTCDTMFSender.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": "13.1"
@@ -71,10 +71,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "13.1"
@@ -120,10 +120,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "13.1"
@@ -169,10 +169,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "13.1"
@@ -218,10 +218,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "13.1"
@@ -268,10 +268,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "13.1"

--- a/api/RTCDTMFToneChangeEvent.json
+++ b/api/RTCDTMFToneChangeEvent.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": "13.1"
@@ -73,10 +73,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "13.1"
@@ -122,10 +122,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "13.1"

--- a/api/RTCPeerConnectionIceEvent.json
+++ b/api/RTCPeerConnectionIceEvent.json
@@ -37,12 +37,26 @@
           "ie": {
             "version_added": false
           },
-          "opera": {
-            "version_added": true
-          },
-          "opera_android": {
-            "version_added": true
-          },
+          "opera": [
+            {
+              "version_added": "43"
+            },
+            {
+              "alternative_name": "RTCIceCandidateEvent",
+              "version_added": "15",
+              "version_removed": "43"
+            }
+          ],
+          "opera_android": [
+            {
+              "version_added": "43"
+            },
+            {
+              "alternative_name": "RTCIceCandidateEvent",
+              "version_added": "14",
+              "version_removed": "43"
+            }
+          ],
           "safari": {
             "version_added": "12"
           },
@@ -150,10 +164,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "12"

--- a/api/StyleSheet.json
+++ b/api/StyleSheet.json
@@ -24,10 +24,10 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": "1"
@@ -72,10 +72,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "1"
@@ -121,10 +121,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "1"
@@ -170,10 +170,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "1"
@@ -219,10 +219,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "1"
@@ -268,10 +268,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "1"
@@ -317,10 +317,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "1"
@@ -366,10 +366,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "1"

--- a/api/StyleSheetList.json
+++ b/api/StyleSheetList.json
@@ -24,10 +24,10 @@
             "version_added": "4"
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": "1"
@@ -72,10 +72,10 @@
               "version_added": "4"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "1"
@@ -121,10 +121,10 @@
               "version_added": "4"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "1"

--- a/api/Text.json
+++ b/api/Text.json
@@ -24,10 +24,10 @@
             "version_added": "5"
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": "1"
@@ -232,11 +232,11 @@
               "version_added": "5"
             },
             "opera": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "notes": "Before Opera 17, the <code>offset</code> parameter was optional."
             },
             "opera_android": {
-              "version_added": true,
+              "version_added": "≤12.1",
               "notes": "Before Opera 17, the <code>offset</code> parameter was optional."
             },
             "safari": {
@@ -287,10 +287,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "4"

--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -813,7 +813,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "4"

--- a/api/TextTrackCue.json
+++ b/api/TextTrackCue.json
@@ -121,10 +121,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -170,10 +170,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"

--- a/api/Touch.json
+++ b/api/Touch.json
@@ -31,10 +31,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "14"
           },
           "safari": {
             "version_added": false
@@ -230,10 +230,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -286,10 +286,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -440,10 +440,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -496,10 +496,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -552,10 +552,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -902,10 +902,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -958,10 +958,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -1014,10 +1014,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false

--- a/api/TouchEvent.json
+++ b/api/TouchEvent.json
@@ -154,10 +154,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -210,10 +210,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -266,10 +266,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -322,10 +322,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -378,10 +378,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -434,10 +434,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false
@@ -490,10 +490,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": false

--- a/api/Window.json
+++ b/api/Window.json
@@ -331,12 +331,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "30"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "30"
+              },
+              {
+                "version_added": "14",
+                "prefix": "webkit"
+              }
+            ],
             "safari": {
               "version_added": "9"
             },
@@ -411,12 +423,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "30"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "30"
+              },
+              {
+                "version_added": "14",
+                "prefix": "webkit"
+              }
+            ],
             "safari": {
               "version_added": "9"
             },
@@ -491,12 +515,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
+            "opera": [
+              {
+                "version_added": "30"
+              },
+              {
+                "version_added": "15",
+                "prefix": "webkit"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "30"
+              },
+              {
+                "version_added": "14",
+                "prefix": "webkit"
+              }
+            ],
             "safari": {
               "version_added": "9"
             },
@@ -863,7 +899,7 @@
                 "version_added": "12"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "12"
               },
               "safari": {
                 "version_added": "3"
@@ -5899,10 +5935,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": "5"
@@ -5949,10 +5985,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": "5"

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -493,7 +493,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": null
@@ -545,7 +545,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": null

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -27,10 +27,10 @@
             "version_added": "10"
           },
           "opera": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": true
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": "4"
@@ -75,10 +75,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "14"
             },
             "safari": {
               "version_added": "10"
@@ -124,10 +124,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "4"
@@ -173,10 +173,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "4"
@@ -692,10 +692,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "4"
@@ -985,10 +985,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "4"

--- a/api/XMLDocument.json
+++ b/api/XMLDocument.json
@@ -44,7 +44,7 @@
               "version_added": "21"
             },
             {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "21",
               "partial_implementation": true,
               "notes": "Implemented as an alias for <code>Document</code>."
@@ -55,7 +55,7 @@
               "version_added": "21"
             },
             {
-              "version_added": true,
+              "version_added": "≤12.1",
               "version_removed": "21",
               "partial_implementation": true,
               "notes": "Implemented as an alias for <code>Document</code>."


### PR DESCRIPTION
This PR mirrors the data from Chrome and Chrome Android to Opera and Opera Android respectively for the API data. This PR focuses solely on the data involving early versions of Opera.  Data is verified using the mdn-bcd-collector project, and when available, data is mirrored from Opera Desktop.
