### PR TITLE
HTTP Set-Cookie SameSite - add specs

### DIFF
--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -148,6 +148,10 @@
         "SameSite": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
+            "spec_url": [
+              "https://httpwg.org/specs/rfc6265.html#sane-set-cookie",
+              "https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html#name-the-samesite-attribute"
+            ],
             "description": "<code>SameSite</code>",
             "support": {
               "chrome": {


### PR DESCRIPTION
[Set-Cookie > SameSite](http://localhost:5000/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#specifications) has a custom spec table. This adds the data into the compat info following attempt by user to report out of date spec in 
https://github.com/mdn/content/pull/11013

If this goes in, will need to update the page with `{{Specifications}}` macro.

Note failing due to this spec -"https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html#name-the-samesite-attribute" - what's the right approach for this case?