### PR TITLE
Update Opera versions for PublicKeyCredential API

### DIFF
--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -36,7 +36,7 @@
             "version_added": "54"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "49"
           },
           "safari": {
             "version_added": "13"
@@ -93,7 +93,7 @@
               "version_added": "54"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "safari": {
               "version_added": "13"
@@ -151,7 +151,7 @@
               "version_added": "54"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "safari": {
               "version_added": "13"
@@ -209,7 +209,7 @@
               "version_added": "54"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "safari": {
               "version_added": "13"
@@ -267,7 +267,7 @@
               "version_added": "54"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "safari": {
               "version_added": "13"


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `PublicKeyCredential` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PublicKeyCredential

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
