### PR TITLE
Update Opera versions for AnimationEvent API

### DIFF
--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -145,10 +145,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "30"
             },
             "safari": [
               {
@@ -304,10 +304,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "55"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": "13.1"


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `AnimationEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AnimationEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
