### PR TITLE
Add Edge versions for api.CacheStorage.worker_support

### DIFF
--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -407,7 +407,7 @@
               "notes": "Before version 43, only service workers are supported. From version 43, all worker types and the main thread are supported."
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "16"
             },
             "firefox": {
               "version_added": "44",


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `worker_support` member of the `CacheStorage` API, based upon manual testing.

Test Code Used: https://mdn-bcd-collector.appspot.com/tests/api/CacheStorage
