### PR TITLE
Put the <dialog> cancel event behind a flag in Firefox

### DIFF
--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -80,10 +80,26 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "78"
+              "version_added": "78",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.dialog_element.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.dialog_element.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
The version number (78) came from here:
https://github.com/mdn/browser-compat-data/pull/6433

But <dialog> itself isn't shipped yet, so fix up the data to match other
subfeatures.
