### PR TITLE
Update all browsers versions for RadioNodeList API

### DIFF
--- a/api/RadioNodeList.json
+++ b/api/RadioNodeList.json
@@ -6,40 +6,40 @@
         "spec_url": "https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#radionodelist",
         "support": {
           "chrome": {
-            "version_added": "34"
+            "version_added": "1"
           },
           "chrome_android": {
-            "version_added": "34"
+            "version_added": "18"
           },
           "edge": {
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "33"
+            "version_added": "1.5"
           },
           "firefox_android": {
-            "version_added": "33"
+            "version_added": "4"
           },
           "ie": {
-            "version_added": "9"
+            "version_added": "8"
           },
           "opera": {
-            "version_added": "21"
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": "21"
+            "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "10"
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": "9"
+            "version_added": "1"
           },
           "samsunginternet_android": {
-            "version_added": "2.0"
+            "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "≤37"
+            "version_added": "1"
           }
         },
         "status": {
@@ -54,10 +54,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#dom-radionodelist-value",
           "support": {
             "chrome": {
-              "version_added": "34"
+              "version_added": "21"
             },
             "chrome_android": {
-              "version_added": "34"
+              "version_added": "25"
             },
             "edge": {
               "version_added": "12"
@@ -72,10 +72,10 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": "21"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "21"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "10"
@@ -84,7 +84,7 @@
               "version_added": "9"
             },
             "samsunginternet_android": {
-              "version_added": "2.0"
+              "version_added": "1.5"
             },
             "webview_android": {
               "version_added": "4.4"

--- a/api/RadioNodeList.json
+++ b/api/RadioNodeList.json
@@ -6,40 +6,40 @@
         "spec_url": "https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#radionodelist",
         "support": {
           "chrome": {
-            "version_added": "1"
+            "version_added": "21"
           },
           "chrome_android": {
-            "version_added": "18"
+            "version_added": "25"
           },
           "edge": {
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "1.5"
+            "version_added": "33"
           },
           "firefox_android": {
-            "version_added": "4"
+            "version_added": "33"
           },
           "ie": {
-            "version_added": "8"
+            "version_added": "9"
           },
           "opera": {
-            "version_added": "≤12.1"
+            "version_added": "15"
           },
           "opera_android": {
-            "version_added": "≤12.1"
+            "version_added": "14"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "7"
           },
           "safari_ios": {
-            "version_added": "1"
+            "version_added": "7"
           },
           "samsunginternet_android": {
-            "version_added": "1.0"
+            "version_added": "1.5"
           },
           "webview_android": {
-            "version_added": "1"
+            "version_added": "4.4"
           }
         },
         "status": {

--- a/api/RadioNodeList.json
+++ b/api/RadioNodeList.json
@@ -78,10 +78,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "9"
+              "version_added": "7"
             },
             "samsunginternet_android": {
               "version_added": "1.5"


### PR DESCRIPTION
This PR updates and corrects the real values for all browsers for the `RadioNodeList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RadioNodeList

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
