### PR TITLE
Update Opera versions for api.TextEncoder.encodeInfo

### DIFF
--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -208,10 +208,10 @@
               "version_added": null
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "50"
             },
             "safari": {
               "version_added": "14.1"


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `encodeInfo` member of the `TextEncoder` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/TextEncoder/encodeInfo

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
