### PR TITLE
Mark transitioncancel event shipping in Chromium 74

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -10844,13 +10844,13 @@
           "spec_url": "https://drafts.csswg.org/css-transitions/#transitioncancel",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "74"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"
@@ -10862,10 +10862,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": [
               {
@@ -10904,10 +10904,10 @@
               }
             ],
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "74"
             }
           },
           "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -9462,13 +9462,13 @@
           "spec_url": "https://drafts.csswg.org/css-transitions/#transitioncancel",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "74"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "74"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "53"
@@ -9480,10 +9480,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "53"
             },
             "safari": [
               {
@@ -9522,10 +9522,10 @@
               }
             ],
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "74"
             }
           },
           "status": {


### PR DESCRIPTION
The data was already updated for HTMLElement, but the event bubbles and
so these other entries should also be updated.

Note that ontransitioncancel was added later, and that data is correct,
but will have to be merged according to this guideline:
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#dom-events-eventname_event