### PR TITLE
Add Edge versions for api.RTCPeerConnection.track_event

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -3896,7 +3896,7 @@
               "version_added": "64"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "22"

--- a/api/RTCTrackEvent.json
+++ b/api/RTCTrackEvent.json
@@ -12,7 +12,7 @@
             "version_added": "56"
           },
           "edge": {
-            "version_added": "≤18"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "22"
@@ -109,7 +109,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "34"
@@ -158,7 +158,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "22"
@@ -207,7 +207,7 @@
               "version_added": "56"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "22"
@@ -256,7 +256,7 @@
               "version_added": "69"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "59"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `track_event` member of the `RTCPeerConnection` API.  The data was copied from its event handler counterpart.
