### PR TITLE
Update IE versions for PerformanceNavigationTiming API

### DIFF
--- a/api/PerformanceNavigationTiming.json
+++ b/api/PerformanceNavigationTiming.json
@@ -23,7 +23,7 @@
             "notes": "You can disable this feature using the <code>dom.enable_performance_navigation_timing</code> preference (see <a href='https://bugzil.la/1403926'>bug 1403926</a>)."
           },
           "ie": {
-            "version_added": false
+            "version_added": "11"
           },
           "opera": {
             "version_added": "44"
@@ -71,7 +71,7 @@
               "version_added": "58"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": "44"
@@ -120,7 +120,7 @@
               "version_added": "58"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": "44"
@@ -169,7 +169,7 @@
               "version_added": "58"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": "44"
@@ -218,7 +218,7 @@
               "version_added": "58"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": "44"
@@ -267,7 +267,7 @@
               "version_added": "58"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": "44"
@@ -316,7 +316,7 @@
               "version_added": "58"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": "44"
@@ -365,7 +365,7 @@
               "version_added": "58"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": "44"
@@ -463,7 +463,7 @@
               "version_added": "58"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": "44"
@@ -512,7 +512,7 @@
               "version_added": "58"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": "44"
@@ -561,7 +561,7 @@
               "version_added": "58"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
               "version_added": "44"


### PR DESCRIPTION
This PR updates and corrects the real values for Internet Explorer for the `PerformanceNavigationTiming` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PerformanceNavigationTiming

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
