### PR TITLE
Add Firefox versions for api.GlobalEventHandlers.ontouch*

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -4768,7 +4768,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": false
@@ -4817,7 +4817,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": false
@@ -4866,7 +4866,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": false
@@ -4915,7 +4915,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "6"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `ontouch*` members of the `GlobalEventHandlers` API, based upon information in a tracking bug.

Tracking Bug: https://bugzil.la/648573
