### PR TITLE
Update Chromium versions for CountQueuingStrategy API

### DIFF
--- a/api/CountQueuingStrategy.json
+++ b/api/CountQueuingStrategy.json
@@ -62,10 +62,10 @@
           "description": "<code>CountQueuingStrategy()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "59"
+              "version_added": "52"
             },
             "chrome_android": {
-              "version_added": "59"
+              "version_added": "52"
             },
             "edge": {
               "version_added": "16"
@@ -80,10 +80,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "46"
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "41"
             },
             "safari": {
               "version_added": "10.1"
@@ -92,10 +92,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": "7.0"
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "59"
+              "version_added": "52"
             }
           },
           "status": {

--- a/api/CountQueuingStrategy.json
+++ b/api/CountQueuingStrategy.json
@@ -6,10 +6,10 @@
         "spec_url": "https://streams.spec.whatwg.org/#cqs-class",
         "support": {
           "chrome": {
-            "version_added": "59"
+            "version_added": "52"
           },
           "chrome_android": {
-            "version_added": "59"
+            "version_added": "52"
           },
           "edge": {
             "version_added": "16"
@@ -31,10 +31,10 @@
             ]
           },
           "opera": {
-            "version_added": "46"
+            "version_added": "39"
           },
           "opera_android": {
-            "version_added": "43"
+            "version_added": "41"
           },
           "safari": {
             "version_added": "10.1"
@@ -43,10 +43,10 @@
             "version_added": "10.3"
           },
           "samsunginternet_android": {
-            "version_added": "7.0"
+            "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": "59"
+            "version_added": "52"
           }
         },
         "status": {
@@ -162,10 +162,10 @@
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-cqs-size②",
           "support": {
             "chrome": {
-              "version_added": "59"
+              "version_added": "52"
             },
             "chrome_android": {
-              "version_added": "59"
+              "version_added": "52"
             },
             "edge": {
               "version_added": "16"
@@ -180,10 +180,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "46"
+              "version_added": "39"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "41"
             },
             "safari": {
               "version_added": "10.1"
@@ -192,10 +192,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": "7.0"
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "59"
+              "version_added": "52"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `CountQueuingStrategy` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CountQueuingStrategy

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
