### PR TITLE
Update Firefox versions for api.DOMTokenList.length

### DIFF
--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -402,10 +402,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "50"
+              "version_added": "3.6"
             },
             "firefox_android": {
-              "version_added": "50"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `length` member of the `DOMTokenList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DOMTokenList/length

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
