### PR TITLE
Add Firefox versions for api.TouchEvent.TouchEvent

### DIFF
--- a/api/TouchEvent.json
+++ b/api/TouchEvent.json
@@ -90,7 +90,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "46"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `TouchEvent` member of the `TouchEvent` API, based upon information in a tracking bug.

Tracking Bug: https://bugzil.la/1234656
