### PR TITLE
Correct iOS support for asyncIterator

### DIFF
--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -151,7 +151,7 @@
                 "version_added": "11.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "11.3"
               },
               "samsunginternet_android": {
                 "version_added": "8.0"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Corrects iOS support for async iterator.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Copies existing data from javascript/builtins/AsyncIterator.json

https://kangax.github.io/compat-table/es2016plus/#test-Asynchronous_Iterators - also shows that iOS safari supports this.
