### PR TITLE
Update all browsers versions for Node API

### DIFF
--- a/api/Node.json
+++ b/api/Node.json
@@ -383,7 +383,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -899,7 +899,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -1095,7 +1095,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -1193,7 +1193,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -1305,7 +1305,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"
@@ -1455,7 +1455,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "≤4"
+              "version_added": "1"
             },
             "safari_ios": {
               "version_added": "1"

--- a/api/Node.json
+++ b/api/Node.json
@@ -135,10 +135,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -267,10 +267,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "9"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "9"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9",
@@ -383,10 +383,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -569,7 +569,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"
@@ -716,7 +716,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "firefox_android": {
               "version_added": "4"
@@ -899,10 +899,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1095,10 +1095,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1193,10 +1193,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1305,10 +1305,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -1455,10 +1455,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "7"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR updates and corrects the real values for all browsers for the `Node` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Node

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
