### PR TITLE
Set Safari 15.2 as current

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -179,14 +179,15 @@
         },
         "15.1": {
           "release_date": "2021-10-25",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "612.2.9"
         },
         "15.2": {
-          "status": "beta",
+          "release_date": "2021-12-13",
+          "status": "current",
           "engine": "WebKit",
-          "engine_version": "612.3.2"
+          "engine_version": "612.3.6"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -150,14 +150,15 @@
         },
         "15.1": {
           "release_date": "2021-10-25",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "612.2.9"
         },
         "15.2": {
-          "status": "beta",
+          "release_date": "2021-12-13",
+          "status": "current",
           "engine": "WebKit",
-          "engine_version": "612.3.2"
+          "engine_version": "612.3.6"
         }
       }
     }

--- a/http/headers/cross-origin-embedder-policy.json
+++ b/http/headers/cross-origin-embedder-policy.json
@@ -31,7 +31,7 @@
               "version_added": "59"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.2"
             },
             "safari_ios": {
               "version_added": false

--- a/http/headers/cross-origin-opener-policy.json
+++ b/http/headers/cross-origin-opener-policy.json
@@ -55,7 +55,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.2"
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Safari 15.2 has been released this PR sets it as current

Also marked COOP and COEP as supported.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

![image](https://user-images.githubusercontent.com/32498324/146016692-1e345a2f-44cf-4a99-ad32-f24f5e15cf95.png)

COOP and COEP are enabled as can be seen in the below image

![image](https://user-images.githubusercontent.com/32498324/146022056-a7a86c7c-bf84-4b40-a29f-967af75c3d07.png)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
