### PR TITLE
Update Chromium versions for EXT_float_blend API

### DIFF
--- a/api/EXT_float_blend.json
+++ b/api/EXT_float_blend.json
@@ -25,10 +25,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "64"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "54"
           },
           "safari": {
             "version_added": "14.1"
@@ -37,10 +37,10 @@
             "version_added": "15"
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "11.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "75"
           }
         },
         "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `EXT_float_blend` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/EXT_float_blend

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
