### PR TITLE
Update Chromium versions for ANGLE_instanced_arrays API

### DIFF
--- a/api/ANGLE_instanced_arrays.json
+++ b/api/ANGLE_instanced_arrays.json
@@ -6,10 +6,10 @@
         "spec_url": "https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/",
         "support": {
           "chrome": {
-            "version_added": "32"
+            "version_added": "30"
           },
           "chrome_android": {
-            "version_added": "32"
+            "version_added": "30"
           },
           "edge": {
             "version_added": "12"
@@ -24,10 +24,10 @@
             "version_added": "11"
           },
           "opera": {
-            "version_added": "19"
+            "version_added": "17"
           },
           "opera_android": {
-            "version_added": "19"
+            "version_added": "18"
           },
           "safari": {
             "version_added": "8"
@@ -54,10 +54,10 @@
           "spec_url": "https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/",
           "support": {
             "chrome": {
-              "version_added": "32"
+              "version_added": "30"
             },
             "chrome_android": {
-              "version_added": "32"
+              "version_added": "30"
             },
             "edge": {
               "version_added": "12"
@@ -72,10 +72,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": "19"
+              "version_added": "17"
             },
             "opera_android": {
-              "version_added": "19"
+              "version_added": "18"
             },
             "safari": {
               "version_added": "8"
@@ -103,10 +103,10 @@
           "spec_url": "https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/",
           "support": {
             "chrome": {
-              "version_added": "32"
+              "version_added": "30"
             },
             "chrome_android": {
-              "version_added": "32"
+              "version_added": "30"
             },
             "edge": {
               "version_added": "12"
@@ -121,10 +121,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": "19"
+              "version_added": "17"
             },
             "opera_android": {
-              "version_added": "19"
+              "version_added": "18"
             },
             "safari": {
               "version_added": "8"
@@ -152,10 +152,10 @@
           "spec_url": "https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/",
           "support": {
             "chrome": {
-              "version_added": "32"
+              "version_added": "30"
             },
             "chrome_android": {
-              "version_added": "32"
+              "version_added": "30"
             },
             "edge": {
               "version_added": "12"
@@ -170,10 +170,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": "19"
+              "version_added": "17"
             },
             "opera_android": {
-              "version_added": "19"
+              "version_added": "18"
             },
             "safari": {
               "version_added": "8"

--- a/api/ANGLE_instanced_arrays.json
+++ b/api/ANGLE_instanced_arrays.json
@@ -5,9 +5,16 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ANGLE_instanced_arrays",
         "spec_url": "https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/",
         "support": {
-          "chrome": {
-            "version_added": "30"
-          },
+          "chrome": [
+            {
+              "version_added": "32"
+            },
+            {
+              "version_added": "30",
+              "partial_implementation": true,
+              "notes": "Available only on macOS."
+            }
+          ],
           "chrome_android": {
             "version_added": "30"
           },
@@ -23,9 +30,16 @@
           "ie": {
             "version_added": "11"
           },
-          "opera": {
-            "version_added": "17"
-          },
+          "opera": [
+            {
+              "version_added": "19"
+            },
+            {
+              "version_added": "17",
+              "partial_implementation": true,
+              "notes": "Available only on macOS."
+            }
+          ],
           "opera_android": {
             "version_added": "18"
           },


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `ANGLE_instanced_arrays` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ANGLE_instanced_arrays

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
