### PR TITLE
FF97 AbortSignal has reason and throwIfAborted

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -126,10 +126,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": "97"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "97"
               },
               "ie": {
                 "version_added": false
@@ -348,10 +348,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "97"
             },
             "ie": {
               "version_added": false

--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -403,10 +403,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "97"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
FF97 adds support for the [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) `reason` property and parameter in https://bugzilla.mozilla.org/show_bug.cgi?id=1737771 and for throwIfAborted() in https://bugzilla.mozilla.org/show_bug.cgi?id=1745372.

These were previously supported only by deno in https://github.com/mdn/browser-compat-data/pull/13380. This PR just adds the support information.

Other FF docs work for this change can be tracked in https://github.com/mdn/content/issues/11593