### PR TITLE
Update Firefox versions for PerformanceMeasure API

### DIFF
--- a/api/PerformanceMeasure.json
+++ b/api/PerformanceMeasure.json
@@ -18,10 +18,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "41"
+            "version_added": "38"
           },
           "firefox_android": {
-            "version_added": "42"
+            "version_added": "38"
           },
           "ie": {
             "version_added": "10"


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `PerformanceMeasure` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PerformanceMeasure

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
