### PR TITLE
Update Opera versions for api.PaymentRequestEvent.changePaymentMethod

### DIFF
--- a/api/PaymentRequestEvent.json
+++ b/api/PaymentRequestEvent.json
@@ -121,7 +121,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "63"
             },
             "opera_android": {
               "version_added": "54"


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `changePaymentMethod` member of the `PaymentRequestEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PaymentRequestEvent/changePaymentMethod

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
