### PR TITLE
Add cookieStoreId to contentScripts.register

### DIFF
--- a/webextensions/api/contentScripts.json
+++ b/webextensions/api/contentScripts.json
@@ -93,6 +93,33 @@
                 "version_added": false
               }
             }
+          },
+          "cookieStoreId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "97"
+                },
+                "firefox_android": {
+                  "version_added": "97"
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
#### Summary
Adds details of `cookieStoreId` to `contentScripts.register`. Addresses browser compatibility data requirements for [bug 1470651](https://bugzilla.mozilla.org/show_bug.cgi?id=1470651)

#### Test results and supporting details
Ran `npm test` with no errors.

#### Related issues
MDN documentation changes made in PR [#11268](https://github.com/mdn/content/pull/11268)
