### PR TITLE
Update all browsers versions for api.AnalyserNode.getFloatTimeDomainData

### DIFF
--- a/api/AnalyserNode.json
+++ b/api/AnalyserNode.json
@@ -349,28 +349,28 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-analysernode-getfloattimedomaindata",
           "support": {
             "chrome": {
-              "version_added": "14"
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "35"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "30"
             },
             "firefox_android": {
-              "version_added": "25"
+              "version_added": "30"
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "22"
             },
             "safari": {
               "version_added": "14.1"
@@ -379,10 +379,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for all browsers for the `getFloatTimeDomainData` member of the `AnalyserNode` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AnalyserNode/getFloatTimeDomainData

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._

Note: the original data had come from the wiki migration.
