### PR TITLE
Update Chromium versions for AudioWorkletNode API

### DIFF
--- a/api/AudioWorkletNode.json
+++ b/api/AudioWorkletNode.json
@@ -104,10 +104,10 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audioworkletnode-onprocessorerror",
           "support": {
             "chrome": {
-              "version_added": "67"
+              "version_added": "66"
             },
             "chrome_android": {
-              "version_added": "67"
+              "version_added": "66"
             },
             "edge": {
               "version_added": "79"
@@ -122,10 +122,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "54"
+              "version_added": "53"
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "safari": {
               "version_added": "14.1"
@@ -137,7 +137,7 @@
               "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "67"
+              "version_added": "66"
             }
           },
           "status": {
@@ -153,10 +153,10 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audioworkletnode-parameters",
           "support": {
             "chrome": {
-              "version_added": "67"
+              "version_added": "66"
             },
             "chrome_android": {
-              "version_added": "67"
+              "version_added": "66"
             },
             "edge": {
               "version_added": "79"
@@ -171,10 +171,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "54"
+              "version_added": "53"
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "safari": {
               "version_added": "14.1"
@@ -186,7 +186,7 @@
               "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "67"
+              "version_added": "66"
             }
           },
           "status": {
@@ -202,10 +202,10 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audioworkletnode-port",
           "support": {
             "chrome": {
-              "version_added": "67"
+              "version_added": "66"
             },
             "chrome_android": {
-              "version_added": "67"
+              "version_added": "66"
             },
             "edge": {
               "version_added": "79"
@@ -220,10 +220,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "54"
+              "version_added": "53"
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "safari": {
               "version_added": "14.1"
@@ -235,7 +235,7 @@
               "version_added": "9.0"
             },
             "webview_android": {
-              "version_added": "67"
+              "version_added": "66"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `AudioWorkletNode` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AudioWorkletNode

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
