### PR TITLE
Update Chromium versions for MessagePort API

### DIFF
--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -131,7 +131,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-message",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"

--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -6,7 +6,7 @@
         "spec_url": "https://html.spec.whatwg.org/multipage/web-messaging.html#message-ports",
         "support": {
           "chrome": {
-            "version_added": "4"
+            "version_added": "1"
           },
           "chrome_android": {
             "version_added": "18"
@@ -67,7 +67,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messageport-close-dev",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -260,7 +260,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/web-messaging.html#handler-messageport-onmessage",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -372,7 +372,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messageport-postmessage-dev",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -439,7 +439,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messageport-start-dev",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `MessagePort` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MessagePort

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
