### PR TITLE
Add api.AbortSignal.throwIfAborted

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -384,6 +384,61 @@
             "deprecated": false
           }
         }
+      },
+      "throwIfAborted": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortSignal/throwIfAborted",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-abortsignal-throwifaborted①",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": "1.17"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Implemented in Deno 1.17.

Relevant spec change: https://github.com/whatwg/dom/commit/cfe2f1e5870aa2f905dc665c34e4278558b9ab1a
