### PR TITLE
Update Chromium versions for ConstantSourceNode API

### DIFF
--- a/api/ConstantSourceNode.json
+++ b/api/ConstantSourceNode.json
@@ -107,7 +107,7 @@
               "version_added": "56"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "56"
             },
             "edge": {
               "version_added": "79"
@@ -122,10 +122,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "43"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "43"
             },
             "safari": {
               "version_added": "14.1"
@@ -134,10 +134,10 @@
               "version_added": "14.5"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "56"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `ConstantSourceNode` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ConstantSourceNode

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
