### PR TITLE
Update Chromium versions for ByteLengthQueuingStrategy API

### DIFF
--- a/api/ByteLengthQueuingStrategy.json
+++ b/api/ByteLengthQueuingStrategy.json
@@ -6,10 +6,10 @@
         "spec_url": "https://streams.spec.whatwg.org/#blqs-class",
         "support": {
           "chrome": {
-            "version_added": "59"
+            "version_added": "52"
           },
           "chrome_android": {
-            "version_added": "59"
+            "version_added": "52"
           },
           "deno": {
             "version_added": "1.0"
@@ -34,10 +34,10 @@
             ]
           },
           "opera": {
-            "version_added": "46"
+            "version_added": "39"
           },
           "opera_android": {
-            "version_added": "43"
+            "version_added": "41"
           },
           "safari": {
             "version_added": "10.1"
@@ -46,10 +46,10 @@
             "version_added": "10.3"
           },
           "samsunginternet_android": {
-            "version_added": "7.0"
+            "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": "59"
+            "version_added": "52"
           }
         },
         "status": {
@@ -171,10 +171,10 @@
           "spec_url": "https://streams.spec.whatwg.org/#blqs-size",
           "support": {
             "chrome": {
-              "version_added": "59"
+              "version_added": "52"
             },
             "chrome_android": {
-              "version_added": "59"
+              "version_added": "52"
             },
             "deno": {
               "version_added": "1.0"
@@ -192,10 +192,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "46"
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "41"
             },
             "safari": {
               "version_added": "10.1"
@@ -204,10 +204,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": "7.0"
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "59"
+              "version_added": "52"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `ByteLengthQueuingStrategy` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ByteLengthQueuingStrategy

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
