### PR TITLE
Add Safari iOS versions for details HTML element

### DIFF
--- a/html/elements/details.json
+++ b/html/elements/details.json
@@ -36,7 +36,7 @@
               "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "6.1"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": true
@@ -82,7 +82,7 @@
                 "version_added": "6"
               },
               "safari_ios": {
-                "version_added": "6.1"
+                "version_added": "6"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari iOS/iPadOS for the `details` HTML element by mirroring the data.
