### PR TITLE
Update Opera versions for ReadableStreamBYOBReader API

### DIFF
--- a/api/ReadableStreamBYOBReader.json
+++ b/api/ReadableStreamBYOBReader.json
@@ -35,10 +35,10 @@
             ]
           },
           "opera": {
-            "version_added": false
+            "version_added": "75"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "63"
           },
           "safari": {
             "version_added": false
@@ -91,10 +91,10 @@
               "version_added": "16.5.0"
             },
             "opera": {
-              "version_added": false
+              "version_added": "75"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "safari": {
               "version_added": false
@@ -147,10 +147,10 @@
               "version_added": "16.5.0"
             },
             "opera": {
-              "version_added": false
+              "version_added": "75"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "safari": {
               "version_added": false
@@ -203,10 +203,10 @@
               "version_added": "16.5.0"
             },
             "opera": {
-              "version_added": false
+              "version_added": "75"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "safari": {
               "version_added": false
@@ -259,10 +259,10 @@
               "version_added": "16.5.0"
             },
             "opera": {
-              "version_added": false
+              "version_added": "75"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "safari": {
               "version_added": false
@@ -315,10 +315,10 @@
               "version_added": "16.5.0"
             },
             "opera": {
-              "version_added": false
+              "version_added": "75"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `ReadableStreamBYOBReader` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ReadableStreamBYOBReader

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
