### PR TITLE
Add note regarding lack of navigator.share support on Edge

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3470,7 +3470,9 @@
               "version_added": "61"
             },
             "edge": {
-              "version_added": "81"
+              "version_added": "81",
+              "partial_implementation": true,
+              "notes": "Not supported on macOS, see <a href='https://crbug.com/1144920'>bug 1144920</a>."
             },
             "firefox": {
               "version_added": "71",


### PR DESCRIPTION
This PR fixes #6817.
