### PR TITLE
Update notes for MediaRecorder's error event in Chromium

### DIFF
--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -252,13 +252,19 @@
           "spec_url": "https://w3c.github.io/mediacapture-record/#errorevent-section",
           "support": {
             "chrome": {
-              "version_added": "49"
+              "version_added": "49",
+              "partial_implementation": true,
+              "notes": "The interface for this event is a plain <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/MediaRecorderErrorEvent'><code>MediaRecorderErrorEvent</code></a>. See <a href='https://crbug.com/1250432'>bug 1250432</a>."
             },
             "chrome_android": {
-              "version_added": "49"
+              "version_added": "49",
+              "partial_implementation": true,
+              "notes": "The interface for this event is a plain <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/MediaRecorderErrorEvent'><code>MediaRecorderErrorEvent</code></a>. See <a href='https://crbug.com/1250432'>bug 1250432</a>."
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "partial_implementation": true,
+              "notes": "The interface for this event is a plain <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/MediaRecorderErrorEvent'><code>MediaRecorderErrorEvent</code></a>. See <a href='https://crbug.com/1250432'>bug 1250432</a>."
             },
             "firefox": {
               "version_added": "25"
@@ -270,10 +276,14 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "36"
+              "version_added": "36",
+              "partial_implementation": true,
+              "notes": "The interface for this event is a plain <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/MediaRecorderErrorEvent'><code>MediaRecorderErrorEvent</code></a>. See <a href='https://crbug.com/1250432'>bug 1250432</a>."
             },
             "opera_android": {
-              "version_added": "36"
+              "version_added": "36",
+              "partial_implementation": true,
+              "notes": "The interface for this event is a plain <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/MediaRecorderErrorEvent'><code>MediaRecorderErrorEvent</code></a>. See <a href='https://crbug.com/1250432'>bug 1250432</a>."
             },
             "safari": {
               "version_added": "14"
@@ -282,10 +292,14 @@
               "version_added": "14"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "5.0",
+              "partial_implementation": true,
+              "notes": "The interface for this event is a plain <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/MediaRecorderErrorEvent'><code>MediaRecorderErrorEvent</code></a>. See <a href='https://crbug.com/1250432'>bug 1250432</a>."
             },
             "webview_android": {
-              "version_added": "49"
+              "version_added": "49",
+              "partial_implementation": true,
+              "notes": "The interface for this event is a plain <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/MediaRecorderErrorEvent'><code>MediaRecorderErrorEvent</code></a>. See <a href='https://crbug.com/1250432'>bug 1250432</a>."
             }
           },
           "status": {
@@ -527,13 +541,19 @@
           "spec_url": "https://w3c.github.io/mediacapture-record/#dom-mediarecorder-onerror",
           "support": {
             "chrome": {
-              "version_added": "49"
+              "version_added": "49",
+              "partial_implementation": true,
+              "notes": "The interface for this event is a plain <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/MediaRecorderErrorEvent'><code>MediaRecorderErrorEvent</code></a>. See <a href='https://crbug.com/1250432'>bug 1250432</a>."
             },
             "chrome_android": {
-              "version_added": "49"
+              "version_added": "49",
+              "partial_implementation": true,
+              "notes": "The interface for this event is a plain <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/MediaRecorderErrorEvent'><code>MediaRecorderErrorEvent</code></a>. See <a href='https://crbug.com/1250432'>bug 1250432</a>."
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "partial_implementation": true,
+              "notes": "The interface for this event is a plain <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/MediaRecorderErrorEvent'><code>MediaRecorderErrorEvent</code></a>. See <a href='https://crbug.com/1250432'>bug 1250432</a>."
             },
             "firefox": {
               "version_added": "25"
@@ -545,10 +565,14 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "36"
+              "version_added": "36",
+              "partial_implementation": true,
+              "notes": "The interface for this event is a plain <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/MediaRecorderErrorEvent'><code>MediaRecorderErrorEvent</code></a>. See <a href='https://crbug.com/1250432'>bug 1250432</a>."
             },
             "opera_android": {
-              "version_added": "36"
+              "version_added": "36",
+              "partial_implementation": true,
+              "notes": "The interface for this event is a plain <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/MediaRecorderErrorEvent'><code>MediaRecorderErrorEvent</code></a>. See <a href='https://crbug.com/1250432'>bug 1250432</a>."
             },
             "safari": {
               "version_added": "14"
@@ -557,10 +581,14 @@
               "version_added": "14"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "5.0",
+              "partial_implementation": true,
+              "notes": "The interface for this event is a plain <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/MediaRecorderErrorEvent'><code>MediaRecorderErrorEvent</code></a>. See <a href='https://crbug.com/1250432'>bug 1250432</a>."
             },
             "webview_android": {
-              "version_added": "49"
+              "version_added": "49",
+              "partial_implementation": true,
+              "notes": "The interface for this event is a plain <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/MediaRecorderErrorEvent'><code>MediaRecorderErrorEvent</code></a>. See <a href='https://crbug.com/1250432'>bug 1250432</a>."
             }
           },
           "status": {

--- a/api/MediaRecorderErrorEvent.json
+++ b/api/MediaRecorderErrorEvent.json
@@ -7,15 +7,15 @@
         "support": {
           "chrome": {
             "version_added": false,
-            "notes": "Uses a generic event with an <code>error</code> property."
+            "notes": "See <a href='https://crbug.com/1250432'>bug 1250432</a>."
           },
           "chrome_android": {
             "version_added": false,
-            "notes": "Uses a generic event with an <code>error</code> property."
+            "notes": "See <a href='https://crbug.com/1250432'>bug 1250432</a>."
           },
           "edge": {
             "version_added": false,
-            "notes": "Uses a generic event with an <code>error</code> property."
+            "notes": "See <a href='https://crbug.com/1250432'>bug 1250432</a>."
           },
           "firefox": {
             "version_added": "57"
@@ -28,11 +28,11 @@
           },
           "opera": {
             "version_added": false,
-            "notes": "Uses a generic event with an <code>error</code> property."
+            "notes": "See <a href='https://crbug.com/1250432'>bug 1250432</a>."
           },
           "opera_android": {
             "version_added": false,
-            "notes": "Uses a generic event with an <code>error</code> property."
+            "notes": "See <a href='https://crbug.com/1250432'>bug 1250432</a>."
           },
           "safari": {
             "version_added": "14"
@@ -42,10 +42,11 @@
           },
           "samsunginternet_android": {
             "version_added": false,
-            "notes": "Uses a generic event with an <code>error</code> property."
+            "notes": "See <a href='https://crbug.com/1250432'>bug 1250432</a>."
           },
           "webview_android": {
-            "version_added": false
+            "version_added": false,
+            "notes": "See <a href='https://crbug.com/1250432'>bug 1250432</a>."
           }
         },
         "status": {
@@ -61,16 +62,13 @@
           "description": "<code>MediaRecorderErrorEvent()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "Uses a generic event with an <code>error</code> property."
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": false,
-              "notes": "Uses a generic event with an <code>error</code> property."
+              "version_added": false
             },
             "edge": {
-              "version_added": false,
-              "notes": "Uses a generic event with an <code>error</code> property."
+              "version_added": false
             },
             "firefox": {
               "version_added": "57"
@@ -82,12 +80,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false,
-              "notes": "Uses a generic event with an <code>error</code> property."
+              "version_added": false
             },
             "opera_android": {
-              "version_added": false,
-              "notes": "Uses a generic event with an <code>error</code> property."
+              "version_added": false
             },
             "safari": {
               "version_added": "14"
@@ -96,8 +92,7 @@
               "version_added": "14"
             },
             "samsunginternet_android": {
-              "version_added": false,
-              "notes": "Uses a generic event with an <code>error</code> property."
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -116,16 +111,13 @@
           "spec_url": "https://w3c.github.io/mediacapture-record/#dom-mediarecordererrorevent-error",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "Uses a generic event with an <code>error</code> property."
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": false,
-              "notes": "Uses a generic event with an <code>error</code> property."
+              "version_added": false
             },
             "edge": {
-              "version_added": false,
-              "notes": "Uses a generic event with an <code>error</code> property."
+              "version_added": false
             },
             "firefox": {
               "version_added": "57"
@@ -137,12 +129,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false,
-              "notes": "Uses a generic event with an <code>error</code> property."
+              "version_added": false
             },
             "opera_android": {
-              "version_added": false,
-              "notes": "Uses a generic event with an <code>error</code> property."
+              "version_added": false
             },
             "safari": {
               "version_added": "14"
@@ -151,8 +141,7 @@
               "version_added": "14"
             },
             "samsunginternet_android": {
-              "version_added": false,
-              "notes": "Uses a generic event with an <code>error</code> property."
+              "version_added": false
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
The original "Uses a generic event with an <code>error</code> property."
is not accurate, the event's type is "error", but nothing special is
done to add an "error" property to that event object:
https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/mediarecorder/media_recorder.cc;l=426-430;drc=2527e75ef31051a4a24b82c6f4bc8a550965995c

Also link https://crbug.com/1250432 everywhere.