### PR TITLE
Update Opera versions for RTCEncodedVideoFrame API

### DIFF
--- a/api/RTCEncodedVideoFrame.json
+++ b/api/RTCEncodedVideoFrame.json
@@ -25,7 +25,7 @@
             "version_added": "72"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "61"
           },
           "safari": {
             "version_added": false
@@ -71,7 +71,7 @@
               "version_added": "72"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "61"
             },
             "safari": {
               "version_added": false
@@ -118,7 +118,7 @@
               "version_added": "72"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "61"
             },
             "safari": {
               "version_added": false
@@ -165,7 +165,7 @@
               "version_added": "72"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "61"
             },
             "safari": {
               "version_added": false
@@ -212,7 +212,7 @@
               "version_added": "72"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "61"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `RTCEncodedVideoFrame` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCEncodedVideoFrame

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
