### PR TITLE
Include Safari 15.2 release notes

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -185,6 +185,7 @@
         },
         "15.2": {
           "release_date": "2021-12-13",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15_2-release-notes",
           "status": "current",
           "engine": "WebKit",
           "engine_version": "612.3.6"

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -156,6 +156,7 @@
         },
         "15.2": {
           "release_date": "2021-12-13",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15_2-release-notes",
           "status": "current",
           "engine": "WebKit",
           "engine_version": "612.3.6"


### PR DESCRIPTION
Hello everyone, everything good?

Safari version 15.2 has [release notes](https://developer.apple.com/documentation/safari-release-notes/safari-15_2-release-notes).

Included in this pull request.