### PR TITLE
Set Chrome 97 as current

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -666,21 +666,27 @@
         "96": {
           "release_date": "2021-11-15",
           "release_notes": "https://chromereleases.googleblog.com/2021/11/stable-channel-update-for-desktop.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "96"
         },
         "97": {
           "release_date": "2022-01-04",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2022/01/stable-channel-update-for-desktop.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "97"
         },
         "98": {
           "release_date": "2022-02-01",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "98"
+        },
+        "99": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "99"
         }
       }
     }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -502,21 +502,27 @@
         "96": {
           "release_date": "2021-11-15",
           "release_notes": "https://chromereleases.googleblog.com/2021/11/chrome-for-android-update.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "96"
         },
         "97": {
           "release_date": "2022-01-04",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2022/01/chrome-for-android-update.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "97"
         },
         "98": {
           "release_date": "2022-02-01",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "98"
+        },
+        "99": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "99"
         }
       }
     }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -467,21 +467,27 @@
         "96": {
           "release_date": "2021-11-15",
           "release_notes": "https://chromereleases.googleblog.com/2021/11/chrome-for-android-update.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "96"
         },
         "97": {
           "release_date": "2022-01-04",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2022/01/chrome-for-android-update.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "97"
         },
         "98": {
           "release_date": "2022-02-01",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "98"
+        },
+        "99": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "99"
         }
       }
     }


### PR DESCRIPTION
Chrome has updated to version 97.

I couldn't find the release date for version 99, so it doesn't include it.

Fixes #14432.