### PR TITLE
Update IE versions for api.Range.createContextualFragment

### DIFF
--- a/api/Range.json
+++ b/api/Range.json
@@ -572,7 +572,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "11"
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR updates and corrects the real values for Internet Explorer for the `createContextualFragment` member of the `Range` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Range/createContextualFragment

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
