### PR TITLE
Update WebView versions for ExtendableCookieChangeEvent API

### DIFF
--- a/api/ExtendableCookieChangeEvent.json
+++ b/api/ExtendableCookieChangeEvent.json
@@ -137,7 +137,7 @@
               "version_added": "14.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "87"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for WebView Android for the `ExtendableCookieChangeEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ExtendableCookieChangeEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
