### PR TITLE
Update all browsers versions for ProgressEvent API

### DIFF
--- a/api/ProgressEvent.json
+++ b/api/ProgressEvent.json
@@ -70,10 +70,10 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "18"
             },
             "firefox_android": {
-              "version_added": "22"
+              "version_added": "18"
             },
             "ie": {
               "version_added": false
@@ -239,7 +239,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -291,7 +291,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR updates and corrects the real values for all browsers for the `ProgressEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ProgressEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
