### PR TITLE
Opera supports RegExp.hasIndicies

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -481,10 +481,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "76"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "64"
               },
               "safari": {
                 "version_added": "15"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Opera supports RegExp.hasIndicies.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
Run this in the console:
```
const re = /(a)(b)/d;      // Note the /d flag.
re.hasIndices              // Will be true
```

This feature landed in Chromium 90 (or V8 9.0) and was shipped in Opera desktop 76 and Opera Android 64.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
