### PR TITLE
Update IE versions for DOMException API

### DIFF
--- a/api/DOMException.json
+++ b/api/DOMException.json
@@ -24,7 +24,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "10"
+            "version_added": "9"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -128,7 +128,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -180,7 +180,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR updates and corrects the real values for Internet Explorer for the `DOMException` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DOMException

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
