### PR TITLE
Add a note of Blob Constructor in IE10

### DIFF
--- a/api/Blob.json
+++ b/api/Blob.json
@@ -86,7 +86,8 @@
               "notes": "Before Firefox 16, the second parameter, when set to <code>null</code> or <code>undefined</code>, leads to an error instead of being handled as an empty dictionary."
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "10",
+              "notes": "IE10 throws <code>InvalidStateError</code> with a <code>TypedArray</code> argument. Consider using <code>MSBuilder</code> as an alternative."
             },
             "nodejs": {
               "version_added": "15.7.0"


### PR DESCRIPTION
#### Summary

Add a note of Blob Constructor in IE10 to specify a special behaviour.

#### Test results and supporting details

```js
new Blob([new Uint8Array(0)]); // => "InvalidStateError"
```

#### Workaround

```js
var bytes = new Uint8Array(0);

try {
    new Blob([bytes]); // => "InvalidStateError"
} catch (ignore) {
    var blobBuilder = new MSBlobBuilder();
    blobBuilder.append(bytes.buffer);
    blobBuilder.getBlob();
}
```