### PR TITLE
Update all versions for Headers API

### DIFF
--- a/api/Headers.json
+++ b/api/Headers.json
@@ -429,7 +429,7 @@
               "version_added": "42"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "42"
             },
             "deno": {
               "version_added": "1.0"
@@ -447,10 +447,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "29"
             },
             "safari": {
               "version_added": "10.1"
@@ -459,10 +459,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "42"
             }
           },
           "status": {
@@ -583,7 +583,7 @@
               "version_added": "42"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "42"
             },
             "deno": {
               "version_added": "1.0"
@@ -601,10 +601,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "29"
             },
             "safari": {
               "version_added": "10.1"
@@ -613,10 +613,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "42"
             }
           },
           "status": {

--- a/api/Headers.json
+++ b/api/Headers.json
@@ -21,7 +21,7 @@
             "version_added": "39"
           },
           "firefox_android": {
-            "version_added": "44"
+            "version_added": "39"
           },
           "ie": {
             "version_added": false
@@ -73,7 +73,7 @@
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
@@ -125,7 +125,7 @@
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
@@ -177,7 +177,7 @@
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
@@ -213,7 +213,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/entries",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "42"
             },
             "chrome_android": {
               "version_added": "45"
@@ -333,7 +333,7 @@
               "notes": "Before version 52, <code>get()</code> returns only the first value for the specified header."
             },
             "firefox_android": {
-              "version_added": "44",
+              "version_added": "39",
               "notes": "Before version 52, <code>get()</code> returns only the first value for the specified header."
             },
             "ie": {
@@ -390,7 +390,7 @@
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
@@ -426,7 +426,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/keys",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "42"
             },
             "chrome_android": {
               "version_added": "45"
@@ -492,7 +492,7 @@
               "version_added": "44"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "44"
             },
             "ie": {
               "version_added": false
@@ -544,7 +544,7 @@
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "39"
             },
             "ie": {
               "version_added": false
@@ -580,7 +580,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/values",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "42"
             },
             "chrome_android": {
               "version_added": "45"

--- a/api/Headers.json
+++ b/api/Headers.json
@@ -216,7 +216,7 @@
               "version_added": "42"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "42"
             },
             "deno": {
               "version_added": "1.0"
@@ -234,10 +234,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "29"
             },
             "safari": {
               "version_added": "10.1"
@@ -246,10 +246,10 @@
               "version_added": "10.3"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "42"
             }
           },
           "status": {

--- a/api/Headers.json
+++ b/api/Headers.json
@@ -21,7 +21,7 @@
             "version_added": "39"
           },
           "firefox_android": {
-            "version_added": "39"
+            "version_added": "44"
           },
           "ie": {
             "version_added": false
@@ -73,7 +73,7 @@
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": "39"
+              "version_added": "44"
             },
             "ie": {
               "version_added": false
@@ -125,7 +125,7 @@
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": "39"
+              "version_added": "44"
             },
             "ie": {
               "version_added": false
@@ -177,7 +177,7 @@
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": "39"
+              "version_added": "44"
             },
             "ie": {
               "version_added": false
@@ -333,7 +333,7 @@
               "notes": "Before version 52, <code>get()</code> returns only the first value for the specified header."
             },
             "firefox_android": {
-              "version_added": "39",
+              "version_added": "44",
               "notes": "Before version 52, <code>get()</code> returns only the first value for the specified header."
             },
             "ie": {
@@ -390,7 +390,7 @@
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": "39"
+              "version_added": "44"
             },
             "ie": {
               "version_added": false
@@ -544,7 +544,7 @@
               "version_added": "39"
             },
             "firefox_android": {
-              "version_added": "39"
+              "version_added": "44"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for all browsers for the `Headers` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Headers

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
