### PR TITLE
Correct data set to Safari 6.1 for CSS data

### DIFF
--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -77,7 +77,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": "7"
                 }
               ],
               "safari_ios": [
@@ -86,7 +86,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": "7"
                 }
               ],
               "samsunginternet_android": [

--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -65,7 +65,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "6.1"
+                "version_added": "7"
               }
             ],
             "safari_ios": [
@@ -74,7 +74,7 @@
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "6.1"
+                "version_added": "7"
               }
             ],
             "samsunginternet_android": [
@@ -179,10 +179,10 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": "1.5"
@@ -277,10 +277,10 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": "1.5"
@@ -404,10 +404,10 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": "1.5"

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -532,7 +532,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": "7"
                 }
               ],
               "safari_ios": [
@@ -541,7 +541,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": "7"
                 }
               ],
               "samsunginternet_android": [

--- a/css/properties/font-feature-settings.json
+++ b/css/properties/font-feature-settings.json
@@ -81,7 +81,7 @@
               {
                 "partial_implementation": true,
                 "version_added": "3.2",
-                "version_removed": "6.1"
+                "version_removed": "6"
               }
             ],
             "samsunginternet_android": {

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -83,7 +83,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": "7"
                 }
               ],
               "safari_ios": [
@@ -92,7 +92,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": "7"
                 }
               ],
               "samsunginternet_android": [

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -155,7 +155,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": "7"
                 },
                 {
                   "alternative_name": "intrinsic",
@@ -168,7 +168,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": "7"
                 },
                 {
                   "alternative_name": "intrinsic",

--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -238,7 +238,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": "7"
                 }
               ],
               "safari_ios": [
@@ -247,7 +247,7 @@
                 },
                 {
                   "prefix": "-webkit-",
-                  "version_added": "6.1"
+                  "version_added": "7"
                 }
               ],
               "samsunginternet_android": {

--- a/css/properties/ruby-position.json
+++ b/css/properties/ruby-position.json
@@ -71,12 +71,12 @@
               }
             ],
             "safari": {
-              "version_added": "6.1",
+              "version_added": "7",
               "prefix": "-webkit-",
               "notes": "Implemented as a non-standard, prefixed, version of <code>ruby-position</code>, <code>-webkit-ruby-position</code>: it has two properties: <code>before</code> and <code>after</code> (both equivalent, for ltr and rtl scripts to the standard <code>over</code> value used with <code>ruby-align: start</code>)."
             },
             "safari_ios": {
-              "version_added": "6.1",
+              "version_added": "7",
               "prefix": "-webkit-",
               "notes": "Implemented as a non-standard, prefixed, version of <code>ruby-position</code>, <code>-webkit-ruby-position</code>: it has two properties: <code>before</code> and <code>after</code> (both equivalent, for ltr and rtl scripts to the standard <code>over</code> value used with <code>ruby-align: start</code>)."
             },

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -78,10 +78,10 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": "1.5"
@@ -585,11 +585,11 @@
               },
               "safari": {
                 "alternative_name": "-webkit-fill-available",
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "safari_ios": {
                 "alternative_name": "-webkit-fill-available",
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": "5.0",

--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -78,10 +78,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/css/selectors/cue.json
+++ b/css/selectors/cue.json
@@ -33,10 +33,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -80,10 +80,10 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": "1.5"

--- a/css/selectors/future.json
+++ b/css/selectors/future.json
@@ -32,10 +32,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/selectors/past.json
+++ b/css/selectors/past.json
@@ -32,10 +32,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -546,7 +546,7 @@
                 ],
                 "safari": [
                   {
-                    "version_added": "6.1"
+                    "version_added": "7"
                   },
                   {
                     "prefix": "-webkit-",
@@ -559,7 +559,7 @@
                 ],
                 "safari_ios": [
                   {
-                    "version_added": "6.1"
+                    "version_added": "7"
                   },
                   {
                     "prefix": "-webkit-",
@@ -672,10 +672,10 @@
                     "version_added": "27"
                   },
                   "safari": {
-                    "version_added": "6.1"
+                    "version_added": "7"
                   },
                   "safari_ios": {
-                    "version_added": "6.1"
+                    "version_added": "7"
                   },
                   "samsunginternet_android": {
                     "version_added": "4.0"
@@ -720,10 +720,10 @@
                     "version_added": "14"
                   },
                   "safari": {
-                    "version_added": "6.1"
+                    "version_added": "7"
                   },
                   "safari_ios": {
-                    "version_added": "6.1"
+                    "version_added": "7"
                   },
                   "samsunginternet_android": {
                     "version_added": "1.5"
@@ -782,10 +782,10 @@
                     "version_added": "14"
                   },
                   "safari": {
-                    "version_added": "6.1"
+                    "version_added": "7"
                   },
                   "safari_ios": {
-                    "version_added": "6.1"
+                    "version_added": "7"
                   },
                   "samsunginternet_android": {
                     "version_added": "1.5"
@@ -893,7 +893,7 @@
                 ],
                 "safari": [
                   {
-                    "version_added": "6.1"
+                    "version_added": "7"
                   },
                   {
                     "prefix": "-webkit-",
@@ -903,7 +903,7 @@
                 ],
                 "safari_ios": [
                   {
-                    "version_added": "6.1"
+                    "version_added": "7"
                   },
                   {
                     "prefix": "-webkit-",
@@ -1093,10 +1093,10 @@
                     "version_added": "27"
                   },
                   "safari": {
-                    "version_added": "6.1"
+                    "version_added": "7"
                   },
                   "safari_ios": {
-                    "version_added": "6.1"
+                    "version_added": "7"
                   },
                   "samsunginternet_android": {
                     "version_added": "4.0"
@@ -1286,7 +1286,7 @@
                 ],
                 "safari": [
                   {
-                    "version_added": "6.1"
+                    "version_added": "7"
                   },
                   {
                     "prefix": "-webkit-",
@@ -1299,7 +1299,7 @@
                 ],
                 "safari_ios": [
                   {
-                    "version_added": "6.1"
+                    "version_added": "7"
                   },
                   {
                     "prefix": "-webkit-",
@@ -1412,10 +1412,10 @@
                     "version_added": "27"
                   },
                   "safari": {
-                    "version_added": "6.1"
+                    "version_added": "7"
                   },
                   "safari_ios": {
-                    "version_added": "6.1"
+                    "version_added": "7"
                   },
                   "samsunginternet_android": {
                     "version_added": "4.0"
@@ -1460,10 +1460,10 @@
                     "version_added": "14"
                   },
                   "safari": {
-                    "version_added": "6.1"
+                    "version_added": "7"
                   },
                   "safari_ios": {
-                    "version_added": "6.1"
+                    "version_added": "7"
                   },
                   "samsunginternet_android": {
                     "version_added": "1.5"
@@ -1522,10 +1522,10 @@
                     "version_added": "14"
                   },
                   "safari": {
-                    "version_added": "6.1"
+                    "version_added": "7"
                   },
                   "safari_ios": {
-                    "version_added": "6.1"
+                    "version_added": "7"
                   },
                   "samsunginternet_android": {
                     "version_added": "1.5"

--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -673,10 +673,10 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": "1.5"
@@ -735,10 +735,10 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": "1.5"

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -675,10 +675,10 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": "1.5"
@@ -737,10 +737,10 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": "1.5"


### PR DESCRIPTION
This PR changes all data set to Safari 6.1 to 7 instead (or for one entry for Safari iOS, 6, to mirror Safari Desktop).  All values were verified via manual testing.
