### PR TITLE
Add Edge versions for api.PerformanceResourceTiming.worker_support

### DIFF
--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -941,7 +941,7 @@
               "version_added": "43"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "15"
             },
             "firefox": {
               "version_added": "60"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `worker_support` member of the `PerformanceResourceTiming` API, based upon manual testing.

Test Code Used: https://mdn-bcd-collector.appspot.com/tests/api/PerformanceResourceTiming
