### PR TITLE
Update all browsers versions for VideoPlaybackQuality API

### DIFF
--- a/api/VideoPlaybackQuality.json
+++ b/api/VideoPlaybackQuality.json
@@ -18,7 +18,7 @@
             "version_added": "42"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "42"
           },
           "ie": {
             "version_added": "11",
@@ -78,7 +78,7 @@
               "version_added": "67"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "57"
             },
             "safari": {
               "version_added": "8"
@@ -118,7 +118,7 @@
               "version_added": "42"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "42"
             },
             "ie": {
               "version_added": "11",
@@ -168,7 +168,7 @@
               "version_added": "42"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "42"
             },
             "ie": {
               "version_added": "11",
@@ -267,7 +267,7 @@
               "version_added": "42"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "42"
             },
             "ie": {
               "version_added": "11",


### PR DESCRIPTION
This PR updates and corrects the real values for all browsers for the `VideoPlaybackQuality` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/VideoPlaybackQuality

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
