### PR TITLE
Update Firefox versions for api.XMLHttpRequest.getAllResponseHeaders

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -268,7 +268,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4",
+              "version_added": "1",
               "notes": "Starting from Firefox 49, empty headers are returned as empty strings in case the preference <code>network.http.keep_empty_response_headers_as_empty_string</code> is set to <code>true</code>, defaulting to <code>false</code>. Before Firefox 49 empty headers had been ignored. Since Firefox 50 the preference defaults to <code>true</code>."
             },
             "firefox_android": {


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `getAllResponseHeaders` member of the `XMLHttpRequest` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/XMLHttpRequest/getAllResponseHeaders

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
