### PR TITLE
Update Chromium versions for Scheduling API

### DIFF
--- a/api/Scheduling.json
+++ b/api/Scheduling.json
@@ -10,7 +10,7 @@
             "version_added": "87"
           },
           "edge": {
-            "version_added": false
+            "version_added": "87"
           },
           "firefox": {
             "version_added": false
@@ -22,10 +22,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "73"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "62"
           },
           "safari": {
             "version_added": false
@@ -56,7 +56,7 @@
               "version_added": "87"
             },
             "edge": {
-              "version_added": false
+              "version_added": "87"
             },
             "firefox": {
               "version_added": false
@@ -68,10 +68,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "73"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "62"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Scheduling` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Scheduling

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
