### PR TITLE
NodeJS supports `Error.cause`

### DIFF
--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -245,7 +245,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "16.9.0"
                 },
                 "opera": {
                   "version_added": "79"
@@ -300,7 +300,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "16.9.0"
               },
               "opera": {
                 "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Documented NodeJS v16.9.0 as introducing `Error.cause` support.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
Validated support by running the following in NodeJS REPL.

```js
new Error('', { cause: new Error('foo') });
_.cause
```

And observing that `cause` was correct based on the message `"foo"` in REPL output.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #14083

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
