### PR TITLE
Update Firefox versions for ErrorEvent API

### DIFF
--- a/api/ErrorEvent.json
+++ b/api/ErrorEvent.json
@@ -18,10 +18,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "30"
+            "version_added": "27"
           },
           "firefox_android": {
-            "version_added": "30"
+            "version_added": "27"
           },
           "ie": {
             "version_added": "10"
@@ -69,10 +69,10 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": "30"
+              "version_added": "27"
             },
             "firefox_android": {
-              "version_added": "30"
+              "version_added": "27"
             },
             "ie": {
               "version_added": false
@@ -222,10 +222,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "30"
+              "version_added": "27"
             },
             "firefox_android": {
-              "version_added": "30"
+              "version_added": "27"
             },
             "ie": {
               "version_added": "10"
@@ -273,10 +273,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "30"
+              "version_added": "27"
             },
             "firefox_android": {
-              "version_added": "30"
+              "version_added": "27"
             },
             "ie": {
               "version_added": "10"
@@ -324,10 +324,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "30"
+              "version_added": "27"
             },
             "firefox_android": {
-              "version_added": "30"
+              "version_added": "27"
             },
             "ie": {
               "version_added": "10"


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `ErrorEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ErrorEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
