### PR TITLE
Change values for Opera for KeyboardEvent to ranges

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -24,10 +24,10 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": "12.1"
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": "12.1"
+            "version_added": "≤12.1"
           },
           "safari": {
             "version_added": "1.2"


### PR DESCRIPTION
This PR is just a quick update to turn the values for the `KeyboardEvent` API into ranges as opposed to just being set to "12.1". It doesn't make much sense for a feature as old as this to not be present in Opera earlier than 12.1.
