### PR TITLE
Fix a deprecation notice

### DIFF
--- a/scripts/release-build.js
+++ b/scripts/release-build.js
@@ -72,7 +72,7 @@ async function writeManifest() {
 async function main() {
   // Remove existing files, if there are any
   await fs
-    .rmdir(directory, {
+    .rm(directory, {
       force: true,
       recursive: true,
     })


### PR DESCRIPTION
Just a nit. Saw the following when running tests and thought I could fix this real quick.


  release-build
(node:92401) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)