### PR TITLE
Update Chromium versions for MediaDeviceInfo API

### DIFF
--- a/api/MediaDeviceInfo.json
+++ b/api/MediaDeviceInfo.json
@@ -6,10 +6,10 @@
         "spec_url": "https://w3c.github.io/mediacapture-main/#device-info",
         "support": {
           "chrome": {
-            "version_added": "55"
+            "version_added": "47"
           },
           "chrome_android": {
-            "version_added": "55"
+            "version_added": "47"
           },
           "edge": {
             "version_added": "12"
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "42"
+            "version_added": "34"
           },
           "opera_android": {
-            "version_added": "42"
+            "version_added": "34"
           },
           "safari": {
             "version_added": "11"
@@ -36,10 +36,10 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": "6.0"
+            "version_added": "5.0"
           },
           "webview_android": {
-            "version_added": "55"
+            "version_added": "47"
           }
         },
         "status": {
@@ -54,10 +54,10 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediadeviceinfo-deviceid",
           "support": {
             "chrome": {
-              "version_added": "55"
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": "55"
+              "version_added": "47"
             },
             "edge": {
               "version_added": "12"
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "42"
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": "42"
+              "version_added": "34"
             },
             "safari": {
               "version_added": "11"
@@ -84,10 +84,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": "55"
+              "version_added": "47"
             }
           },
           "status": {
@@ -103,10 +103,10 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediadeviceinfo-groupid",
           "support": {
             "chrome": {
-              "version_added": "55"
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": "55"
+              "version_added": "47"
             },
             "edge": {
               "version_added": "12"
@@ -123,10 +123,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "42"
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": "42"
+              "version_added": "34"
             },
             "safari": {
               "version_added": "11"
@@ -135,10 +135,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": "55"
+              "version_added": "47"
             }
           },
           "status": {
@@ -154,10 +154,10 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediadeviceinfo-kind",
           "support": {
             "chrome": {
-              "version_added": "55"
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": "55"
+              "version_added": "47"
             },
             "edge": {
               "version_added": "12"
@@ -172,10 +172,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "42"
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": "42"
+              "version_added": "34"
             },
             "safari": {
               "version_added": "11"
@@ -184,10 +184,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": "55"
+              "version_added": "47"
             }
           },
           "status": {
@@ -203,10 +203,10 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediadeviceinfo-label",
           "support": {
             "chrome": {
-              "version_added": "55"
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": "55"
+              "version_added": "47"
             },
             "edge": {
               "version_added": "12"
@@ -221,10 +221,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "42"
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": "42"
+              "version_added": "34"
             },
             "safari": {
               "version_added": "11"
@@ -233,10 +233,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": "55"
+              "version_added": "47"
             }
           },
           "status": {
@@ -252,10 +252,10 @@
           "description": "<code>toJSON()</code>",
           "support": {
             "chrome": {
-              "version_added": "55"
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": "55"
+              "version_added": "47"
             },
             "edge": {
               "version_added": "18"
@@ -270,10 +270,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "42"
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": "42"
+              "version_added": "34"
             },
             "safari": {
               "version_added": "11"
@@ -282,10 +282,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": "55"
+              "version_added": "47"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `MediaDeviceInfo` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaDeviceInfo

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
