### PR TITLE
Update Opera versions for DataTransferItem API

### DIFF
--- a/api/DataTransferItem.json
+++ b/api/DataTransferItem.json
@@ -27,7 +27,7 @@
             "version_added": "12"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "12"
           },
           "safari": {
             "version_added": "5.1"
@@ -75,7 +75,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari": {
               "version_added": "5.1"
@@ -173,7 +173,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari": {
               "version_added": "5.1"
@@ -222,7 +222,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari": {
               "version_added": "5.1"
@@ -271,7 +271,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari": {
               "version_added": "5.1"
@@ -317,10 +317,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11.1"

--- a/api/DataTransferItem.json
+++ b/api/DataTransferItem.json
@@ -27,7 +27,7 @@
             "version_added": "12"
           },
           "opera_android": {
-            "version_added": "12"
+            "version_added": "≤14"
           },
           "safari": {
             "version_added": "5.1"
@@ -75,7 +75,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": "12"
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": "5.1"
@@ -173,7 +173,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": "12"
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": "5.1"
@@ -222,7 +222,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": "12"
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": "5.1"
@@ -271,7 +271,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": "12"
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": "5.1"


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `DataTransferItem` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DataTransferItem

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
