### PR TITLE
Update Safari versions for CSS API

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -30,10 +30,10 @@
             "version_added": "12.1"
           },
           "safari": {
-            "version_added": "10"
+            "version_added": "9"
           },
           "safari_ios": {
-            "version_added": "10"
+            "version_added": "9"
           },
           "samsunginternet_android": {
             "version_added": "1.5"
@@ -1558,10 +1558,10 @@
               "version_added": "12.1"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "samsunginternet_android": [
               {


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `CSS` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CSS

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
