### PR TITLE
Firefox Android removed RegExp.toSource

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1753,8 +1753,8 @@
               },
               "firefox_android": {
                 "version_added": "4",
-                "version_removed": "74",
-                "notes": "Starting in Firefox 74, <code>toSource()</code> is no longer available for use by web content. It is still allowed for internal and privileged code."
+                "version_removed": "79",
+                "notes": "Starting in Firefox 79, <code>toSource()</code> is no longer available for use by web content. It is still allowed for internal and privileged code."
               },
               "ie": {
                 "version_added": false

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1752,7 +1752,9 @@
                 "notes": "Starting in Firefox 74, <code>toSource()</code> is no longer available for use by web content. It is still allowed for internal and privileged code."
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": "4",
+                "version_removed": "74",
+                "notes": "Starting in Firefox 74, <code>toSource()</code> is no longer available for use by web content. It is still allowed for internal and privileged code."
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Firefox Android removed `RegExp.toSource` from web-fecing contexts.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
Open Firefox Android and go to https://jsconsole.com and run this code:
```
/aaa/.toSource
```
will be `undefined`.

In contrast, a well-supported `toString()` is working:
```
/aaa/.toString()
```
will be `"/aaa/"`.
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
