### PR TITLE
Update all browsers versions for CanvasCaptureMediaStreamTrack API

### DIFF
--- a/api/CanvasCaptureMediaStreamTrack.json
+++ b/api/CanvasCaptureMediaStreamTrack.json
@@ -39,16 +39,16 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "38"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "41"
           },
           "safari": {
-            "version_added": false
+            "version_added": "11"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "11"
           },
           "samsunginternet_android": {
             "version_added": "5.0"
@@ -69,13 +69,13 @@
           "spec_url": "https://w3c.github.io/mediacapture-fromelement/#dom-canvascapturemediastreamtrack-canvas",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "51"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "51"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "41",
@@ -102,22 +102,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "38"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "51"
             }
           },
           "status": {
@@ -166,16 +166,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "38"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
This PR updates and corrects the real values for all browsers for the `CanvasCaptureMediaStreamTrack` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CanvasCaptureMediaStreamTrack

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
