### PR TITLE
Update support for flex-basis property values

### DIFF
--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -183,15 +183,20 @@
             "description": "<code>content</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "94"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "94"
               },
-              "edge": {
-                "version_added": "12",
-                "version_removed": "79"
-              },
+              "edge": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "version_added": "12",
+                  "version_removed": "79"
+                }
+              ],
               "firefox": {
                 "version_added": "61"
               },
@@ -202,7 +207,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "80"
               },
               "opera_android": {
                 "version_added": false
@@ -217,7 +222,67 @@
                 "version_added": false
               },
               "webview_android": {
+                "version_added": "94"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "fit-content": {
+          "__compat": {
+            "description": "<code>fit-content</code>",
+            "support": {
+              "chrome": {
+                "version_added": "94"
+              },
+              "chrome_android": {
+                "version_added": "94"
+              },
+              "edge": {
+                "version_added": "94"
+              },
+              "firefox": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "version_added": "22",
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "version_added": "22",
+                  "prefix": "-moz-"
+                }
+              ],
+              "ie": {
                 "version_added": false
+              },
+              "opera": {
+                "version_added": "80"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "94"
               }
             },
             "status": {
@@ -231,13 +296,13 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "94"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "94"
               },
               "edge": {
-                "version_added": false
+                "version_added": "94"
               },
               "firefox": [
                 {
@@ -261,7 +326,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "80"
               },
               "opera_android": {
                 "version_added": false
@@ -276,7 +341,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "94"
               }
             },
             "status": {
@@ -290,13 +355,13 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "94"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "94"
               },
               "edge": {
-                "version_added": false
+                "version_added": "94"
               },
               "firefox": [
                 {
@@ -320,7 +385,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "80"
               },
               "opera_android": {
                 "version_added": false
@@ -335,7 +400,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "94"
               }
             },
             "status": {


### PR DESCRIPTION
Support for content and min/max/fit-content shipped in Chrome 94:
https://storage.googleapis.com/chromium-find-releases-static/b3f.html#b3fc034c85b71d3575333731879d82e2e729d0e9

-moz-fit-content was unprefixed in Firefox 94:
https://bugzilla.mozilla.org/show_bug.cgi?id=1732759

This was also confirmed using
`CSS.supports('flex-basis', 'fit-content')` in Firefox 93 and 94 and
support for the prefixed form in Firefox 22 was confirmed using
`CSS.supports('flex-basis', '-moz-fit-content')`.

Lack of support for fit-content in Edge and Safari was confirmed using
`CSS.supports('flex-basis', 'fit-content')`.