### PR TITLE
Correct Safari support for ImageBitmap

### DIFF
--- a/api/ImageBitmap.json
+++ b/api/ImageBitmap.json
@@ -30,12 +30,10 @@
             "version_added": "37"
           },
           "safari": {
-            "version_added": false,
-            "notes": "See <a href='https://webkit.org/b/182424'>bug 182424</a>."
+            "version_added": "15"
           },
           "safari_ios": {
-            "version_added": false,
-            "notes": "See <a href='https://webkit.org/b/182424'>bug 182424</a>."
+            "version_added": "15"
           },
           "samsunginternet_android": {
             "version_added": "5.0"
@@ -80,10 +78,10 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -129,10 +127,10 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -178,10 +176,10 @@
               "version_added": "37"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15"
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Corrects Safari support for ImageBitmap

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Images of enabled flags from macOS and iOS

![image](https://user-images.githubusercontent.com/32498324/146465264-77d55216-5864-470d-8fbb-4be4eac30ec6.png)


![image](https://user-images.githubusercontent.com/32498324/146465256-6e4af8c1-139f-4fb3-8f21-7ddd7a8fe94b.png)


#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Fixes https://github.com/mdn/browser-compat-data/issues/13812