### PR TITLE
Update Chromium versions for HTMLQuoteElement API

### DIFF
--- a/api/HTMLQuoteElement.json
+++ b/api/HTMLQuoteElement.json
@@ -6,7 +6,7 @@
         "spec_url": "https://html.spec.whatwg.org/multipage/grouping-content.html#htmlquoteelement",
         "support": {
           "chrome": {
-            "version_added": "16"
+            "version_added": "1"
           },
           "chrome_android": {
             "version_added": "18"
@@ -53,7 +53,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLQuoteElement/cite",
           "support": {
             "chrome": {
-              "version_added": "16"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `HTMLQuoteElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLQuoteElement

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
