### PR TITLE
Add HTMLInputElement showPicker()

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2217,11 +2217,11 @@
             },
             "firefox": {
               "version_added": false,
-              "notes": "Mozilla folks <a href='https://github.com/whatwg/html/pull/7319#issuecomment-988837778'>expressed interest</a>."
+              "notes": "See <a href='https://bugzil.la/1745005'>bug 1745005</a>."
             },
             "firefox_android": {
               "version_added": false,
-              "notes": "Mozilla folks <a href='https://github.com/whatwg/html/pull/7319#issuecomment-988837778'>expressed interest</a>."
+              "notes": "See <a href='https://bugzil.la/1745005'>bug 1745005</a>."
             },
             "ie": {
               "version_added": false

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2244,7 +2244,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "99"
             }
           },
           "status": {

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2213,7 +2213,7 @@
               "version_added": "99"
             },
             "edge": {
-              "version_added": false
+              "version_added": "99"
             },
             "firefox": {
               "version_added": false,

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2214,7 +2214,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2233,10 +2233,12 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2201,6 +2201,25 @@
           }
         }
       },
+      "showPicker": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLInputElement/showPicker",
+          "spec_url": "https://html.spec.whatwg.org/multipage/input.html#dom-input-showpicker",
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "99"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "size": {
         "__compat": {
           "support": {

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2216,10 +2216,12 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "notes": "Mozilla folks <a href='https://github.com/whatwg/html/pull/7319#issuecomment-988837778'>expressed interest</a>."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "Mozilla folks <a href='https://github.com/whatwg/html/pull/7319#issuecomment-988837778'>expressed interest</a>."
             },
             "ie": {
               "version_added": false

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2211,6 +2211,36 @@
             },
             "chrome_android": {
               "version_added": "99"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds HTMLInputElement.showPicker()

- [WHATWG explainer][explainer]
- [WHATWG specification][spec]
- [TAG review][tag]
- [Chromium bug][cr-bug]
- [ChromeStatus.com entry][cr-status]

[explainer]: https://github.com/whatwg/html/pull/7319
[spec]: https://html.spec.whatwg.org/multipage/input.html#dom-input-showpicker
[tag]: https://github.com/w3ctag/design-reviews/issues/688
[cr-bug]: https://bugs.chromium.org/p/chromium/issues/detail?id=939561
[cr-status]: https://www.chromestatus.com/feature/5692248021794816

See related PR at https://github.com/mdn/content/pull/11753
