### PR TITLE
Add Opera versions for FileSystemDirectoryEntry API

### DIFF
--- a/api/FileSystemDirectoryEntry.json
+++ b/api/FileSystemDirectoryEntry.json
@@ -27,7 +27,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true,
+            "version_added": "15",
             "prefix": "webkit"
           },
           "opera_android": {


### PR DESCRIPTION
This PR adds real values for Opera and Opera Android for the `FileSystemDirectoryEntry` API by mirroring the data.
