### PR TITLE
Update Opera versions for NavigatorUAData API

### DIFF
--- a/api/NavigatorUAData.json
+++ b/api/NavigatorUAData.json
@@ -26,7 +26,7 @@
             "version_added": "76"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "64"
           },
           "safari": {
             "version_added": false
@@ -74,7 +74,7 @@
               "version_added": "76"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false
@@ -122,7 +122,7 @@
               "version_added": "76"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false
@@ -170,7 +170,7 @@
               "version_added": "76"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `NavigatorUAData` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/NavigatorUAData

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
