### PR TITLE
Add Math __compat feature; sort

### DIFF
--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -2,65 +2,63 @@
   "javascript": {
     "builtins": {
       "Math": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math",
+          "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math-object",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "3"
+            },
+            "nodejs": {
+              "version_added": "0.10.0"
+            },
+            "opera": {
+              "version_added": "3"
+            },
+            "opera_android": {
+              "version_added": "10.1"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "E": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/E",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.e",
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "deno": {
-                "version_added": "1.0"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
-              "ie": {
-                "version_added": "3"
-              },
-              "nodejs": {
-                "version_added": "0.10.0"
-              },
-              "opera": {
-                "version_added": "3"
-              },
-              "opera_android": {
-                "version_added": "10.1"
-              },
-              "safari": {
-                "version_added": "1"
-              },
-              "safari_ios": {
-                "version_added": "1"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0"
-              },
-              "webview_android": {
-                "version_added": "1"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "LN2": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/LN2",
-            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.ln2",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -167,10 +165,10 @@
             }
           }
         },
-        "LOG2E": {
+        "LN2": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/LOG2E",
-            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.log2e",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/LN2",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.ln2",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -226,6 +224,61 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/LOG10E",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.log10e",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "deno": {
+                "version_added": "1.0"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "3"
+              },
+              "nodejs": {
+                "version_added": "0.10.0"
+              },
+              "opera": {
+                "version_added": "3"
+              },
+              "opera_android": {
+                "version_added": "10.1"
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": "1"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": "1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "LOG2E": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/LOG2E",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.log2e",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1542,6 +1595,61 @@
             }
           }
         },
+        "log10": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/log10",
+            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.log10",
+            "support": {
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": {
+                "version_added": "38"
+              },
+              "deno": {
+                "version_added": "1.0"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "25"
+              },
+              "firefox_android": {
+                "version_added": "25"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "0.12.0"
+              },
+              "opera": {
+                "version_added": "25"
+              },
+              "opera_android": {
+                "version_added": "25"
+              },
+              "safari": {
+                "version_added": "8"
+              },
+              "safari_ios": {
+                "version_added": "8"
+              },
+              "samsunginternet_android": {
+                "version_added": "3.0"
+              },
+              "webview_android": {
+                "version_added": "38"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "log1p": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/log1p",
@@ -1601,61 +1709,6 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/log2",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.log2",
-            "support": {
-              "chrome": {
-                "version_added": "38"
-              },
-              "chrome_android": {
-                "version_added": "38"
-              },
-              "deno": {
-                "version_added": "1.0"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "25"
-              },
-              "firefox_android": {
-                "version_added": "25"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": "0.12.0"
-              },
-              "opera": {
-                "version_added": "25"
-              },
-              "opera_android": {
-                "version_added": "25"
-              },
-              "safari": {
-                "version_added": "8"
-              },
-              "safari_ios": {
-                "version_added": "8"
-              },
-              "samsunginternet_android": {
-                "version_added": "3.0"
-              },
-              "webview_android": {
-                "version_added": "38"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "log10": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/log10",
-            "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.log10",
             "support": {
               "chrome": {
                 "version_added": "38"


### PR DESCRIPTION
Adds a top-level __compat feature for Math per https://github.com/mdn/browser-compat-data/issues/13804.

Also sorts the entries (not sure why it complains about this now)