### PR TITLE
Update Firefox versions for MessageEvent API

### DIFF
--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -73,10 +73,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "26"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "26"
             },
             "ie": {
               "version_added": "9"

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -183,7 +183,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "3"
             },
             "firefox_android": {
               "version_added": "4"
@@ -348,7 +348,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "3"
             },
             "firefox_android": {
               "version_added": "4"

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -18,7 +18,7 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "4"
+            "version_added": "3"
           },
           "firefox_android": {
             "version_added": "4"
@@ -128,7 +128,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "3"
             },
             "firefox_android": {
               "version_added": "4"
@@ -238,7 +238,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "3"
             },
             "firefox_android": {
               "version_added": "4"
@@ -293,7 +293,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "3"
             },
             "firefox_android": {
               "version_added": "4"
@@ -403,10 +403,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "55"
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "4"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `MessageEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MessageEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
