### PR TITLE
Mark Web Locks API as supported in Safari Technology Preview

### DIFF
--- a/api/Lock.json
+++ b/api/Lock.json
@@ -43,7 +43,7 @@
             "version_added": "48"
           },
           "safari": {
-            "version_added": false
+            "version_added": "preview"
           },
           "safari_ios": {
             "version_added": false
@@ -56,7 +56,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -104,7 +104,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -117,7 +117,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -166,7 +166,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -179,7 +179,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/LockManager.json
+++ b/api/LockManager.json
@@ -43,7 +43,7 @@
             "version_added": "48"
           },
           "safari": {
-            "version_added": false
+            "version_added": "preview"
           },
           "safari_ios": {
             "version_added": false
@@ -56,7 +56,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -104,7 +104,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -117,7 +117,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -166,7 +166,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -179,7 +179,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2082,7 +2082,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false
@@ -2095,7 +2095,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -541,7 +541,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=232436

These tests pass in STP 137 but not Safari 15.1:
https://mdn-bcd-collector.appspot.com/tests/api/Lock
https://mdn-bcd-collector.appspot.com/tests/api/LockManager
https://mdn-bcd-collector.appspot.com/tests/api/Navigator/locks
https://mdn-bcd-collector.appspot.com/tests/api/WorkerNavigator/locks

Also mark as not experimental, since all of this is already in Chrome
and Firefox.
