### PR TITLE
Update Firefox versions for api.PerformanceEventTiming.toJSON

### DIFF
--- a/api/PerformanceEventTiming.json
+++ b/api/PerformanceEventTiming.json
@@ -254,10 +254,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "89"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "89"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `toJSON` member of the `PerformanceEventTiming` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PerformanceEventTiming/toJSON

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
