### PR TITLE
Update Chromium versions for BaseAudioContext API

### DIFF
--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -1047,10 +1047,10 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createstereopanner",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "41"
             },
             "chrome_android": {
-              "version_added": "42"
+              "version_added": "41"
             },
             "edge": {
               "version_added": "12"
@@ -1065,10 +1065,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "29"
+              "version_added": "28"
             },
             "opera_android": {
-              "version_added": "29"
+              "version_added": "28"
             },
             "safari": {
               "version_added": "14.1"
@@ -1080,7 +1080,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "42"
+              "version_added": "41"
             }
           },
           "status": {
@@ -1389,10 +1389,10 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-onstatechange",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "41"
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": "41"
             },
             "edge": {
               "version_added": "14"
@@ -1407,10 +1407,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "30"
+              "version_added": "28"
             },
             "opera_android": {
-              "version_added": "30"
+              "version_added": "28"
             },
             "safari": {
               "version_added": "9"
@@ -1422,7 +1422,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": "41"
             }
           },
           "status": {
@@ -1487,10 +1487,10 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-state",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "41"
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": "41"
             },
             "edge": {
               "version_added": "14"
@@ -1505,10 +1505,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "30"
+              "version_added": "28"
             },
             "opera_android": {
-              "version_added": "30"
+              "version_added": "28"
             },
             "safari": {
               "version_added": "9"
@@ -1520,7 +1520,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": "41"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `BaseAudioContext` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/BaseAudioContext

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
