### PR TITLE
Update Opera versions for SerialPort API

### DIFF
--- a/api/SerialPort.json
+++ b/api/SerialPort.json
@@ -24,7 +24,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "75"
           },
           "opera_android": {
             "version_added": false
@@ -72,7 +72,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "75"
             },
             "opera_android": {
               "version_added": false
@@ -121,7 +121,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "75"
             },
             "opera_android": {
               "version_added": false
@@ -170,7 +170,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "75"
             },
             "opera_android": {
               "version_added": false
@@ -219,7 +219,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "75"
             },
             "opera_android": {
               "version_added": false
@@ -268,7 +268,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "75"
             },
             "opera_android": {
               "version_added": false
@@ -317,7 +317,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "75"
             },
             "opera_android": {
               "version_added": false
@@ -366,7 +366,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "75"
             },
             "opera_android": {
               "version_added": false
@@ -415,7 +415,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "75"
             },
             "opera_android": {
               "version_added": false
@@ -464,7 +464,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "75"
             },
             "opera_android": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `SerialPort` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SerialPort

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
