### PR TITLE
Update WebView versions for USB API

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3821,7 +3821,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this member, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "notes": "WebView exposes <code>navigator.usb</code>, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3820,7 +3820,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this member, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {

--- a/api/USB.json
+++ b/api/USB.json
@@ -88,8 +88,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -138,8 +137,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -188,8 +186,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -238,8 +235,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {

--- a/api/USB.json
+++ b/api/USB.json
@@ -39,7 +39,7 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "61"
           }
         },
         "status": {
@@ -87,7 +87,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -136,7 +136,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -185,7 +185,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -234,7 +234,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {

--- a/api/USB.json
+++ b/api/USB.json
@@ -39,7 +39,8 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": "61"
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
           }
         },
         "status": {
@@ -87,7 +88,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -136,7 +138,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -185,7 +188,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -234,7 +238,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {

--- a/api/USBAlternateInterface.json
+++ b/api/USBAlternateInterface.json
@@ -39,7 +39,8 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": "61"
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
           }
         },
         "status": {
@@ -87,7 +88,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -135,7 +137,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -183,7 +186,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -231,7 +235,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -279,7 +284,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -327,7 +333,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -375,7 +382,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {

--- a/api/USBAlternateInterface.json
+++ b/api/USBAlternateInterface.json
@@ -88,8 +88,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -137,8 +136,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -186,8 +184,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -235,8 +232,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -284,8 +280,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -333,8 +328,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -382,8 +376,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {

--- a/api/USBAlternateInterface.json
+++ b/api/USBAlternateInterface.json
@@ -39,7 +39,7 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "61"
           }
         },
         "status": {
@@ -87,7 +87,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -135,7 +135,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -183,7 +183,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -231,7 +231,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -279,7 +279,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -327,7 +327,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -375,7 +375,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {

--- a/api/USBConfiguration.json
+++ b/api/USBConfiguration.json
@@ -39,7 +39,7 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "61"
           }
         },
         "status": {
@@ -88,7 +88,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -137,7 +137,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -186,7 +186,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -235,7 +235,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {

--- a/api/USBConfiguration.json
+++ b/api/USBConfiguration.json
@@ -89,8 +89,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -139,8 +138,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -189,8 +187,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -239,8 +236,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {

--- a/api/USBConfiguration.json
+++ b/api/USBConfiguration.json
@@ -39,7 +39,8 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": "61"
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
           }
         },
         "status": {
@@ -88,7 +89,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -137,7 +139,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -186,7 +189,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -235,7 +239,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {

--- a/api/USBConnectionEvent.json
+++ b/api/USBConnectionEvent.json
@@ -39,7 +39,7 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "61"
           }
         },
         "status": {
@@ -88,7 +88,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -137,7 +137,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {

--- a/api/USBConnectionEvent.json
+++ b/api/USBConnectionEvent.json
@@ -39,7 +39,8 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": "61"
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
           }
         },
         "status": {
@@ -88,7 +89,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -137,7 +139,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {

--- a/api/USBConnectionEvent.json
+++ b/api/USBConnectionEvent.json
@@ -89,8 +89,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -139,8 +138,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {

--- a/api/USBDevice.json
+++ b/api/USBDevice.json
@@ -88,8 +88,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -138,8 +137,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -188,8 +186,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -238,8 +235,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -288,8 +284,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -338,8 +333,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -388,8 +382,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -438,8 +431,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -488,8 +480,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -538,8 +529,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -588,8 +578,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -638,8 +627,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -688,8 +676,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -738,8 +725,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -788,8 +774,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -838,8 +823,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -888,8 +872,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -938,8 +921,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -988,8 +970,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -1038,8 +1019,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -1088,8 +1068,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -1138,8 +1117,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -1188,8 +1166,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -1238,8 +1215,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -1288,8 +1264,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -1338,8 +1313,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -1388,8 +1362,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -1438,8 +1411,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -1488,8 +1460,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -1538,8 +1509,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -1588,8 +1558,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {

--- a/api/USBDevice.json
+++ b/api/USBDevice.json
@@ -39,7 +39,7 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "61"
           }
         },
         "status": {
@@ -87,7 +87,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -136,7 +136,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -185,7 +185,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -234,7 +234,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -283,7 +283,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -332,7 +332,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -381,7 +381,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -430,7 +430,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -479,7 +479,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -528,7 +528,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -577,7 +577,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -626,7 +626,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -675,7 +675,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -724,7 +724,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -773,7 +773,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -822,7 +822,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -871,7 +871,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -920,7 +920,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -969,7 +969,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -1018,7 +1018,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -1067,7 +1067,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -1116,7 +1116,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -1165,7 +1165,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -1214,7 +1214,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -1263,7 +1263,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -1312,7 +1312,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -1361,7 +1361,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -1410,7 +1410,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -1459,7 +1459,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -1508,7 +1508,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -1557,7 +1557,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {

--- a/api/USBDevice.json
+++ b/api/USBDevice.json
@@ -39,7 +39,8 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": "61"
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
           }
         },
         "status": {
@@ -87,7 +88,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -136,7 +138,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -185,7 +188,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -234,7 +238,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -283,7 +288,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -332,7 +338,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -381,7 +388,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -430,7 +438,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -479,7 +488,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -528,7 +538,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -577,7 +588,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -626,7 +638,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -675,7 +688,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -724,7 +738,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -773,7 +788,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -822,7 +838,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -871,7 +888,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -920,7 +938,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -969,7 +988,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -1018,7 +1038,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -1067,7 +1088,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -1116,7 +1138,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -1165,7 +1188,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -1214,7 +1238,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -1263,7 +1288,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -1312,7 +1338,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -1361,7 +1388,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -1410,7 +1438,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -1459,7 +1488,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -1508,7 +1538,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -1557,7 +1588,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {

--- a/api/USBEndpoint.json
+++ b/api/USBEndpoint.json
@@ -88,8 +88,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -137,8 +136,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -186,8 +184,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -235,8 +232,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -284,8 +280,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {

--- a/api/USBEndpoint.json
+++ b/api/USBEndpoint.json
@@ -39,7 +39,7 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "61"
           }
         },
         "status": {
@@ -87,7 +87,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -135,7 +135,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -183,7 +183,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -231,7 +231,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -279,7 +279,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {

--- a/api/USBEndpoint.json
+++ b/api/USBEndpoint.json
@@ -39,7 +39,8 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": "61"
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
           }
         },
         "status": {
@@ -87,7 +88,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -135,7 +137,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -183,7 +186,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -231,7 +235,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -279,7 +284,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {

--- a/api/USBInTransferResult.json
+++ b/api/USBInTransferResult.json
@@ -39,7 +39,8 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": "61"
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
           }
         },
         "status": {
@@ -87,7 +88,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -135,7 +137,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -183,7 +186,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {

--- a/api/USBInTransferResult.json
+++ b/api/USBInTransferResult.json
@@ -88,8 +88,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -137,8 +136,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -186,8 +184,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {

--- a/api/USBInTransferResult.json
+++ b/api/USBInTransferResult.json
@@ -39,7 +39,7 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "61"
           }
         },
         "status": {
@@ -87,7 +87,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -135,7 +135,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -183,7 +183,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {

--- a/api/USBInterface.json
+++ b/api/USBInterface.json
@@ -39,7 +39,7 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "61"
           }
         },
         "status": {
@@ -87,7 +87,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -135,7 +135,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -183,7 +183,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -231,7 +231,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -279,7 +279,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {

--- a/api/USBInterface.json
+++ b/api/USBInterface.json
@@ -39,7 +39,8 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": "61"
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
           }
         },
         "status": {
@@ -87,7 +88,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false
             }
           },
           "status": {
@@ -135,7 +136,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false
             }
           },
           "status": {
@@ -183,7 +184,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false
             }
           },
           "status": {
@@ -231,7 +232,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false
             }
           },
           "status": {
@@ -279,7 +280,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false
             }
           },
           "status": {

--- a/api/USBIsochronousInTransferPacket.json
+++ b/api/USBIsochronousInTransferPacket.json
@@ -39,7 +39,8 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": "61"
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
           }
         },
         "status": {
@@ -87,7 +88,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -135,7 +137,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -183,7 +186,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {

--- a/api/USBIsochronousInTransferPacket.json
+++ b/api/USBIsochronousInTransferPacket.json
@@ -88,8 +88,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -137,8 +136,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -186,8 +184,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {

--- a/api/USBIsochronousInTransferPacket.json
+++ b/api/USBIsochronousInTransferPacket.json
@@ -39,7 +39,7 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "61"
           }
         },
         "status": {
@@ -87,7 +87,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -135,7 +135,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -183,7 +183,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {

--- a/api/USBIsochronousInTransferResult.json
+++ b/api/USBIsochronousInTransferResult.json
@@ -39,7 +39,8 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": "61"
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
           }
         },
         "status": {
@@ -87,7 +88,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -135,7 +137,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -183,7 +186,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {

--- a/api/USBIsochronousInTransferResult.json
+++ b/api/USBIsochronousInTransferResult.json
@@ -88,8 +88,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -137,8 +136,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -186,8 +184,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {

--- a/api/USBIsochronousInTransferResult.json
+++ b/api/USBIsochronousInTransferResult.json
@@ -39,7 +39,7 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "61"
           }
         },
         "status": {
@@ -87,7 +87,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -135,7 +135,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -183,7 +183,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {

--- a/api/USBIsochronousOutTransferPacket.json
+++ b/api/USBIsochronousOutTransferPacket.json
@@ -39,7 +39,8 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": "61"
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
           }
         },
         "status": {
@@ -87,7 +88,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -135,7 +137,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -183,7 +186,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {

--- a/api/USBIsochronousOutTransferPacket.json
+++ b/api/USBIsochronousOutTransferPacket.json
@@ -88,8 +88,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -137,8 +136,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -186,8 +184,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {

--- a/api/USBIsochronousOutTransferPacket.json
+++ b/api/USBIsochronousOutTransferPacket.json
@@ -39,7 +39,7 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "61"
           }
         },
         "status": {
@@ -87,7 +87,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -135,7 +135,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -183,7 +183,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {

--- a/api/USBIsochronousOutTransferResult.json
+++ b/api/USBIsochronousOutTransferResult.json
@@ -39,7 +39,7 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "61"
           }
         },
         "status": {
@@ -87,7 +87,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -135,7 +135,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {

--- a/api/USBIsochronousOutTransferResult.json
+++ b/api/USBIsochronousOutTransferResult.json
@@ -88,8 +88,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -137,8 +136,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {

--- a/api/USBIsochronousOutTransferResult.json
+++ b/api/USBIsochronousOutTransferResult.json
@@ -39,7 +39,8 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": "61"
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
           }
         },
         "status": {
@@ -87,7 +88,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -135,7 +137,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {

--- a/api/USBOutTransferResult.json
+++ b/api/USBOutTransferResult.json
@@ -39,7 +39,8 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": "61"
+            "version_added": false,
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
           }
         },
         "status": {
@@ -87,7 +88,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -135,7 +137,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {
@@ -183,7 +186,8 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {

--- a/api/USBOutTransferResult.json
+++ b/api/USBOutTransferResult.json
@@ -88,8 +88,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -137,8 +136,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {
@@ -186,8 +184,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "version_added": false
             }
           },
           "status": {

--- a/api/USBOutTransferResult.json
+++ b/api/USBOutTransferResult.json
@@ -39,7 +39,7 @@
             "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "61"
           }
         },
         "status": {
@@ -87,7 +87,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -135,7 +135,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {
@@ -183,7 +183,7 @@
               "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "61"
             }
           },
           "status": {

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -999,7 +999,8 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "70"
+              "version_added": false,
+              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -1000,7 +1000,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "notes": "WebView exposes <code>navigator.usb</code>, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
             }
           },
           "status": {

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -1682,7 +1682,7 @@
                 "version_added": "8.0"
               },
               "webview_android": {
-                "version_added": "60"
+                "version_added": false
               }
             },
             "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for WebView Android for the `USB` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/USB

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
