### PR TITLE
Update Window API VR data for Samsung Internet

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -4979,7 +4979,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "6.0",
+              "version_removed": "13.0",
               "notes": "Supported on Samsung Internet for GearVR."
             },
             "webview_android": {
@@ -5104,6 +5105,7 @@
             },
             "samsunginternet_android": {
               "version_added": "6.0",
+              "version_removed": "13.0",
               "notes": "Supported on Samsung Internet for GearVR."
             },
             "webview_android": {
@@ -5320,6 +5322,7 @@
             },
             "samsunginternet_android": {
               "version_added": "6.0",
+              "version_removed": "13.0",
               "notes": "Supported on Samsung Internet for GearVR."
             },
             "webview_android": {
@@ -10130,7 +10133,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": true,
+              "version_added": "6.0",
+              "version_removed": "13.0",
               "notes": "Supported on Samsung Internet for GearVR."
             },
             "webview_android": {
@@ -10256,6 +10260,7 @@
             },
             "samsunginternet_android": {
               "version_added": "6.0",
+              "version_removed": "13.0",
               "notes": "Supported on Samsung Internet for GearVR."
             },
             "webview_android": {
@@ -10474,6 +10479,7 @@
             },
             "samsunginternet_android": {
               "version_added": "6.0",
+              "version_removed": "13.0",
               "notes": "Supported on Samsung Internet for GearVR."
             },
             "webview_android": {


### PR DESCRIPTION
This PR updates the VR data for Samsung Internet for the Window API.  GearVR became [deprecated in 2019 and shut down entirely on September 30th, 2020](https://www.engadget.com/samsung-is-killing-its-vr-applications-now-that-gear-vr-is-dead-181025444.html), so this PR adds a `version_removed` that roughly matches with this date.  Additionally, this sets the two values currently `true` to `6.0` to match the other data; since it will be removed in the future trying to search for a specific version number isn't as worthwhile.
