### PR TITLE
Update Opera versions for AuthenticatorAttestationResponse API

### DIFF
--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -36,7 +36,7 @@
             "version_added": "54"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "48"
           },
           "safari": {
             "version_added": "13"
@@ -93,7 +93,7 @@
               "version_added": "54"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": "13"
@@ -140,7 +140,7 @@
               "version_added": "71"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "safari": {
               "version_added": false
@@ -187,7 +187,7 @@
               "version_added": "71"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "safari": {
               "version_added": false
@@ -234,7 +234,7 @@
               "version_added": "71"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "safari": {
               "version_added": false
@@ -283,7 +283,7 @@
               "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `AuthenticatorAttestationResponse` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AuthenticatorAttestationResponse

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
