### PR TITLE
Add Edge versions for WebVR APIs

### DIFF
--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -23,7 +23,7 @@
             ]
           },
           "edge": {
-            "version_added": "≤18",
+            "version_added": "15",
             "version_removed": "79"
           },
           "firefox": [

--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -23,7 +23,7 @@
             ]
           },
           "edge": {
-            "version_added": "≤18",
+            "version_added": "15",
             "version_removed": "79"
           },
           "firefox": [

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -23,7 +23,7 @@
             ]
           },
           "edge": {
-            "version_added": "≤18",
+            "version_added": "15",
             "version_removed": "79"
           },
           "firefox": [
@@ -92,7 +92,7 @@
               ]
             },
             "edge": {
-              "version_added": "≤18",
+              "version_added": "15",
               "version_removed": "79"
             },
             "firefox": [

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -23,7 +23,7 @@
             ]
           },
           "edge": {
-            "version_added": "≤18",
+            "version_added": "15",
             "version_removed": "79"
           },
           "firefox": [

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -23,7 +23,7 @@
             ]
           },
           "edge": {
-            "version_added": "≤18",
+            "version_added": "15",
             "version_removed": "79"
           },
           "firefox": [

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -23,7 +23,7 @@
             ]
           },
           "edge": {
-            "version_added": "≤18",
+            "version_added": "15",
             "version_removed": "79"
           },
           "firefox": [
@@ -92,7 +92,7 @@
               ]
             },
             "edge": {
-              "version_added": "≤18",
+              "version_added": "15",
               "version_removed": "79"
             },
             "firefox": [

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -23,7 +23,7 @@
             ]
           },
           "edge": {
-            "version_added": "≤18",
+            "version_added": "15",
             "version_removed": "79"
           },
           "firefox": [

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -23,7 +23,7 @@
             ]
           },
           "edge": {
-            "version_added": "≤18",
+            "version_added": "15",
             "version_removed": "79"
           },
           "firefox": [
@@ -91,7 +91,7 @@
               ]
             },
             "edge": {
-              "version_added": "≤18",
+              "version_added": "15",
               "version_removed": "79"
             },
             "firefox": [
@@ -160,7 +160,7 @@
               ]
             },
             "edge": {
-              "version_added": "≤18",
+              "version_added": "15",
               "version_removed": "79"
             },
             "firefox": [
@@ -229,7 +229,7 @@
               ]
             },
             "edge": {
-              "version_added": "≤18",
+              "version_added": "15",
               "version_removed": "79"
             },
             "firefox": [


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the WebVR APIs, based upon manual testing.  Testing was simple: just checking if `VRDisplay` (or whatever API) is in `self` in the browser console.  This data matches with existing data for WebVR features.
