### PR TITLE
FF97 supports cap and ic units for CSS lengths

### DIFF
--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -112,10 +112,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": "97"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "97"
               },
               "ie": {
                 "version_added": false
@@ -260,11 +260,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1531223'>bug 1531223</a>."
+                "version_added": "97"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "97"
               },
               "ie": {
                 "version_added": false

--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -140,7 +140,7 @@
               }
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -289,7 +289,7 @@
               }
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -112,10 +112,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": "97"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "97"
               },
               "ie": {
                 "version_added": false
@@ -260,11 +260,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1531223'>bug 1531223</a>."
+                "version_added": "97"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "97"
               },
               "ie": {
                 "version_added": false

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -140,7 +140,7 @@
               }
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -289,7 +289,7 @@
               }
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
Support was added in https://bugzilla.mozilla.org/show_bug.cgi?id=1531223 (ic) and https://bugzilla.mozilla.org/show_bug.cgi?id=1702924 (cap)

Associated docs work can be tracked in: https://github.com/mdn/content/issues/11592
