### PR TITLE
Add IE/Edge versions for api.Document.copy_event

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -1750,7 +1750,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "6"
@@ -1759,7 +1759,7 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
             "opera": {
               "version_added": "15"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `copy_event` member of the `Document` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<p>Copy me!</p>
</div>

<script>
	document.addEventListener('copy', function() {
		alert('Copied!');
	});
</script>
```
