### PR TITLE
Update docs for needs-release-note label usage

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -41,7 +41,7 @@ whichever comes first.
 
 When a release is imminent:
 
-1. Confirm that all pull requests labeled [needs-release-note 📰](https://github.com/mdn/browser-compat-data/pulls?q=is%3Apr+label%3A%22needs-release-note+%3Anewspaper%3A%22+) have been entered into the release notes. Run `npm run release-pulls` to get a link to all of the since the previous release to `HEAD`.
+1. Confirm that all pull requests labeled [needs-release-note 📰](https://github.com/mdn/browser-compat-data/pulls?q=is%3Apr+label%3A%22needs-release-note+%3Anewspaper%3A%22+) have been entered into the release notes. Run `npm run release-pulls` to get a link to all of the labeled pull requests since the previous release to `HEAD`.
 
 2. Add the release statistics to the release notes. Switch to the `main` branch, then run `npm run release-stats`. After completing the prompts, copy the output, switch back to the release branch, and add the statistics to `RELEASE_NOTES.md`.
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -44,11 +44,11 @@ Remove this label after a pull request, which makes the required content changes
 
 This label indicates that a pull request needs a corresponding entry in [`RELEASE_NOTES.md`](../RELEASE_NOTES.md).
 
-You must set this label on a pull request when it:
+Set this label on a pull request when it:
 
 - Breaks backward compatibility (see [_Semantic versioning policy_](../README.md#semantic-versioning-policy))
-- Removes or renames data (for example, removing an irrelevant feature)
-- Adds or changes a data guideline or schema document
+- Adds or changes a data guideline
+- Adds or changes schema documentation
 - Adds, removes, or changes linting and other non-schematic data restrictions
 - Does anything else that would trigger a SemVer minor release
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Revise documentation mentions of the [needs-release-note :newspaper:](https://github.com/mdn/browser-compat-data/labels/needs-release-note%20%3Anewspaper%3A) label.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

As part of our ongoing efforts to automate more of the release process, the use of the [needs-release-note :newspaper:](https://github.com/mdn/browser-compat-data/labels/needs-release-note%20%3Anewspaper%3A) label has changed slightly. It is no longer required to set the label on PRs that remove individual features.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Prompted by https://github.com/mdn/browser-compat-data/issues/14228

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
