### PR TITLE
Update Firefox versions for SVGComponentTransferFunctionElement API

### DIFF
--- a/api/SVGComponentTransferFunctionElement.json
+++ b/api/SVGComponentTransferFunctionElement.json
@@ -61,10 +61,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "21"
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": "21"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -108,10 +108,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "21"
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": "21"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -155,10 +155,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "21"
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": "21"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -202,10 +202,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "21"
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": "21"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -249,10 +249,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "21"
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": "21"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -296,10 +296,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "21"
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": "21"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"
@@ -343,10 +343,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "21"
+              "version_added": "3"
             },
             "firefox_android": {
-              "version_added": "21"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `SVGComponentTransferFunctionElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGComponentTransferFunctionElement

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
