### PR TITLE
Update Edge versions for SVGMPathElement API

### DIFF
--- a/api/SVGMPathElement.json
+++ b/api/SVGMPathElement.json
@@ -12,7 +12,7 @@
             "version_added": "25"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "4"


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `SVGMPathElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGMPathElement

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
