### PR TITLE
Update Firefox versions for CanvasGradient API

### DIFF
--- a/api/CanvasGradient.json
+++ b/api/CanvasGradient.json
@@ -15,7 +15,7 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "3.6",
+            "version_added": "1.5",
             "notes": "Before Firefox 5.0, specifying non-finite values when adding color stops through a call to <code>addColorStop()</code> incorrectly throws <code>SYNTAX_ERR</code> instead of <code>INDEX_SIZE_ERR</code>."
           },
           "firefox_android": {
@@ -64,7 +64,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3.6"
+              "version_added": "1.5"
             },
             "firefox_android": {
               "version_added": "4"


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `CanvasGradient` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CanvasGradient

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
