### PR TITLE
Update Firefox versions for BlobEvent API

### DIFF
--- a/api/BlobEvent.json
+++ b/api/BlobEvent.json
@@ -15,10 +15,10 @@
             "version_added": "79"
           },
           "firefox": {
-            "version_added": "25"
+            "version_added": "21"
           },
           "firefox_android": {
-            "version_added": "25"
+            "version_added": "21"
           },
           "ie": {
             "version_added": false
@@ -64,10 +64,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "21"
             },
             "firefox_android": {
-              "version_added": "25"
+              "version_added": "21"
             },
             "ie": {
               "version_added": false
@@ -113,10 +113,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "21"
             },
             "firefox_android": {
-              "version_added": "25"
+              "version_added": "21"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `BlobEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/BlobEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
