### PR TITLE
Add Firefox versions for RelativeOrientationSensor API

### DIFF
--- a/api/RelativeOrientationSensor.json
+++ b/api/RelativeOrientationSensor.json
@@ -17,6 +17,9 @@
           "firefox": {
             "version_added": false
           },
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },
@@ -61,6 +64,9 @@
               "version_added": "79"
             },
             "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
               "version_added": false
             },
             "ie": {


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `RelativeOrientationSensor` API by mirroring the data.
