### PR TITLE
Update Safari versions for PopStateEvent API

### DIFF
--- a/api/PopStateEvent.json
+++ b/api/PopStateEvent.json
@@ -126,10 +126,10 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "6"
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `PopStateEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PopStateEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
