### PR TITLE
TaskSignal: onprioritychange -> prioritychange_event

### DIFF
--- a/api/TaskSignal.json
+++ b/api/TaskSignal.json
@@ -47,9 +47,9 @@
           "deprecated": false
         }
       },
-      "onprioritychange": {
+      "priority": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/scheduling-apis/#dom-tasksignal-onprioritychange",
+          "spec_url": "https://wicg.github.io/scheduling-apis/#dom-tasksignal-priority",
           "support": {
             "chrome": {
               "version_added": "94"
@@ -95,9 +95,13 @@
           }
         }
       },
-      "priority": {
+      "prioritychange_event": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/scheduling-apis/#dom-tasksignal-priority",
+          "description": "<code>prioritychange</code> event",
+          "spec_url": [
+            "https://wicg.github.io/scheduling-apis/#ref-for-eventdef-tasksignal-prioritychange",
+            "https://wicg.github.io/scheduling-apis/#dom-tasksignal-onprioritychange"
+          ],
           "support": {
             "chrome": {
               "version_added": "94"


### PR DESCRIPTION
Update per new events guideline.

No content update needed because the docs aren't written yet.