### PR TITLE
Update Firefox Android versions for api.FetchEvent.handled

### DIFF
--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -167,7 +167,7 @@
               "version_added": "84"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "84"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox Android for the `handled` member of the `FetchEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FetchEvent/handled

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
