### PR TITLE
Update Firefox Android versions for StaticRange API

### DIFF
--- a/api/StaticRange.json
+++ b/api/StaticRange.json
@@ -19,7 +19,7 @@
             "notes": "In Firefox, <code>StaticRange</code> can currently only be used by browser-internal code or code with enhanced permissions; it is not yet exposed to the web."
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "79"
           },
           "ie": {
             "version_added": false
@@ -68,7 +68,7 @@
               "version_added": "71"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox Android for the `StaticRange` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/StaticRange

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
