### PR TITLE
Update Chromium versions for NavigationPreloadManager API

### DIFF
--- a/api/NavigationPreloadManager.json
+++ b/api/NavigationPreloadManager.json
@@ -6,10 +6,10 @@
         "spec_url": "https://w3c.github.io/ServiceWorker/#navigation-preload-manager",
         "support": {
           "chrome": {
-            "version_added": "62"
+            "version_added": "59"
           },
           "chrome_android": {
-            "version_added": "62"
+            "version_added": "59"
           },
           "edge": {
             "version_added": "18"
@@ -26,10 +26,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "49"
+            "version_added": "46"
           },
           "opera_android": {
-            "version_added": "46"
+            "version_added": "43"
           },
           "safari": {
             "version_added": false
@@ -38,10 +38,10 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "8.0"
+            "version_added": "7.0"
           },
           "webview_android": {
-            "version_added": "62"
+            "version_added": "59"
           }
         },
         "status": {
@@ -55,7 +55,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationPreloadManager/disable",
           "support": {
             "chrome": {
-              "version_added": "62"
+              "version_added": "59"
             },
             "chrome_android": {
               "version_added": "62"
@@ -75,10 +75,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "49"
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": "46"
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -87,10 +87,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "8.0"
+              "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": "62"
+              "version_added": "59"
             }
           },
           "status": {
@@ -105,7 +105,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationPreloadManager/enable",
           "support": {
             "chrome": {
-              "version_added": "62"
+              "version_added": "59"
             },
             "chrome_android": {
               "version_added": "62"
@@ -125,10 +125,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "49"
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": "46"
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -137,10 +137,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "8.0"
+              "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": "62"
+              "version_added": "59"
             }
           },
           "status": {
@@ -155,7 +155,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationPreloadManager/getState",
           "support": {
             "chrome": {
-              "version_added": "62"
+              "version_added": "59"
             },
             "chrome_android": {
               "version_added": "62"
@@ -175,10 +175,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "49"
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": "46"
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -187,10 +187,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "8.0"
+              "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": "62"
+              "version_added": "59"
             }
           },
           "status": {
@@ -205,10 +205,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationPreloadManager/setHeaderValue",
           "support": {
             "chrome": {
-              "version_added": "62"
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": "62"
+              "version_added": "59"
             },
             "edge": {
               "version_added": "18"
@@ -225,10 +225,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "49"
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": "46"
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -237,10 +237,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "8.0"
+              "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": "62"
+              "version_added": "59"
             }
           },
           "status": {

--- a/api/NavigationPreloadManager.json
+++ b/api/NavigationPreloadManager.json
@@ -58,7 +58,7 @@
               "version_added": "59"
             },
             "chrome_android": {
-              "version_added": "62"
+              "version_added": "59"
             },
             "edge": {
               "version_added": "18"
@@ -108,7 +108,7 @@
               "version_added": "59"
             },
             "chrome_android": {
-              "version_added": "62"
+              "version_added": "59"
             },
             "edge": {
               "version_added": "18"
@@ -158,7 +158,7 @@
               "version_added": "59"
             },
             "chrome_android": {
-              "version_added": "62"
+              "version_added": "59"
             },
             "edge": {
               "version_added": "18"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `NavigationPreloadManager` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/NavigationPreloadManager

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
