### PR TITLE
Update all browsers versions for PerformanceMark API

### DIFF
--- a/api/PerformanceMark.json
+++ b/api/PerformanceMark.json
@@ -6,10 +6,10 @@
         "spec_url": "https://w3c.github.io/user-timing/#performancemark",
         "support": {
           "chrome": {
-            "version_added": "43"
+            "version_added": "28"
           },
           "chrome_android": {
-            "version_added": "43"
+            "version_added": "28"
           },
           "deno": {
             "version_added": "1.2"
@@ -18,10 +18,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "41"
+            "version_added": "38"
           },
           "firefox_android": {
-            "version_added": "42"
+            "version_added": "38"
           },
           "ie": {
             "version_added": "10"
@@ -30,10 +30,10 @@
             "version_added": "8.5.0"
           },
           "opera": {
-            "version_added": "33"
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": "33"
+            "version_added": "14"
           },
           "safari": {
             "version_added": "11"
@@ -42,10 +42,10 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": "4.0"
+            "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": "43"
+            "version_added": "≤37"
           }
         },
         "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for all browsers for the `PerformanceMark` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PerformanceMark

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
