### PR TITLE
Update Firefox versions for api.SVGSVGElement.getElementById

### DIFF
--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -990,10 +990,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "11"
+              "version_added": "1.5"
             },
             "firefox_android": {
-              "version_added": "14"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "9"


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `getElementById` member of the `SVGSVGElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGSVGElement/getElementById

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
