### PR TITLE
Fix AudioWorkletGlobalScope/AudioWorkletProcessor support in Safari

### DIFF
--- a/api/AudioWorkletGlobalScope.json
+++ b/api/AudioWorkletGlobalScope.json
@@ -77,10 +77,10 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -125,10 +125,10 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -174,10 +174,10 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -222,10 +222,10 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"

--- a/api/AudioWorkletProcessor.json
+++ b/api/AudioWorkletProcessor.json
@@ -79,10 +79,10 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"
@@ -128,10 +128,10 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "9.0"


### PR DESCRIPTION
These were all in the IDL/C++ well before Safari 14.1's release:
https://trac.webkit.org/changeset/267891/webkit
https://trac.webkit.org/changeset/268103/webkit