### PR TITLE
Update Opera versions for RTCSctpTransport API

### DIFF
--- a/api/RTCSctpTransport.json
+++ b/api/RTCSctpTransport.json
@@ -26,7 +26,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "63"
           },
           "opera_android": {
             "version_added": "54"
@@ -75,7 +75,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "63"
             },
             "opera_android": {
               "version_added": "54"
@@ -125,7 +125,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "63"
             },
             "opera_android": {
               "version_added": "54"
@@ -175,7 +175,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "63"
             },
             "opera_android": {
               "version_added": "54"
@@ -226,7 +226,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "63"
             },
             "opera_android": {
               "version_added": "54"
@@ -276,7 +276,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "63"
             },
             "opera_android": {
               "version_added": "54"


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `RTCSctpTransport` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCSctpTransport

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
