### PR TITLE
Name Chrome OS and macOS consistently in descriptions

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -6208,7 +6208,7 @@
             "firefox": [
               {
                 "version_added": "18",
-                "notes": "Since Firefox 56 it also returns <code>true</code> on Mac when the window is completely hidden by another non-translucent application."
+                "notes": "Since Firefox 56 it also returns <code>true</code> on macOS when the window is completely hidden by another non-translucent application."
               },
               {
                 "version_added": "10",
@@ -6219,7 +6219,7 @@
             "firefox_android": [
               {
                 "version_added": "18",
-                "notes": "Since Firefox 56 it also returns <code>true</code> on Mac when the window is completely hidden by another non-translucent application."
+                "notes": "Since Firefox 56 it also returns <code>true</code> on macOS when the window is completely hidden by another non-translucent application."
               },
               {
                 "version_added": "10",

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -413,12 +413,12 @@
                 "chrome": [
                   {
                     "version_added": "81",
-                    "notes": "ChromeOS and Windows"
+                    "notes": "Chrome OS and Windows"
                   },
                   {
                     "version_added": "75",
                     "partial_implementation": true,
-                    "notes": "ChromeOS only"
+                    "notes": "Chrome OS only"
                   }
                 ],
                 "chrome_android": {
@@ -679,12 +679,12 @@
                 "chrome": [
                   {
                     "version_added": "81",
-                    "notes": "ChromeOS and Windows"
+                    "notes": "Chrome OS and Windows"
                   },
                   {
                     "version_added": "75",
                     "partial_implementation": true,
-                    "notes": "ChromeOS only"
+                    "notes": "Chrome OS only"
                   }
                 ],
                 "chrome_android": {
@@ -933,12 +933,12 @@
                 "chrome": [
                   {
                     "version_added": "81",
-                    "notes": "ChromeOS and Windows"
+                    "notes": "Chrome OS and Windows"
                   },
                   {
                     "version_added": "75",
                     "partial_implementation": true,
-                    "notes": "ChromeOS only"
+                    "notes": "Chrome OS only"
                   }
                 ],
                 "chrome_android": {

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -244,14 +244,14 @@
             "support": {
               "chrome": {
                 "version_added": "74",
-                "notes": "On Windows and Chrome OS the entire system audio can be captured, but on Linux and Mac only the audio of a tab can be captured."
+                "notes": "On Windows and Chrome OS the entire system audio can be captured, but on Linux and macOS only the audio of a tab can be captured."
               },
               "chrome_android": {
                 "version_added": false
               },
               "edge": {
                 "version_added": "≤79",
-                "notes": "On Windows, the entire system audio can be captured, but on Linux and Mac only the audio of a tab can be captured."
+                "notes": "On Windows, the entire system audio can be captured, but on Linux and macOS only the audio of a tab can be captured."
               },
               "firefox": {
                 "version_added": false
@@ -264,7 +264,7 @@
               },
               "opera": {
                 "version_added": "62",
-                "notes": "On Windows and Opera OS the entire system audio can be captured, but on Linux and Mac only the audio of a tab can be captured."
+                "notes": "On Windows, the entire system audio can be captured, but on Linux and macOS only the audio of a tab can be captured."
               },
               "opera_android": {
                 "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -721,7 +721,7 @@
             "chrome": {
               "version_added": "83",
               "partial_implementation": true,
-              "notes": "Windows and Mac only."
+              "notes": "Windows and macOS only."
             },
             "chrome_android": {
               "version_added": false
@@ -2492,7 +2492,7 @@
           "support": {
             "chrome": {
               "version_added": "1",
-              "notes": "Earlier versions of Chrome incorrectly return true when a tab is first opened, but it starts reporting the correct connectivity status after the first network event. Windows: 11, Mac: 14, Chrome OS: 13, Linux: Always returns <code>true</code>. For history, see <a href='https://crbug.com/7469'>crbug.com/7469</a>."
+              "notes": "Earlier versions of Chrome incorrectly return true when a tab is first opened, but it starts reporting the correct connectivity status after the first network event. Windows: 11, macOS: 14, Chrome OS: 13, Linux: Always returns <code>true</code>. For history, see <a href='https://crbug.com/7469'>crbug.com/7469</a>."
             },
             "chrome_android": {
               "version_added": "18"
@@ -3411,7 +3411,7 @@
             "chrome": {
               "version_added": "83",
               "partial_implementation": true,
-              "notes": "Windows and Mac only."
+              "notes": "Windows and macOS only."
             },
             "chrome_android": {
               "version_added": false
@@ -3419,7 +3419,7 @@
             "edge": {
               "version_added": "83",
               "partial_implementation": true,
-              "notes": "Windows and Mac only."
+              "notes": "Windows and macOS only."
             },
             "firefox": {
               "version_added": false

--- a/webextensions/api/notifications.json
+++ b/webextensions/api/notifications.json
@@ -606,7 +606,7 @@
                 "version_added": false
               },
               "opera": {
-                "notes": "Not supported on Macs.",
+                "notes": "Not supported on macOS.",
                 "version_added": "25"
               },
               "safari": {


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Chrome_OS
https://en.wikipedia.org/wiki/MacOS

This also fixes an "Opera OS" copypasta error.
