### PR TITLE
Update Opera versions for api.ElementInternals.states

### DIFF
--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -438,7 +438,7 @@
               "version_added": "76"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `states` member of the `ElementInternals` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ElementInternals/states

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
