### PR TITLE
Update all browsers versions for Event API

### DIFF
--- a/api/Event.json
+++ b/api/Event.json
@@ -528,7 +528,7 @@
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-event-defaultprevented①",
           "support": {
             "chrome": {
-              "version_added": "18"
+              "version_added": "5"
             },
             "chrome_android": {
               "version_added": "18"
@@ -583,10 +583,10 @@
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-event-eventphase③",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "18"
             },
             "deno": {
               "version_added": "1.0"
@@ -607,10 +607,10 @@
               "version_added": "14.5.0"
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "1"
@@ -619,10 +619,10 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "1"
             }
           },
           "status": {
@@ -783,7 +783,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": false,
+              "version_added": "9",
               "notes": "In Internet Explorer, all events are trusted except those that are created with the <code>createEvent()</code> method."
             },
             "nodejs": {
@@ -1047,7 +1047,7 @@
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-event-stopimmediatepropagation①",
           "support": {
             "chrome": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "chrome_android": {
               "version_added": "18"
@@ -1071,10 +1071,10 @@
               "version_added": "14.5.0"
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "5"
@@ -1213,11 +1213,11 @@
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-event-timestamp①",
           "support": {
             "chrome": {
-              "version_added": "49",
+              "version_added": "1",
               "notes": "Starting with Chrome 49, Firefox 54 and Opera 36, this property returns <a href='https://developer.mozilla.org/docs/Web/API/DOMHighResTimeStamp'><code>DOMHighResTimeStamp</code></a> instead of <a href='https://developer.mozilla.org/docs/Web/API/DOMTimeStamp'><code>DOMTimeStamp</code></a>."
             },
             "chrome_android": {
-              "version_added": "49",
+              "version_added": "18",
               "notes": "Starting with Chrome 49, Firefox 54 and Opera 36, this property returns <a href='https://developer.mozilla.org/docs/Web/API/DOMHighResTimeStamp'><code>DOMHighResTimeStamp</code></a> instead of <a href='https://developer.mozilla.org/docs/Web/API/DOMTimeStamp'><code>DOMTimeStamp</code></a>."
             },
             "deno": {
@@ -1247,7 +1247,7 @@
               "notes": "Starting with Chrome 49, Firefox 54 and Opera 36, this property returns <a href='https://developer.mozilla.org/docs/Web/API/DOMHighResTimeStamp'><code>DOMHighResTimeStamp</code></a> instead of <a href='https://developer.mozilla.org/docs/Web/API/DOMTimeStamp'><code>DOMTimeStamp</code></a>."
             },
             "opera_android": {
-              "version_added": "36",
+              "version_added": "≤12.1",
               "notes": "Starting with Chrome 49, Firefox 54 and Opera 36, this property returns <a href='https://developer.mozilla.org/docs/Web/API/DOMHighResTimeStamp'><code>DOMHighResTimeStamp</code></a> instead of <a href='https://developer.mozilla.org/docs/Web/API/DOMTimeStamp'><code>DOMTimeStamp</code></a>."
             },
             "safari": {
@@ -1257,11 +1257,11 @@
               "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "5.0",
+              "version_added": "1.0",
               "notes": "Starting with Samsung Internet 5.0, Firefox 54 and Opera 36, this property returns <a href='https://developer.mozilla.org/docs/Web/API/DOMHighResTimeStamp'><code>DOMHighResTimeStamp</code></a> instead of <a href='https://developer.mozilla.org/docs/Web/API/DOMTimeStamp'><code>DOMTimeStamp</code></a>."
             },
             "webview_android": {
-              "version_added": "49",
+              "version_added": "1",
               "notes": "Starting with version 49, this property returns <a href='https://developer.mozilla.org/docs/Web/API/DOMHighResTimeStamp'><code>DOMHighResTimeStamp</code></a> instead of <a href='https://developer.mozilla.org/docs/Web/API/DOMTimeStamp'><code>DOMTimeStamp</code></a>."
             }
           },


### PR DESCRIPTION
This PR updates and corrects the real values for all browsers for the `Event` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Event

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
