### PR TITLE
Update Firefox versions for api.ShadowRoot.slotAssignment

### DIFF
--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -353,10 +353,10 @@
               "version_added": "86"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "92"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "92"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `slotAssignment` member of the `ShadowRoot` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ShadowRoot/slotAssignment

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
