### PR TITLE
Require real values for Opera for api/

### DIFF
--- a/test/linter/test-real-values.js
+++ b/test/linter/test-real-values.js
@@ -34,6 +34,8 @@ const blockList = {
     'edge',
     'firefox',
     'ie',
+    'opera',
+    'opera_android',
     'safari',
     'safari_ios',
     'samsunginternet_android',


### PR DESCRIPTION
After this, only one more browser (Firefox Android) before we can use `blockMany`!
