### PR TITLE
Update IE versions for DeviceMotionEvent API

### DIFF
--- a/api/DeviceMotionEvent.json
+++ b/api/DeviceMotionEvent.json
@@ -21,7 +21,7 @@
             "version_added": "6"
           },
           "ie": {
-            "version_added": false
+            "version_added": "11"
           },
           "opera": {
             "version_added": "15"
@@ -119,7 +119,7 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": "15"
@@ -168,7 +168,7 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": "15"
@@ -217,7 +217,7 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": "15"
@@ -314,7 +314,7 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": "15"


### PR DESCRIPTION
This PR updates and corrects the real values for Internet Explorer for the `DeviceMotionEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DeviceMotionEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
