### PR TITLE
Add support for :has() with STP 137

### DIFF
--- a/css/selectors/has.json
+++ b/css/selectors/has.json
@@ -36,7 +36,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
#### Summary
Set's Safari support to `preview` for `:has()` pseudo-selector.

#### Test results and supporting details
See [Safari Technology Preview 137 Release Notes](https://developer.apple.com/safari/technology-preview/release-notes/#r137) with support for `:has()`.