### PR TITLE
Update all browsers versions for Blob API

### DIFF
--- a/api/Blob.json
+++ b/api/Blob.json
@@ -41,7 +41,7 @@
             "version_added": "11"
           },
           "safari": {
-            "version_added": "5.1"
+            "version_added": "6"
           },
           "safari_ios": {
             "version_added": "6"
@@ -209,7 +209,7 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": "6"
@@ -299,7 +299,7 @@
                 "version_added": "7"
               },
               {
-                "version_added": "5.1",
+                "version_added": "6",
                 "version_removed": "7",
                 "prefix": "webkit"
               }
@@ -483,7 +483,7 @@
               "version_added": "11"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "6"
             },
             "safari_ios": {
               "version_added": "6"

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -21,7 +21,7 @@
             "version_added": "4"
           },
           "firefox_android": {
-            "version_added": "14"
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"
@@ -98,10 +98,10 @@
               "version_added": "12"
             },
             "safari": {
-              "version_added": "8"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "8"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.5"
@@ -194,7 +194,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -206,13 +206,13 @@
               "version_added": "11"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari": {
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -271,9 +271,17 @@
                 "prefix": "moz"
               }
             ],
-            "firefox_android": {
-              "version_added": "14"
-            },
+            "firefox_android": [
+              {
+                "version_added": "14",
+                "notes": "Before Firefox 12, there was a bug that affected the behavior of <code>Blob.slice()</code>; it did not work for <code>start</code> and <code>end</code> positions outside the range of signed 64-bit values; it has now been fixed to support unsigned 64-bit values."
+              },
+              {
+                "version_added": "5",
+                "version_removed": "14",
+                "prefix": "moz"
+              }
+            ],
             "ie": {
               "version_added": "10"
             },
@@ -460,7 +468,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -472,13 +480,13 @@
               "version_added": "11"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari": {
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR updates and corrects the real values for all browsers for the `Blob` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Blob

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
