### PR TITLE
Add IE/Edge versions for api.Document.cut_event

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -2987,7 +2987,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "6"
@@ -2996,7 +2996,7 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
             "opera": {
               "version_added": "15"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `cut_event` member of the `Document` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<input value="Cut me!" />
</div>

<script>
	document.addEventListener('cut', function() {
		alert('Cut!');
	});
</script>
```
