### PR TITLE
Mark CSSConditionRule and CSSGroupingRule supported in Safari

### DIFF
--- a/api/CSSConditionRule.json
+++ b/api/CSSConditionRule.json
@@ -30,10 +30,10 @@
             "version_added": "43"
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -78,10 +78,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/CSSGroupingRule.json
+++ b/api/CSSGroupingRule.json
@@ -30,10 +30,10 @@
             "version_added": "32"
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5"
           },
           "samsunginternet_android": {
             "version_added": "5.0"
@@ -78,10 +78,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -127,10 +127,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "5.0"
@@ -176,10 +176,10 @@
               "version_added": "32"
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5"
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
This was implemented at WebKit trunk version 611.1.1:
https://trac.webkit.org/changeset/267576/webkit
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=267576