### PR TITLE
IE does not also support `visibility: unset`

### DIFF
--- a/css/properties/visibility.json
+++ b/css/properties/visibility.json
@@ -25,6 +25,7 @@
               "version_added": "4",
               "notes": [
                 "Internet Explorer doesn't support <code>visibility: initial</code>.",
+                "Internet Explorer doesn't support <code>visibility: unset</code>.",
                 "Up to Internet Explorer 7, descendants of <code>hidden</code> elements will still be invisible even if they have <code>visibility</code> set to <code>visible</code>."
               ]
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

In addition to `visibility: initial`, `visibility: unset` is also not supported under IE.

#### Test results and supporting details

I have tested under IE11.

![image](https://user-images.githubusercontent.com/9573300/148365628-e8c320a3-be15-41b6-9419-f5ab117b36cb.png)

