### PR TITLE
Update data for WebView 4.4/4.4.3

### DIFF
--- a/api/AnalyserNode.json
+++ b/api/AnalyserNode.json
@@ -39,7 +39,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "4.4"
+            "version_added": "4.4.3"
           }
         },
         "status": {
@@ -137,7 +137,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -186,7 +186,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -235,7 +235,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -284,7 +284,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -333,7 +333,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -431,7 +431,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -480,7 +480,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -529,7 +529,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/AudioBuffer.json
+++ b/api/AudioBuffer.json
@@ -39,7 +39,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "4.4"
+            "version_added": "4.4.3"
           }
         },
         "status": {
@@ -241,7 +241,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -290,7 +290,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -339,7 +339,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -388,7 +388,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -437,7 +437,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/AudioBufferSourceNode.json
+++ b/api/AudioBufferSourceNode.json
@@ -39,7 +39,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "4.4"
+            "version_added": "4.4.3"
           }
         },
         "status": {
@@ -143,7 +143,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -241,7 +241,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -388,7 +388,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -469,7 +469,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -469,7 +469,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/AudioDestinationNode.json
+++ b/api/AudioDestinationNode.json
@@ -39,7 +39,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "4.4"
+            "version_added": "4.4.3"
           }
         },
         "status": {

--- a/api/AudioListener.json
+++ b/api/AudioListener.json
@@ -39,7 +39,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "4.4"
+            "version_added": "4.4.3"
           }
         },
         "status": {
@@ -451,7 +451,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -500,7 +500,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/AudioNode.json
+++ b/api/AudioNode.json
@@ -39,7 +39,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "4.4"
+            "version_added": "4.4.3"
           }
         },
         "status": {
@@ -237,7 +237,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -286,7 +286,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -335,7 +335,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -480,7 +480,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -529,7 +529,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -224,7 +224,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -273,7 +273,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -322,7 +322,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -371,7 +371,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -420,7 +420,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -469,7 +469,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -567,7 +567,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -665,7 +665,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -861,7 +861,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1129,7 +1129,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1178,7 +1178,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1227,7 +1227,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1324,7 +1324,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1373,7 +1373,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1471,7 +1471,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/BiquadFilterNode.json
+++ b/api/BiquadFilterNode.json
@@ -39,7 +39,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "4.4"
+            "version_added": "4.4.3"
           }
         },
         "status": {
@@ -143,7 +143,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -241,7 +241,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -290,7 +290,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -339,7 +339,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -388,7 +388,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/ChannelMergerNode.json
+++ b/api/ChannelMergerNode.json
@@ -39,7 +39,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "4.4"
+            "version_added": "4.4.3"
           }
         },
         "status": {

--- a/api/ChannelSplitterNode.json
+++ b/api/ChannelSplitterNode.json
@@ -44,7 +44,7 @@
             "notes": "Starting in Samsung Internet 6.0, <code>channelCountMode</code> is set to <code>explicit</code> and <code>channelCount</code> is fixed to the number of outputs, as per the latest spec."
           },
           "webview_android": {
-            "version_added": "4.4",
+            "version_added": "4.4.3",
             "notes": "Starting in version 56, <code>channelCountMode</code> is set to <code>explicit</code> and <code>channelCount</code> is fixed to the number of outputs, as per the latest spec."
           }
         },

--- a/api/ConvolverNode.json
+++ b/api/ConvolverNode.json
@@ -39,7 +39,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "4.4"
+            "version_added": "4.4.3"
           }
         },
         "status": {
@@ -137,7 +137,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -186,7 +186,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/DynamicsCompressorNode.json
+++ b/api/DynamicsCompressorNode.json
@@ -39,7 +39,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "4.4"
+            "version_added": "4.4.3"
           }
         },
         "status": {

--- a/api/External.json
+++ b/api/External.json
@@ -38,7 +38,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "1"
+            "version_added": "4.4.3"
           }
         },
         "status": {
@@ -86,7 +86,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -134,7 +134,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/HTMLDataListElement.json
+++ b/api/HTMLDataListElement.json
@@ -39,7 +39,7 @@
             "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": "4.4"
+            "version_added": "4.4.3"
           }
         },
         "status": {
@@ -86,7 +86,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1184,7 +1184,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/MediaElementAudioSourceNode.json
+++ b/api/MediaElementAudioSourceNode.json
@@ -39,7 +39,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "4.4"
+            "version_added": "4.4.3"
           }
         },
         "status": {

--- a/api/PannerNode.json
+++ b/api/PannerNode.json
@@ -53,7 +53,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "4.4"
+            "version_added": "4.4.3"
           }
         },
         "status": {
@@ -155,7 +155,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -204,7 +204,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -253,7 +253,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -302,7 +302,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -351,7 +351,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -547,7 +547,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -743,7 +743,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -792,7 +792,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -841,7 +841,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -890,7 +890,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/WaveShaperNode.json
+++ b/api/WaveShaperNode.json
@@ -39,7 +39,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "4.4"
+            "version_added": "4.4.3"
           }
         },
         "status": {
@@ -141,7 +141,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -41,7 +41,7 @@
             "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": "4.4"
+            "version_added": "4.4.3"
           }
         },
         "status": {
@@ -89,7 +89,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -138,7 +138,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -187,7 +187,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -239,7 +239,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -338,7 +338,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -434,7 +434,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -486,7 +486,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -582,7 +582,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -631,7 +631,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -727,7 +727,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -823,7 +823,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -872,7 +872,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -969,7 +969,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1065,7 +1065,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1161,7 +1161,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1267,7 +1267,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1363,7 +1363,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1412,7 +1412,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1461,7 +1461,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1510,7 +1510,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1559,7 +1559,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1664,7 +1664,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1713,7 +1713,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -1857,7 +1857,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -2001,7 +2001,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -2050,7 +2050,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -2099,7 +2099,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -2148,7 +2148,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -2197,7 +2197,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -2246,7 +2246,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -2295,7 +2295,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -2344,7 +2344,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -2393,7 +2393,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -2442,7 +2442,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -2491,7 +2491,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -2540,7 +2540,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -2589,7 +2589,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -2638,7 +2638,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -2687,7 +2687,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -2736,7 +2736,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -2785,7 +2785,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -2834,7 +2834,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -2883,7 +2883,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -2932,7 +2932,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -2981,7 +2981,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -3030,7 +3030,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -3079,7 +3079,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -3128,7 +3128,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -3177,7 +3177,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -3226,7 +3226,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -3275,7 +3275,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -3324,7 +3324,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -3373,7 +3373,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -3422,7 +3422,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -3518,7 +3518,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -3614,7 +3614,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -3663,7 +3663,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -3759,7 +3759,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -3808,7 +3808,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -3857,7 +3857,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -3906,7 +3906,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -3958,7 +3958,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -4054,7 +4054,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -4103,7 +4103,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -4152,7 +4152,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -4204,7 +4204,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -4303,7 +4303,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -4352,7 +4352,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -4404,7 +4404,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -4503,7 +4503,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -4599,7 +4599,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -4648,7 +4648,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -4746,7 +4746,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -4795,7 +4795,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -4847,7 +4847,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -4946,7 +4946,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -5042,7 +5042,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -5094,7 +5094,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -5190,7 +5190,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -5239,7 +5239,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -5288,7 +5288,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -5337,7 +5337,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -5389,7 +5389,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -5485,7 +5485,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -5534,7 +5534,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -5583,7 +5583,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -5632,7 +5632,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -5681,7 +5681,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -5731,7 +5731,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -5780,7 +5780,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -5882,7 +5882,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -5978,7 +5978,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -6027,7 +6027,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -6174,7 +6174,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -6270,7 +6270,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -6319,7 +6319,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -6368,7 +6368,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -6417,7 +6417,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -6466,7 +6466,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -6515,7 +6515,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -6564,7 +6564,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -6613,7 +6613,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -6662,7 +6662,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -6714,7 +6714,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -6861,7 +6861,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -6960,7 +6960,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -7059,7 +7059,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -7203,7 +7203,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -7252,7 +7252,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -7301,7 +7301,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -7350,7 +7350,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -7399,7 +7399,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -7448,7 +7448,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -7497,7 +7497,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -7546,7 +7546,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -7595,7 +7595,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -7644,7 +7644,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -7693,7 +7693,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -7742,7 +7742,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -7791,7 +7791,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -7840,7 +7840,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -7889,7 +7889,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -7938,7 +7938,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -7987,7 +7987,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -8131,7 +8131,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -8275,7 +8275,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -8419,7 +8419,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -8468,7 +8468,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -8517,7 +8517,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -8566,7 +8566,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -8663,7 +8663,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -8712,7 +8712,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -8809,7 +8809,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -8858,7 +8858,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -8955,7 +8955,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -9004,7 +9004,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -9101,7 +9101,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -9150,7 +9150,7 @@
               "version_added": "1.5"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -2023,7 +2023,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3"
             }
           },
           "status": {

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -417,7 +417,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4"
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -527,7 +527,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4"
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -582,7 +582,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4"
+              "version_added": "4.4"
             }
           },
           "status": {

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -77,7 +77,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "4"
+            "version_added": "4.4"
           }
         },
         "status": {
@@ -134,7 +134,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4"
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -725,7 +725,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4"
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -781,7 +781,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4"
+              "version_added": "4.4"
             }
           },
           "status": {

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -42,7 +42,7 @@
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "1"
+            "version_added": "4.4"
           }
         },
         "status": {
@@ -139,7 +139,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -188,7 +188,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -755,7 +755,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -1048,7 +1048,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "4.4"
             }
           },
           "status": {

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -90,7 +90,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -444,7 +444,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -804,7 +804,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "4.4"
             }
           },
           "status": {


### PR DESCRIPTION
This PR is a follow-up to #13936 to update the data for WebView 4.4 and 4.4.3 respectively, based upon results from the mdn-bcd-collector project.  Due to a bug in the update script, results for "4.4.3" were accidentally set to "4.4".

This PR also corrects old data set to WebView 1 due to mirroring from Chrome.
