### PR TITLE
Update Opera versions for AuthenticatorResponse API

### DIFF
--- a/api/AuthenticatorResponse.json
+++ b/api/AuthenticatorResponse.json
@@ -36,7 +36,7 @@
             "version_added": "54"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "48"
           },
           "safari": {
             "version_added": "13"
@@ -93,7 +93,7 @@
               "version_added": "54"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": "13"


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `AuthenticatorResponse` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AuthenticatorResponse

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
