### PR TITLE
Correct description for css.types.transform-function.translateZ

### DIFF
--- a/css/types/transform-function.json
+++ b/css/types/transform-function.json
@@ -1061,7 +1061,7 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/translateZ()",
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#funcdef-translatez",
-            "description": "<code>rotateZ()</code>",
+            "description": "<code>translateZ()</code>",
             "support": {
               "chrome": {
                 "version_added": "12"


### PR DESCRIPTION
This PR fixes #14141 by correcting the description for the `translateZ` CSS function.
