### PR TITLE
Fix api.Navigator.mediaDevices.secure_context_required for Safari

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2307,10 +2307,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "11"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "11"
               },
               "samsunginternet_android": {
                 "version_added": "11.0"


### PR DESCRIPTION
navigator.mediaDevices isn't exposed over HTTP in Safari. Copy the data
from api.MediaDevices.getUserMedia.secure_context_required which also
matches the parent feature.
