### PR TITLE
Update Firefox versions for api.CanvasRenderingContext2D.isPointInStroke

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2293,26 +2293,12 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "20"
-              },
-              {
-                "version_added": "19",
-                "version_removed": "20",
-                "prefix": "moz"
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "20"
-              },
-              {
-                "version_added": "19",
-                "version_removed": "20",
-                "prefix": "moz"
-              }
-            ],
+            "firefox": {
+              "version_added": "19"
+            },
+            "firefox_android": {
+              "version_added": "19"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `isPointInStroke` member of the `CanvasRenderingContext2D` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CanvasRenderingContext2D/isPointInStroke

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
