### PR TITLE
HTTP Clear-Site-Data cache is behind pref

### DIFF
--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -66,7 +66,6 @@
               "firefox": [
                 {
                   "version_added": "94",
-                  "partial_implementation": true,
                   "flags": [
                     {
                       "type": "preference",
@@ -77,14 +76,12 @@
                 },
                 {
                   "version_added": "63",
-                  "version_removed": "94",
-                  "partial_implementation": true
+                  "version_removed": "94"
                 }
               ],
               "firefox_android": {
                 "version_added": "63",
-                "version_removed": "94",
-                "partial_implementation": true
+                "version_removed": "94"
               },
               "ie": {
                 "version_added": false

--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -70,7 +70,7 @@
                   "flags": [
                     {
                       "type": "preference",
-                      "name": "#privacy.clearsitedata.cache.enabled",
+                      "name": "privacy.clearsitedata.cache.enabled",
                       "value_to_set": "true"
                     }
                   ]

--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -63,11 +63,28 @@
               "edge": {
                 "version_added": "≤79"
               },
-              "firefox": {
-                "version_added": "63"
-              },
+              "firefox": [
+                {
+                  "version_added": "94",
+                  "partial_implementation": true,
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#privacy.clearsitedata.cache.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "63",
+                  "version_removed": "94",
+                  "partial_implementation": true
+                }
+              ],
               "firefox_android": {
-                "version_added": "63"
+                "version_added": "63",
+                "version_removed": "94",
+                "partial_implementation": true
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
Fixes #13942

The `cache` was removed behind a pref in FF94: https://bugzilla.mozilla.org/show_bug.cgi?id=1671182

The fix marks versions support as partial. It also removes the old version and adds a (partial) support behind a pref for FF94.
Note that the reasons why support is partial were not detailed so I have not added notes about that. Might reasonably add bug link if you wished?