### PR TITLE
Add Edge versions for api.Notification.worker_support

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -1332,7 +1332,7 @@
               "version_added": "45"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "15"
             },
             "firefox": {
               "version_added": "41"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `worker_support` member of the `Notification` API, based upon manual testing.

Test Code Used: https://mdn-bcd-collector.appspot.com/tests/api/Notification
