### PR TITLE
Update Safari versions for AnimationEvent API

### DIFF
--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -77,7 +77,7 @@
           ],
           "safari": [
             {
-              "version_added": "9.1"
+              "version_added": "9"
             },
             {
               "prefix": "WebKit",
@@ -86,7 +86,7 @@
           ],
           "safari_ios": [
             {
-              "version_added": "9.3"
+              "version_added": "9"
             },
             {
               "prefix": "WebKit",
@@ -152,7 +152,7 @@
             },
             "safari": [
               {
-                "version_added": "9.1"
+                "version_added": "9"
               },
               {
                 "prefix": "WebKit",
@@ -161,7 +161,7 @@
             ],
             "safari_ios": [
               {
-                "version_added": "9.3"
+                "version_added": "9"
               },
               {
                 "prefix": "WebKit",


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `AnimationEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AnimationEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
