### PR TITLE
Update Opera versions for DataTransferItemList API

### DIFF
--- a/api/DataTransferItemList.json
+++ b/api/DataTransferItemList.json
@@ -27,7 +27,7 @@
             "version_added": "12"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "12"
           },
           "safari": {
             "version_added": "6"
@@ -75,7 +75,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari": {
               "version_added": "6"
@@ -124,7 +124,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari": {
               "version_added": "6"
@@ -173,7 +173,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari": {
               "version_added": "6"
@@ -222,7 +222,7 @@
               "version_added": "12"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "12"
             },
             "safari": {
               "version_added": "6"


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `DataTransferItemList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DataTransferItemList

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
