### PR TITLE
Update Safari versions for api.XMLHttpRequest.upload

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1907,10 +1907,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "3"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `upload` member of the `XMLHttpRequest` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/XMLHttpRequest/upload

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
