### PR TITLE
Link WebKit bug for form.requestSubmit()

### DIFF
--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -714,10 +714,12 @@
               "version_added": "54"
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/197958'>bug 197958</a>."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/197958'>bug 197958</a>."
             },
             "samsunginternet_android": {
               "version_added": "12.0"


### PR DESCRIPTION
While the bug is resolved as fixed, it's not yet enabled by default, and
this bug is where the discussion is happening.