### PR TITLE
Add Opera versions for FileSystemDirectoryReader API

### DIFF
--- a/api/FileSystemDirectoryReader.json
+++ b/api/FileSystemDirectoryReader.json
@@ -27,7 +27,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": true,
+            "version_added": "15",
             "prefix": "webkit"
           },
           "opera_android": {
@@ -78,7 +78,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": null
+              "version_added": "15"
             },
             "opera_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Opera and Opera Android for the `FileSystemDirectoryReader` API by mirroring the data.
