### PR TITLE
Update all browsers versions for ImageData API

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -588,7 +588,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "2"
+              "version_added": "3.5"
             },
             "firefox_android": {
               "version_added": "4"

--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -15,10 +15,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "14"
+            "version_added": "3.5"
           },
           "firefox_android": {
-            "version_added": "14"
+            "version_added": "4"
           },
           "ie": {
             "version_added": "9"
@@ -55,10 +55,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-imagedata-dev",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "36"
             },
             "chrome_android": {
-              "version_added": "42"
+              "version_added": "36"
             },
             "edge": {
               "version_added": "14"
@@ -85,10 +85,10 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "37"
             }
           },
           "status": {
@@ -161,10 +161,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "14"
+              "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "14"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -210,10 +210,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "14"
+              "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "14"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"
@@ -259,10 +259,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "14"
+              "version_added": "3.5"
             },
             "firefox_android": {
-              "version_added": "14"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"

--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -73,10 +73,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "29"
+              "version_added": "23"
             },
             "opera_android": {
-              "version_added": "29"
+              "version_added": "24"
             },
             "safari": {
               "version_added": "7"


### PR DESCRIPTION
This PR updates and corrects the real values for all browsers for the `ImageData` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ImageData

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
