### PR TITLE
Update all browsers versions for DOMRectList API

### DIFF
--- a/api/DOMRectList.json
+++ b/api/DOMRectList.json
@@ -4,120 +4,42 @@
       "__compat": {
         "spec_url": "https://drafts.fxtf.org/geometry/#DOMRectList",
         "support": {
-          "chrome": [
-            {
-              "version_added": "61"
-            },
-            {
-              "alternative_name": "ClientRectList",
-              "version_added": "2",
-              "version_removed": "61"
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_added": "61"
-            },
-            {
-              "alternative_name": "ClientRectList",
-              "version_added": "18",
-              "version_removed": "61"
-            }
-          ],
-          "edge": [
-            {
-              "version_added": "79"
-            },
-            {
-              "alternative_name": "ClientRectList",
-              "version_added": "12",
-              "version_removed": "79"
-            }
-          ],
-          "firefox": [
-            {
-              "version_added": "27"
-            },
-            {
-              "alternative_name": "ClientRectList",
-              "version_added": "3",
-              "version_removed": "27"
-            }
-          ],
-          "firefox_android": [
-            {
-              "version_added": "27"
-            },
-            {
-              "alternative_name": "ClientRectList",
-              "version_added": "4",
-              "version_removed": "27"
-            }
-          ],
+          "chrome": {
+            "version_added": "2"
+          },
+          "chrome_android": {
+            "version_added": "18"
+          },
+          "edge": {
+            "version_added": "12"
+          },
+          "firefox": {
+            "version_added": "3"
+          },
+          "firefox_android": {
+            "version_added": "4"
+          },
           "ie": {
-            "alternative_name": "ClientRectList",
             "version_added": "9"
           },
-          "opera": [
-            {
-              "version_added": "48"
-            },
-            {
-              "alternative_name": "ClientRectList",
-              "version_added": "≤12.1",
-              "version_removed": "48"
-            }
-          ],
-          "opera_android": [
-            {
-              "version_added": "45"
-            },
-            {
-              "alternative_name": "ClientRectList",
-              "version_added": "≤12.1",
-              "version_removed": "45"
-            }
-          ],
-          "safari": [
-            {
-              "version_added": "10.1"
-            },
-            {
-              "alternative_name": "ClientRectList",
-              "version_added": "4",
-              "version_removed": "11"
-            }
-          ],
-          "safari_ios": [
-            {
-              "version_added": "10.3"
-            },
-            {
-              "alternative_name": "ClientRectList",
-              "version_added": "3",
-              "version_removed": "11"
-            }
-          ],
-          "samsunginternet_android": [
-            {
-              "version_added": "8.0"
-            },
-            {
-              "alternative_name": "ClientRectList",
-              "version_added": "1.0",
-              "version_removed": "8.0"
-            }
-          ],
-          "webview_android": [
-            {
-              "version_added": "61"
-            },
-            {
-              "alternative_name": "ClientRectList",
-              "version_added": "≤37",
-              "version_removed": "61"
-            }
-          ]
+          "opera": {
+            "version_added": "≤12.1"
+          },
+          "opera_android": {
+            "version_added": "≤12.1"
+          },
+          "safari": {
+            "version_added": "4"
+          },
+          "safari_ios": {
+            "version_added": "3"
+          },
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
+          "webview_android": {
+            "version_added": "≤37"
+          }
         },
         "status": {
           "experimental": false,


### PR DESCRIPTION
This PR updates and corrects the real values for all browsers for the `DOMRectList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DOMRectList

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._

Note: this interface is never accessed by name, so the alt. names are pointless to record.  This interface is only accessed via api.Element.getClientRects().
