### PR TITLE
Update the compatible version of `dblclick` events under IE

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2429,7 +2429,7 @@
               "version_added": "6"
             },
             "ie": {
-              "version_added": "11"
+              "version_added": "8"
             },
             "opera": {
               "version_added": "11.6"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

I have tested `dblclick` event with the following snippet is supported down to IE8, so update the compatible version.

```js
document.body.addEventListener('dblclick', function () { console.log('double clicked') });

// IE8
document.body.attachEvent('ondblclick', function () { console.log('double clicked') });
```

#### Test Snapshots

- IE10:

![image](https://user-images.githubusercontent.com/9573300/148526745-8865c20d-e0ff-47c8-b7cd-557957e66c74.png)

- IE9: 

![image](https://user-images.githubusercontent.com/9573300/148527371-35932758-b315-4c90-a148-11a4566ecc51.png)

- IE8:

![image](https://user-images.githubusercontent.com/9573300/148527559-9f75eb0f-09d2-4766-8649-c441337e3e3e.png)
