### PR TITLE
Update Firefox versions for EventCounts API

### DIFF
--- a/api/EventCounts.json
+++ b/api/EventCounts.json
@@ -13,10 +13,10 @@
             "version_added": "85"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "89"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "89"
           },
           "ie": {
             "version_added": false
@@ -59,10 +59,10 @@
               "version_added": "85"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "89"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "89"
             },
             "ie": {
               "version_added": false
@@ -106,10 +106,10 @@
               "version_added": "85"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "89"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "89"
             },
             "ie": {
               "version_added": false
@@ -153,10 +153,10 @@
               "version_added": "85"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "89"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "89"
             },
             "ie": {
               "version_added": false
@@ -200,10 +200,10 @@
               "version_added": "85"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "89"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "89"
             },
             "ie": {
               "version_added": false
@@ -247,10 +247,10 @@
               "version_added": "85"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "89"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "89"
             },
             "ie": {
               "version_added": false
@@ -294,10 +294,10 @@
               "version_added": "85"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "89"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "89"
             },
             "ie": {
               "version_added": false
@@ -341,10 +341,10 @@
               "version_added": "85"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "89"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "89"
             },
             "ie": {
               "version_added": false

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -329,10 +329,10 @@
               "version_added": "85"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "89"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "89"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `EventCounts` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/EventCounts

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
