### PR TITLE
FF96 Web Lock API supported

### DIFF
--- a/api/Lock.json
+++ b/api/Lock.json
@@ -14,11 +14,24 @@
           "edge": {
             "version_added": "79"
           },
-          "firefox": {
-            "version_added": false
-          },
+          "firefox": [
+            {
+              "version_added": "96"
+            },
+            {
+              "version_added": "93",
+              "version_removed": "96",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.weblocks.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
-            "version_added": false
+            "version_added": "96"
           },
           "ie": {
             "version_added": false
@@ -62,11 +75,24 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "96"
+              },
+              {
+                "version_added": "93",
+                "version_removed": "96",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.weblocks.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "96"
             },
             "ie": {
               "version_added": false
@@ -111,11 +137,24 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "96"
+              },
+              {
+                "version_added": "93",
+                "version_removed": "96",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.weblocks.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "96"
             },
             "ie": {
               "version_added": false

--- a/api/LockManager.json
+++ b/api/LockManager.json
@@ -14,11 +14,24 @@
           "edge": {
             "version_added": "79"
           },
-          "firefox": {
-            "version_added": false
-          },
+          "firefox": [
+            {
+              "version_added": "96"
+            },
+            {
+              "version_added": "93",
+              "version_removed": "96",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.weblocks.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
-            "version_added": false
+            "version_added": "96"
           },
           "ie": {
             "version_added": false
@@ -62,11 +75,24 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "96"
+              },
+              {
+                "version_added": "93",
+                "version_removed": "96",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.weblocks.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "96"
             },
             "ie": {
               "version_added": false
@@ -111,11 +137,24 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "96"
+              },
+              {
+                "version_added": "93",
+                "version_removed": "96",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.weblocks.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "96"
             },
             "ie": {
               "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2044,11 +2044,24 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "96"
+              },
+              {
+                "version_added": "93",
+                "version_removed": "96",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.weblocks.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "96"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
FF96 adds support for web locks API (in this release was done first in Nightly [bug1739233](https://bugzilla.mozilla.org/show_bug.cgi?id=1739233) and then release [bug 1740044](https://bugzilla.mozilla.org/show_bug.cgi?id=1740044).

Further, it seems to have first been implemented in FF93 behind pref ([bug 1725734](https://bugzilla.mozilla.org/show_bug.cgi?id=1725734)). Since android doesn't support preferences, I've indicated support there from FF96.

Associated with docs work in https://github.com/mdn/content/issues/10859