### PR TITLE
ScreenOrientation.lock - partially supported from 69/79

### DIFF
--- a/api/ScreenOrientation.json
+++ b/api/ScreenOrientation.json
@@ -111,17 +111,9 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": [
-              {
-                "version_added": "69",
-                "partial_implementation": true,
-                "notes": "The API exists but does not lock the screen orientation."
-              },
-              {
-                "version_added": "43",
-                "version_removed": "69"
-              }
-            ],
+            "firefox": {
+              "version_added": "43"
+            },
             "firefox_android": [
               {
                 "version_added": "79",

--- a/api/ScreenOrientation.json
+++ b/api/ScreenOrientation.json
@@ -123,8 +123,9 @@
             "firefox_android": [
               {
                 "version_added": "79",
+                "version_removed": "97",
                 "partial_implementation": true,
-                "notes": "The API exists but does not lock the screen orientation."
+                "notes": "The API exists but returns <code>NS_ERROR_UNEXPECTED</code>."
               },
               {
                 "version_added": "43",

--- a/api/ScreenOrientation.json
+++ b/api/ScreenOrientation.json
@@ -111,12 +111,28 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "43"
-            },
-            "firefox_android": {
-              "version_added": "43"
-            },
+            "firefox": [
+              {
+                "version_added": "69",
+                "partial_implementation": true,
+                "notes": "The API exists but does not lock the screen orientation."
+              },
+              {
+                "version_added": "43",
+                "version_removed": "69"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "79",
+                "partial_implementation": true,
+                "notes": "The API exists but does not lock the screen orientation."
+              },
+              {
+                "version_added": "43",
+                "version_removed": "79"
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/ScreenOrientation.json
+++ b/api/ScreenOrientation.json
@@ -103,16 +103,22 @@
           "spec_url": "https://w3c.github.io/screen-orientation/#dom-screenorientation-lock",
           "support": {
             "chrome": {
-              "version_added": "38"
+              "version_added": "38",
+              "partial_implementation": true,
+              "notes": "Always throws <code>NotSupportedError</code>."
             },
             "chrome_android": {
               "version_added": "38"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "partial_implementation": true,
+              "notes": "Always throws <code>NotSupportedError</code>."
             },
             "firefox": {
-              "version_added": "43"
+              "version_added": "43",
+              "partial_implementation": true,
+              "notes": "Always throws <code>NotSupportedError</code>."
             },
             "firefox_android": [
               {
@@ -129,7 +135,9 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "25"
+              "version_added": "25",
+              "partial_implementation": true,
+              "notes": "Always throws <code>NotSupportedError</code>."
             },
             "opera_android": {
               "version_added": "25"


### PR DESCRIPTION
Fixes #8524

As discussed in https://github.com/mdn/browser-compat-data/issues/8524#issuecomment-1004476882 [ScreenOrientation.lock()](https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/lock) was broken by Fenix rewrite or as part of the Fennec code removal project at around FFv69. As the first release of Android after 68 is FF 79 I have marked removed in that version, and partially supported afterwards - indicating the API exists but does not work. 

I have left desktop unchanged - it does not appear to behave differently in those versions. i.e. you can't set desktop orientation anyway, but this is expected.

This relates to docs work in https://github.com/mdn/content/issues/11594 . There is a fix for the bug but it requires a preference, and so is not recorded here. 