### PR TITLE
Update Edge versions for EXT_disjoint_timer_query API

### DIFF
--- a/api/EXT_disjoint_timer_query.json
+++ b/api/EXT_disjoint_timer_query.json
@@ -16,7 +16,7 @@
             "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
           },
           "edge": {
-            "version_added": false
+            "version_added": "80"
           },
           "firefox": {
             "version_added": "51",
@@ -78,7 +78,7 @@
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": "80"
             },
             "firefox": {
               "version_added": "51",
@@ -141,7 +141,7 @@
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": "80"
             },
             "firefox": {
               "version_added": "51",
@@ -204,7 +204,7 @@
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": "80"
             },
             "firefox": {
               "version_added": "51",
@@ -267,7 +267,7 @@
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": "80"
             },
             "firefox": {
               "version_added": "51",
@@ -330,7 +330,7 @@
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": "80"
             },
             "firefox": {
               "version_added": "51",
@@ -393,7 +393,7 @@
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": "80"
             },
             "firefox": {
               "version_added": "51",
@@ -456,7 +456,7 @@
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": "80"
             },
             "firefox": {
               "version_added": "51",
@@ -519,7 +519,7 @@
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": false
+              "version_added": "80"
             },
             "firefox": {
               "version_added": "51",

--- a/api/EXT_disjoint_timer_query.json
+++ b/api/EXT_disjoint_timer_query.json
@@ -5,18 +5,27 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_disjoint_timer_query",
         "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/",
         "support": {
-          "chrome": {
-            "version_added": "47",
-            "version_removed": "65",
-            "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
-          },
+          "chrome": [
+            {
+              "version_added": "70",
+              "partial_implementation": true,
+              "notes": "Only supported on macOS."
+            },
+            {
+              "version_added": "47",
+              "version_removed": "65",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+            }
+          ],
           "chrome_android": {
             "version_added": "47",
             "version_removed": "65",
             "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
           },
           "edge": {
-            "version_added": "80"
+            "version_added": "79",
+            "partial_implementation": true,
+            "notes": "Only supported on macOS."
           },
           "firefox": {
             "version_added": "51",
@@ -29,11 +38,18 @@
           "ie": {
             "version_added": false
           },
-          "opera": {
-            "version_added": "34",
-            "version_removed": "52",
-            "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
-          },
+          "opera": [
+            {
+              "version_added": "57",
+              "partial_implementation": true,
+              "notes": "Only supported on macOS."
+            },
+            {
+              "version_added": "34",
+              "version_removed": "52",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+            }
+          ],
           "opera_android": {
             "version_added": "34",
             "version_removed": "47",
@@ -67,18 +83,27 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_disjoint_timer_query/beginQueryEXT",
           "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/",
           "support": {
-            "chrome": {
-              "version_added": "47",
-              "version_removed": "65",
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
-            },
+            "chrome": [
+              {
+                "version_added": "70",
+                "partial_implementation": true,
+                "notes": "Only supported on macOS."
+              },
+              {
+                "version_added": "47",
+                "version_removed": "65",
+                "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              }
+            ],
             "chrome_android": {
               "version_added": "47",
               "version_removed": "65",
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79",
+              "partial_implementation": true,
+              "notes": "Only supported on macOS."
             },
             "firefox": {
               "version_added": "51",
@@ -91,11 +116,18 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "34",
-              "version_removed": "52",
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
-            },
+            "opera": [
+              {
+                "version_added": "57",
+                "partial_implementation": true,
+                "notes": "Only supported on macOS."
+              },
+              {
+                "version_added": "34",
+                "version_removed": "52",
+                "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              }
+            ],
             "opera_android": {
               "version_added": "34",
               "version_removed": "47",
@@ -130,18 +162,27 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_disjoint_timer_query/createQueryEXT",
           "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/",
           "support": {
-            "chrome": {
-              "version_added": "47",
-              "version_removed": "65",
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
-            },
+            "chrome": [
+              {
+                "version_added": "70",
+                "partial_implementation": true,
+                "notes": "Only supported on macOS."
+              },
+              {
+                "version_added": "47",
+                "version_removed": "65",
+                "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              }
+            ],
             "chrome_android": {
               "version_added": "47",
               "version_removed": "65",
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79",
+              "partial_implementation": true,
+              "notes": "Only supported on macOS."
             },
             "firefox": {
               "version_added": "51",
@@ -154,11 +195,18 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "34",
-              "version_removed": "52",
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
-            },
+            "opera": [
+              {
+                "version_added": "57",
+                "partial_implementation": true,
+                "notes": "Only supported on macOS."
+              },
+              {
+                "version_added": "34",
+                "version_removed": "52",
+                "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              }
+            ],
             "opera_android": {
               "version_added": "34",
               "version_removed": "47",
@@ -193,18 +241,27 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_disjoint_timer_query/deleteQueryEXT",
           "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/",
           "support": {
-            "chrome": {
-              "version_added": "47",
-              "version_removed": "65",
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
-            },
+            "chrome": [
+              {
+                "version_added": "70",
+                "partial_implementation": true,
+                "notes": "Only supported on macOS."
+              },
+              {
+                "version_added": "47",
+                "version_removed": "65",
+                "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              }
+            ],
             "chrome_android": {
               "version_added": "47",
               "version_removed": "65",
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79",
+              "partial_implementation": true,
+              "notes": "Only supported on macOS."
             },
             "firefox": {
               "version_added": "51",
@@ -217,11 +274,18 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "34",
-              "version_removed": "52",
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
-            },
+            "opera": [
+              {
+                "version_added": "57",
+                "partial_implementation": true,
+                "notes": "Only supported on macOS."
+              },
+              {
+                "version_added": "34",
+                "version_removed": "52",
+                "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              }
+            ],
             "opera_android": {
               "version_added": "34",
               "version_removed": "47",
@@ -256,18 +320,27 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_disjoint_timer_query/endQueryEXT",
           "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/",
           "support": {
-            "chrome": {
-              "version_added": "47",
-              "version_removed": "65",
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
-            },
+            "chrome": [
+              {
+                "version_added": "70",
+                "partial_implementation": true,
+                "notes": "Only supported on macOS."
+              },
+              {
+                "version_added": "47",
+                "version_removed": "65",
+                "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              }
+            ],
             "chrome_android": {
               "version_added": "47",
               "version_removed": "65",
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79",
+              "partial_implementation": true,
+              "notes": "Only supported on macOS."
             },
             "firefox": {
               "version_added": "51",
@@ -280,11 +353,18 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "34",
-              "version_removed": "52",
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
-            },
+            "opera": [
+              {
+                "version_added": "57",
+                "partial_implementation": true,
+                "notes": "Only supported on macOS."
+              },
+              {
+                "version_added": "34",
+                "version_removed": "52",
+                "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              }
+            ],
             "opera_android": {
               "version_added": "34",
               "version_removed": "47",
@@ -319,18 +399,27 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_disjoint_timer_query/getQueryEXT",
           "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/",
           "support": {
-            "chrome": {
-              "version_added": "47",
-              "version_removed": "65",
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
-            },
+            "chrome": [
+              {
+                "version_added": "70",
+                "partial_implementation": true,
+                "notes": "Only supported on macOS."
+              },
+              {
+                "version_added": "47",
+                "version_removed": "65",
+                "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              }
+            ],
             "chrome_android": {
               "version_added": "47",
               "version_removed": "65",
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79",
+              "partial_implementation": true,
+              "notes": "Only supported on macOS."
             },
             "firefox": {
               "version_added": "51",
@@ -343,11 +432,18 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "34",
-              "version_removed": "52",
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
-            },
+            "opera": [
+              {
+                "version_added": "57",
+                "partial_implementation": true,
+                "notes": "Only supported on macOS."
+              },
+              {
+                "version_added": "34",
+                "version_removed": "52",
+                "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              }
+            ],
             "opera_android": {
               "version_added": "34",
               "version_removed": "47",
@@ -382,18 +478,27 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_disjoint_timer_query/getQueryObjectEXT",
           "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/",
           "support": {
-            "chrome": {
-              "version_added": "47",
-              "version_removed": "65",
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
-            },
+            "chrome": [
+              {
+                "version_added": "70",
+                "partial_implementation": true,
+                "notes": "Only supported on macOS."
+              },
+              {
+                "version_added": "47",
+                "version_removed": "65",
+                "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              }
+            ],
             "chrome_android": {
               "version_added": "47",
               "version_removed": "65",
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79",
+              "partial_implementation": true,
+              "notes": "Only supported on macOS."
             },
             "firefox": {
               "version_added": "51",
@@ -406,11 +511,18 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "34",
-              "version_removed": "52",
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
-            },
+            "opera": [
+              {
+                "version_added": "57",
+                "partial_implementation": true,
+                "notes": "Only supported on macOS."
+              },
+              {
+                "version_added": "34",
+                "version_removed": "52",
+                "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              }
+            ],
             "opera_android": {
               "version_added": "34",
               "version_removed": "47",
@@ -445,18 +557,27 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_disjoint_timer_query/isQueryEXT",
           "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/",
           "support": {
-            "chrome": {
-              "version_added": "47",
-              "version_removed": "65",
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
-            },
+            "chrome": [
+              {
+                "version_added": "70",
+                "partial_implementation": true,
+                "notes": "Only supported on macOS."
+              },
+              {
+                "version_added": "47",
+                "version_removed": "65",
+                "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              }
+            ],
             "chrome_android": {
               "version_added": "47",
               "version_removed": "65",
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79",
+              "partial_implementation": true,
+              "notes": "Only supported on macOS."
             },
             "firefox": {
               "version_added": "51",
@@ -469,11 +590,18 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "34",
-              "version_removed": "52",
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
-            },
+            "opera": [
+              {
+                "version_added": "57",
+                "partial_implementation": true,
+                "notes": "Only supported on macOS."
+              },
+              {
+                "version_added": "34",
+                "version_removed": "52",
+                "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              }
+            ],
             "opera_android": {
               "version_added": "34",
               "version_removed": "47",
@@ -508,18 +636,27 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_disjoint_timer_query/queryCounterEXT",
           "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/",
           "support": {
-            "chrome": {
-              "version_added": "47",
-              "version_removed": "65",
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
-            },
+            "chrome": [
+              {
+                "version_added": "70",
+                "partial_implementation": true,
+                "notes": "Only supported on macOS."
+              },
+              {
+                "version_added": "47",
+                "version_removed": "65",
+                "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              }
+            ],
             "chrome_android": {
               "version_added": "47",
               "version_removed": "65",
               "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
             },
             "edge": {
-              "version_added": "80"
+              "version_added": "79",
+              "partial_implementation": true,
+              "notes": "Only supported on macOS."
             },
             "firefox": {
               "version_added": "51",
@@ -532,11 +669,18 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "34",
-              "version_removed": "52",
-              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
-            },
+            "opera": [
+              {
+                "version_added": "57",
+                "partial_implementation": true,
+                "notes": "Only supported on macOS."
+              },
+              {
+                "version_added": "34",
+                "version_removed": "52",
+                "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+              }
+            ],
             "opera_android": {
               "version_added": "34",
               "version_removed": "47",


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `EXT_disjoint_timer_query` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/EXT_disjoint_timer_query

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
