### PR TITLE
Update IE/Edge versions for Screen API

### DIFF
--- a/api/Screen.json
+++ b/api/Screen.json
@@ -581,7 +581,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "≤18",
+              "version_added": "12",
               "alternative_name": "onmsorientationchange",
               "version_removed": "79"
             },

--- a/api/Screen.json
+++ b/api/Screen.json
@@ -357,8 +357,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "≤18",
-              "version_removed": "79"
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"
@@ -594,7 +593,8 @@
               "alternative_name": "onmozorientationchange"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11",
+              "alternative_name": "onmsorientationchange"
             },
             "opera": {
               "version_added": false
@@ -756,8 +756,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "≤18",
-              "version_removed": "79"
+              "version_added": false
             },
             "firefox": {
               "version_added": "1"


### PR DESCRIPTION
This PR updates and corrects the real values for Internet Explorer and Edge for the `Screen` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Screen

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
