### PR TITLE
HTTP Sec-Ch-UA-Bitness header in Chrome 93

### DIFF
--- a/http/headers/sec-ch-ua-bitness.json
+++ b/http/headers/sec-ch-ua-bitness.json
@@ -1,0 +1,56 @@
+{
+  "http": {
+    "headers": {
+      "Sec-CH-UA-Bitness": {
+        "__compat": {
+          "description": "<code>Sec-CH-UA-Bitness</code> request header",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-CH-UA-Bitness",
+          "spec_url": "https://wicg.github.io/ua-client-hints/#sec-ch-ua-bitness",
+          "support": {
+            "chrome": {
+              "version_added": "93"
+            },
+            "chrome_android": {
+              "version_added": "93"
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "79"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "93"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The header is in the spec, and has an implementation in from Chrome 93. I couldn't find an announcement of that version, but it is live on my local version and browserstack testing indicates first version it went in was 93. There is no corresponding opera on android or samsunginternet version released yet.

Note it is mentioned as planned for delivery in https://chromestatus.com/feature/5733498725859328





