### PR TITLE
@media type speech is deprecated

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1751,56 +1751,6 @@
             }
           }
         },
-        "speech_type": {
-          "__compat": {
-            "description": "<code>speech</code> media type",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "9.2",
-                "version_removed": "15"
-              },
-              "opera_android": {
-                "version_added": "10.1",
-                "version_removed": "14"
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": true
-            }
-          }
-        },
         "width": {
           "__compat": {
             "description": "<code>width</code> media feature",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1797,7 +1797,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
In the [Media Queries Level 4](https://drafts.csswg.org/mediaqueries/#valdef-media-speech) editors draft the @media option of speech is listed as deprecated. 

If this goes through, will update matching docs as per https://github.com/mdn/content/issues/11317