### PR TITLE
HTTP Sec-CH-UA-Full-Version header deprecated

### DIFF
--- a/http/headers/sec-ch-ua-full-version.json
+++ b/http/headers/sec-ch-ua-full-version.json
@@ -47,7 +47,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
`Sec-CH-UA-Full-Version` header is deprecated; replaced by `Sec-CH-UA-Full-Version-List`. See spec here: https://wicg.github.io/ua-client-hints/#sec-ch-ua-full-version

It is still supported by Chrome.