### PR TITLE
Update Chromium versions for api.RTCDataChannelEvent.RTCDataChannelEvent

### DIFF
--- a/api/RTCDataChannelEvent.json
+++ b/api/RTCDataChannelEvent.json
@@ -55,10 +55,10 @@
           "description": "<code>RTCDataChannelEvent()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "57"
+              "version_added": "56"
             },
             "chrome_android": {
-              "version_added": "57"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "79"
@@ -73,7 +73,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "44"
+              "version_added": "43"
             },
             "opera_android": {
               "version_added": "43"
@@ -88,7 +88,7 @@
               "version_added": "7.0"
             },
             "webview_android": {
-              "version_added": "57"
+              "version_added": "56"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `RTCDataChannelEvent` member of the `RTCDataChannelEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCDataChannelEvent/RTCDataChannelEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
