### PR TITLE
Link Chromium bug for inBandMetadataTrackDispatchType

### DIFF
--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -298,13 +298,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrack/inBandMetadataTrackDispatchType",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/754093'>bug 754093</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/754093'>bug 754093</a>."
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "version_removed": "79"
             },
             "firefox": {
               "version_added": "31"
@@ -316,10 +319,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/754093'>bug 754093</a>."
             },
             "opera_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/754093'>bug 754093</a>."
             },
             "safari": {
               "version_added": "7"
@@ -328,10 +333,12 @@
               "version_added": "7"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/754093'>bug 754093</a>."
             },
             "webview_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/754093'>bug 754093</a>."
             }
           },
           "status": {


### PR DESCRIPTION
Also mark it removed in Edge 79, but don't link the bug because there's
a high chance that note would remain if it does eventually ship in Edge
again.
