### PR TITLE
Update Edge versions for EXT_disjoint_timer_query_webgl2 API

### DIFF
--- a/api/EXT_disjoint_timer_query_webgl2.json
+++ b/api/EXT_disjoint_timer_query_webgl2.json
@@ -16,7 +16,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": false
+            "version_added": "80"
           },
           "firefox": {
             "version_added": false
@@ -68,7 +68,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "80"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `EXT_disjoint_timer_query_webgl2` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/EXT_disjoint_timer_query_webgl2

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
