### PR TITLE
Mirror Firefox Android data (null to false) for api/

### DIFF
--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -266,6 +266,9 @@
             "firefox": {
               "version_added": false
             },
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -727,6 +730,9 @@
               "version_added": "17"
             },
             "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
               "version_added": false
             },
             "ie": {

--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -859,6 +859,9 @@
             "firefox": {
               "version_added": false
             },
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -317,6 +317,9 @@
             "firefox": {
               "version_added": false
             },
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -423,6 +426,9 @@
               "version_added": false
             },
             "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
               "version_added": false
             },
             "ie": {

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -82,6 +82,9 @@
             "firefox": {
               "version_added": false
             },
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -213,6 +213,9 @@
             "firefox": {
               "version_added": false
             },
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -253,6 +256,9 @@
               "version_added": false
             },
             "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
               "version_added": false
             },
             "ie": {
@@ -560,6 +566,9 @@
               "version_removed": "79"
             },
             "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
               "version_added": false
             },
             "ie": {


### PR DESCRIPTION
This PR mirrors the data from Firefox to Firefox Android for the API data. This PR focuses on changes where Firefox Android is null and the resulting value is false.
