### PR TITLE
Update Firefox versions for StyleSheetList API

### DIFF
--- a/api/StyleSheetList.json
+++ b/api/StyleSheetList.json
@@ -15,10 +15,10 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "31"
+            "version_added": "1"
           },
           "firefox_android": {
-            "version_added": "31"
+            "version_added": "4"
           },
           "ie": {
             "version_added": "4"
@@ -63,10 +63,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "31"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4"
@@ -112,10 +112,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "31"
+              "version_added": "4"
             },
             "ie": {
               "version_added": "4"


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `StyleSheetList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/StyleSheetList

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
