### PR TITLE
Update Opera versions for MediaSession API

### DIFF
--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -41,7 +41,7 @@
             "version_added": "60"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "43"
           },
           "safari": {
             "version_added": "15"
@@ -103,7 +103,7 @@
               "version_added": "60"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "43"
             },
             "safari": {
               "version_added": "15"
@@ -166,7 +166,7 @@
               "version_added": "60"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "43"
             },
             "safari": {
               "version_added": "15"
@@ -230,7 +230,7 @@
               "version_added": "60"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "43"
             },
             "safari": {
               "version_added": "15"
@@ -390,7 +390,7 @@
               "version_added": "60"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "43"
             },
             "safari": {
               "version_added": "15"


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `MediaSession` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaSession

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
