### PR TITLE
Add spec_url to HTTP Link header

### DIFF
--- a/http/headers/link.json
+++ b/http/headers/link.json
@@ -1,0 +1,55 @@
+{
+  "http": {
+    "headers": {
+      "Link": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Link",
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": null
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": null
+            },
+            "safari_ios": {
+              "version_added": null
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "spec_url": "https://www.rfc-editor.org/rfc/rfc8288#section-3",
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
A suggestion to partly replace mdn/content#11121 by adding the spec data to this repository.

I'm fine with both ways of doing it. Maybe removing the `support`-attribute in the json is also an option instead of setting all platforms to `null`.