### PR TITLE
Show Safari support for SharedArrayBuffer

### DIFF
--- a/http/headers/cross-origin-embedder-policy.json
+++ b/http/headers/cross-origin-embedder-policy.json
@@ -34,7 +34,7 @@
               "version_added": "15.2"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"

--- a/http/headers/cross-origin-opener-policy.json
+++ b/http/headers/cross-origin-opener-policy.json
@@ -58,7 +58,7 @@
               "version_added": "15.2"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "samsunginternet_android": {
               "version_added": "13.0"

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -116,7 +116,7 @@
             },
             "safari": [
               {
-                "version_added": "preview",
+                "version_added": "15.2",
                 "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
               },
               {
@@ -124,10 +124,16 @@
                 "version_removed": "11"
               }
             ],
-            "safari_ios": {
-              "version_added": "10.3",
-              "version_removed": "11"
-            },
+            "safari_ios": [
+              {
+                "version_added": "15.2",
+                "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+              },
+              {
+                "version_added": "10.3",
+                "version_removed": "11"
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "15.0",
               "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Adds Safari support for Shared Array Buffer

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://developer.apple.com/documentation/safari-release-notes/safari-15_2-release-notes#:~:text=Re%2Denabled%20SharedArrayBuffer%20for%20sites%20that%20use%20COOP%20and%20COEP%20securely%20to%20create%20an%20isolated%20environment.

