### PR TITLE
Update WebView versions for PerformanceObserverEntryList API

### DIFF
--- a/api/PerformanceObserverEntryList.json
+++ b/api/PerformanceObserverEntryList.json
@@ -43,7 +43,7 @@
             "version_added": "6.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "52"
           }
         },
         "status": {
@@ -94,7 +94,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "52"
             }
           },
           "status": {
@@ -146,7 +146,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "52"
             }
           },
           "status": {
@@ -198,7 +198,7 @@
               "version_added": "6.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "52"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for WebView Android for the `PerformanceObserverEntryList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PerformanceObserverEntryList

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
