### PR TITLE
Added release date for Chrome 99

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -684,6 +684,7 @@
           "engine_version": "98"
         },
         "99": {
+          "release_date": "2022-03-01",
           "status": "nightly",
           "engine": "Blink",
           "engine_version": "99"

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -520,6 +520,7 @@
           "engine_version": "98"
         },
         "99": {
+          "release_date": "2022-03-01",
           "status": "nightly",
           "engine": "Blink",
           "engine_version": "99"

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -485,6 +485,7 @@
           "engine_version": "98"
         },
         "99": {
+          "release_date": "2022-03-01",
           "status": "nightly",
           "engine": "Blink",
           "engine_version": "99"


### PR DESCRIPTION
Following up with https://github.com/mdn/browser-compat-data/pull/14433, this PR adds missing release date for Chrome 99. Source is https://chromiumdash.appspot.com/schedule

![image](https://user-images.githubusercontent.com/634478/148360209-cd75cfbc-19a7-469d-8aa5-b49796834ab3.png)

@foolip Can you review? 