### PR TITLE
Update Firefox Android versions for CanvasCaptureMediaStreamTrack API

### DIFF
--- a/api/CanvasCaptureMediaStreamTrack.json
+++ b/api/CanvasCaptureMediaStreamTrack.json
@@ -26,6 +26,7 @@
           },
           "firefox_android": {
             "version_added": "41",
+            "version_removed": "79",
             "flags": [
               {
                 "type": "preference",
@@ -88,6 +89,7 @@
             },
             "firefox_android": {
               "version_added": "41",
+              "version_removed": "79",
               "flags": [
                 {
                   "type": "preference",
@@ -150,7 +152,15 @@
               ]
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "41",
+              "version_removed": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "canvas.capturestream.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR corrects the real values for Firefox Android for the `CanvasCaptureMediaStreamTrack` API.  Since Firefox Android doesn't support flags anymore, this is effectively removed since flag support was cut off.
