### PR TITLE
Update Firefox Android versions for PromiseRejectionEvent API

### DIFF
--- a/api/PromiseRejectionEvent.json
+++ b/api/PromiseRejectionEvent.json
@@ -32,16 +32,21 @@
               ]
             }
           ],
-          "firefox_android": {
-            "version_added": "68",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.promise_rejection_events.enabled",
-                "value_to_set": "true"
-              }
-            ]
-          },
+          "firefox_android": [
+            {
+              "version_added": "79"
+            },
+            {
+              "version_added": "68",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.promise_rejection_events.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "ie": {
             "version_added": false
           },
@@ -103,16 +108,21 @@
                 ]
               }
             ],
-            "firefox_android": {
-              "version_added": "68",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.promise_rejection_events.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox_android": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "68",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.promise_rejection_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -174,16 +184,21 @@
                 ]
               }
             ],
-            "firefox_android": {
-              "version_added": "68",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.promise_rejection_events.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox_android": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "68",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.promise_rejection_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -245,16 +260,21 @@
                 ]
               }
             ],
-            "firefox_android": {
-              "version_added": "68",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.promise_rejection_events.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox_android": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "68",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.promise_rejection_events.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox Android for the `PromiseRejectionEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PromiseRejectionEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
