### PR TITLE
Update WebView versions for AnimationPlaybackEvent API

### DIFF
--- a/api/AnimationPlaybackEvent.json
+++ b/api/AnimationPlaybackEvent.json
@@ -39,7 +39,7 @@
             "version_added": "14.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "84"
           }
         },
         "status": {
@@ -88,7 +88,7 @@
               "version_added": "14.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "84"
             }
           },
           "status": {
@@ -137,7 +137,7 @@
               "version_added": "14.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "84"
             }
           },
           "status": {
@@ -186,7 +186,7 @@
               "version_added": "14.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "84"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for WebView Android for the `AnimationPlaybackEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AnimationPlaybackEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
