### PR TITLE
Element.requestPointerLock - Chromium returns promise

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -6570,7 +6570,8 @@
           "support": {
             "chrome": [
               {
-                "version_added": "37"
+                "version_added": "37",
+                "notes": "Version 92 returns a promise instead of <code>undefined</code>. The behaviour reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
               },
               {
                 "version_added": "22",


### PR DESCRIPTION
Chrome 92 has started returning a promise rather than undefined for [Element.requestPointerLock()](https://developer.mozilla.org/en-US/docs/Web/API/Element/requestPointerLock).

There is an [explainer here](https://github.com/slightlyoff/unadjusted_pointer_lock_explainer) for the change and an [intent to ship here](https://groups.google.com/a/chromium.org/g/blink-dev/c/cQn7OwcMQ64). Fact is though that this is off-spec pending approval of this spec PR: https://github.com/w3c/pointerlock/pull/49

I have verified that this appears in Chrome 92 (but not 91) on Windows. I have recorded the incompatibility as a note with a link to the PR above. I was not sure if this was correct approach, so have only done for Chrome. Once the approach is agreed/confirmed by BCD team I'll roll out to the other chromiums. 

This issue originated here: https://github.com/mdn/content/issues/11282