### PR TITLE
Fix support data for TypedArray.from

### DIFF
--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -943,7 +943,7 @@
                 "version_added": "45"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "45"
               },
               "deno": {
                 "version_added": "1.0"
@@ -964,10 +964,10 @@
                 "version_added": "4.0.0"
               },
               "opera": {
-                "version_added": false
+                "version_added": "32"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "32"
               },
               "safari": {
                 "version_added": "10"
@@ -976,10 +976,10 @@
                 "version_added": "10"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "5.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "45"
               }
             },
             "status": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Fixes support data for typed array from

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Tested the demo on the MDN page in latest version of the all the currently unsupported browsers (except IE) and they all work. So I'm assuming this is just faulty data and they're in fact all meant to match the engine versions for Chrome.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Fixes https://github.com/mdn/browser-compat-data/issues/13817