### PR TITLE
Firefox 96 supports `hwb()` CSS color function

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -566,10 +566,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": "96"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "96"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Support for `hwb()` css color function coming in Firefox 96 - this updates version

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://bugzilla.mozilla.org/show_bug.cgi?id=1352755

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Part of https://github.com/mdn/content/issues/10849

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
