### PR TITLE
Add Firefox versions for NetworkInformation API

### DIFF
--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -69,7 +69,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -172,7 +172,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -376,7 +376,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `NetworkInformation` API, based upon commit history and date.

Commit: https://github.com/mozilla/gecko-dev/blob/master/dom/webidl/NetworkInformation.webidl
