### PR TITLE
Add Edge versions for api.Window.requestFileSystem

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -6810,7 +6810,7 @@
               "prefix": "webkit"
             },
             "edge": {
-              "version_added": "≤18",
+              "version_added": "79",
               "prefix": "webkit"
             },
             "firefox": {


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `requestFileSystem` member of the `Window` API, based upon manual testing.

Test Code Used: `window.webkitRequestFileSystem || window.requestFileSystem;`
