### PR TITLE
Update Opera versions for VideoDecoder API

### DIFF
--- a/api/VideoDecoder.json
+++ b/api/VideoDecoder.json
@@ -24,7 +24,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "80"
           },
           "opera_android": {
             "version_added": false
@@ -73,7 +73,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -122,7 +122,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -171,7 +171,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -220,7 +220,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -269,7 +269,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -318,7 +318,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -366,7 +366,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -415,7 +415,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false
@@ -464,7 +464,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "80"
             },
             "opera_android": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `VideoDecoder` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/VideoDecoder

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
