### PR TITLE
Update Samsung Internet versions for api.Window.onvrdisplayconnect

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -4979,8 +4979,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "Supported on Samsung Internet for GearVR."
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -10130,8 +10129,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
-              "notes": "Supported on Samsung Internet for GearVR."
+              "version_added": false
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Samsung Internet for the `onvrdisplayconnect` member of the `Window` API, as well as its event counterpart, based upon manual testing.

Test Code Used: `alert(window.onvrdisplayconnect);`
