### PR TITLE
Unmark `env()` as experimental

### DIFF
--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -108,7 +108,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
`env()` is no longer experimental this updates the data to reflect that.