### PR TITLE
Update Chromium versions for OTPCredential API

### DIFF
--- a/api/OTPCredential.json
+++ b/api/OTPCredential.json
@@ -6,13 +6,13 @@
         "spec_url": "https://wicg.github.io/web-otp/#OTPCredential",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "93"
           },
           "chrome_android": {
             "version_added": "84"
           },
           "edge": {
-            "version_added": false
+            "version_added": "93"
           },
           "firefox": {
             "version_added": false
@@ -24,7 +24,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "79"
           },
           "opera_android": {
             "version_added": "60"
@@ -54,13 +54,13 @@
           "spec_url": "https://wicg.github.io/web-otp/#dom-otpcredential-code",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "93"
             },
             "chrome_android": {
               "version_added": "84"
             },
             "edge": {
-              "version_added": false
+              "version_added": "93"
             },
             "firefox": {
               "version_added": false
@@ -72,7 +72,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "79"
             },
             "opera_android": {
               "version_added": "60"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `OTPCredential` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/OTPCredential

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
