### PR TITLE
Update Chromium versions for XR APIs

### DIFF
--- a/api/XRAnchor.json
+++ b/api/XRAnchor.json
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "71"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "60"
           },
           "safari": {
             "version_added": false
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "71"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "safari": {
               "version_added": false
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "71"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the XR APIs, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v4.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/XRAnchor

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
