### PR TITLE
Update Firefox versions for ExtendableMessageEvent API

### DIFF
--- a/api/ExtendableMessageEvent.json
+++ b/api/ExtendableMessageEvent.json
@@ -15,11 +15,11 @@
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "45",
+            "version_added": "44",
             "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
           },
           "firefox_android": {
-            "version_added": "45"
+            "version_added": "44"
           },
           "ie": {
             "version_added": false
@@ -65,11 +65,11 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "45",
+              "version_added": "44",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "45"
+              "version_added": "44"
             },
             "ie": {
               "version_added": false
@@ -115,11 +115,11 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "45",
+              "version_added": "44",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "45"
+              "version_added": "44"
             },
             "ie": {
               "version_added": false
@@ -165,11 +165,11 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "45",
+              "version_added": "44",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "45"
+              "version_added": "44"
             },
             "ie": {
               "version_added": false
@@ -215,10 +215,10 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "44"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "44"
             },
             "ie": {
               "version_added": false
@@ -264,11 +264,11 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "45",
+              "version_added": "44",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "45"
+              "version_added": "44"
             },
             "ie": {
               "version_added": false
@@ -314,11 +314,11 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "45",
+              "version_added": "44",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "45"
+              "version_added": "44"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `ExtendableMessageEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ExtendableMessageEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
