### PR TITLE
Update Chromium versions for PresentationAvailability API

### DIFF
--- a/api/PresentationAvailability.json
+++ b/api/PresentationAvailability.json
@@ -6,10 +6,10 @@
         "spec_url": "https://w3c.github.io/presentation-api/#interface-presentationavailability",
         "support": {
           "chrome": {
-            "version_added": "48"
+            "version_added": "47"
           },
           "chrome_android": {
-            "version_added": "48"
+            "version_added": "47"
           },
           "edge": {
             "version_added": "79"
@@ -40,10 +40,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "35"
+            "version_added": "34"
           },
           "opera_android": {
-            "version_added": "35"
+            "version_added": "34"
           },
           "safari": {
             "version_added": false
@@ -70,10 +70,10 @@
           "spec_url": "https://w3c.github.io/presentation-api/#dom-presentationavailability-onchange",
           "support": {
             "chrome": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "edge": {
               "version_added": "79"
@@ -104,10 +104,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "35"
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": "35"
+              "version_added": "34"
             },
             "safari": {
               "version_added": false
@@ -135,10 +135,10 @@
           "spec_url": "https://w3c.github.io/presentation-api/#dom-presentationavailability-value",
           "support": {
             "chrome": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "edge": {
               "version_added": "79"
@@ -169,10 +169,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "35"
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": "35"
+              "version_added": "34"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `PresentationAvailability` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PresentationAvailability

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
