### PR TITLE
Update all browsers versions for OfflineAudioContext API

### DIFF
--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -430,10 +430,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "36"
+              "version_added": "28"
             },
             "opera_android": {
-              "version_added": "36"
+              "version_added": "28"
             },
             "safari": {
               "version_added": "9"
@@ -590,10 +590,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "36"
+              "version_added": "28"
             },
             "opera_android": {
-              "version_added": "36"
+              "version_added": "28"
             },
             "safari": {
               "version_added": "9"

--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -134,10 +134,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "25"
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -412,19 +412,19 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-resume",
           "support": {
             "chrome": {
-              "version_added": "49"
+              "version_added": "41"
             },
             "chrome_android": {
-              "version_added": "49"
+              "version_added": "41"
             },
             "edge": {
               "version_added": "14"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "40"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "40"
             },
             "ie": {
               "version_added": false
@@ -436,16 +436,16 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": "14.1"
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": "14.5"
+              "version_added": "9"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "49"
+              "version_added": "41"
             }
           },
           "status": {
@@ -572,10 +572,10 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-suspend",
           "support": {
             "chrome": {
-              "version_added": "49"
+              "version_added": "41"
             },
             "chrome_android": {
-              "version_added": "49"
+              "version_added": "41"
             },
             "edge": {
               "version_added": "14"
@@ -596,16 +596,16 @@
               "version_added": "36"
             },
             "safari": {
-              "version_added": "14.1"
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": "14.5"
+              "version_added": "9"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "49"
+              "version_added": "41"
             }
           },
           "status": {

--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -486,21 +486,21 @@
             },
             "safari": [
               {
-                "version_added": "14.1"
+                "version_added": "9"
               },
               {
                 "version_added": "6",
-                "version_removed": "14.1",
+                "version_removed": "9",
                 "prefix": "webkit"
               }
             ],
             "safari_ios": [
               {
-                "version_added": "14.5"
+                "version_added": "9"
               },
               {
                 "version_added": "6",
-                "version_removed": "14.5",
+                "version_removed": "9",
                 "prefix": "webkit"
               }
             ],

--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -484,26 +484,12 @@
             "opera_android": {
               "version_added": "14"
             },
-            "safari": [
-              {
-                "version_added": "9"
-              },
-              {
-                "version_added": "6",
-                "version_removed": "9",
-                "prefix": "webkit"
-              }
-            ],
-            "safari_ios": [
-              {
-                "version_added": "9"
-              },
-              {
-                "version_added": "6",
-                "version_removed": "9",
-                "prefix": "webkit"
-              }
-            ],
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": {
+              "version_added": "6"
+            },
             "samsunginternet_android": {
               "version_added": "1.5"
             },


### PR DESCRIPTION
This PR updates and corrects the real values for all browsers for the `OfflineAudioContext` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/OfflineAudioContext

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
