### PR TITLE
Update Chromium versions for PresentationRequest API

### DIFF
--- a/api/PresentationRequest.json
+++ b/api/PresentationRequest.json
@@ -6,10 +6,10 @@
         "spec_url": "https://w3c.github.io/presentation-api/#interface-presentationrequest",
         "support": {
           "chrome": {
-            "version_added": "48"
+            "version_added": "47"
           },
           "chrome_android": {
-            "version_added": "48"
+            "version_added": "47"
           },
           "edge": {
             "version_added": "79"
@@ -40,10 +40,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "35"
+            "version_added": "34"
           },
           "opera_android": {
-            "version_added": "35"
+            "version_added": "34"
           },
           "safari": {
             "version_added": false
@@ -71,10 +71,10 @@
           "description": "<code>PresentationRequest()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "edge": {
               "version_added": "79"
@@ -105,10 +105,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "35"
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": "35"
+              "version_added": "34"
             },
             "safari": {
               "version_added": false
@@ -136,10 +136,10 @@
           "spec_url": "https://w3c.github.io/presentation-api/#getting-the-presentation-displays-availability-information",
           "support": {
             "chrome": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "edge": {
               "version_added": "79"
@@ -170,10 +170,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "35"
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": "35"
+              "version_added": "34"
             },
             "safari": {
               "version_added": false
@@ -201,10 +201,10 @@
           "spec_url": "https://w3c.github.io/presentation-api/#dom-presentationrequest-onconnectionavailable",
           "support": {
             "chrome": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "edge": {
               "version_added": "79"
@@ -235,10 +235,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "35"
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": "35"
+              "version_added": "34"
             },
             "safari": {
               "version_added": false
@@ -266,10 +266,10 @@
           "spec_url": "https://w3c.github.io/presentation-api/#reconnecting-to-a-presentation",
           "support": {
             "chrome": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "edge": {
               "version_added": "79"
@@ -300,10 +300,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "35"
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": "35"
+              "version_added": "34"
             },
             "safari": {
               "version_added": false
@@ -381,10 +381,10 @@
           "spec_url": "https://w3c.github.io/presentation-api/#selecting-a-presentation-display",
           "support": {
             "chrome": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "chrome_android": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "edge": {
               "version_added": "79"
@@ -415,10 +415,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "35"
+              "version_added": "34"
             },
             "opera_android": {
-              "version_added": "35"
+              "version_added": "34"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `PresentationRequest` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PresentationRequest

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
