### PR TITLE
Update Firefox versions for ResizeObserverEntry API

### DIFF
--- a/api/ResizeObserverEntry.json
+++ b/api/ResizeObserverEntry.json
@@ -18,7 +18,7 @@
             "version_added": "69"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "79"
           },
           "ie": {
             "version_added": false
@@ -66,7 +66,7 @@
               "version_added": "69"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -122,9 +122,17 @@
                 "notes": "Implemented as a single object representing a content box size, rather than an array of content box size objects."
               }
             ],
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": [
+              {
+                "version_added": "92"
+              },
+              {
+                "version_added": "79",
+                "version_removed": "92",
+                "partial_implementation": true,
+                "notes": "Implemented as a single object representing a content box size, rather than an array of content box size objects."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -172,7 +180,7 @@
               "version_added": "69"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -216,10 +224,10 @@
               "version_added": "84"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "93"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "93"
             },
             "ie": {
               "version_added": false
@@ -268,7 +276,7 @@
               "version_added": "69"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `ResizeObserverEntry` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ResizeObserverEntry

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
