### PR TITLE
FF96 webp supported for Canvas todataurl/blob

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -1333,6 +1333,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "type_webp_parameter": {
+          "__compat": {
+            "description": "<code>type</code> parameter <code>image/webp</code>",
+            "support": {
+              "chrome": {
+                "version_added": "17"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "96"
+              },
+              "firefox_android": {
+                "version_added": "96"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": true
+              },
+              "opera_android": {
+                "version_added": true
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "transferControlToOffscreen": {

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -1284,6 +1284,54 @@
               "deprecated": false
             }
           }
+        },
+        "type_parameter_webp": {
+          "__compat": {
+            "description": "<code>type</code> parameter supports <code>\"image/webp\"</code>",
+            "support": {
+              "chrome": {
+                "version_added": "50"
+              },
+              "chrome_android": {
+                "version_added": "50"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "96"
+              },
+              "firefox_android": {
+                "version_added": "96"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "37"
+              },
+              "opera_android": {
+                "version_added": "37"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "5.0"
+              },
+              "webview_android": {
+                "version_added": "50"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "toDataURL": {

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -1334,9 +1334,9 @@
             "deprecated": false
           }
         },
-        "type_webp_parameter": {
+        "type_parameter_webp": {
           "__compat": {
-            "description": "<code>type</code> parameter <code>image/webp</code>",
+            "description": "<code>type</code> parameter supports <code>\"image/webp\"</code>",
             "support": {
               "chrome": {
                 "version_added": "17"
@@ -1357,22 +1357,22 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true
+                "version_added": "15"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "14"
               },
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": null
+                "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": null
+                "version_added": "1.5"
               },
               "webview_android": {
-                "version_added": null
+                "version_added": "≤37"
               }
             },
             "status": {

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -195,6 +195,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "option_type_parameter_webp": {
+          "__compat": {
+            "description": "<code>option.type</code> parameter supports <code>\"image/webp\"</code>",
+            "support": {
+              "chrome": {
+                "version_added": "69"
+              },
+              "chrome_android": {
+                "version_added": "69"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "96"
+              },
+              "firefox_android": {
+                "version_added": "96"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "56"
+              },
+              "opera_android": {
+                "version_added": "48"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "10.0"
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "getContext": {


### PR DESCRIPTION
FF96 adds support for a webp encoder https://bugzilla.mozilla.org/show_bug.cgi?id=1511670
This can be used in [HTMLCanvasElement.toDataURL()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL), [HTMLCanvasElement.toBlob()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob), [OffscreenCanvas.convertToBlob()](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas/convertToBlob) to output webp.

The spec requires support only for the png format (used by default and as a fallback). Nothing in the spec that says a browser must support any other format. 

**However it is useful to know about what formats are supported. So this PR is a test to see the gods of BCD will allow reporting supported types as a subfeature (and help me update this).** Currently just for toDataUrl. If this approach works would roll out to the other methods. Do not propose to add other supported types like jpg, but that could happen in time.

What I know now.

-Chrome supports webp in toDataUrl , and I think from M17 https://bugs.chromium.org/p/chromium/issues/detail?id=63221 - Note that this is pre-Blink engine, which makes mapping to other versions hard.
- FF96 supports webp
- IE does not.
- Current Opera and Edge do too. However not clear when this would have gone in.
- No idea about the others

For toBlob, I know that support went in for Chrome 50 for the method, by which time webp was supported. So we can assume Blink mappings for the others.

Thoughts?

PS, my test html page for toDataURL support is
```html
<!DOCTYPE html>
<html>
  <head>
    <meta charset="utf-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <title>Canvas - toData</title>
  </head>
  <body>
  <p>Canvas toDataURL</p>
<canvas id="canvas"></canvas>
<script>
lets ctx = canvas.getContext("2d");
ctx.fillStyle = "red";
ctx.fillRect(0, 0, 8, 8);

const webp = canvas.toDataURL("image/webp"); // Chrome only?
const png  = canvas.toDataURL("image/png");
const jpg  = canvas.toDataURL("image/jpeg");

console.log(webp.length, webp); //  263 byte
console.log(png.length, png);   // 1918 byte
console.log(jpg.length, jpg);   // 1938 byte

document.body.appendChild(new Image).src = webp;
document.body.appendChild(new Image).src = png;
document.body.appendChild(new Image).src = jpg;
</script>
  </body>
</html>
```


