### PR TITLE
Update Chromium versions for Clients API

### DIFF
--- a/api/Clients.json
+++ b/api/Clients.json
@@ -139,7 +139,7 @@
               "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "51"
             }
           },
           "status": {
@@ -155,11 +155,11 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#clients-matchall",
           "support": {
             "chrome": {
-              "version_added": "47",
+              "version_added": "42",
               "notes": "<code>Client</code> objects returned in most recent focus order."
             },
             "chrome_android": {
-              "version_added": "47",
+              "version_added": "42",
               "notes": "<code>Client</code> objects returned in most recent focus order."
             },
             "edge": {
@@ -189,10 +189,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "29"
             },
             "safari": {
               "version_added": "11.1"
@@ -205,7 +205,7 @@
               "notes": "<code>Client</code> objects returned in most recent focus order."
             },
             "webview_android": {
-              "version_added": "47",
+              "version_added": "42",
               "notes": "<code>Client</code> objects returned in most recent focus order."
             }
           },


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Clients` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Clients

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
