### PR TITLE
Update Opera versions for ReadableStreamBYOBRequest API

### DIFF
--- a/api/ReadableStreamBYOBRequest.json
+++ b/api/ReadableStreamBYOBRequest.json
@@ -34,10 +34,10 @@
             ]
           },
           "opera": {
-            "version_added": false
+            "version_added": "75"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "63"
           },
           "safari": {
             "version_added": false
@@ -88,10 +88,10 @@
               "version_added": "16.5.0"
             },
             "opera": {
-              "version_added": false
+              "version_added": "75"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "safari": {
               "version_added": false
@@ -143,10 +143,10 @@
               "version_added": "16.5.0"
             },
             "opera": {
-              "version_added": false
+              "version_added": "75"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "safari": {
               "version_added": false
@@ -198,10 +198,10 @@
               "version_added": "16.5.0"
             },
             "opera": {
-              "version_added": false
+              "version_added": "75"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "63"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `ReadableStreamBYOBRequest` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ReadableStreamBYOBRequest

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
