### PR TITLE
Update Firefox versions for api.DataTransfer.setData

### DIFF
--- a/api/DataTransfer.json
+++ b/api/DataTransfer.json
@@ -851,10 +851,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "10"
+              "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "10"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "8"


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `setData` member of the `DataTransfer` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DataTransfer/setData

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
