### PR TITLE
Single event entries for TextTrack APIs

### DIFF
--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -150,7 +150,10 @@
         "__compat": {
           "description": "<code>cuechange</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrack/cuechange_event",
-          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#event-media-cuechange",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/media.html#event-media-cuechange",
+            "https://html.spec.whatwg.org/multipage/media.html#handler-texttrack-oncuechange"
+          ],
           "support": {
             "chrome": {
               "version_added": "23"
@@ -520,54 +523,6 @@
             },
             "safari_ios": {
               "version_added": "7"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.5"
-            },
-            "webview_android": {
-              "version_added": "4.4"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "oncuechange": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrack/oncuechange",
-          "support": {
-            "chrome": {
-              "version_added": "23"
-            },
-            "chrome_android": {
-              "version_added": "25"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "31"
-            },
-            "firefox_android": {
-              "version_added": "31"
-            },
-            "ie": {
-              "version_added": "10"
-            },
-            "opera": {
-              "version_added": "≤12.1"
-            },
-            "opera_android": {
-              "version_added": "≤12.1"
-            },
-            "safari": {
-              "version_added": "6"
-            },
-            "safari_ios": {
-              "version_added": "8"
             },
             "samsunginternet_android": {
               "version_added": "1.5"

--- a/api/TextTrackCue.json
+++ b/api/TextTrackCue.json
@@ -100,6 +100,10 @@
       "enter_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackCue/enter_event",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/media.html#event-media-enter",
+            "https://html.spec.whatwg.org/multipage/media.html#handler-texttrackcue-onenter"
+          ],
           "description": "<code>enter</code> event",
           "support": {
             "chrome": {
@@ -149,6 +153,10 @@
       "exit_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackCue/exit_event",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/media.html#event-media-exit",
+            "https://html.spec.whatwg.org/multipage/media.html#handler-texttrackcue-onexit"
+          ],
           "description": "<code>exit</code> event",
           "support": {
             "chrome": {
@@ -199,104 +207,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackCue/id",
           "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-texttrackcue-id",
-          "support": {
-            "chrome": {
-              "version_added": "23"
-            },
-            "chrome_android": {
-              "version_added": "25"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "31"
-            },
-            "firefox_android": {
-              "version_added": "31"
-            },
-            "ie": {
-              "version_added": "10"
-            },
-            "opera": {
-              "version_added": "≤12.1"
-            },
-            "opera_android": {
-              "version_added": "≤12.1"
-            },
-            "safari": {
-              "version_added": "6"
-            },
-            "safari_ios": {
-              "version_added": "7"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.5"
-            },
-            "webview_android": {
-              "version_added": "≤37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onenter": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackCue/onenter",
-          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#handler-texttrackcue-onenter",
-          "support": {
-            "chrome": {
-              "version_added": "23"
-            },
-            "chrome_android": {
-              "version_added": "25"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "31"
-            },
-            "firefox_android": {
-              "version_added": "31"
-            },
-            "ie": {
-              "version_added": "10"
-            },
-            "opera": {
-              "version_added": "≤12.1"
-            },
-            "opera_android": {
-              "version_added": "≤12.1"
-            },
-            "safari": {
-              "version_added": "6"
-            },
-            "safari_ios": {
-              "version_added": "7"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.5"
-            },
-            "webview_android": {
-              "version_added": "≤37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onexit": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackCue/onexit",
-          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#handler-texttrackcue-onexit",
           "support": {
             "chrome": {
               "version_added": "23"

--- a/api/TextTrackList.json
+++ b/api/TextTrackList.json
@@ -51,7 +51,10 @@
       "addtrack_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackList/addtrack_event",
-          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#event-media-addtrack",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/media.html#event-media-addtrack",
+            "https://html.spec.whatwg.org/multipage/media.html#handler-tracklist-onaddtrack"
+          ],
           "description": "<code>addtrack</code> event",
           "support": {
             "chrome": {
@@ -101,7 +104,10 @@
       "change_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackList/change_event",
-          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#event-media-change",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/media.html#event-media-change",
+            "https://html.spec.whatwg.org/multipage/media.html#handler-tracklist-onchange"
+          ],
           "description": "<code>change</code> event",
           "support": {
             "chrome": {
@@ -246,169 +252,13 @@
           }
         }
       },
-      "onaddtrack": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackList/onaddtrack",
-          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#handler-tracklist-onaddtrack",
-          "support": {
-            "chrome": {
-              "version_added": "23"
-            },
-            "chrome_android": {
-              "version_added": "25"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "31"
-            },
-            "firefox_android": {
-              "version_added": "31"
-            },
-            "ie": {
-              "version_added": "11"
-            },
-            "opera": {
-              "version_added": "≤12.1"
-            },
-            "opera_android": {
-              "version_added": "≤12.1"
-            },
-            "safari": {
-              "version_added": "6"
-            },
-            "safari_ios": {
-              "version_added": "7"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.5"
-            },
-            "webview_android": {
-              "version_added": "≤37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onchange": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackList/onchange",
-          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#handler-tracklist-onchange",
-          "support": {
-            "chrome": {
-              "version_added": "33"
-            },
-            "chrome_android": {
-              "version_added": "33"
-            },
-            "edge": {
-              "version_added": "18"
-            },
-            "firefox": {
-              "version_added": "31"
-            },
-            "firefox_android": {
-              "version_added": "31"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "20"
-            },
-            "opera_android": {
-              "version_added": "20"
-            },
-            "safari": {
-              "version_added": "7"
-            },
-            "safari_ios": {
-              "version_added": "7"
-            },
-            "samsunginternet_android": {
-              "version_added": "2.0"
-            },
-            "webview_android": {
-              "version_added": "4.4"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onremovetrack": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackList/onremovetrack",
-          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#handler-tracklist-onremovetrack",
-          "support": {
-            "chrome": {
-              "version_added": "33"
-            },
-            "chrome_android": {
-              "version_added": "33"
-            },
-            "edge": {
-              "version_added": "18"
-            },
-            "firefox": {
-              "version_added": "31"
-            },
-            "firefox_android": {
-              "version_added": "31"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": [
-              {
-                "version_added": "20"
-              },
-              {
-                "version_added": "≤12.1",
-                "version_removed": "15"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "20"
-              },
-              {
-                "version_added": "≤12.1",
-                "version_removed": "14"
-              }
-            ],
-            "safari": {
-              "version_added": "7"
-            },
-            "safari_ios": {
-              "version_added": "7"
-            },
-            "samsunginternet_android": {
-              "version_added": "2.0"
-            },
-            "webview_android": {
-              "version_added": "4.4"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "removetrack_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackList/removetrack_event",
-          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#event-media-removetrack",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/media.html#event-media-removetrack",
+            "https://html.spec.whatwg.org/multipage/media.html#handler-tracklist-onremovetrack"
+          ],
           "description": "<code>removetrack</code> event",
           "support": {
             "chrome": {


### PR DESCRIPTION
Per the new guideline: https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#dom-events-eventname_event

Content work to be done.