### PR TITLE
Fix Chromium versions for presentation connection API

### DIFF
--- a/api/Presentation.json
+++ b/api/Presentation.json
@@ -135,10 +135,10 @@
           "spec_url": "https://w3c.github.io/presentation-api/#dom-presentation-receiver",
           "support": {
             "chrome": {
-              "version_added": "48"
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": "48"
+              "version_added": "59"
             },
             "edge": {
               "version_added": "79"
@@ -169,10 +169,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "35"
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": "35"
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -181,7 +181,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationConnectionList.json
+++ b/api/PresentationConnectionList.json
@@ -6,10 +6,10 @@
         "spec_url": "https://w3c.github.io/presentation-api/#interface-presentationconnectionlist",
         "support": {
           "chrome": {
-            "version_added": "51"
+            "version_added": "59"
           },
           "chrome_android": {
-            "version_added": "51"
+            "version_added": "59"
           },
           "edge": {
             "version_added": "79"
@@ -40,10 +40,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "38"
+            "version_added": "46"
           },
           "opera_android": {
-            "version_added": "41"
+            "version_added": "43"
           },
           "safari": {
             "version_added": false
@@ -52,7 +52,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "5.0"
+            "version_added": "7.0"
           },
           "webview_android": {
             "version_added": false
@@ -69,10 +69,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationConnectionList/connections",
           "support": {
             "chrome": {
-              "version_added": "51"
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": "51"
+              "version_added": "59"
             },
             "edge": {
               "version_added": "79"
@@ -103,10 +103,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "38"
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -115,7 +115,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": false
@@ -133,10 +133,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationConnectionList/onconnectionavailable",
           "support": {
             "chrome": {
-              "version_added": "51"
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": "51"
+              "version_added": "59"
             },
             "edge": {
               "version_added": "79"
@@ -167,10 +167,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "38"
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": "41"
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -179,7 +179,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/PresentationReceiver.json
+++ b/api/PresentationReceiver.json
@@ -6,10 +6,10 @@
         "spec_url": "https://w3c.github.io/presentation-api/#interface-presentationreceiver",
         "support": {
           "chrome": {
-            "version_added": "55"
+            "version_added": "59"
           },
           "chrome_android": {
-            "version_added": "55"
+            "version_added": "59"
           },
           "edge": {
             "version_added": "79"
@@ -40,10 +40,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "42"
+            "version_added": "46"
           },
           "opera_android": {
-            "version_added": "42"
+            "version_added": "43"
           },
           "safari": {
             "version_added": false
@@ -52,7 +52,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "6.0"
+            "version_added": "7.0"
           },
           "webview_android": {
             "version_added": false
@@ -69,10 +69,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationReceiver/connectionList",
           "support": {
             "chrome": {
-              "version_added": "55"
+              "version_added": "59"
             },
             "chrome_android": {
-              "version_added": "55"
+              "version_added": "59"
             },
             "edge": {
               "version_added": "79"
@@ -103,10 +103,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "42"
+              "version_added": "46"
             },
             "opera_android": {
-              "version_added": "42"
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -115,7 +115,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "6.0"
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
Source for 59:
https://storage.googleapis.com/chromium-find-releases-static/995.html#99571b384c472ba1a11be6bcf14ddd9de195bffe
https://chromestatus.com/feature/5414209298890752

Original source of the data:
https://github.com/mdn/browser-compat-data/pull/1249