### PR TITLE
An array of cookieStoreId supported in the tabs.query API

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -3660,9 +3660,15 @@
                   "edge": {
                     "version_added": false
                   },
-                  "firefox": {
-                    "version_added": "52"
-                  },
+                  "firefox": [
+                    {
+                      "version_added": "52"
+                    },
+                    {
+                      "notes": "Where <code>cookieStoreId</code>s are associated with the tab, returns an array of strings.",
+                      "version_added": "97"
+                    }
+                  ],
                   "firefox_android": {
                     "version_added": false
                   },

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -3665,7 +3665,7 @@
                       "version_added": "52"
                     },
                     {
-                      "notes": "Where <code>cookieStoreId</code>s are associated with the tab, returns an array of strings.",
+                      "notes": "Supports an array of strings to return tabs associated with any of the list of <code>cookieStoreId</code>s.",
                       "version_added": "97"
                     }
                   ],


### PR DESCRIPTION
#### Summary
Added information about the support for an array of `cookieStoreId` in the `tabs.query` API.

#### Test results and supporting details
`npm test`  found no errors.

#### Related issues
Addresses documentation requirements of [Bug 1730931](https://bugzilla.mozilla.org/show_bug.cgi?id=1730931) Supporting an array of cookieStoreId in the tabs.query API.

Supporting MDN documentation updates made in An array of cookieStoreId supported in the tabs.query API [#11123 ](https://github.com/mdn/content/pull/11123)


