### PR TITLE
Add IE/Edge versions for api.Window.copy_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1484,7 +1484,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "6"
@@ -1493,7 +1493,7 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
             "opera": {
               "version_added": "15"


### PR DESCRIPTION
This PR adds real values for Internet Explorer and Edge for the `copy_event` member of the `Window` API, based upon manual testing.

Test Code Used:
```html
<div id="test">
	<input value="Copy me!" />
</div>

<script>
	window.addEventListener('copy', function() {
		alert('Copied!');
	});
</script>
```
