### PR TITLE
Includes FF97 scrollbar-gutter support

### DIFF
--- a/css/properties/scrollbar-gutter.json
+++ b/css/properties/scrollbar-gutter.json
@@ -40,12 +40,10 @@
               "version_added": "94"
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1715112'>bug 1715112</a>."
+              "version_added": "97"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1715112'>bug 1715112</a>."
+              "version_added": "97"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Hello!

According to this [bugfix](https://bugzilla.mozilla.org/show_bug.cgi?id=1715112#c12), FF97 now supports the `scrollbar-gutter` property.

Fixes #14099.