### PR TITLE
Update Chromium versions for PointerEvent API

### DIFF
--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -837,10 +837,10 @@
           "spec_url": "https://w3c.github.io/pointerevents/#dom-pointerevent-tangentialpressure",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "57"
             },
             "chrome_android": {
-              "version_added": "58"
+              "version_added": "57"
             },
             "edge": {
               "version_added": "79"
@@ -879,7 +879,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "45"
+              "version_added": "43"
             },
             "opera_android": {
               "version_added": "43"
@@ -894,7 +894,7 @@
               "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": "58"
+              "version_added": "57"
             }
           },
           "status": {
@@ -1056,10 +1056,10 @@
           "spec_url": "https://w3c.github.io/pointerevents/#dom-pointerevent-twist",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "57"
             },
             "chrome_android": {
-              "version_added": "58"
+              "version_added": "57"
             },
             "edge": {
               "version_added": "18"
@@ -1098,7 +1098,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "45"
+              "version_added": "44"
             },
             "opera_android": {
               "version_added": "43"
@@ -1113,7 +1113,7 @@
               "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": "58"
+              "version_added": "57"
             }
           },
           "status": {

--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -879,7 +879,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "43"
+              "version_added": "44"
             },
             "opera_android": {
               "version_added": "43"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `PointerEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PointerEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
