### PR TITLE
Update all browsers versions for ValidityState API

### DIFF
--- a/api/ValidityState.json
+++ b/api/ValidityState.json
@@ -6,7 +6,7 @@
         "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-constraint-validation-api:validitystate-3",
         "support": {
           "chrome": {
-            "version_added": "15"
+            "version_added": "3"
           },
           "chrome_android": {
             "version_added": "18"
@@ -60,7 +60,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "14"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "29"
@@ -101,7 +101,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "15"
+              "version_added": "3"
             },
             "chrome_android": {
               "version_added": "18"
@@ -150,7 +150,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-validitystate-patternmismatch",
           "support": {
             "chrome": {
-              "version_added": "15"
+              "version_added": "3"
             },
             "chrome_android": {
               "version_added": "18"
@@ -199,7 +199,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-validitystate-rangeoverflow",
           "support": {
             "chrome": {
-              "version_added": "15"
+              "version_added": "3"
             },
             "chrome_android": {
               "version_added": "18"
@@ -248,7 +248,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-validitystate-rangeunderflow",
           "support": {
             "chrome": {
-              "version_added": "15"
+              "version_added": "3"
             },
             "chrome_android": {
               "version_added": "18"
@@ -297,7 +297,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-validitystate-stepmismatch",
           "support": {
             "chrome": {
-              "version_added": "15"
+              "version_added": "3"
             },
             "chrome_android": {
               "version_added": "18"
@@ -346,7 +346,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-validitystate-toolong-dev",
           "support": {
             "chrome": {
-              "version_added": "15"
+              "version_added": "3"
             },
             "chrome_android": {
               "version_added": "18"
@@ -372,7 +372,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "5"
             },
             "safari_ios": {
               "version_added": "5"
@@ -421,7 +421,7 @@
               "version_added": "27"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "10"
             },
             "safari_ios": {
               "version_added": "10"
@@ -446,7 +446,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-validitystate-typemismatch",
           "support": {
             "chrome": {
-              "version_added": "15"
+              "version_added": "3"
             },
             "chrome_android": {
               "version_added": "18"
@@ -493,7 +493,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "15"
+              "version_added": "3"
             },
             "chrome_android": {
               "version_added": "18"
@@ -540,7 +540,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "15"
+              "version_added": "3"
             },
             "chrome_android": {
               "version_added": "18"


### PR DESCRIPTION
This PR updates and corrects the real values for all browsers for the `ValidityState` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ValidityState

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
