### PR TITLE
Correct Safari support for background-clip

### DIFF
--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -82,16 +82,26 @@
                 "notes": "Opera accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
-            "safari": {
-              "version_added": "3",
-              "prefix": "-webkit-",
-              "notes": "Safari accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
-            },
-            "safari_ios": {
-              "version_added": "1",
-              "prefix": "-webkit-",
-              "notes": "Safari accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
-            },
+            "safari": [
+              {
+                "version_added": "14"
+              },
+              {
+                "version_added": "3",
+                "prefix": "-webkit-",
+                "notes": "Safari accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14"
+              },
+              {
+                "version_added": "1",
+                "prefix": "-webkit-",
+                "notes": "Safari accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "1.0"
@@ -225,22 +235,32 @@
                   "According to the <a href='https://webkit.org/blog/164/background-clip-text/'>WebKit blog</a>, text decorations or shadows are not included in the clipping."
                 ]
               },
-              "safari": {
-                "version_added": "4",
-                "partial_implementation": true,
-                "notes": [
-                  "This value is supported with the prefixed version of the property only.",
-                  "According to the <a href='https://webkit.org/blog/164/background-clip-text/'>WebKit blog</a>, text decorations or shadows are not included in the clipping."
-                ]
-              },
-              "safari_ios": {
-                "version_added": "3.2",
-                "partial_implementation": true,
-                "notes": [
-                  "This value is supported with the prefixed version of the property only.",
-                  "According to the <a href='https://webkit.org/blog/164/background-clip-text/'>WebKit blog</a>, text decorations or shadows are not included in the clipping."
-                ]
-              },
+              "safari": [
+                {
+                  "version_added": "14"
+                },
+                {
+                  "version_added": "4",
+                  "partial_implementation": true,
+                  "notes": [
+                    "This value is supported with the prefixed version of the property only.",
+                    "According to the <a href='https://webkit.org/blog/164/background-clip-text/'>WebKit blog</a>, text decorations or shadows are not included in the clipping."
+                  ]
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "14"
+                },
+                {
+                  "version_added": "3.2",
+                  "partial_implementation": true,
+                  "notes": [
+                    "This value is supported with the prefixed version of the property only.",
+                    "According to the <a href='https://webkit.org/blog/164/background-clip-text/'>WebKit blog</a>, text decorations or shadows are not included in the clipping."
+                  ]
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": "1.0",
                 "partial_implementation": true,


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

This PR updates Safari support data for the background-clip property to show it's supported as of Safari 14.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Based on issue it definitely wasn't supported before Safari 14. And definitely was from at least Safari 14.1. 

I have verified it works on iOS 14.5 and Safari 15.2 personally.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/13977
