### PR TITLE
Update Opera versions for SyncManager API

### DIFF
--- a/api/SyncManager.json
+++ b/api/SyncManager.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "36"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "36"
           },
           "safari": {
             "version_added": false
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "36"
             },
             "safari": {
               "version_added": false
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "36"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "36"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `SyncManager` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SyncManager

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
