### PR TITLE
IntersectionObserver is not experimental

### DIFF
--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -43,7 +43,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -92,7 +92,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -190,7 +190,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -239,7 +239,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -288,7 +288,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -339,7 +339,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -389,7 +389,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -438,7 +438,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -488,7 +488,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
Most of the methods on [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver) are marked as experimental, but all are supported by multiple browser engines. This removes that tagging.

@ddbeck I'm actually here for some advice on whether I need to record a bug/compatibility issue for this API, and if so how. Specifically, the [`IntersectionObserver` constructor](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver#parameters) can take an option object that specifies a rootmargin. The spec and chrome allow for an empty string to be specified for this option, but until [bug 1738791](https://bugzilla.mozilla.org/show_bug.cgi?id=1738791) was fixed in FF96 Firefox raised an exception.

Does this need to be recorded. If so, what's the best way?

