### PR TITLE
Add Edge versions for WEBGL_compressed_texture_s3tc_srgb API

### DIFF
--- a/api/WEBGL_compressed_texture_s3tc_srgb.json
+++ b/api/WEBGL_compressed_texture_s3tc_srgb.json
@@ -12,7 +12,7 @@
             "version_added": "60"
           },
           "edge": {
-            "version_added": "≤79"
+            "version_added": "80"
           },
           "firefox": {
             "version_added": "55"


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `WEBGL_compressed_texture_s3tc_srgb` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WEBGL_compressed_texture_s3tc_srgb

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
