### PR TITLE
Update WebView versions for api.OffscreenCanvasRenderingContext2D.canvas

### DIFF
--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -277,7 +277,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "69"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for WebView Android for the `canvas` member of the `OffscreenCanvasRenderingContext2D` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/OffscreenCanvasRenderingContext2D/canvas

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
