### PR TITLE
Update Opera versions for api.AudioEncoder.encodeQueueSize

### DIFF
--- a/api/AudioEncoder.json
+++ b/api/AudioEncoder.json
@@ -269,7 +269,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `encodeQueueSize` member of the `AudioEncoder` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AudioEncoder/encodeQueueSize

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
