### PR TITLE
Update Firefox versions for api.HTMLOptionsCollection.add

### DIFF
--- a/api/HTMLOptionsCollection.json
+++ b/api/HTMLOptionsCollection.json
@@ -62,7 +62,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `add` member of the `HTMLOptionsCollection` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLOptionsCollection/add

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
