### PR TITLE
Update Safari versions for javascript.builtins.Array.toLocaleString

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -2187,10 +2187,10 @@
                   "version_added": "14"
                 },
                 "safari": {
-                  "version_added": "6.1"
+                  "version_added": "7"
                 },
                 "safari_ios": {
-                  "version_added": "6.1"
+                  "version_added": "7"
                 },
                 "samsunginternet_android": {
                   "version_added": "2.0"
@@ -2241,10 +2241,10 @@
                   "version_added": "14"
                 },
                 "safari": {
-                  "version_added": "6.1"
+                  "version_added": "7"
                 },
                 "safari_ios": {
-                  "version_added": "6.1"
+                  "version_added": "7"
                 },
                 "samsunginternet_android": {
                   "version_added": "2.0"


### PR DESCRIPTION
This PR corrects the versions for Safari (Desktop and iOS/iPadOS) for the `toLocaleString` member of the `Array` JavaScript builtin based upon manual testing.
