### PR TITLE
Update Firefox versions for AnimationEvent API

### DIFF
--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -29,10 +29,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "6"
+            "version_added": "5"
           },
           "firefox_android": {
-            "version_added": "6"
+            "version_added": "5"
           },
           "ie": {
             "version_added": "10"
@@ -197,10 +197,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "firefox_android": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "ie": {
               "version_added": "10"
@@ -246,10 +246,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "firefox_android": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "ie": {
               "version_added": "10"


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `AnimationEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AnimationEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
