### PR TITLE
Mark some CanvasRenderingContext2D features as non-experimental

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1347,7 +1347,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -1640,7 +1640,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -2984,7 +2984,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This is part of the fix for https://github.com/mdn/content/issues/11401.

I've gone through https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D#browser_compatibility and removed "experimental" for the features where (based on browser support) that doesn't seem plausible.
