### PR TITLE
Update WebView versions for WindowClient API

### DIFF
--- a/api/WindowClient.json
+++ b/api/WindowClient.json
@@ -40,7 +40,7 @@
             "version_added": "4.0"
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "42"
           }
         },
         "status": {
@@ -89,7 +89,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "42"
             }
           },
           "status": {
@@ -139,7 +139,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "42"
             }
           },
           "status": {
@@ -189,7 +189,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "42"
             }
           },
           "status": {
@@ -239,7 +239,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "42"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for WebView Android for the `WindowClient` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WindowClient

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
