### PR TITLE
Update Chromium versions for PresentationConnectionAvailableEvent API

### DIFF
--- a/api/PresentationConnectionAvailableEvent.json
+++ b/api/PresentationConnectionAvailableEvent.json
@@ -6,10 +6,10 @@
         "spec_url": "https://w3c.github.io/presentation-api/#interface-presentationconnectionavailableevent",
         "support": {
           "chrome": {
-            "version_added": "48"
+            "version_added": "47"
           },
           "chrome_android": {
-            "version_added": "48"
+            "version_added": "47"
           },
           "edge": {
             "version_added": "79"
@@ -40,10 +40,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "35"
+            "version_added": "34"
           },
           "opera_android": {
-            "version_added": "35"
+            "version_added": "34"
           },
           "safari": {
             "version_added": false
@@ -71,10 +71,10 @@
           "description": "<code>PresentationConnectionAvailableEvent()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "edge": {
               "version_added": "79"
@@ -105,10 +105,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "35"
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": "35"
+              "version_added": "34"
             },
             "safari": {
               "version_added": false
@@ -136,10 +136,10 @@
           "spec_url": "https://w3c.github.io/presentation-api/#dom-presentationconnectionavailableevent-connection",
           "support": {
             "chrome": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "edge": {
               "version_added": "79"
@@ -170,10 +170,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "35"
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": "35"
+              "version_added": "34"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `PresentationConnectionAvailableEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PresentationConnectionAvailableEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
