### PR TITLE
Update IE versions for DeviceOrientationEvent API

### DIFF
--- a/api/DeviceOrientationEvent.json
+++ b/api/DeviceOrientationEvent.json
@@ -25,7 +25,7 @@
             "notes": "Firefox 3.6, 4, and 5 supported <code>mozOrientation</code> instead of the standard DeviceOrientationEvent interface."
           },
           "ie": {
-            "version_added": false
+            "version_added": "11"
           },
           "opera": {
             "version_added": "15"
@@ -125,7 +125,7 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": "15"
@@ -174,7 +174,7 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": "15"
@@ -223,7 +223,7 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": "15"
@@ -272,7 +272,7 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": "15"


### PR DESCRIPTION
This PR updates and corrects the real values for Internet Explorer for the `DeviceOrientationEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DeviceOrientationEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
