### PR TITLE
Update IE versions for VTTCue API

### DIFF
--- a/api/VTTCue.json
+++ b/api/VTTCue.json
@@ -21,7 +21,7 @@
             "version_added": "31"
           },
           "ie": {
-            "version_added": false
+            "version_added": "10"
           },
           "opera": {
             "version_added": "≤12.1"
@@ -168,7 +168,7 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"
@@ -560,7 +560,7 @@
               "version_added": "31"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
This PR updates and corrects the real values for Internet Explorer for the `VTTCue` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/VTTCue

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
