### PR TITLE
Update Chromium versions for FederatedCredential API

### DIFF
--- a/api/FederatedCredential.json
+++ b/api/FederatedCredential.json
@@ -103,10 +103,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FederatedCredential/iconURL",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": "51"
             },
             "chrome_android": {
-              "version_added": "60"
+              "version_added": "51"
             },
             "edge": {
               "version_added": "79"
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "47"
+              "version_added": "38"
             },
             "opera_android": {
-              "version_added": "44"
+              "version_added": "41"
             },
             "safari": {
               "version_added": false
@@ -133,10 +133,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "8.0"
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "60"
+              "version_added": "51"
             }
           },
           "status": {
@@ -151,10 +151,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FederatedCredential/name",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": "51"
             },
             "chrome_android": {
-              "version_added": "60"
+              "version_added": "51"
             },
             "edge": {
               "version_added": "79"
@@ -169,10 +169,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "47"
+              "version_added": "38"
             },
             "opera_android": {
-              "version_added": "44"
+              "version_added": "41"
             },
             "safari": {
               "version_added": false
@@ -181,10 +181,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "8.0"
+              "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": "60"
+              "version_added": "51"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `FederatedCredential` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FederatedCredential

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
