### PR TITLE
Update WebView versions for SyncEvent API

### DIFF
--- a/api/SyncEvent.json
+++ b/api/SyncEvent.json
@@ -39,7 +39,7 @@
             "version_added": "5.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "49"
           }
         },
         "status": {
@@ -88,7 +88,7 @@
               "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "49"
             }
           },
           "status": {
@@ -137,7 +137,7 @@
               "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "49"
             }
           },
           "status": {
@@ -186,7 +186,7 @@
               "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "49"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for WebView Android for the `SyncEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SyncEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
