### PR TITLE
Remove notes about innerHTML/outHTML prototype move

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -4339,12 +4339,10 @@
           "spec_url": "https://w3c.github.io/DOM-Parsing/#dom-innerhtml-innerhtml",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "This API was previously available on the <code>Node</code> API."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": "33",
-              "notes": "This API was previously available on the <code>Node</code> API."
+              "version_added": "33"
             },
             "edge": {
               "version_added": "12"
@@ -4365,20 +4363,16 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "9",
-              "notes": "This API was previously available on the <code>Node</code> API."
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": "9",
-              "notes": "This API was previously available on the <code>Node</code> API."
+              "version_added": "9"
             },
             "samsunginternet_android": {
-              "version_added": "2.0",
-              "notes": "This API was previously available on the <code>Node</code> API."
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "4.4",
-              "notes": "This API was previously available on the <code>Node</code> API."
+              "version_added": "4.4"
             }
           },
           "status": {
@@ -5759,12 +5753,10 @@
           "spec_url": "https://w3c.github.io/DOM-Parsing/#dom-element-outerhtml",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "This API was previously available on the <code>Node</code> API."
+              "version_added": "33"
             },
             "chrome_android": {
-              "version_added": "33",
-              "notes": "This API was previously available on the <code>Node</code> API."
+              "version_added": "33"
             },
             "edge": {
               "version_added": "12"
@@ -5791,12 +5783,10 @@
               "version_added": "9"
             },
             "samsunginternet_android": {
-              "version_added": "2.0",
-              "notes": "This API was previously available on the <code>Node</code> API."
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "4.4",
-              "notes": "This API was previously available on the <code>Node</code> API."
+              "version_added": "4.4"
             }
           },
           "status": {


### PR DESCRIPTION
This is a case of "When members are moved down the prototype chain" and
shouldn't have any notes, per our guideline:
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#apis-moved-on-the-prototype-chain