### PR TITLE
Update Chromium versions for api.CompositionEvent.data

### DIFF
--- a/api/CompositionEvent.json
+++ b/api/CompositionEvent.json
@@ -104,10 +104,10 @@
           "spec_url": "https://w3c.github.io/uievents/#dom-compositionevent-data",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "15"
             },
             "chrome_android": {
-              "version_added": "43"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -122,10 +122,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": "30"
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": "30"
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": "5"
@@ -134,10 +134,10 @@
               "version_added": "5"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "43"
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `data` member of the `CompositionEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CompositionEvent/data

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
