### PR TITLE
Update all browsers versions for File API

### DIFF
--- a/api/File.json
+++ b/api/File.json
@@ -145,10 +145,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "16"
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": "16"
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": "10"
@@ -197,7 +197,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "16"
+              "version_added": "≤15"
             },
             "opera_android": {
               "version_added": false
@@ -251,10 +251,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "16"
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": "16"
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": "7"
@@ -303,7 +303,7 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "16"
+              "version_added": "≤15"
             },
             "opera_android": {
               "version_added": false

--- a/api/File.json
+++ b/api/File.json
@@ -6,7 +6,7 @@
         "spec_url": "https://w3c.github.io/FileAPI/#file-section",
         "support": {
           "chrome": {
-            "version_added": "13"
+            "version_added": "1"
           },
           "chrome_android": {
             "version_added": "18"
@@ -139,7 +139,7 @@
               "version_added": "15"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "15"
             },
             "ie": {
               "version_added": false
@@ -148,7 +148,7 @@
               "version_added": "16"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "16"
             },
             "safari": {
               "version_added": "10"
@@ -254,7 +254,7 @@
               "version_added": "16"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "16"
             },
             "safari": {
               "version_added": "7"
@@ -355,10 +355,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "14"
             },
             "safari": {
               "version_added": "11.1"

--- a/api/File.json
+++ b/api/File.json
@@ -200,7 +200,7 @@
               "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": "7",
@@ -306,7 +306,7 @@
               "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤14"
             },
             "safari": {
               "version_added": "7"

--- a/api/File.json
+++ b/api/File.json
@@ -6,7 +6,7 @@
         "spec_url": "https://w3c.github.io/FileAPI/#file-section",
         "support": {
           "chrome": {
-            "version_added": "1"
+            "version_added": "13"
           },
           "chrome_android": {
             "version_added": "18"


### PR DESCRIPTION
This PR updates and corrects the real values for all browsers for the `File` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/File

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
