### PR TITLE
Update Chrome/Safari versions for ServiceWorkerRegistration API

### DIFF
--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -175,7 +175,7 @@
               "version_added": "73"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "62"
             },
             "safari": {
               "version_added": false
@@ -451,35 +451,38 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/paymentManager",
           "support": {
-            "chrome": {
-              "version_added": "56",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            "chrome_android": {
-              "version_added": "56",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "70"
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#service-worker-payment-apps",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "70"
+              },
+              {
+                "version_added": "56",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#service-worker-payment-apps",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "edge": {
-              "version_added": "≤79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -490,18 +493,23 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "43",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#service-worker-payment-apps",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "opera": [
+              {
+                "version_added": "57"
+              },
+              {
+                "version_added": "43",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#service-worker-payment-apps",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "opera_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -510,7 +518,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -547,10 +555,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "67"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "57"
             },
             "safari": {
               "version_added": false
@@ -657,7 +665,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1202,7 +1210,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0",
@@ -1309,7 +1317,7 @@
               "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Chrome and Safari for the `ServiceWorkerRegistration` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ServiceWorkerRegistration

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
