### PR TITLE
Conform gamepad Window events to new style; update Chromium versions

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -2338,10 +2338,7 @@
       "gamepadconnected_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/gamepadconnected_event",
-          "spec_url": [
-            "https://w3c.github.io/gamepad/#the-gamepadconnected-event",
-            "https://w3c.github.io/gamepad/#event-gamepadconnected"
-          ],
+          "spec_url": "https://w3c.github.io/gamepad/#event-gamepadconnected",
           "description": "<code>gamepadconnected</code> event",
           "support": {
             "chrome": {
@@ -2405,16 +2402,13 @@
       "gamepaddisconnected_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/gamepaddisconnected_event",
-          "spec_url": [
-            "https://w3c.github.io/gamepad/#the-gamepaddisconnected-event",
-            "https://w3c.github.io/gamepad/#event-gamepaddisconnected"
-          ],
+          "spec_url": "https://w3c.github.io/gamepad/#event-gamepaddisconnected",
           "description": "<code>gamepaddisconnected</code> event",
           "support": {
             "chrome": {
               "version_added": "35",
               "partial_implementation": true,
-              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
+              "notes": "The event handler property (<code>ongamepaddisconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "chrome_android": {
               "version_added": "37",

--- a/api/Window.json
+++ b/api/Window.json
@@ -2413,12 +2413,12 @@
             "chrome_android": {
               "version_added": "37",
               "partial_implementation": true,
-              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
+              "notes": "The event handler property (<code>ongamepaddisconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "edge": {
               "version_added": "≤18",
               "partial_implementation": true,
-              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
+              "notes": "The event handler property (<code>ongamepaddisconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "firefox": {
               "version_added": "29"
@@ -2432,12 +2432,12 @@
             "opera": {
               "version_added": "22",
               "partial_implementation": true,
-              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
+              "notes": "The event handler property (<code>ongamepaddisconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "opera_android": {
               "version_added": "24",
               "partial_implementation": true,
-              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
+              "notes": "The event handler property (<code>ongamepaddisconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "safari": {
               "version_added": "10.1"
@@ -2448,12 +2448,12 @@
             "samsunginternet_android": {
               "version_added": "3.0",
               "partial_implementation": true,
-              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
+              "notes": "The event handler property (<code>ongamepaddisconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "webview_android": {
               "version_added": "37",
               "partial_implementation": true,
-              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
+              "notes": "The event handler property (<code>ongamepaddisconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -2349,7 +2349,6 @@
               "partial_implementation": true,
               "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
-
             "chrome_android": {
               "version_added": "37",
               "partial_implementation": true,
@@ -2374,7 +2373,6 @@
               "partial_implementation": true,
               "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
-
             "opera_android": {
               "version_added": "24",
               "partial_implementation": true,
@@ -2418,7 +2416,6 @@
               "partial_implementation": true,
               "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
-
             "chrome_android": {
               "version_added": "37",
               "partial_implementation": true,
@@ -2443,7 +2440,6 @@
               "partial_implementation": true,
               "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
-
             "opera_android": {
               "version_added": "24",
               "partial_implementation": true,

--- a/api/Window.json
+++ b/api/Window.json
@@ -4358,28 +4358,17 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/ongamepadconnected",
           "spec_url": "https://w3c.github.io/gamepad/#event-gamepadconnected",
           "support": {
-            "chrome": [
-              {
-                "version_added": "35"
-              },
-              {
-                "version_added": "21",
-                "version_removed": "35",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "35"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "35",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": false,
+              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
+            },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
             },
             "firefox": {
               "version_added": "29"
@@ -4390,42 +4379,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "version_removed": "22",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "version_removed": "22",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": false,
+              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
+            },
             "safari": {
               "version_added": "10.1"
             },
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "3.0"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "1.5",
-                "version_removed": "3.0"
-              }
-            ],
+            "samsunginternet_android": {
+              "version_added": false,
+              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
+            },
             "webview_android": {
               "version_added": false
             }
@@ -4441,24 +4412,10 @@
             "description": "Secure context required",
             "support": {
               "chrome": {
-                "version_added": "86",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#restrict-gamepad-access",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": "86",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#restrict-gamepad-access",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "edge": {
                 "version_added": false
@@ -4473,24 +4430,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "72",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#restrict-gamepad-access",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "opera_android": {
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#restrict-gamepad-access",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "safari": {
                 "version_added": false
@@ -4518,28 +4461,17 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/ongamepaddisconnected",
           "spec_url": "https://w3c.github.io/gamepad/#event-gamepaddisconnected",
           "support": {
-            "chrome": [
-              {
-                "version_added": "35"
-              },
-              {
-                "version_added": "21",
-                "version_removed": "35",
-                "prefix": "webkit"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "35"
-              },
-              {
-                "version_added": "25",
-                "version_removed": "35",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": false,
+              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
+            },
+            "chrome_android": {
+              "version_added": false,
+              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
+            },
             "edge": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
             },
             "firefox": {
               "version_added": "29"
@@ -4550,42 +4482,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "15",
-                "version_removed": "22",
-                "prefix": "webkit"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "22"
-              },
-              {
-                "version_added": "14",
-                "version_removed": "22",
-                "prefix": "webkit"
-              }
-            ],
+            "opera": {
+              "version_added": false,
+              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
+            },
             "safari": {
               "version_added": "10.1"
             },
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "3.0"
-              },
-              {
-                "prefix": "webkit",
-                "version_added": "1.5",
-                "version_removed": "3.0"
-              }
-            ],
+            "samsunginternet_android": {
+              "version_added": false,
+              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
+            },
             "webview_android": {
               "version_added": false
             }
@@ -4601,24 +4515,10 @@
             "description": "Secure context required",
             "support": {
               "chrome": {
-                "version_added": "86",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#restrict-gamepad-access",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": "86",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#restrict-gamepad-access",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "edge": {
                 "version_added": false
@@ -4633,24 +4533,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "72",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#restrict-gamepad-access",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "opera_android": {
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#restrict-gamepad-access",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "safari": {
                 "version_added": false

--- a/api/Window.json
+++ b/api/Window.json
@@ -2355,7 +2355,7 @@
               "version_added": "37"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": false
             },
             "firefox": {
               "version_added": "29"
@@ -2419,7 +2419,7 @@
               "version_added": "37"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": false
             },
             "firefox": {
               "version_added": "29"
@@ -4379,7 +4379,7 @@
               }
             ],
             "edge": {
-              "version_added": "≤18"
+              "version_added": false
             },
             "firefox": {
               "version_added": "29"
@@ -4461,14 +4461,7 @@
                 ]
               },
               "edge": {
-                "version_added": "86",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#restrict-gamepad-access",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "firefox": {
                 "version_added": "91"
@@ -4546,7 +4539,7 @@
               }
             ],
             "edge": {
-              "version_added": "≤18"
+              "version_added": false
             },
             "firefox": {
               "version_added": "29"
@@ -4628,14 +4621,7 @@
                 ]
               },
               "edge": {
-                "version_added": "86",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#restrict-gamepad-access",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "firefox": {
                 "version_added": "91"

--- a/api/Window.json
+++ b/api/Window.json
@@ -2355,7 +2355,7 @@
               "version_added": "37"
             },
             "edge": {
-              "version_added": false
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "29"
@@ -2419,7 +2419,7 @@
               "version_added": "37"
             },
             "edge": {
-              "version_added": false
+              "version_added": "≤18"
             },
             "firefox": {
               "version_added": "29"

--- a/api/Window.json
+++ b/api/Window.json
@@ -4360,15 +4360,15 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
+              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
+              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "edge": {
               "version_added": false,
-              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
+              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "firefox": {
               "version_added": "29"
@@ -4381,11 +4381,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
+              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
+              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "safari": {
               "version_added": "10.1"
@@ -4395,7 +4395,7 @@
             },
             "samsunginternet_android": {
               "version_added": false,
-              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
+              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "webview_android": {
               "version_added": false
@@ -4463,15 +4463,15 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
+              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
+              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "edge": {
               "version_added": false,
-              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
+              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "firefox": {
               "version_added": "29"
@@ -4484,11 +4484,11 @@
             },
             "opera": {
               "version_added": false,
-              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
+              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "opera_android": {
               "version_added": false,
-              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
+              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "safari": {
               "version_added": "10.1"
@@ -4498,7 +4498,7 @@
             },
             "samsunginternet_android": {
               "version_added": false,
-              "notes": "See <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=1192878'>bug 1192878</a>."
+              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "webview_android": {
               "version_added": false

--- a/api/Window.json
+++ b/api/Window.json
@@ -2338,24 +2338,35 @@
       "gamepadconnected_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/gamepadconnected_event",
-          "spec_url": "https://w3c.github.io/gamepad/#the-gamepadconnected-event",
+          "spec_url": [
+            "https://w3c.github.io/gamepad/#the-gamepadconnected-event",
+            "https://w3c.github.io/gamepad/#event-gamepadconnected"
+          ],
           "description": "<code>gamepadconnected</code> event",
           "support": {
             "chrome": [
               {
-                "version_added": "35"
+                "version_added": "35",
+                "partial_implementation": true,
+                "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
               },
               {
                 "version_added": "21",
                 "version_removed": "35",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "partial_implementation": true,
+                "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
               }
             ],
             "chrome_android": {
-              "version_added": "37"
+              "version_added": "37",
+              "partial_implementation": true,
+              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "≤18",
+              "partial_implementation": true,
+              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "firefox": {
               "version_added": "29"
@@ -2368,16 +2379,22 @@
             },
             "opera": [
               {
-                "version_added": "22"
+                "version_added": "22",
+                "partial_implementation": true,
+                "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
               },
               {
                 "version_added": "15",
                 "version_removed": "22",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "partial_implementation": true,
+                "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
               }
             ],
             "opera_android": {
-              "version_added": "24"
+              "version_added": "24",
+              "partial_implementation": true,
+              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "safari": {
               "version_added": "10.1"
@@ -2386,10 +2403,14 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "3.0"
+              "version_added": "3.0",
+              "partial_implementation": true,
+              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "37",
+              "partial_implementation": true,
+              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
             }
           },
           "status": {
@@ -2397,29 +2418,88 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "secure_context_required": {
+          "__compat": {
+            "description": "Secure context required",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "91"
+              },
+              "firefox_android": {
+                "version_added": "91"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "gamepaddisconnected_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/gamepaddisconnected_event",
-          "spec_url": "https://w3c.github.io/gamepad/#the-gamepaddisconnected-event",
+          "spec_url": [
+            "https://w3c.github.io/gamepad/#the-gamepaddisconnected-event",
+            "https://w3c.github.io/gamepad/#event-gamepaddisconnected"
+          ],
           "description": "<code>gamepaddisconnected</code> event",
           "support": {
             "chrome": [
               {
-                "version_added": "35"
+                "version_added": "35",
+                "partial_implementation": true,
+                "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
               },
               {
                 "version_added": "21",
                 "version_removed": "35",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "partial_implementation": true,
+                "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
               }
             ],
             "chrome_android": {
-              "version_added": "37"
+              "version_added": "37",
+              "partial_implementation": true,
+              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "≤18",
+              "partial_implementation": true,
+              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "firefox": {
               "version_added": "29"
@@ -2432,16 +2512,22 @@
             },
             "opera": [
               {
-                "version_added": "22"
+                "version_added": "22",
+                "partial_implementation": true,
+                "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
               },
               {
                 "version_added": "15",
                 "version_removed": "22",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "partial_implementation": true,
+                "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
               }
             ],
             "opera_android": {
-              "version_added": "24"
+              "version_added": "24",
+              "partial_implementation": true,
+              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "safari": {
               "version_added": "10.1"
@@ -2450,16 +2536,68 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "3.0"
+              "version_added": "3.0",
+              "partial_implementation": true,
+              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "webview_android": {
-              "version_added": "37"
+              "version_added": "37",
+              "partial_implementation": true,
+              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
             }
           },
           "status": {
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "secure_context_required": {
+          "__compat": {
+            "description": "Secure context required",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "91"
+              },
+              "firefox_android": {
+                "version_added": "91"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },
@@ -4350,212 +4488,6 @@
             "experimental": false,
             "standard_track": false,
             "deprecated": true
-          }
-        }
-      },
-      "ongamepadconnected": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/ongamepadconnected",
-          "spec_url": "https://w3c.github.io/gamepad/#event-gamepadconnected",
-          "support": {
-            "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
-            },
-            "chrome_android": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
-            },
-            "edge": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
-            },
-            "firefox": {
-              "version_added": "29"
-            },
-            "firefox_android": {
-              "version_added": "32"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
-            },
-            "opera_android": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
-            },
-            "safari": {
-              "version_added": "10.1"
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        },
-        "secure_context_required": {
-          "__compat": {
-            "description": "Secure context required",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "91"
-              },
-              "firefox_android": {
-                "version_added": "91"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        }
-      },
-      "ongamepaddisconnected": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/ongamepaddisconnected",
-          "spec_url": "https://w3c.github.io/gamepad/#event-gamepaddisconnected",
-          "support": {
-            "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
-            },
-            "chrome_android": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
-            },
-            "edge": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
-            },
-            "firefox": {
-              "version_added": "29"
-            },
-            "firefox_android": {
-              "version_added": "32"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
-            },
-            "opera_android": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
-            },
-            "safari": {
-              "version_added": "10.1"
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/1192878'>bug 1192878</a>."
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        },
-        "secure_context_required": {
-          "__compat": {
-            "description": "Secure context required",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "91"
-              },
-              "firefox_android": {
-                "version_added": "91"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },

--- a/api/Window.json
+++ b/api/Window.json
@@ -2344,20 +2344,12 @@
           ],
           "description": "<code>gamepadconnected</code> event",
           "support": {
-            "chrome": [
-              {
-                "version_added": "35",
-                "partial_implementation": true,
-                "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
-              },
-              {
-                "version_added": "21",
-                "version_removed": "35",
-                "prefix": "webkit",
-                "partial_implementation": true,
-                "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
-              }
-            ],
+            "chrome": {
+              "version_added": "35",
+              "partial_implementation": true,
+              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
+            },
+
             "chrome_android": {
               "version_added": "37",
               "partial_implementation": true,
@@ -2377,20 +2369,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22",
-                "partial_implementation": true,
-                "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
-              },
-              {
-                "version_added": "15",
-                "version_removed": "22",
-                "prefix": "webkit",
-                "partial_implementation": true,
-                "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
-              }
-            ],
+            "opera": {
+              "version_added": "22",
+              "partial_implementation": true,
+              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
+            },
+
             "opera_android": {
               "version_added": "24",
               "partial_implementation": true,
@@ -2417,54 +2401,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "secure_context_required": {
-          "__compat": {
-            "description": "Secure context required",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "91"
-              },
-              "firefox_android": {
-                "version_added": "91"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -2477,20 +2413,12 @@
           ],
           "description": "<code>gamepaddisconnected</code> event",
           "support": {
-            "chrome": [
-              {
-                "version_added": "35",
-                "partial_implementation": true,
-                "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
-              },
-              {
-                "version_added": "21",
-                "version_removed": "35",
-                "prefix": "webkit",
-                "partial_implementation": true,
-                "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
-              }
-            ],
+            "chrome": {
+              "version_added": "35",
+              "partial_implementation": true,
+              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
+            },
+
             "chrome_android": {
               "version_added": "37",
               "partial_implementation": true,
@@ -2510,20 +2438,12 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "22",
-                "partial_implementation": true,
-                "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
-              },
-              {
-                "version_added": "15",
-                "version_removed": "22",
-                "prefix": "webkit",
-                "partial_implementation": true,
-                "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
-              }
-            ],
+            "opera": {
+              "version_added": "22",
+              "partial_implementation": true,
+              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
+            },
+
             "opera_android": {
               "version_added": "24",
               "partial_implementation": true,
@@ -2550,54 +2470,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "secure_context_required": {
-          "__compat": {
-            "description": "Secure context required",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "91"
-              },
-              "firefox_android": {
-                "version_added": "91"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium for the `ongamepadconnected` and `ongamepaddisconnected` members of the `Window` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Window/ongamepadconnected

_Check out the [collector's guide on how to review the version changes of this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._

---

This PR also merges the event handles with the events to conform to the new style.

Content PR: https://github.com/mdn/content/pull/12933