### PR TITLE
Update Chromium versions for FormData API

### DIFF
--- a/api/FormData.json
+++ b/api/FormData.json
@@ -6,7 +6,7 @@
         "spec_url": "https://xhr.spec.whatwg.org/#interface-formdata",
         "support": {
           "chrome": {
-            "version_added": "7"
+            "version_added": "5"
           },
           "chrome_android": {
             "version_added": "18"
@@ -61,7 +61,7 @@
           "spec_url": "https://xhr.spec.whatwg.org/#dom-formdata",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "5"
             },
             "chrome_android": {
               "version_added": "18"
@@ -113,7 +113,7 @@
           "spec_url": "https://xhr.spec.whatwg.org/#dom-formdata-append",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": "5"
             },
             "chrome_android": {
               "version_added": "18"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `FormData` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FormData

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
