### PR TITLE
FF96 supports ElementInternals:willValidate

### DIFF
--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -573,10 +573,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "96"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "96"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
[ElementInternals.willValidate](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/willValidate)  supported from FF96 - as per https://bugzilla.mozilla.org/show_bug.cgi?id=1556365

Other docs work can be tracked in https://github.com/mdn/content/issues/10851
