### PR TITLE
Update Edge versions for SVGAElement API

### DIFF
--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -153,8 +153,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "≤18",
-              "version_removed": "79"
+              "version_added": false
             },
             "firefox": {
               "version_added": "61"
@@ -295,8 +294,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "≤18",
-              "version_removed": "79"
+              "version_added": false
             },
             "firefox": {
               "version_added": "61"
@@ -343,8 +341,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "≤18",
-              "version_removed": "79"
+              "version_added": false
             },
             "firefox": {
               "version_added": "61"
@@ -440,8 +437,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "≤18",
-              "version_removed": "79"
+              "version_added": false
             },
             "firefox": {
               "version_added": "61"
@@ -488,8 +484,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "≤18",
-              "version_removed": "79"
+              "version_added": false
             },
             "firefox": {
               "version_added": "61"


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `SVGAElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGAElement

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
