### PR TITLE
Update Chromium versions for api.Screen.orientation

### DIFF
--- a/api/Screen.json
+++ b/api/Screen.json
@@ -670,7 +670,7 @@
               "version_added": "25"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "26"
             },
             "safari": {
               "version_added": false
@@ -682,7 +682,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "39"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `orientation` member of the `Screen` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Screen/orientation

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
