### PR TITLE
Update Chromium versions for Keyboard API

### DIFF
--- a/api/Keyboard.json
+++ b/api/Keyboard.json
@@ -12,7 +12,7 @@
             "version_added": "68"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "68"
           },
           "edge": {
             "version_added": "79"
@@ -30,7 +30,7 @@
             "version_added": "55"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "48"
           },
           "safari": {
             "version_added": false
@@ -39,10 +39,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "10.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "68"
           }
         },
         "status": {
@@ -60,7 +60,7 @@
               "version_added": "69"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": "79"
@@ -78,7 +78,7 @@
               "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": false
@@ -87,10 +87,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {
@@ -109,7 +109,7 @@
               "version_added": "68"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "edge": {
               "version_added": "79"
@@ -127,7 +127,7 @@
               "version_added": "55"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": false
@@ -136,10 +136,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "68"
             }
           },
           "status": {
@@ -158,7 +158,7 @@
               "version_added": "68"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "edge": {
               "version_added": "79"
@@ -176,7 +176,7 @@
               "version_added": "55"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": false
@@ -185,10 +185,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "68"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Keyboard` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Keyboard

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
