### PR TITLE
Mark Gamepad's id property as supported in Safari

### DIFF
--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -410,10 +410,10 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": false
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "1.5"


### PR DESCRIPTION
This was missed in https://github.com/mdn/browser-compat-data/pull/4645 and it's not clear why.

The id attribute has been in the IDL/C++ in WebKit for very long:
https://trac.webkit.org/changeset/170309/webkit
https://trac.webkit.org/changeset/170465/webkit