### PR TITLE
More data for JS Class features

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -332,6 +332,13 @@
           "engine": "V8",
           "engine_version": "9.3"
         },
+        "16.11.0": {
+          "release_date": "2021-10-08",
+          "release_notes": "https://nodejs.org/en/blog/release/v16.11.0/",
+          "status": "current",
+          "engine": "V8",
+          "engine_version": "9.4"
+        },
         "17.0.0": {
           "release_date": "2021-10-19",
           "release_notes": "https://nodejs.org/en/blog/release/v17.0.0/",

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -946,10 +946,10 @@
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#prod-ClassStaticBlock",
           "support": {
             "chrome": {
-              "version_added": "91"
+              "version_added": "94"
             },
             "chrome_android": {
-              "version_added": "91"
+              "version_added": "94"
             },
             "deno": {
               "version_added": "1.14"
@@ -967,7 +967,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": "16.4.0"
+              "version_added": "16.11.0"
             },
             "opera": {
               "version_added": "80"

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -566,7 +566,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": false
+              "version_added": "16.4.0"
             },
             "opera": {
               "version_added": "77"
@@ -575,10 +575,10 @@
               "version_added": "64"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15"
             },
             "samsunginternet_android": {
               "version_added": "16.0"
@@ -622,7 +622,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": "14.0.0"
+              "version_added": "14.6.0"
             },
             "opera": {
               "version_added": "70"
@@ -946,10 +946,10 @@
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#prod-ClassStaticBlock",
           "support": {
             "chrome": {
-              "version_added": "94"
+              "version_added": "91"
             },
             "chrome_android": {
-              "version_added": "94"
+              "version_added": "91"
             },
             "deno": {
               "version_added": "1.14"
@@ -967,7 +967,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": false
+              "version_added": "16.4.0"
             },
             "opera": {
               "version_added": "80"


### PR DESCRIPTION
The following JS class feature versions are now specified.

**Private In**

- [Chrome 91](https://chromestatus.com/feature/5006138707804160)
- [Node 16.4.0](https://nodejs.org/en/download/releases/) ships V8 9.1
- [Safari 15](https://bugs.webkit.org/show_bug.cgi?id=221093)

**Private Methods**

- [Node 14.6.0](https://nodejs.org/en/download/releases/) ships V8 8.4

**Static Initializer Blocks**

- [Chrome 94](https://v8.dev/blog/v8-release-94)
- [Node 16.11.0](https://nodejs.org/en/download/releases/) ships V8 9.4

---

Fixes: https://github.com/mdn/browser-compat-data/issues/14769