### PR TITLE
Require real values for Samsung Internet for api/

### DIFF
--- a/test/linter/test-real-values.js
+++ b/test/linter/test-real-values.js
@@ -36,6 +36,7 @@ const blockList = {
     'ie',
     'safari',
     'safari_ios',
+    'samsunginternet_android',
     'webview_android',
   ],
   css: blockMany,


### PR DESCRIPTION
We no longer have any nonreal values for Samsung Internet for the API folder -- let's keep it that way!
