### PR TITLE
Update Chromium versions for api.WorkerGlobalScope.ononlineoffline

### DIFF
--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -472,16 +472,16 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/workers.html#handler-workerglobalscope-onoffline",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "40"
+              "version_added": false
             },
             "deno": {
               "version_added": false
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": false
             },
             "firefox": {
               "version_added": "29"
@@ -493,10 +493,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "15"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "27"
+              "version_added": false
             },
             "safari": {
               "version_added": "8"
@@ -505,10 +505,10 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "40"
+              "version_added": false
             }
           },
           "status": {
@@ -524,16 +524,16 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/workers.html#handler-workerglobalscope-ononline",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "40"
+              "version_added": false
             },
             "deno": {
               "version_added": false
             },
             "edge": {
-              "version_added": "≤79"
+              "version_added": false
             },
             "firefox": {
               "version_added": "29"
@@ -545,10 +545,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "15"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "27"
+              "version_added": false
             },
             "safari": {
               "version_added": "8"
@@ -557,10 +557,10 @@
               "version_added": "8"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "40"
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `ononline` and `onoffline` members of the `WorkerGlobalScope` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WorkerGlobalScope/ononlineoffline

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._

Note: this lack of support is backed by the fact that these two event handlers are commented out in Chrome's source code, see https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/workers/worker_global_scope.idl;l=40-41;drc=6ae6a462afcd3e740d18cbcd8abff9d8a55d4233
