### PR TITLE
HTTP Warning Header is deprecated

### DIFF
--- a/http/headers/warning.json
+++ b/http/headers/warning.json
@@ -46,7 +46,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
Supporting information is here:
- https://github.com/httpwg/http-core/issues/139
- https://github.com/whatwg/fetch/issues/913

This came up as part of reviewing https://github.com/mdn/content/pull/11079