### PR TITLE
Update Edge versions for api.Text.assignedSlot

### DIFF
--- a/api/Text.json
+++ b/api/Text.json
@@ -110,7 +110,7 @@
               "version_added": "53"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "63"


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `assignedSlot` member of the `Text` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Text/assignedSlot

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
