### PR TITLE
Update Chromium versions for MessageChannel API

### DIFF
--- a/api/MessageChannel.json
+++ b/api/MessageChannel.json
@@ -6,7 +6,7 @@
         "spec_url": "https://html.spec.whatwg.org/multipage/web-messaging.html#message-channels",
         "support": {
           "chrome": {
-            "version_added": "4"
+            "version_added": "1"
           },
           "chrome_android": {
             "version_added": "18"
@@ -67,7 +67,7 @@
           "description": "<code>MessageChannel()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -128,7 +128,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messagechannel-port1-dev",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -183,7 +183,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messagechannel-port2-dev",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `MessageChannel` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MessageChannel

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
