### PR TITLE
Update Opera versions for HTMLImageElement API

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -1107,7 +1107,7 @@
               "version_added": "21"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "21"
             },
             "safari": {
               "version_added": "8"


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `HTMLImageElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLImageElement

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
