### PR TITLE
Update IE versions for DocumentFragment API

### DIFF
--- a/api/DocumentFragment.json
+++ b/api/DocumentFragment.json
@@ -21,7 +21,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": "9"
+            "version_added": "6"
           },
           "opera": {
             "version_added": "8"


### PR DESCRIPTION
This PR updates and corrects the real values for Internet Explorer for the `DocumentFragment` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DocumentFragment

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
