### PR TITLE
Update Chromium/Firefox versions for Navigator API

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1306,7 +1306,7 @@
               "version_added": "29"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "32"
             },
             "ie": {
               "version_added": false
@@ -1893,7 +1893,7 @@
               "version_added": "68"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "edge": {
               "version_added": "79"
@@ -1911,7 +1911,7 @@
               "version_added": "55"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": false
@@ -1920,7 +1920,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": "68"
@@ -2363,10 +2363,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "60"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "43"
             },
             "safari": {
               "version_added": "15"
@@ -2991,10 +2991,10 @@
               ]
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "2"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4"
             },
             "ie": {
               "version_added": false
@@ -3214,7 +3214,7 @@
               "version_added": "87"
             },
             "edge": {
-              "version_added": false
+              "version_added": "87"
             },
             "firefox": {
               "version_added": false
@@ -3226,10 +3226,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "74"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "62"
             },
             "safari": {
               "version_added": false
@@ -3411,15 +3411,15 @@
           "spec_url": "https://w3c.github.io/badging/#setappbadge-method",
           "support": {
             "chrome": {
-              "version_added": "83",
+              "version_added": "81",
               "partial_implementation": true,
               "notes": "Windows and macOS only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "81"
             },
             "edge": {
-              "version_added": "83",
+              "version_added": "81",
               "partial_implementation": true,
               "notes": "Windows and macOS only."
             },
@@ -3436,7 +3436,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "58"
             },
             "safari": {
               "version_added": false
@@ -3445,10 +3445,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "13.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "81"
             }
           },
           "status": {
@@ -3905,7 +3905,7 @@
               "version_added": "76"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false
@@ -3952,7 +3952,7 @@
                 "version_added": "76"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "64"
               },
               "safari": {
                 "version_added": false
@@ -4130,7 +4130,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "19"
             },
             "opera_android": {
               "version_added": "19",
@@ -4303,7 +4303,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "63"
             }
           },
           "status": {
@@ -4385,10 +4385,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "66"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "57"
             },
             "safari": {
               "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -719,15 +719,15 @@
           "spec_url": "https://w3c.github.io/badging/#clearappbadge-method",
           "support": {
             "chrome": {
-              "version_added": "83",
+              "version_added": "81",
               "partial_implementation": true,
               "notes": "Windows and macOS only."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "81"
             },
             "edge": {
-              "version_added": "83",
+              "version_added": "81",
               "partial_implementation": true,
               "notes": "Windows and macOS only."
             },
@@ -744,7 +744,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "58"
             },
             "safari": {
               "version_added": false
@@ -753,10 +753,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "13.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "81"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) and Firefox (Desktop/Android) for the `Navigator` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Navigator

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
