### PR TITLE
Element.requestPointerLock - non spec behaviour all chromiums

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -6592,7 +6592,7 @@
             ],
             "edge": {
               "version_added": "13",
-                "notes": "Version 92 returns a promise instead of <code>undefined</code>. The behaviour reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
+              "notes": "Version 92 returns a promise instead of <code>undefined</code>. The behaviour reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
             },
             "firefox": [
               {

--- a/api/Element.json
+++ b/api/Element.json
@@ -6571,7 +6571,7 @@
             "chrome": [
               {
                 "version_added": "37",
-                "notes": "From version 92, returns a promise instead of <code>undefined</code>. The behavior reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
+                "notes": "From version 92, returns a promise instead of <code>undefined</code>. The behavior reflects <a href='https://github.com/w3c/pointerlock/pull/49'>a proposed specification change</a>."
               },
               {
                 "version_added": "22",
@@ -6582,7 +6582,7 @@
             "chrome_android": [
               {
                 "version_added": "37",
-                "notes": "From version 92, returns a promise instead of <code>undefined</code>. The behavior reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
+                "notes": "From version 92, returns a promise instead of <code>undefined</code>. The behavior reflects <a href='https://github.com/w3c/pointerlock/pull/49'>a proposed specification change</a>."
               },
               {
                 "version_added": "25",
@@ -6592,7 +6592,7 @@
             ],
             "edge": {
               "version_added": "13",
-              "notes": "From version 92, returns a promise instead of <code>undefined</code>. The behavior reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
+              "notes": "From version 92, returns a promise instead of <code>undefined</code>. The behavior reflects <a href='https://github.com/w3c/pointerlock/pull/49'>a proposed specification change</a>."
             },
             "firefox": [
               {
@@ -6620,7 +6620,7 @@
             "opera": [
               {
                 "version_added": "24",
-                "notes": "From version 78, returns a promise instead of <code>undefined</code>. The behavior reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
+                "notes": "From version 78, returns a promise instead of <code>undefined</code>. The behavior reflects <a href='https://github.com/w3c/pointerlock/pull/49'>a proposed specification change</a>."
               },
               {
                 "version_added": "15",
@@ -6631,7 +6631,7 @@
             "opera_android": [
               {
                 "version_added": "24",
-                "notes": "From version 65, returns a promise instead of <code>undefined</code>. The behavior reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
+                "notes": "From version 65, returns a promise instead of <code>undefined</code>. The behavior reflects <a href='https://github.com/w3c/pointerlock/pull/49'>a proposed specification change</a>."
               },
               {
                 "version_added": "14",
@@ -6648,7 +6648,7 @@
             "samsunginternet_android": [
               {
                 "version_added": "3.0",
-                "notes": "From version 16, returns a promise instead of <code>undefined</code>. The behavior reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
+                "notes": "From version 16, returns a promise instead of <code>undefined</code>. The behavior reflects <a href='https://github.com/w3c/pointerlock/pull/49'>a proposed specification change</a>."
               },
               {
                 "version_added": "1.5",
@@ -6659,7 +6659,7 @@
             "webview_android": [
               {
                 "version_added": "37",
-                "notes": "From version 92, returns a promise instead of <code>undefined</code>. The behavior reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
+                "notes": "From version 92, returns a promise instead of <code>undefined</code>. The behavior reflects <a href='https://github.com/w3c/pointerlock/pull/49'>a proposed specification change</a>."
               },
               {
                 "version_added": "≤37",

--- a/api/Element.json
+++ b/api/Element.json
@@ -6581,7 +6581,8 @@
             ],
             "chrome_android": [
               {
-                "version_added": "37"
+                "version_added": "37",
+                "notes": "Version 92 returns a promise instead of <code>undefined</code>. The behaviour reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
               },
               {
                 "version_added": "25",
@@ -6590,7 +6591,8 @@
               }
             ],
             "edge": {
-              "version_added": "13"
+              "version_added": "13",
+                "notes": "Version 92 returns a promise instead of <code>undefined</code>. The behaviour reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
             },
             "firefox": [
               {
@@ -6617,7 +6619,8 @@
             },
             "opera": [
               {
-                "version_added": "24"
+                "version_added": "24",
+                "notes": "Version 78 returns a promise instead of <code>undefined</code>. The behaviour reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
               },
               {
                 "version_added": "15",
@@ -6627,7 +6630,8 @@
             ],
             "opera_android": [
               {
-                "version_added": "24"
+                "version_added": "24",
+                "notes": "Version 65 returns a promise instead of <code>undefined</code>. The behaviour reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
               },
               {
                 "version_added": "14",
@@ -6643,7 +6647,8 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": "3.0"
+                "version_added": "3.0",
+                "notes": "Version 16 returns a promise instead of <code>undefined</code>. The behaviour reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
               },
               {
                 "version_added": "1.5",
@@ -6653,7 +6658,8 @@
             ],
             "webview_android": [
               {
-                "version_added": "37"
+                "version_added": "37",
+                "notes": "Version 92 returns a promise instead of <code>undefined</code>. The behaviour reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
               },
               {
                 "version_added": "≤37",

--- a/api/Element.json
+++ b/api/Element.json
@@ -6571,7 +6571,7 @@
             "chrome": [
               {
                 "version_added": "37",
-                "notes": "Version 92 returns a promise instead of <code>undefined</code>. The behaviour reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
+                "notes": "From version 92, returns a promise instead of <code>undefined</code>. The behavior reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
               },
               {
                 "version_added": "22",
@@ -6582,7 +6582,7 @@
             "chrome_android": [
               {
                 "version_added": "37",
-                "notes": "Version 92 returns a promise instead of <code>undefined</code>. The behaviour reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
+                "notes": "From version 92, returns a promise instead of <code>undefined</code>. The behavior reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
               },
               {
                 "version_added": "25",
@@ -6592,7 +6592,7 @@
             ],
             "edge": {
               "version_added": "13",
-              "notes": "Version 92 returns a promise instead of <code>undefined</code>. The behaviour reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
+              "notes": "From version 92, returns a promise instead of <code>undefined</code>. The behavior reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
             },
             "firefox": [
               {
@@ -6620,7 +6620,7 @@
             "opera": [
               {
                 "version_added": "24",
-                "notes": "Version 78 returns a promise instead of <code>undefined</code>. The behaviour reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
+                "notes": "From version 78, returns a promise instead of <code>undefined</code>. The behavior reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
               },
               {
                 "version_added": "15",
@@ -6631,7 +6631,7 @@
             "opera_android": [
               {
                 "version_added": "24",
-                "notes": "Version 65 returns a promise instead of <code>undefined</code>. The behaviour reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
+                "notes": "From version 65, returns a promise instead of <code>undefined</code>. The behavior reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
               },
               {
                 "version_added": "14",
@@ -6648,7 +6648,7 @@
             "samsunginternet_android": [
               {
                 "version_added": "3.0",
-                "notes": "Version 16 returns a promise instead of <code>undefined</code>. The behaviour reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
+                "notes": "From version 16, returns a promise instead of <code>undefined</code>. The behavior reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
               },
               {
                 "version_added": "1.5",
@@ -6659,7 +6659,7 @@
             "webview_android": [
               {
                 "version_added": "37",
-                "notes": "Version 92 returns a promise instead of <code>undefined</code>. The behaviour reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
+                "notes": "From version 92, returns a promise instead of <code>undefined</code>. The behavior reflects this proposed specification change: https://github.com/w3c/pointerlock/pull/49."
               },
               {
                 "version_added": "≤37",


### PR DESCRIPTION
This follows on from change in #14091, adding note about non-spec behaviour for other chromium variants.

Chrome 92 has started returning a promise rather than undefined for [Element.requestPointerLock()](https://developer.mozilla.org/en-US/docs/Web/API/Element/requestPointerLock).

This issue originated here: https://github.com/mdn/content/issues/11282