### PR TITLE
Update Opera versions for api.CSS.registerProperty

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -1330,7 +1330,7 @@
               "version_added": "65"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `registerProperty` member of the `CSS` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CSS/registerProperty

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
