### PR TITLE
Aspect ratio for lazy loading images without a valid src fixed in Safari TP

### DIFF
--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -186,20 +186,26 @@
               },
               "safari": [
                 {
-                  "version_added": "preview"
+                  "version_added": "15"
                 },
                 {
                   "version_added": "14",
-                  "version_removed": "preview",
+                  "version_removed": "15",
                   "partial_implementation": true,
                   "notes": "Safari doesn't preserve space for images without a valid <code>src</code>, which may disrupt layouts that rely on lazy loading (see <a href='https://webkit.org/b/224197'>bug 224197</a>)."
                 }
               ],
-              "safari_ios": {
-                "version_added": "14",
-                "partial_implementation": true,
-                "notes": "Safari doesn't preserve space for images without a valid <code>src</code>, which may disrupt layouts that rely on lazy loading (see <a href='https://webkit.org/b/224197'>bug 224197</a>)."
-              },
+              "safari_ios": [
+                {
+                  "version_added": "15"
+                },
+                {
+                  "version_added": "14",
+                  "version_removed": "15",
+                  "partial_implementation": true,
+                  "notes": "Safari doesn't preserve space for images without a valid <code>src</code>, which may disrupt layouts that rely on lazy loading (see <a href='https://webkit.org/b/224197'>bug 224197</a>)."
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": "12.0"
               },

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -184,11 +184,17 @@
               "opera_android": {
                 "version_added": "57"
               },
-              "safari": {
-                "version_added": "14",
-                "partial_implementation": true,
-                "notes": "Safari doesn't preserve space for images without a valid <code>src</code>, which may disrupt layouts that rely on lazy loading (see <a href='https://webkit.org/b/224197'>bug 224197</a>)."
-              },
+              "safari": [
+                {
+                  "version_added": "preview"
+                },
+                {
+                  "version_added": "14",
+                  "version_removed": "preview",
+                  "partial_implementation": true,
+                  "notes": "Safari doesn't preserve space for images without a valid <code>src</code>, which may disrupt layouts that rely on lazy loading (see <a href='https://webkit.org/b/224197'>bug 224197</a>)."
+                },
+              ],
               "safari_ios": {
                 "version_added": "14",
                 "partial_implementation": true,

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -193,7 +193,7 @@
                   "version_removed": "preview",
                   "partial_implementation": true,
                   "notes": "Safari doesn't preserve space for images without a valid <code>src</code>, which may disrupt layouts that rely on lazy loading (see <a href='https://webkit.org/b/224197'>bug 224197</a>)."
-                },
+                }
               ],
               "safari_ios": {
                 "version_added": "14",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
> Safari doesn't preserve space for images without a valid `src`, which may disrupt layouts that rely on lazy loading (see [bug 224197](https://webkit.org/b/224197)).

The bug has been marked as fixed, seems to work at the very least in TP.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
- https://bugs.webkit.org/show_bug.cgi?id=224197#c18
- https://wpt.fyi/results/html/rendering/replaced-elements/attributes-for-embedded-content-and-images?label=master&label=experimental&aligned&q=aspect%20ratio
- https://wpt.fyi/results/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/img-aspect-ratio-lazy.html?label=master&product=chrome%5Bexperimental%5D&product=edge%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bstable%5D&product=safari%5Bexperimental%5D&aligned&q=aspect%20ratio

At first I was about to make it so that Safari and iOS 15 had it fixed, but since 15.1 seems to fail in [this test](https://wpt.fyi/results/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/img-aspect-ratio-lazy.html?label=master&product=chrome%5Bexperimental%5D&product=edge%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bstable%5D&product=safari%5Bexperimental%5D&aligned&q=aspect%20ratio) - not sure if thats actually the right one? - I went for TP only.

I would assume it's fixed in 15 as well [because](https://webkit.org/blog/11989/new-webkit-features-in-safari-15/)

> Changes in this release of Safari were included in the following Safari Technology Preview releases: [123](https://webkit.org/blog/11585/release-notes-for-safari-technology-preview-123/), [124](https://webkit.org/blog/11672/release-notes-for-safari-technology-preview-124/), [125](https://webkit.org/blog/11680/release-notes-for-safari-technology-preview-125/), [126](https://webkit.org/blog/11727/release-notes-for-safari-technology-preview-126-with-safari-15-features/), [127](https://webkit.org/blog/11736/release-notes-for-safari-technology-preview-127/), [128](https://webkit.org/blog/11925/release-notes-for-safari-technology-preview-128/), [129](https://webkit.org/blog/11951/release-notes-for-safari-technology-preview-129/).

and it [being part](https://wpt.fyi/compat2021?feature=aspect-ratio) of Compat/Interop 2021…

At least I hope to get the ball rolling with this PR :)

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A
<!-- ✅ After submitting, review the results of the "Checks" tab! -->
