### PR TITLE
Fix data for api.ServiceWorkerRegistration.showNotification

### DIFF
--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -687,10 +687,10 @@
           "spec_url": "https://notifications.spec.whatwg.org/#dom-serviceworkerregistration-shownotification",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "chrome_android": {
-              "version_added": "40"
+              "version_added": "42"
             },
             "edge": {
               "version_added": "17"
@@ -706,10 +706,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "27"
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": "27"
+              "version_added": "29"
             },
             "safari": {
               "version_added": false
@@ -722,7 +722,7 @@
             },
             "webview_android": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/551446'>bug 551446</a>."
+              "notes": "See <a href='https://crbug.com/421921'>bug 421921</a>."
             }
           },
           "status": {


### PR DESCRIPTION
This was shipped together with PushManager and PushSubscription:
https://chromium.googlesource.com/chromium/src/+/23f1b21f73d8dd7fb32a62067b623686c7623c51

Chrome 42 confirmed by testing:
https://mdn-bcd-collector.appspot.com/tests/api/ServiceWorkerRegistration/showNotification

Also update the WebView bug to a more specific one.
