### PR TITLE
FF97 supports AnimationFrameProvider in DedicatedWorkerGlobalScope

### DIFF
--- a/api/DedicatedWorkerGlobalScope.json
+++ b/api/DedicatedWorkerGlobalScope.json
@@ -65,10 +65,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "97"
             },
             "ie": {
               "version_added": false
@@ -513,10 +513,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "97"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
FF97 supports `cancelAnimationFrame` and `requestAnimationFrame` in workers (aka AnimationFrameProvider). See https://bugzilla.mozilla.org/show_bug.cgi?id=1738971

This just adds the versioning. Might require further update to provide links to docs. 

This is part of https://github.com/mdn/content/issues/11591