### PR TITLE
Update Opera versions for ReadableByteStreamController API

### DIFF
--- a/api/ReadableByteStreamController.json
+++ b/api/ReadableByteStreamController.json
@@ -45,7 +45,7 @@
             "version_added": "75"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "63"
           },
           "safari": {
             "version_added": false
@@ -99,7 +99,7 @@
               "version_added": "75"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "safari": {
               "version_added": false
@@ -154,7 +154,7 @@
               "version_added": "75"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "safari": {
               "version_added": false
@@ -209,7 +209,7 @@
               "version_added": "75"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "safari": {
               "version_added": false
@@ -264,7 +264,7 @@
               "version_added": "75"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "safari": {
               "version_added": false
@@ -319,7 +319,7 @@
               "version_added": "75"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `ReadableByteStreamController` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ReadableByteStreamController

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
