### PR TITLE
Add Edge versions for OES_texture_half_float_linear API

### DIFF
--- a/api/OES_texture_half_float_linear.json
+++ b/api/OES_texture_half_float_linear.json
@@ -12,7 +12,7 @@
             "version_added": "29"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "14"
           },
           "firefox": {
             "version_added": "30"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `OES_texture_half_float_linear` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/OES_texture_half_float_linear

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
