### PR TITLE
Update Chromium versions for RTCRtpTransceiver API

### DIFF
--- a/api/RTCRtpTransceiver.json
+++ b/api/RTCRtpTransceiver.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "56"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "48"
           },
           "safari": {
             "version_added": "11"
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": "12.1"
@@ -109,7 +109,7 @@
               "version_added": "69"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "59"
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": "11"
@@ -158,7 +158,7 @@
               "version_added": "69"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "59"
@@ -170,10 +170,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": "11"
@@ -207,7 +207,7 @@
               "version_added": "69"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "59"
@@ -219,10 +219,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": "11"
@@ -256,7 +256,7 @@
               "version_added": "69"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "59"
@@ -268,10 +268,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "56"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "48"
             },
             "safari": {
               "version_added": "11"
@@ -300,13 +300,13 @@
           "description": "<code>setCodecPreferences()</code>",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "76"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "76"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -318,10 +318,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "63"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "54"
             },
             "safari": {
               "version_added": "13.1"
@@ -330,10 +330,10 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "12.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "76"
             }
           },
           "status": {
@@ -368,10 +368,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "74"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "safari": {
               "version_added": "11"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `RTCRtpTransceiver` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCRtpTransceiver

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
