### PR TITLE
Add Firefox versions for api.Window.orientation

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -4753,7 +4753,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "ie": {
               "version_added": false
@@ -5686,7 +5686,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "44"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `orientation` member of the `Window` API, based upon information in a tracking bug.

Tracking Bug: https://bugzil.la/920734
