### PR TITLE
Update WebView versions for Animation API

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -207,7 +207,7 @@
               "version_added": "14.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "84"
             }
           },
           "status": {
@@ -403,7 +403,7 @@
               "version_added": "14.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "84"
             }
           },
           "status": {
@@ -599,7 +599,7 @@
               "version_added": "14.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "84"
             }
           },
           "status": {
@@ -748,7 +748,7 @@
               "version_added": "14.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "84"
             }
           },
           "status": {
@@ -952,7 +952,7 @@
               "version_added": "14.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "84"
             }
           },
           "status": {
@@ -1052,7 +1052,7 @@
               "version_added": "14.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "84"
             }
           },
           "status": {
@@ -1203,7 +1203,7 @@
               "version_added": "14.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "84"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for WebView Android for the `Animation` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Animation

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
