### PR TITLE
Update Chromium versions for PerformanceEventTiming API

### DIFF
--- a/api/PerformanceEventTiming.json
+++ b/api/PerformanceEventTiming.json
@@ -6,10 +6,10 @@
         "spec_url": "https://wicg.github.io/event-timing/#sec-performance-event-timing",
         "support": {
           "chrome": {
-            "version_added": "77"
+            "version_added": "76"
           },
           "chrome_android": {
-            "version_added": "77"
+            "version_added": "76"
           },
           "edge": {
             "version_added": "79"
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "64"
+            "version_added": "63"
           },
           "opera_android": {
-            "version_added": "55"
+            "version_added": "54"
           },
           "safari": {
             "version_added": false
@@ -39,7 +39,7 @@
             "version_added": "12.0"
           },
           "webview_android": {
-            "version_added": "77"
+            "version_added": "76"
           }
         },
         "status": {
@@ -53,10 +53,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceEventTiming/cancelable",
           "support": {
             "chrome": {
-              "version_added": "77"
+              "version_added": "76"
             },
             "chrome_android": {
-              "version_added": "77"
+              "version_added": "76"
             },
             "edge": {
               "version_added": "79"
@@ -71,10 +71,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "64"
+              "version_added": "63"
             },
             "opera_android": {
-              "version_added": "55"
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -86,7 +86,7 @@
               "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": "77"
+              "version_added": "76"
             }
           },
           "status": {
@@ -101,10 +101,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceEventTiming/processingEnd",
           "support": {
             "chrome": {
-              "version_added": "77"
+              "version_added": "76"
             },
             "chrome_android": {
-              "version_added": "77"
+              "version_added": "76"
             },
             "edge": {
               "version_added": "79"
@@ -119,10 +119,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "64"
+              "version_added": "63"
             },
             "opera_android": {
-              "version_added": "55"
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -134,7 +134,7 @@
               "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": "77"
+              "version_added": "76"
             }
           },
           "status": {
@@ -149,10 +149,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceEventTiming/processingStart",
           "support": {
             "chrome": {
-              "version_added": "77"
+              "version_added": "76"
             },
             "chrome_android": {
-              "version_added": "77"
+              "version_added": "76"
             },
             "edge": {
               "version_added": "79"
@@ -167,10 +167,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "64"
+              "version_added": "63"
             },
             "opera_android": {
-              "version_added": "55"
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -182,7 +182,7 @@
               "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": "77"
+              "version_added": "76"
             }
           },
           "status": {
@@ -245,10 +245,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceEventTiming/toJSON",
           "support": {
             "chrome": {
-              "version_added": "77"
+              "version_added": "76"
             },
             "chrome_android": {
-              "version_added": "77"
+              "version_added": "76"
             },
             "edge": {
               "version_added": "79"
@@ -263,10 +263,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "64"
+              "version_added": "63"
             },
             "opera_android": {
-              "version_added": "55"
+              "version_added": "54"
             },
             "safari": {
               "version_added": false
@@ -278,7 +278,7 @@
               "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": "77"
+              "version_added": "76"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `PerformanceEventTiming` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PerformanceEventTiming

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
