### PR TITLE
Update Chromium versions for api.PushEvent.data

### DIFF
--- a/api/PushEvent.json
+++ b/api/PushEvent.json
@@ -119,10 +119,10 @@
           "spec_url": "https://w3c.github.io/push-api/#dom-pushevent-data",
           "support": {
             "chrome": {
-              "version_added": "57"
+              "version_added": "50"
             },
             "chrome_android": {
-              "version_added": "57"
+              "version_added": "50"
             },
             "edge": {
               "version_added": "17"
@@ -144,10 +144,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "44"
+              "version_added": "37"
             },
             "opera_android": {
-              "version_added": "43"
+              "version_added": "37"
             },
             "safari": {
               "version_added": false
@@ -156,7 +156,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "5.0"
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `data` member of the `PushEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PushEvent/data

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
