### PR TITLE
Correct Chromium data for navigator.[set/clear]AppBadge

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -727,7 +727,9 @@
               "version_added": false
             },
             "edge": {
-              "version_added": "81"
+              "version_added": "83",
+              "partial_implementation": true,
+              "notes": "Windows and Mac only."
             },
             "firefox": {
               "version_added": false
@@ -742,7 +744,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": "58"
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -751,7 +753,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "13.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -3434,7 +3436,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": "58"
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -3443,7 +3445,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "13.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -729,7 +729,7 @@
             "edge": {
               "version_added": "83",
               "partial_implementation": true,
-              "notes": "Windows and Mac only."
+              "notes": "Windows and macOS only."
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR is a follow-up to #9988 that corrects the data for Opera Android and Samsung Internet, as well as `clearAppBadge` for Edge.  Fixes #11879.
