### PR TITLE
Update Chromium versions for api.DataTransfer.DataTransfer

### DIFF
--- a/api/DataTransfer.json
+++ b/api/DataTransfer.json
@@ -57,10 +57,10 @@
           "description": "<code>DataTransfer()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": "60"
+              "version_added": "59"
             },
             "edge": {
               "version_added": "17"
@@ -75,7 +75,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "47"
+              "version_added": "46"
             },
             "opera_android": {
               "version_added": "44"
@@ -90,7 +90,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "60"
+              "version_added": "59"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `DataTransfer` member of the `DataTransfer` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DataTransfer/DataTransfer

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
