### PR TITLE
Update IE versions for XMLDocument API

### DIFF
--- a/api/XMLDocument.json
+++ b/api/XMLDocument.json
@@ -37,7 +37,7 @@
             "version_added": "4"
           },
           "ie": {
-            "version_added": false
+            "version_added": "11"
           },
           "opera": [
             {


### PR DESCRIPTION
This PR updates and corrects the real values for Internet Explorer for the `XMLDocument` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/XMLDocument

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
