### PR TITLE
Fix Chromium data for devicemotion event interfaces

### DIFF
--- a/api/DeviceMotionEvent.json
+++ b/api/DeviceMotionEvent.json
@@ -6,10 +6,10 @@
         "spec_url": "https://w3c.github.io/deviceorientation/#devicemotion",
         "support": {
           "chrome": {
-            "version_added": "11"
+            "version_added": "31"
           },
           "chrome_android": {
-            "version_added": "18"
+            "version_added": "31"
           },
           "edge": {
             "version_added": "12"
@@ -24,10 +24,10 @@
             "version_added": "11"
           },
           "opera": {
-            "version_added": "15"
+            "version_added": "18"
           },
           "opera_android": {
-            "version_added": "14"
+            "version_added": "18"
           },
           "safari": {
             "version_added": false
@@ -36,10 +36,10 @@
             "version_added": "4.2"
           },
           "samsunginternet_android": {
-            "version_added": "1.0"
+            "version_added": "2.0"
           },
           "webview_android": {
-            "version_added": "3"
+            "version_added": "≤37"
           }
         },
         "status": {
@@ -104,10 +104,10 @@
           "spec_url": "https://w3c.github.io/deviceorientation/#ref-for-dom-devicemotionevent-acceleration③",
           "support": {
             "chrome": {
-              "version_added": "11"
+              "version_added": "31"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "31"
             },
             "edge": {
               "version_added": "12"
@@ -122,10 +122,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "18"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "safari": {
               "version_added": false
@@ -134,10 +134,10 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "3"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -153,10 +153,10 @@
           "spec_url": "https://w3c.github.io/deviceorientation/#ref-for-dom-devicemotionevent-accelerationincludinggravity④",
           "support": {
             "chrome": {
-              "version_added": "11"
+              "version_added": "31"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "31"
             },
             "edge": {
               "version_added": "12"
@@ -171,10 +171,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "18"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "safari": {
               "version_added": false
@@ -183,10 +183,10 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "3"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -202,10 +202,10 @@
           "spec_url": "https://w3c.github.io/deviceorientation/#ref-for-dom-devicemotionevent-interval①",
           "support": {
             "chrome": {
-              "version_added": "11"
+              "version_added": "31"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "31"
             },
             "edge": {
               "version_added": "12"
@@ -220,10 +220,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "18"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "safari": {
               "version_added": false
@@ -232,10 +232,10 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "3"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -299,10 +299,10 @@
           "spec_url": "https://w3c.github.io/deviceorientation/#ref-for-dom-devicemotionevent-rotationrate②",
           "support": {
             "chrome": {
-              "version_added": "11"
+              "version_added": "31"
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "31"
             },
             "edge": {
               "version_added": "12"
@@ -317,10 +317,10 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "18"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "safari": {
               "version_added": false
@@ -329,10 +329,10 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "3"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/api/DeviceMotionEventAcceleration.json
+++ b/api/DeviceMotionEventAcceleration.json
@@ -6,135 +6,46 @@
         "spec_url": "https://w3c.github.io/deviceorientation/#devicemotioneventacceleration",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "31"
           },
-          "chrome_android": [
-            {
-              "version_added": "74"
-            },
-            {
-              "alternative_name": "DeviceAcceleration",
-              "version_added": "28",
-              "version_removed": "73"
-            }
-          ],
+          "chrome_android": {
+            "version_added": "31"
+          },
           "edge": {
-            "version_added": "12",
-            "version_removed": "79"
+            "version_added": "12"
           },
           "firefox": {
-            "version_added": "6",
-            "partial_implementation": true,
-            "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
+            "version_added": "6"
           },
           "firefox_android": {
-            "version_added": "6",
-            "partial_implementation": true,
-            "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
+            "version_added": "6"
           },
           "ie": {
-            "version_added": false
+            "version_added": "11"
           },
           "opera": {
+            "version_added": "18"
+          },
+          "opera_android": {
+            "version_added": "18"
+          },
+          "safari": {
             "version_added": false
           },
-          "opera_android": [
-            {
-              "version_added": "53"
-            },
-            {
-              "alternative_name": "DeviceAcceleration",
-              "version_added": "15",
-              "version_removed": "52"
-            }
-          ],
-          "safari": {
-            "version_added": "5.1",
-            "partial_implementation": true,
-            "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
-          },
           "safari_ios": {
-            "version_added": "5",
-            "partial_implementation": true,
-            "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
+            "version_added": "4.2"
           },
-          "samsunginternet_android": [
-            {
-              "version_added": "11.0"
-            },
-            {
-              "alternative_name": "DeviceAcceleration",
-              "version_added": "1.5",
-              "version_removed": "11.0"
-            }
-          ],
-          "webview_android": [
-            {
-              "version_added": "74"
-            },
-            {
-              "alternative_name": "DeviceAcceleration",
-              "version_added": "≤37",
-              "version_removed": "73"
-            }
-          ]
+          "samsunginternet_android": {
+            "version_added": "2.0"
+          },
+          "webview_android": {
+            "version_added": "≤37"
+          }
         },
         "status": {
           "experimental": false,
           "standard_track": true,
           "deprecated": false
-        }
-      },
-      "secure_context_required": {
-        "__compat": {
-          "description": "Secure context required",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": "28"
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": "15"
-            },
-            "safari": {
-              "version_added": "5.1",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
-            },
-            "safari_ios": {
-              "version_added": "5",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
-            },
-            "samsunginternet_android": {
-              "version_added": "1.5"
-            },
-            "webview_android": {
-              "version_added": "≤37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
         }
       },
       "x": {
@@ -143,14 +54,13 @@
           "spec_url": "https://w3c.github.io/deviceorientation/#dom-devicemotioneventacceleration-x",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "31"
             },
             "chrome_android": {
-              "version_added": "28"
+              "version_added": "31"
             },
             "edge": {
-              "version_added": "12",
-              "version_removed": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "6"
@@ -159,26 +69,22 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
-              "version_added": false
+              "version_added": "18"
             },
             "opera_android": {
-              "version_added": "15"
+              "version_added": "18"
             },
             "safari": {
-              "version_added": "5.1",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "5",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": "1.5"
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -197,14 +103,13 @@
           "spec_url": "https://w3c.github.io/deviceorientation/#dom-devicemotioneventacceleration-y",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "31"
             },
             "chrome_android": {
-              "version_added": "28"
+              "version_added": "31"
             },
             "edge": {
-              "version_added": "12",
-              "version_removed": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "6"
@@ -213,26 +118,22 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
-              "version_added": false
+              "version_added": "18"
             },
             "opera_android": {
-              "version_added": "15"
+              "version_added": "18"
             },
             "safari": {
-              "version_added": "5.1",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "5",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": "1.5"
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -251,14 +152,13 @@
           "spec_url": "https://w3c.github.io/deviceorientation/#dom-devicemotioneventacceleration-z",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "31"
             },
             "chrome_android": {
-              "version_added": "28"
+              "version_added": "31"
             },
             "edge": {
-              "version_added": "12",
-              "version_removed": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "6"
@@ -267,26 +167,22 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
-              "version_added": false
+              "version_added": "18"
             },
             "opera_android": {
-              "version_added": "15"
+              "version_added": "18"
             },
             "safari": {
-              "version_added": "5.1",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "5",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": "1.5"
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "≤37"

--- a/api/DeviceMotionEventRotationRate.json
+++ b/api/DeviceMotionEventRotationRate.json
@@ -6,78 +6,41 @@
         "spec_url": "https://w3c.github.io/deviceorientation/#devicemotioneventrotationrate",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "31"
           },
-          "chrome_android": [
-            {
-              "version_added": "74"
-            },
-            {
-              "alternative_name": "DeviceRotation",
-              "version_added": "28",
-              "version_removed": "73"
-            }
-          ],
+          "chrome_android": {
+            "version_added": "31"
+          },
           "edge": {
-            "version_added": "12",
-            "version_removed": "79"
+            "version_added": "12"
           },
           "firefox": {
-            "version_added": "6",
-            "partial_implementation": true,
-            "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
+            "version_added": "6"
           },
           "firefox_android": {
-            "version_added": "6",
-            "partial_implementation": true,
-            "notes": "Doesn't expose the <code>DeviceMotionEventAcceleration</code> interface itself."
+            "version_added": "6"
           },
           "ie": {
-            "version_added": false
+            "version_added": "11"
           },
           "opera": {
+            "version_added": "18"
+          },
+          "opera_android": {
+            "version_added": "18"
+          },
+          "safari": {
             "version_added": false
           },
-          "opera_android": [
-            {
-              "version_added": "53"
-            },
-            {
-              "alternative_name": "DeviceRotation",
-              "version_added": "15",
-              "version_removed": "52"
-            }
-          ],
-          "safari": {
-            "version_added": "5.1",
-            "partial_implementation": true,
-            "notes": "Doesn't expose the <code>DeviceMotionEventRotationRate</code> interface itself."
-          },
           "safari_ios": {
-            "version_added": "5",
-            "partial_implementation": true,
-            "notes": "Doesn't expose the <code>DeviceMotionEventRotationRate</code> interface itself."
+            "version_added": "4.2"
           },
-          "samsunginternet_android": [
-            {
-              "version_added": "11.0"
-            },
-            {
-              "alternative_name": "DeviceRotation",
-              "version_added": "1.5",
-              "version_removed": "11.0"
-            }
-          ],
-          "webview_android": [
-            {
-              "version_added": "74"
-            },
-            {
-              "alternative_name": "DeviceAcceleration",
-              "version_added": "≤37",
-              "version_removed": "73"
-            }
-          ]
+          "samsunginternet_android": {
+            "version_added": "2.0"
+          },
+          "webview_android": {
+            "version_added": "≤37"
+          }
         },
         "status": {
           "experimental": false,
@@ -91,14 +54,13 @@
           "spec_url": "https://w3c.github.io/deviceorientation/#dom-devicemotioneventrotationrate-alpha",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "31"
             },
             "chrome_android": {
-              "version_added": "28"
+              "version_added": "31"
             },
             "edge": {
-              "version_added": "12",
-              "version_removed": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "6"
@@ -107,26 +69,22 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
-              "version_added": false
+              "version_added": "18"
             },
             "opera_android": {
-              "version_added": "15"
+              "version_added": "18"
             },
             "safari": {
-              "version_added": "5.1",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventRotationRate</code> interface itself."
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "5",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventRotationRate</code> interface itself."
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": "1.5"
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -145,14 +103,13 @@
           "spec_url": "https://w3c.github.io/deviceorientation/#dom-devicemotioneventrotationrate-beta",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "31"
             },
             "chrome_android": {
-              "version_added": "28"
+              "version_added": "31"
             },
             "edge": {
-              "version_added": "12",
-              "version_removed": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "6"
@@ -161,26 +118,22 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
-              "version_added": false
+              "version_added": "18"
             },
             "opera_android": {
-              "version_added": "15"
+              "version_added": "18"
             },
             "safari": {
-              "version_added": "5.1",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventRotationRate</code> interface itself."
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "5",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventRotationRate</code> interface itself."
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": "1.5"
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "≤37"
@@ -199,14 +152,13 @@
           "spec_url": "https://w3c.github.io/deviceorientation/#dom-devicemotioneventrotationrate-gamma",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "31"
             },
             "chrome_android": {
-              "version_added": "28"
+              "version_added": "31"
             },
             "edge": {
-              "version_added": "12",
-              "version_removed": "79"
+              "version_added": "12"
             },
             "firefox": {
               "version_added": "6"
@@ -215,78 +167,22 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": false
+              "version_added": "11"
             },
             "opera": {
-              "version_added": false
+              "version_added": "18"
             },
             "opera_android": {
-              "version_added": "15"
+              "version_added": "18"
             },
             "safari": {
-              "version_added": "5.1",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventRotationRate</code> interface itself."
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "5",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventRotationRate</code> interface itself."
+              "version_added": "4.2"
             },
             "samsunginternet_android": {
-              "version_added": "1.5"
-            },
-            "webview_android": {
-              "version_added": "≤37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "secure_context_required": {
-        "__compat": {
-          "description": "Secure context required",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": "28"
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": "15"
-            },
-            "safari": {
-              "version_added": "5.1",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventRotationRate</code> interface itself."
-            },
-            "safari_ios": {
-              "version_added": "5",
-              "partial_implementation": true,
-              "notes": "Doesn't expose the <code>DeviceMotionEventRotationRate</code> interface itself."
-            },
-            "samsunginternet_android": {
-              "version_added": "1.5"
+              "version_added": "2.0"
             },
             "webview_android": {
               "version_added": "≤37"

--- a/api/Window.json
+++ b/api/Window.json
@@ -1648,7 +1648,7 @@
               "version_added": "18"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "18"
             },
             "safari": {
               "version_added": false
@@ -1660,7 +1660,7 @@
               "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "≤37"
             }
           },
           "status": {
@@ -4169,7 +4169,7 @@
               "version_added": "2.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This was all added in WebKit trunk 534.5 and 534.9:
https://trac.webkit.org/changeset/64845/webkit
https://trac.webkit.org/changeset/68252/webkit

It wasn't enabled then, but because it all went together, it can all be
assumed to match the ondevicemotion property being exposed. That was
confirmed to be Chrome 31 with this test:
http://mdn-bcd-collector.appspot.com/tests/api/Window/ondevicemotion

The source of Chrome 11 is here:
https://github.com/mdn/browser-compat-data/pull/5834

The description says Chrome 31, so this must have been a copy-paste
error from the IE version.

Also update the Samsung Internet and WebView versions based on
conservative mirroring. It's possible this was supported earlier, but
the current version numbers also seem to be based on mirroring, not
testing:
https://github.com/mdn/browser-compat-data/pull/6838