### PR TITLE
Update Chromium versions for api.ServiceWorkerContainer.onmessageerror

### DIFF
--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -406,14 +406,13 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#dom-serviceworkerglobalscope-onmessageerror",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "80"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "80"
             },
             "edge": {
-              "version_added": "17",
-              "version_removed": "79"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": "65"
@@ -425,10 +424,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "67"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "57"
             },
             "safari": {
               "version_added": "11.1",
@@ -441,10 +440,10 @@
               "notes": "Although the <code>onmessageerror</code> property is supported, the <code>messageerror</code> event is never fired. See <a href='https://webkit.org/b/171216'>bug 171216</a>."
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "13.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "80"
             }
           },
           "status": {

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -411,9 +411,15 @@
             "chrome_android": {
               "version_added": "80"
             },
-            "edge": {
-              "version_added": "17"
-            },
+            "edge": [
+              {
+                "version_added": "80"
+              },
+              {
+                "version_added": "17",
+                "version_removed": "79"
+              }
+            ],
             "firefox": {
               "version_added": "65"
             },


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `onmessageerror` member of the `ServiceWorkerContainer` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ServiceWorkerContainer/onmessageerror

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
