### PR TITLE
Update Chromium versions for NDEFReader API

### DIFF
--- a/api/NDEFReader.json
+++ b/api/NDEFReader.json
@@ -27,7 +27,7 @@
             "version_added": false
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "63"
           },
           "safari": {
             "version_added": false
@@ -39,7 +39,7 @@
             "version_added": "15.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "89"
           }
         },
         "status": {
@@ -76,7 +76,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "safari": {
               "version_added": false
@@ -88,7 +88,7 @@
               "version_added": "15.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "89"
             }
           },
           "status": {
@@ -125,7 +125,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "safari": {
               "version_added": false
@@ -137,7 +137,7 @@
               "version_added": "15.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "89"
             }
           },
           "status": {
@@ -174,7 +174,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "safari": {
               "version_added": false
@@ -186,7 +186,7 @@
               "version_added": "15.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "89"
             }
           },
           "status": {
@@ -223,7 +223,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "safari": {
               "version_added": false
@@ -235,7 +235,7 @@
               "version_added": "15.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "89"
             }
           },
           "status": {
@@ -271,7 +271,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "safari": {
               "version_added": false
@@ -283,7 +283,7 @@
               "version_added": "15.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "89"
             }
           },
           "status": {
@@ -320,7 +320,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "safari": {
               "version_added": false
@@ -332,7 +332,7 @@
               "version_added": "15.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "89"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `NDEFReader` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/NDEFReader

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
