### PR TITLE
USB events: on(dis)connect -> (dis)connect_event

### DIFF
--- a/api/USB.json
+++ b/api/USB.json
@@ -48,55 +48,6 @@
           "deprecated": false
         }
       },
-      "getDevices": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/USB/getDevices",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usb-getdevices②",
-          "support": {
-            "chrome": {
-              "version_added": "61"
-            },
-            "chrome_android": {
-              "version_added": "61"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "48"
-            },
-            "opera_android": {
-              "version_added": "45"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "8.0"
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "connect_event": {
         "__compat": {
           "description": "<code>connect</code> event",
@@ -158,6 +109,55 @@
             "https://wicg.github.io/webusb/#disconnect",
             "https://wicg.github.io/webusb/#ref-for-dom-usb-ondisconnect"
           ],
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "61"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "48"
+            },
+            "opera_android": {
+              "version_added": "45"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "8.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getDevices": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/USB/getDevices",
+          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usb-getdevices②",
           "support": {
             "chrome": {
               "version_added": "61"

--- a/api/USB.json
+++ b/api/USB.json
@@ -97,10 +97,14 @@
           }
         }
       },
-      "onconnect": {
+      "connect_event": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/USB/onconnect",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usb-onconnect",
+          "description": "<code>connect</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/USB/connect_event",
+          "spec_url": [
+            "https://wicg.github.io/webusb/#connect",
+            "https://wicg.github.io/webusb/#ref-for-dom-usb-onconnect"
+          ],
           "support": {
             "chrome": {
               "version_added": "61"
@@ -146,10 +150,14 @@
           }
         }
       },
-      "ondisconnect": {
+      "disconnect_event": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/USB/ondisconnect",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usb-ondisconnect",
+          "description": "<code>disconnect</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/USB/disconnect_event",
+          "spec_url": [
+            "https://wicg.github.io/webusb/#disconnect",
+            "https://wicg.github.io/webusb/#ref-for-dom-usb-ondisconnect"
+          ],
           "support": {
             "chrome": {
               "version_added": "61"


### PR DESCRIPTION
Per the new guideline: https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#dom-events-eventname_event

Content work https://github.com/mdn/content/pull/11051