### PR TITLE
Update Chromium versions for FileReader API

### DIFF
--- a/api/FileReader.json
+++ b/api/FileReader.json
@@ -6,7 +6,7 @@
         "spec_url": "https://w3c.github.io/FileAPI/#APIASynch",
         "support": {
           "chrome": {
-            "version_added": "7"
+            "version_added": "6"
           },
           "chrome_android": {
             "version_added": "18"
@@ -59,7 +59,7 @@
           "spec_url": "https://w3c.github.io/FileAPI/#filereaderConstrctr",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "chrome_android": {
               "version_added": "18"
@@ -111,7 +111,7 @@
           "spec_url": "https://w3c.github.io/FileAPI/#abort",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "chrome_android": {
               "version_added": "18"
@@ -216,7 +216,7 @@
           "spec_url": "https://w3c.github.io/FileAPI/#dom-filereader-error",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "chrome_android": {
               "version_added": "18"
@@ -508,7 +508,7 @@
           "spec_url": "https://w3c.github.io/FileAPI/#dfn-onabort",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "chrome_android": {
               "version_added": "18"
@@ -560,7 +560,7 @@
           "spec_url": "https://w3c.github.io/FileAPI/#dfn-onerror",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "chrome_android": {
               "version_added": "18"
@@ -612,7 +612,7 @@
           "spec_url": "https://w3c.github.io/FileAPI/#dfn-onload",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "chrome_android": {
               "version_added": "18"
@@ -663,7 +663,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileReader/onloadend",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "chrome_android": {
               "version_added": "18"
@@ -714,7 +714,7 @@
           "spec_url": "https://w3c.github.io/FileAPI/#dfn-onloadstart",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "chrome_android": {
               "version_added": "18"
@@ -735,10 +735,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "6"
@@ -765,7 +765,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileReader/onprogress",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "chrome_android": {
               "version_added": "18"
@@ -922,7 +922,7 @@
           "spec_url": "https://w3c.github.io/FileAPI/#readAsBinaryString",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "chrome_android": {
               "version_added": "18"
@@ -974,7 +974,7 @@
           "spec_url": "https://w3c.github.io/FileAPI/#readAsDataURL",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "chrome_android": {
               "version_added": "18"
@@ -1027,7 +1027,7 @@
           "spec_url": "https://w3c.github.io/FileAPI/#readAsDataText",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "chrome_android": {
               "version_added": "18"
@@ -1079,7 +1079,7 @@
           "spec_url": "https://w3c.github.io/FileAPI/#dom-filereader-readystate",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "chrome_android": {
               "version_added": "18"
@@ -1131,7 +1131,7 @@
           "spec_url": "https://w3c.github.io/FileAPI/#dom-filereader-result",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "chrome_android": {
               "version_added": "18"

--- a/api/FileReader.json
+++ b/api/FileReader.json
@@ -164,7 +164,7 @@
           "spec_url": "https://w3c.github.io/FileAPI/#dfn-abort-event",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "chrome_android": {
               "version_added": "18"
@@ -281,7 +281,7 @@
           "spec_url": "https://w3c.github.io/FileAPI/#dfn-error-event",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "chrome_android": {
               "version_added": "18"
@@ -334,7 +334,7 @@
           "spec_url": "https://w3c.github.io/FileAPI/#dfn-load-event",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "chrome_android": {
               "version_added": "18"
@@ -387,7 +387,7 @@
           "spec_url": "https://w3c.github.io/FileAPI/#dfn-loadend-event",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "chrome_android": {
               "version_added": "18"
@@ -440,7 +440,7 @@
           "spec_url": "https://w3c.github.io/FileAPI/#dfn-loadstart-event",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "chrome_android": {
               "version_added": "18"
@@ -818,7 +818,7 @@
           "spec_url": "https://w3c.github.io/FileAPI/#dfn-progress-event",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "chrome_android": {
               "version_added": "18"
@@ -870,7 +870,7 @@
           "spec_url": "https://w3c.github.io/FileAPI/#readAsArrayBuffer",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "chrome_android": {
               "version_added": "18"
@@ -1182,7 +1182,7 @@
           "description": "Available in workers",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "6"
             },
             "chrome_android": {
               "version_added": "18"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `FileReader` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FileReader

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
