### PR TITLE
Update Firefox versions for Crypto API

### DIFF
--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -26,10 +26,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "26"
+            "version_added": "1"
           },
           "firefox_android": {
-            "version_added": "26"
+            "version_added": "4"
           },
           "ie": {
             "version_added": "11"
@@ -84,10 +84,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "26"
+              "version_added": "21"
             },
             "firefox_android": {
-              "version_added": "26"
+              "version_added": "21"
             },
             "ie": {
               "version_added": "11"

--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -26,10 +26,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "1"
+            "version_added": "21"
           },
           "firefox_android": {
-            "version_added": "4"
+            "version_added": "21"
           },
           "ie": {
             "version_added": "11"


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `Crypto` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Crypto

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
