### PR TITLE
Firefox 96 supports CSS `counter-reset: reversed()`

### DIFF
--- a/css/properties/counter-reset.json
+++ b/css/properties/counter-reset.json
@@ -51,7 +51,6 @@
         },
         "reversed": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/counter-reset",
             "spec_url": "https://drafts.csswg.org/css-lists/#css-counter-reversed",
             "description": "<code>reversed()</code>",
             "support": {

--- a/css/properties/counter-reset.json
+++ b/css/properties/counter-reset.json
@@ -48,6 +48,56 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "reversed": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/counter-reset",
+            "spec_url": "https://drafts.csswg.org/css-lists/#css-counter-reversed",
+            "description": "<code>reversed()</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "96"
+              },
+              "firefox_android": {
+                "version_added": "96"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
FF96 supports new `reversed()` option for CSS [counter-reset](https://developer.mozilla.org/en-US/docs/Web/CSS/counter-reset) property. This was added in https://bugzilla.mozilla.org/show_bug.cgi?id=1706346

I have tested on chrome and it isn't supported in current versions. I have not tested on Safari, but this is recent and I suspect it has not been implemented.
This is in the spec but is only in firefox, so I have marked as experimental.

Should a feature also be added for the  [implicit `list-item` counter](https://drafts.csswg.org/css-lists/#list-item-counter) that was also added in FF96? This is needed to apply counter behaviour to number and reverse normal `<ol>` elements.

While it is unlikely that you would support `reversed()` without supporting `list-item`, it is possible that people might come along and try list-item for forward lists, because it is documented. If they try this in a browser that hasn't updated it will look like a different incompatibility. So my gut feeling is yes, but I wanted to get an opinion. 
