### PR TITLE
Update all browsers versions for PerformanceResourceTiming API

### DIFF
--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -6,28 +6,28 @@
         "spec_url": "https://w3c.github.io/resource-timing/#resources-included-in-the-performanceresourcetiming-interface",
         "support": {
           "chrome": {
-            "version_added": "43"
+            "version_added": "29"
           },
           "chrome_android": {
-            "version_added": "43"
+            "version_added": "29"
           },
           "edge": {
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "40"
+            "version_added": "31"
           },
           "firefox_android": {
-            "version_added": "42"
+            "version_added": "31"
           },
           "ie": {
             "version_added": "10"
           },
           "opera": {
-            "version_added": "30"
+            "version_added": "16"
           },
           "opera_android": {
-            "version_added": "30"
+            "version_added": "16"
           },
           "safari": {
             "version_added": "11"
@@ -36,10 +36,10 @@
             "version_added": "11"
           },
           "samsunginternet_android": {
-            "version_added": "4.0"
+            "version_added": "2.0"
           },
           "webview_android": {
-            "version_added": "43"
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -63,10 +63,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "40"
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": "42"
+              "version_added": "31"
             },
             "ie": {
               "version_added": "10"
@@ -112,10 +112,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "40"
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": "42"
+              "version_added": "31"
             },
             "ie": {
               "version_added": "10"
@@ -210,13 +210,13 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "40"
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": "42"
+              "version_added": "31"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "30"
@@ -259,13 +259,13 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "40"
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": "42"
+              "version_added": "31"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "30"
@@ -357,13 +357,13 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "40"
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": "42"
+              "version_added": "31"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "30"
@@ -406,13 +406,13 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "40"
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": "42"
+              "version_added": "31"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "30"
@@ -464,16 +464,16 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "45"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11"
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -504,13 +504,13 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "40"
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": "42"
+              "version_added": "31"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "30"
@@ -553,13 +553,13 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "40"
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": "42"
+              "version_added": "31"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "30"
@@ -602,13 +602,13 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "40"
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": "42"
+              "version_added": "31"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "30"
@@ -651,13 +651,13 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "40"
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": "42"
+              "version_added": "31"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "30"
@@ -700,13 +700,13 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "40"
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": "42"
+              "version_added": "31"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "30"
@@ -749,10 +749,10 @@
               "version_added": "18"
             },
             "firefox": {
-              "version_added": "40"
+              "version_added": "31"
             },
             "firefox_android": {
-              "version_added": "42"
+              "version_added": "31"
             },
             "ie": {
               "version_added": false
@@ -847,10 +847,10 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "40"
+              "version_added": "34"
             },
             "firefox_android": {
-              "version_added": "42"
+              "version_added": "34"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for all browsers for the `PerformanceResourceTiming` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PerformanceResourceTiming

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
