### PR TITLE
Add Firefox versions for api.HTMLInputElement.capture

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -253,7 +253,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "79"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `capture` member of the `HTMLInputElement` API, based upon information in a tracking bug.

Tracking Bug: https://bugzil.la/1553603
