### PR TITLE
Add Safari versions for svg.elements.use.external_uri

### DIFF
--- a/svg/elements/use.json
+++ b/svg/elements/use.json
@@ -128,10 +128,10 @@
                 "version_added": "11.5"
               },
               "safari": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": "6.1"
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": true


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `external_uri` member of the `use` SVG element, based upon manual testing.
