### PR TITLE
Update Edge versions for KeyframeEffect API

### DIFF
--- a/api/KeyframeEffect.json
+++ b/api/KeyframeEffect.json
@@ -329,15 +329,20 @@
                 ]
               }
             ],
-            "edge": {
-              "version_added": "81",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental Web Platform Features"
-                }
-              ]
-            },
+            "edge": [
+              {
+                "version_added": "84"
+              },
+              {
+                "version_added": "81",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Experimental Web Platform Features"
+                  }
+                ]
+              }
+            ],
             "firefox": {
               "version_added": "75"
             },
@@ -396,7 +401,7 @@
               "version_added": "84"
             },
             "edge": {
-              "version_added": false
+              "version_added": "84"
             },
             "firefox": {
               "version_added": "63"


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `KeyframeEffect` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/KeyframeEffect

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
