### PR TITLE
Add Safari on iOS support and full support on macOS

### DIFF
--- a/webextensions/manifest/browser_specific_settings.json
+++ b/webextensions/manifest/browser_specific_settings.json
@@ -37,8 +37,11 @@
             },
             "safari": {
               "notes": "Supports <code>strict_min_version</code> and <code>strict_max_version</code> in a <code>safari</code> block.",
-              "partial_implementation": true,
               "version_added": "14"
+            },
+            "safari_ios": {
+              "notes": "Supports <code>strict_min_version</code> and <code>strict_max_version</code> in a <code>safari</code> block.",
+              "version_added": "15"
             }
           }
         }


### PR DESCRIPTION
#### Summary
Removed "partial support" for macOS which doesn't make sense in the context of browser specific settings.

Added support for Safari on iOS with the same note for macOS.

#### Test results and supporting details
This change was recommended with input from Safari engineering.
