### PR TITLE
Updates opera browser to version 82

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -622,19 +622,26 @@
         "81": {
           "release_date": "2021-11-04",
           "release_notes": "https://blogs.opera.com/desktop/2021/11/opera-81-stable/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "95"
         },
         "82": {
-          "status": "beta",
+          "release_date": "2021-12-02",
+          "release_notes": "https://blogs.opera.com/desktop/2021/12/opera-82/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "96"
         },
         "83": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "97"
+        },
+        "84": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "98"
         }
       }
     }


### PR DESCRIPTION
Hello!

According to these [release notes](https://blogs.opera.com/desktop/2021/12/opera-82/), Opera has been updated to version 82.

:)