### PR TITLE
Initial addition for Intl.Segmenter - Fixes #8894

### DIFF
--- a/javascript/builtins/intl/Segmenter.json
+++ b/javascript/builtins/intl/Segmenter.json
@@ -1,0 +1,284 @@
+{
+  "javascript": {
+    "builtins": {
+      "Intl": {
+        "Segmenter": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter",
+            "spec_url": "https://tc39.es/proposal-intl-segmenter/#segmenter-objects",
+            "support": {
+              "chrome": {
+                "version_added": "87"
+              },
+              "chrome_android": {
+                "version_added": "87"
+              },
+              "deno": {
+                "version_added": "1.8"
+              },
+              "edge": {
+                "version_added": "87"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "16.0.0"
+              },
+              "opera": {
+                "version_added": "73"
+              },
+              "opera_android": {
+                "version_added": "62"
+              },
+              "safari": {
+                "version_added": "14.1"
+              },
+              "safari_ios": {
+                "version_added": "14.1"
+              },
+              "samsunginternet_android": {
+                "version_added": "14.0"
+              },
+              "webview_android": {
+                "version_added": "87"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "Segmenter": {
+            "__compat": {
+              "description": "<code>Segmenter()</code> constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/Segmenter",
+              "spec_url": "https://tc39.es/proposal-intl-segmenter/#sec-intl-segmenter-constructor",
+              "support": {
+                "chrome": {
+                  "version_added": "87"
+                },
+                "chrome_android": {
+                  "version_added": "87"
+                },
+                "deno": {
+                  "version_added": "1.8"
+                },
+                "edge": {
+                  "version_added": "87"
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "16.0.0"
+                },
+                "opera": {
+                  "version_added": "73"
+                },
+                "opera_android": {
+                  "version_added": "62"
+                },
+                "safari": {
+                  "version_added": "14.1"
+                },
+                "safari_ios": {
+                  "version_added": "14.1"
+                },
+                "samsunginternet_android": {
+                  "version_added": "14.0"
+                },
+                "webview_android": {
+                  "version_added": "87"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "supportedLocalesOf": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/supportedLocalesOf",
+              "spec_url": "https://tc39.es/proposal-intl-segmenter/#sec-intl.segmenter.supportedlocalesof",
+              "support": {
+                "chrome": {
+                  "version_added": "87"
+                },
+                "chrome_android": {
+                  "version_added": "87"
+                },
+                "deno": {
+                  "version_added": "1.8"
+                },
+                "edge": {
+                  "version_added": "87"
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "16.0.0"
+                },
+                "opera": {
+                  "version_added": "73"
+                },
+                "opera_android": {
+                  "version_added": "62"
+                },
+                "safari": {
+                  "version_added": "14.1"
+                },
+                "safari_ios": {
+                  "version_added": "14.1"
+                },
+                "samsunginternet_android": {
+                  "version_added": "14.0"
+                },
+                "webview_android": {
+                  "version_added": "87"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "segment": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment",
+              "spec_url": "https://tc39.es/proposal-intl-segmenter/#sec-intl.segmenter.prototype.segment",
+              "support": {
+                "chrome": {
+                  "version_added": "87"
+                },
+                "chrome_android": {
+                  "version_added": "87"
+                },
+                "deno": {
+                  "version_added": "1.8"
+                },
+                "edge": {
+                  "version_added": "87"
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "16.0.0"
+                },
+                "opera": {
+                  "version_added": "73"
+                },
+                "opera_android": {
+                  "version_added": "62"
+                },
+                "safari": {
+                  "version_added": "14.1"
+                },
+                "safari_ios": {
+                  "version_added": "14.1"
+                },
+                "samsunginternet_android": {
+                  "version_added": "14.0"
+                },
+                "webview_android": {
+                  "version_added": "87"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "resolvedOptions": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/resolvedOptions",
+              "spec_url": "https://tc39.es/proposal-intl-segmenter/#sec-intl.segmenter.prototype.resolvedoptions",
+              "support": {
+                "chrome": {
+                  "version_added": "87"
+                },
+                "chrome_android": {
+                  "version_added": "87"
+                },
+                "deno": {
+                  "version_added": "1.8"
+                },
+                "edge": {
+                  "version_added": "87"
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "16.0.0"
+                },
+                "opera": {
+                  "version_added": "73"
+                },
+                "opera_android": {
+                  "version_added": "62"
+                },
+                "safari": {
+                  "version_added": "14.1"
+                },
+                "safari_ios": {
+                  "version_added": "14.1"
+                },
+                "samsunginternet_android": {
+                  "version_added": "14.0"
+                },
+                "webview_android": {
+                  "version_added": "87"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/javascript/builtins/intl/Segmenter.json
+++ b/javascript/builtins/intl/Segmenter.json
@@ -41,7 +41,7 @@
                 "version_added": "14.1"
               },
               "safari_ios": {
-                "version_added": "14.1"
+                "version_added": "14.5"
               },
               "samsunginternet_android": {
                 "version_added": "14.0"
@@ -96,117 +96,7 @@
                   "version_added": "14.1"
                 },
                 "safari_ios": {
-                  "version_added": "14.1"
-                },
-                "samsunginternet_android": {
-                  "version_added": "14.0"
-                },
-                "webview_android": {
-                  "version_added": "87"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "supportedLocalesOf": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/supportedLocalesOf",
-              "spec_url": "https://tc39.es/proposal-intl-segmenter/#sec-intl.segmenter.supportedlocalesof",
-              "support": {
-                "chrome": {
-                  "version_added": "87"
-                },
-                "chrome_android": {
-                  "version_added": "87"
-                },
-                "deno": {
-                  "version_added": "1.8"
-                },
-                "edge": {
-                  "version_added": "87"
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": "16.0.0"
-                },
-                "opera": {
-                  "version_added": "73"
-                },
-                "opera_android": {
-                  "version_added": "62"
-                },
-                "safari": {
-                  "version_added": "14.1"
-                },
-                "safari_ios": {
-                  "version_added": "14.1"
-                },
-                "samsunginternet_android": {
-                  "version_added": "14.0"
-                },
-                "webview_android": {
-                  "version_added": "87"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "segment": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment",
-              "spec_url": "https://tc39.es/proposal-intl-segmenter/#sec-intl.segmenter.prototype.segment",
-              "support": {
-                "chrome": {
-                  "version_added": "87"
-                },
-                "chrome_android": {
-                  "version_added": "87"
-                },
-                "deno": {
-                  "version_added": "1.8"
-                },
-                "edge": {
-                  "version_added": "87"
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": "16.0.0"
-                },
-                "opera": {
-                  "version_added": "73"
-                },
-                "opera_android": {
-                  "version_added": "62"
-                },
-                "safari": {
-                  "version_added": "14.1"
-                },
-                "safari_ios": {
-                  "version_added": "14.1"
+                  "version_added": "14.5"
                 },
                 "samsunginternet_android": {
                   "version_added": "14.0"
@@ -261,7 +151,117 @@
                   "version_added": "14.1"
                 },
                 "safari_ios": {
+                  "version_added": "14.5"
+                },
+                "samsunginternet_android": {
+                  "version_added": "14.0"
+                },
+                "webview_android": {
+                  "version_added": "87"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "segment": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/segment",
+              "spec_url": "https://tc39.es/proposal-intl-segmenter/#sec-intl.segmenter.prototype.segment",
+              "support": {
+                "chrome": {
+                  "version_added": "87"
+                },
+                "chrome_android": {
+                  "version_added": "87"
+                },
+                "deno": {
+                  "version_added": "1.8"
+                },
+                "edge": {
+                  "version_added": "87"
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "16.0.0"
+                },
+                "opera": {
+                  "version_added": "73"
+                },
+                "opera_android": {
+                  "version_added": "62"
+                },
+                "safari": {
                   "version_added": "14.1"
+                },
+                "safari_ios": {
+                  "version_added": "14.5"
+                },
+                "samsunginternet_android": {
+                  "version_added": "14.0"
+                },
+                "webview_android": {
+                  "version_added": "87"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "supportedLocalesOf": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/supportedLocalesOf",
+              "spec_url": "https://tc39.es/proposal-intl-segmenter/#sec-intl.segmenter.supportedlocalesof",
+              "support": {
+                "chrome": {
+                  "version_added": "87"
+                },
+                "chrome_android": {
+                  "version_added": "87"
+                },
+                "deno": {
+                  "version_added": "1.8"
+                },
+                "edge": {
+                  "version_added": "87"
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "16.0.0"
+                },
+                "opera": {
+                  "version_added": "73"
+                },
+                "opera_android": {
+                  "version_added": "62"
+                },
+                "safari": {
+                  "version_added": "14.1"
+                },
+                "safari_ios": {
+                  "version_added": "14.5"
                 },
                 "samsunginternet_android": {
                   "version_added": "14.0"

--- a/javascript/builtins/intl/Segments.json
+++ b/javascript/builtins/intl/Segments.json
@@ -1,0 +1,228 @@
+{
+  "javascript": {
+    "builtins": {
+      "Intl": {
+        "Segmenter": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segments",
+            "spec_url": "https://tc39.es/proposal-intl-segmenter/#sec-segments-objects",
+            "support": {
+              "chrome": {
+                "version_added": "87"
+              },
+              "chrome_android": {
+                "version_added": "87"
+              },
+              "deno": {
+                "version_added": "1.8"
+              },
+              "edge": {
+                "version_added": "87"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "16.0.0"
+              },
+              "opera": {
+                "version_added": "73"
+              },
+              "opera_android": {
+                "version_added": "62"
+              },
+              "safari": {
+                "version_added": "14.1"
+              },
+              "safari_ios": {
+                "version_added": "14.1"
+              },
+              "samsunginternet_android": {
+                "version_added": "14.0"
+              },
+              "webview_android": {
+                "version_added": "87"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "containing": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segments/containing",
+              "spec_url": "https://tc39.es/proposal-intl-segmenter/#sec-%segmentsprototype%.containing",
+              "support": {
+                "chrome": {
+                  "version_added": "87"
+                },
+                "chrome_android": {
+                  "version_added": "87"
+                },
+                "deno": {
+                  "version_added": "1.8"
+                },
+                "edge": {
+                  "version_added": "87"
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "16.0.0"
+                },
+                "opera": {
+                  "version_added": "73"
+                },
+                "opera_android": {
+                  "version_added": "62"
+                },
+                "safari": {
+                  "version_added": "14.1"
+                },
+                "safari_ios": {
+                  "version_added": "14.1"
+                },
+                "samsunginternet_android": {
+                  "version_added": "14.0"
+                },
+                "webview_android": {
+                  "version_added": "87"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "@@iterator": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segments/@@iterator",
+              "spec_url": "https://tc39.es/proposal-intl-segmenter/#sec-%segmentsprototype%-@@iterator",
+              "support": {
+                "chrome": {
+                  "version_added": "87"
+                },
+                "chrome_android": {
+                  "version_added": "87"
+                },
+                "deno": {
+                  "version_added": "1.8"
+                },
+                "edge": {
+                  "version_added": "87"
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "16.0.0"
+                },
+                "opera": {
+                  "version_added": "73"
+                },
+                "opera_android": {
+                  "version_added": "62"
+                },
+                "safari": {
+                  "version_added": "14.1"
+                },
+                "safari_ios": {
+                  "version_added": "14.1"
+                },
+                "samsunginternet_android": {
+                  "version_added": "14.0"
+                },
+                "webview_android": {
+                  "version_added": "87"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "resolvedOptions": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/resolvedOptions",
+              "spec_url": "https://tc39.es/proposal-intl-segmenter/#sec-intl.segmenter.prototype.resolvedoptions",
+              "support": {
+                "chrome": {
+                  "version_added": "87"
+                },
+                "chrome_android": {
+                  "version_added": "87"
+                },
+                "deno": {
+                  "version_added": "1.8"
+                },
+                "edge": {
+                  "version_added": "87"
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "16.0.0"
+                },
+                "opera": {
+                  "version_added": "73"
+                },
+                "opera_android": {
+                  "version_added": "62"
+                },
+                "safari": {
+                  "version_added": "14.1"
+                },
+                "safari_ios": {
+                  "version_added": "14.1"
+                },
+                "samsunginternet_android": {
+                  "version_added": "14.0"
+                },
+                "webview_android": {
+                  "version_added": "87"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/javascript/builtins/intl/Segments.json
+++ b/javascript/builtins/intl/Segments.json
@@ -2,7 +2,7 @@
   "javascript": {
     "builtins": {
       "Intl": {
-        "Segmenter": {
+        "Segments": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segments",
             "spec_url": "https://tc39.es/proposal-intl-segmenter/#sec-segments-objects",
@@ -41,7 +41,7 @@
                 "version_added": "14.1"
               },
               "safari_ios": {
-                "version_added": "14.1"
+                "version_added": "14.5"
               },
               "samsunginternet_android": {
                 "version_added": "14.0"
@@ -95,7 +95,7 @@
                   "version_added": "14.1"
                 },
                 "safari_ios": {
-                  "version_added": "14.1"
+                  "version_added": "14.5"
                 },
                 "samsunginternet_android": {
                   "version_added": "14.0"
@@ -150,62 +150,7 @@
                   "version_added": "14.1"
                 },
                 "safari_ios": {
-                  "version_added": "14.1"
-                },
-                "samsunginternet_android": {
-                  "version_added": "14.0"
-                },
-                "webview_android": {
-                  "version_added": "87"
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "resolvedOptions": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/resolvedOptions",
-              "spec_url": "https://tc39.es/proposal-intl-segmenter/#sec-intl.segmenter.prototype.resolvedoptions",
-              "support": {
-                "chrome": {
-                  "version_added": "87"
-                },
-                "chrome_android": {
-                  "version_added": "87"
-                },
-                "deno": {
-                  "version_added": "1.8"
-                },
-                "edge": {
-                  "version_added": "87"
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": "16.0.0"
-                },
-                "opera": {
-                  "version_added": "73"
-                },
-                "opera_android": {
-                  "version_added": "62"
-                },
-                "safari": {
-                  "version_added": "14.1"
-                },
-                "safari_ios": {
-                  "version_added": "14.1"
+                  "version_added": "14.5"
                 },
                 "samsunginternet_android": {
                   "version_added": "14.0"


### PR DESCRIPTION
#### Summary
This PR intends to complete BCD data for ECMA402 `Intl.Segmenter`
It is also intended to be a companion of https://github.com/mdn/content/pull/8402

This adds data for two objects `Intl.Segmenter` and `Intl.Segments` as per https://github.com/mdn/content/pull/8402#issuecomment-957304456
I completely admit I mimicked the target MDN structure to fill the data. Let me know if something should be added/adapted here.

#### Test results and supporting details

Chromium: 
https://chromestatus.com/feature/6099397733515264#details

Deno: 
https://deno.com/blog/v1.8#icu-support (could not find a more fine-grained detail) and tested locally for the latest version

Node:
I used the table on https://nodejs.org/en/download/releases/ to dtermine Node.js 16.0.0 was the first one with a V8 version > 8.7

Firefox: 
https://bugzilla.mozilla.org/show_bug.cgi?id=1423593

WebKit:
https://trac.webkit.org/changeset/266032/webkit
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=266081 (closest revision of this file after 266032)
Safari 14.1 Release Notes https://developer.apple.com/documentation/safari-release-notes/safari-14_1-release-notes 

Samsung Internet:
https://en.wikipedia.org/wiki/Samsung_Internet#cite_note-27 / https://medium.com/samsung-internet-dev/samsung-internet-releases-14-0-cf62d916193 (links to Chromium 87)

Opera: 
Thanks for https://github.com/mdn/browser-compat-data/blob/main/browsers/opera_android.json and https://github.com/mdn/browser-compat-data/blob/main/browsers/opera.json :)

#### Related issues

Fixes  #8894
Relates to mdn/content https://github.com/mdn/content/pull/8402

