### PR TITLE
Add nodejs compatibility for fetch api

### DIFF
--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -27,6 +27,9 @@
           "ie": {
             "version_added": false
           },
+          "nodejs": {
+            "version_added": false
+          },
           "opera": {
             "version_added": "29"
           },
@@ -75,6 +78,9 @@
               "version_added": "39"
             },
             "ie": {
+              "version_added": false
+            },
+            "nodejs": {
               "version_added": false
             },
             "opera": {
@@ -128,6 +134,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "39"
             },
@@ -177,6 +186,9 @@
               "version_added": "57"
             },
             "ie": {
+              "version_added": false
+            },
+            "nodejs": {
               "version_added": false
             },
             "opera": {
@@ -236,6 +248,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "29"
             },
@@ -285,6 +300,9 @@
               "version_added": "39"
             },
             "ie": {
+              "version_added": false
+            },
+            "nodejs": {
               "version_added": false
             },
             "opera": {


### PR DESCRIPTION


#### Summary
fetch API does not exist in nodejs and instead has to use libraries such as [node-fetch](https://www.npmjs.com/package/node-fetch) in order to achieve the same result. 

This adds nodejs non-compatibility to reflect this on the MDN page.

#### Test results and supporting details
Ran `npm test` without issue

#### Related issues
https://github.com/mdn/browser-compat-data/issues/12942

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
