### PR TITLE
Updates edge to version 97

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -168,17 +168,19 @@
         "96": {
           "release_date": "2021-11-19",
           "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-960105429-november-19",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "96"
         },
         "97": {
-          "status": "beta",
+          "release_date": "2022-01-06",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-970107255-january-6",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "97"
         },
         "98": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "98"
         },


### PR DESCRIPTION
Hello everyone!

I updated Edge browser to version 97, according to this [release note](https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-970107255-january-6).

Fixes #14470.

:)