### PR TITLE
Update all browsers versions for HTMLFormControlsCollection API

### DIFF
--- a/api/HTMLFormControlsCollection.json
+++ b/api/HTMLFormControlsCollection.json
@@ -6,40 +6,40 @@
         "spec_url": "https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#htmlformcontrolscollection",
         "support": {
           "chrome": {
-            "version_added": "25"
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": "25"
+            "version_added": "18"
           },
           "edge": {
-            "version_added": "79"
+            "version_added": "12"
           },
           "firefox": {
-            "version_added": "27"
+            "version_added": "1"
           },
           "firefox_android": {
-            "version_added": "27"
+            "version_added": "4"
           },
           "ie": {
             "version_added": false
           },
           "opera": {
-            "version_added": "15"
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": "14"
+            "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "7"
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": "7"
+            "version_added": "1"
           },
           "samsunginternet_android": {
-            "version_added": "1.5"
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "≤37"
+            "version_added": "1"
           }
         },
         "status": {
@@ -54,13 +54,13 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#dom-htmlformcontrolscollection-nameditem-dev",
           "support": {
             "chrome": {
-              "version_added": "25"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "25"
+              "version_added": "18"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "12"
             },
             "firefox": [
               {
@@ -88,22 +88,22 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "1"
             },
             "samsunginternet_android": {
-              "version_added": "1.5"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for all browsers for the `HTMLFormControlsCollection` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLFormControlsCollection

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
