### PR TITLE
Update IE versions for CSSImportRule API

### DIFF
--- a/api/CSSImportRule.json
+++ b/api/CSSImportRule.json
@@ -118,7 +118,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR updates and corrects the real values for Internet Explorer for the `CSSImportRule` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CSSImportRule

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
