### PR TITLE
Update Chromium versions for IdleDetector API

### DIFF
--- a/api/IdleDetector.json
+++ b/api/IdleDetector.json
@@ -24,7 +24,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "80"
           },
           "opera_android": {
             "version_added": false
@@ -39,7 +39,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "94"
           }
         },
         "status": {
@@ -73,7 +73,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -88,7 +88,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "94"
             }
           },
           "status": {
@@ -122,7 +122,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -137,7 +137,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "94"
             }
           },
           "status": {
@@ -171,7 +171,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -186,7 +186,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "94"
             }
           },
           "status": {
@@ -220,7 +220,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -235,7 +235,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "94"
             }
           },
           "status": {
@@ -269,7 +269,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -284,7 +284,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "94"
             }
           },
           "status": {
@@ -318,7 +318,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -333,7 +333,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "94"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `IdleDetector` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/IdleDetector

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
