### PR TITLE
Mark onsecuritypolicyviolation as supported in Chromium 97

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -4081,13 +4081,13 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onsecuritypolicyviolation",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "97"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "97"
             },
             "edge": {
-              "version_added": false
+              "version_added": "97"
             },
             "firefox": {
               "version_added": "93"
@@ -4099,7 +4099,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "83"
             },
             "opera_android": {
               "version_added": false
@@ -4114,7 +4114,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "97"
             }
           },
           "status": {


### PR DESCRIPTION
Source: https://storage.googleapis.com/chromium-find-releases-static/bec.html#bec147a63f30ec6e1157bc591c4cdb4998387d00

Also confirmed by logging `window.onsecuritypolicyviolation` in Chrome 97.