### PR TITLE
Clean up data for file system APIs

### DIFF
--- a/api/FileSystem.json
+++ b/api/FileSystem.json
@@ -6,16 +6,13 @@
         "spec_url": "https://wicg.github.io/entries-api/#api-domfilesystem",
         "support": {
           "chrome": {
-            "version_added": "7",
-            "alternative_name": "DOMFileSystem"
+            "version_added": "7"
           },
           "chrome_android": {
-            "version_added": "18",
-            "alternative_name": "DOMFileSystem"
+            "version_added": "18"
           },
           "edge": {
             "version_added": "≤18",
-            "prefix": "WebKit",
             "notes": "Edge only supports this API in drag-and-drop scenarios using the the <code><a href='https://developer.mozilla.org/docs/Web/API/DataTransferItem/webkitGetAsEntry'>DataTransferItem.webkitGetAsEntry()</a></code> method. It's not available for use in file or folder picker panels (such as when you use an <code><a href='https://developer.mozilla.org/docs/Web/HTML/Element/input'>&lt;input&gt;</a></code> element with the <code><a href='https://developer.mozilla.org/docs/Web/API/HTMLInputElement/webkitdirectory'>HTMLInputElement.webkitdirectory</a></code> attribute."
           },
           "firefox": {
@@ -28,12 +25,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "15",
-            "prefix": "webkit"
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": "14",
-            "prefix": "webkit"
+            "version_added": "14"
           },
           "safari": {
             "version_added": "11.1"
@@ -42,12 +37,10 @@
             "version_added": "11.3"
           },
           "samsunginternet_android": {
-            "prefix": "webkit",
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "≤37",
-            "alternative_name": "DOMFileSystem"
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/FileSystemDirectoryEntry.json
+++ b/api/FileSystemDirectoryEntry.json
@@ -6,16 +6,13 @@
         "spec_url": "https://wicg.github.io/entries-api/#api-directoryentry",
         "support": {
           "chrome": {
-            "version_added": "8",
-            "alternative_name": "DirectoryEntry"
+            "version_added": "8"
           },
           "chrome_android": {
-            "version_added": "18",
-            "alternative_name": "DirectoryEntry"
+            "version_added": "18"
           },
           "edge": {
-            "version_added": "79",
-            "prefix": "webkit"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "50"
@@ -27,8 +24,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "15",
-            "prefix": "webkit"
+            "version_added": "15"
           },
           "opera_android": {
             "version_added": false
@@ -40,12 +36,10 @@
             "version_added": "11.3"
           },
           "samsunginternet_android": {
-            "version_added": "1.0",
-            "alternative_name": "DirectoryEntry"
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "≤37",
-            "alternative_name": "DirectoryEntry"
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/FileSystemDirectoryReader.json
+++ b/api/FileSystemDirectoryReader.json
@@ -6,16 +6,13 @@
         "spec_url": "https://wicg.github.io/entries-api/#api-directoryreader",
         "support": {
           "chrome": {
-            "version_added": "8",
-            "alternative_name": "DirectoryReader"
+            "version_added": "8"
           },
           "chrome_android": {
-            "version_added": "18",
-            "alternative_name": "DirectoryReader"
+            "version_added": "18"
           },
           "edge": {
-            "version_added": "≤18",
-            "alternative_name": "WebKitDirectoryReader"
+            "version_added": "≤18"
           },
           "firefox": {
             "version_added": "50"
@@ -27,8 +24,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "15",
-            "prefix": "webkit"
+            "version_added": "15"
           },
           "opera_android": {
             "version_added": false
@@ -40,12 +36,10 @@
             "version_added": "11.3"
           },
           "samsunginternet_android": {
-            "version_added": "1.0",
-            "alternative_name": "DirectoryReader"
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "≤37",
-            "alternative_name": "DirectoryReader"
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/FileSystemEntry.json
+++ b/api/FileSystemEntry.json
@@ -6,16 +6,13 @@
         "spec_url": "https://wicg.github.io/entries-api/#api-entry",
         "support": {
           "chrome": {
-            "version_added": "8",
-            "alternative_name": "Entry"
+            "version_added": "8"
           },
           "chrome_android": {
-            "version_added": "18",
-            "alternative_name": "Entry"
+            "version_added": "18"
           },
           "edge": {
-            "version_added": "79",
-            "prefix": "webkit"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "50"
@@ -39,12 +36,10 @@
             "version_added": "11.3"
           },
           "samsunginternet_android": {
-            "version_added": "1.0",
-            "alternative_name": "Entry"
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "≤37",
-            "alternative_name": "Entry"
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/FileSystemFileEntry.json
+++ b/api/FileSystemFileEntry.json
@@ -6,16 +6,13 @@
         "spec_url": "https://wicg.github.io/entries-api/#api-fileentry",
         "support": {
           "chrome": {
-            "version_added": "8",
-            "alternative_name": "FileEntry"
+            "version_added": "8"
           },
           "chrome_android": {
-            "version_added": "18",
-            "alternative_name": "FileEntry"
+            "version_added": "18"
           },
           "edge": {
-            "version_added": "79",
-            "prefix": "webkit"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": "50"
@@ -39,12 +36,10 @@
             "version_added": "11.3"
           },
           "samsunginternet_android": {
-            "version_added": "1.0",
-            "alternative_name": "FileEntry"
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "≤37",
-            "alternative_name": "FileEntry"
+            "version_added": "≤37"
           }
         },
         "status": {

--- a/api/FileSystemSync.json
+++ b/api/FileSystemSync.json
@@ -5,16 +5,13 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemSync",
         "support": {
           "chrome": {
-            "version_added": "13",
-            "prefix": "webkit"
+            "version_added": "13"
           },
           "chrome_android": {
-            "version_added": "18",
-            "prefix": "webkit"
+            "version_added": "18"
           },
           "edge": {
-            "version_added": "79",
-            "prefix": "webkit"
+            "version_added": "79"
           },
           "firefox": {
             "version_added": false
@@ -26,28 +23,22 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "15",
-            "prefix": "webkit"
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": "14",
-            "prefix": "webkit"
+            "version_added": "14"
           },
           "safari": {
-            "version_added": "6",
-            "prefix": "webkit"
+            "version_added": "6"
           },
           "safari_ios": {
-            "version_added": "6",
-            "prefix": "webkit"
+            "version_added": "6"
           },
           "samsunginternet_android": {
-            "prefix": "webkit",
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "≤37",
-            "prefix": "webkit"
+            "version_added": "≤37"
           }
         },
         "status": {


### PR DESCRIPTION
This PR cleans up the data for the file system APIs.  All of these APIs had prefixes and alternative names applied to them, however they are not exposed or accessed on their own, so alternative names are irrelevant (I question their accuracy to begin with).
