### PR TITLE
Update Chromium versions for BarProp API

### DIFF
--- a/api/BarProp.json
+++ b/api/BarProp.json
@@ -6,10 +6,10 @@
         "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#barprop",
         "support": {
           "chrome": {
-            "version_added": "29"
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": "29"
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "16"
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": "16"
+            "version_added": "14"
           },
           "safari": {
             "version_added": "3"
@@ -36,7 +36,7 @@
             "version_added": "1"
           },
           "samsunginternet_android": {
-            "version_added": "2.0"
+            "version_added": "1.0"
           },
           "webview_android": {
             "version_added": "≤37"
@@ -54,10 +54,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/window-object.html#dom-barprop-visible",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "30"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "30"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "3"
@@ -84,10 +84,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `BarProp` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/BarProp

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
