### PR TITLE
Add Firefox versions for api.Screen.onorientationchange

### DIFF
--- a/api/Screen.json
+++ b/api/Screen.json
@@ -590,7 +590,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": true,
+              "version_added": "14",
               "alternative_name": "onmozorientationchange"
             },
             "ie": {


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `onorientationchange` member of the `Screen` API, based upon information in a tracking bug.

Tracking Bug: https://bugzil.la/720794
