### PR TITLE
Add Opera versions for api.Document.createTreeWalker.expandEntityReferences_parameter

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -2849,7 +2849,7 @@
                 "version_removed": "15"
               },
               "opera_android": {
-                "version_added": true,
+                "version_added": "10.1",
                 "version_removed": "14"
               },
               "safari": {


### PR DESCRIPTION
This PR adds real values for Opera and Opera Android for the `createTreeWalker.expandEntityReferences_parameter` member of the `Document` API by mirroring the data.
