### PR TITLE
Update Chrome/Safari versions for SVGAnimatedString API

### DIFF
--- a/api/SVGAnimatedString.json
+++ b/api/SVGAnimatedString.json
@@ -6,7 +6,7 @@
         "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedString",
         "support": {
           "chrome": {
-            "version_added": "5"
+            "version_added": "1"
           },
           "chrome_android": {
             "version_added": "18"
@@ -24,22 +24,22 @@
             "version_added": "9"
           },
           "opera": {
-            "version_added": "15"
+            "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": "14"
+            "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "5"
+            "version_added": "≤4"
           },
           "safari_ios": {
-            "version_added": "4"
+            "version_added": "1"
           },
           "samsunginternet_android": {
             "version_added": "1.0"
           },
           "webview_android": {
-            "version_added": "≤37"
+            "version_added": "1"
           }
         },
         "status": {
@@ -54,7 +54,7 @@
           "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedString__animVal",
           "support": {
             "chrome": {
-              "version_added": "15"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -72,22 +72,22 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "1"
             }
           },
           "status": {
@@ -103,7 +103,7 @@
           "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedString__baseVal",
           "support": {
             "chrome": {
-              "version_added": "15"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"
@@ -121,22 +121,22 @@
               "version_added": "9"
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chrome and Safari for the `SVGAnimatedString` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGAnimatedString

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
