### PR TITLE
FF96 ElementInternals.willValidate behind preference

### DIFF
--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -573,10 +573,17 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "96"
+              "version_added": "96",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webcomponents.formAssociatedCustomElement.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": "96"
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Fixes #13976

[Late breaking news](https://github.com/mdn/content/pull/11165#issuecomment-992257770) is that this API is behind a preference. I've added the preference for FF96 desktop, and set FF96 android to false as per normal policy (since it has no flag setting API on releases other than nightly).