### PR TITLE
Mark onslotchange properties as supported in Chromium 97

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -4475,13 +4475,13 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onslotchange",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "97"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "97"
             },
             "edge": {
-              "version_added": false
+              "version_added": "97"
             },
             "firefox": {
               "version_added": "93"
@@ -4493,7 +4493,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "83"
             },
             "opera_android": {
               "version_added": false
@@ -4508,11 +4508,11 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "97"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -296,13 +296,13 @@
           "spec_url": "https://dom.spec.whatwg.org/#dom-shadowroot-onslotchange",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "97"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "97"
             },
             "edge": {
-              "version_added": false
+              "version_added": "97"
             },
             "firefox": {
               "version_added": "93"
@@ -314,7 +314,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "83"
             },
             "opera_android": {
               "version_added": false
@@ -329,7 +329,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "97"
             }
           },
           "status": {


### PR DESCRIPTION
https://storage.googleapis.com/chromium-find-releases-static/ec5.html#ec5cf31361e9822ad4c8999dcb34aa1bcca2907a

Also mark it as not experimental given multi-engine support.

Note that the data for api.HTMLSlotElement.slotchange_event doesn't
match, because the event itself was supported earlier.