### PR TITLE
Add Edge versions for SpeechSynthesis API

### DIFF
--- a/api/SpeechSynthesis.json
+++ b/api/SpeechSynthesis.json
@@ -12,7 +12,7 @@
             "version_added": "33"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "14"
           },
           "firefox": {
             "version_added": "49"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `SpeechSynthesis` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SpeechSynthesis

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
