### PR TITLE
Update Safari versions for DOMTokenList API

### DIFF
--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -30,7 +30,7 @@
             "version_added": "11.5"
           },
           "safari": {
-            "version_added": "6"
+            "version_added": "5.1"
           },
           "safari_ios": {
             "version_added": "6"
@@ -78,7 +78,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "5.1"
             },
             "safari_ios": {
               "version_added": "6"
@@ -175,7 +175,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "5.1"
             },
             "safari_ios": {
               "version_added": "6"
@@ -320,7 +320,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "5.1"
             },
             "safari_ios": {
               "version_added": "6"
@@ -417,7 +417,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "5.1"
             },
             "safari_ios": {
               "version_added": "6"
@@ -466,7 +466,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "5.1"
             },
             "safari_ios": {
               "version_added": "6"
@@ -758,7 +758,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "5.1"
             },
             "safari_ios": {
               "version_added": "6"

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -33,7 +33,7 @@
             "version_added": "5.1"
           },
           "safari_ios": {
-            "version_added": "6"
+            "version_added": "5"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
@@ -81,7 +81,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -178,7 +178,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -323,7 +323,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -420,7 +420,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -469,7 +469,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -761,7 +761,7 @@
               "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `DOMTokenList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DOMTokenList

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
