### PR TITLE
Update Chromium versions for KeyboardLayoutMap API

### DIFF
--- a/api/KeyboardLayoutMap.json
+++ b/api/KeyboardLayoutMap.json
@@ -9,7 +9,7 @@
             "version_added": "69"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "69"
           },
           "edge": {
             "version_added": "79"
@@ -36,10 +36,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "10.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "69"
           }
         },
         "status": {
@@ -56,7 +56,7 @@
               "version_added": "69"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": "79"
@@ -83,10 +83,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {
@@ -104,7 +104,7 @@
               "version_added": "69"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": "79"
@@ -131,10 +131,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {
@@ -152,7 +152,7 @@
               "version_added": "69"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": "79"
@@ -179,10 +179,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {
@@ -200,7 +200,7 @@
               "version_added": "69"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": "79"
@@ -227,10 +227,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {
@@ -248,7 +248,7 @@
               "version_added": "69"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "69"
             },
             "edge": {
               "version_added": "79"
@@ -275,10 +275,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {
@@ -296,55 +296,7 @@
               "version_added": "69"
             },
             "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "56"
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "values": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyboardLayoutMap/values",
-          "support": {
-            "chrome": {
               "version_added": "69"
-            },
-            "chrome_android": {
-              "version_added": false
             },
             "edge": {
               "version_added": "79"
@@ -371,10 +323,58 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
+              "version_added": "69"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "values": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyboardLayoutMap/values",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "69"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
               "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "56"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "69"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `KeyboardLayoutMap` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/KeyboardLayoutMap

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
