### PR TITLE
CSS hyphenate-character property - add

### DIFF
--- a/css/properties/hyphenate-character.json
+++ b/css/properties/hyphenate-character.json
@@ -8,11 +8,11 @@
           "support": {
             "chrome": {
               "prefix": "-webkit-",
-              "version_added": "37"
+              "version_added": "6"
             },
             "chrome_android": {
               "prefix": "-webkit-",
-              "version_added": "37"
+              "version_added": "18"
             },
             "edge": {
               "prefix": "-webkit-",
@@ -35,26 +35,28 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "24",
-              "prefix": "-webkit-"
+              "prefix": "-webkit-",
+              "version_added": "15"
             },
             "opera_android": {
               "prefix": "-webkit-",
-              "version_added": "24"
+              "version_added": "14"
             },
             "safari": {
-              "version_added": false
+              "prefix": "-webkit-",
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": false
+              "prefix": "-webkit-",
+              "version_added": "5"
             },
             "samsunginternet_android": {
               "prefix": "-webkit-",
-              "version_added": "3.0"
+              "version_added": "1.0"
             },
             "webview_android": {
               "prefix": "-webkit-",
-              "version_added": "37"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/hyphenate-character.json
+++ b/css/properties/hyphenate-character.json
@@ -8,11 +8,11 @@
           "support": {
             "chrome": {
               "prefix": "-webkit-",
-              "version_added": "45"
+              "version_added": "37"
             },
             "chrome_android": {
               "prefix": "-webkit-",
-              "version_added": "45"
+              "version_added": "37"
             },
             "edge": {
               "prefix": "-webkit-",
@@ -35,12 +35,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "44",
+              "version_added": "24",
               "prefix": "-webkit-"
             },
             "opera_android": {
               "prefix": "-webkit-",
-              "version_added": "32"
+              "version_added": "24"
             },
             "safari": {
               "version_added": false
@@ -50,11 +50,11 @@
             },
             "samsunginternet_android": {
               "prefix": "-webkit-",
-              "version_added": "5.0"
+              "version_added": "3.0"
             },
             "webview_android": {
               "prefix": "-webkit-",
-              "version_added": "45"
+              "version_added": "37"
             }
           },
           "status": {

--- a/css/properties/hyphenate-character.json
+++ b/css/properties/hyphenate-character.json
@@ -36,8 +36,7 @@
             },
             "opera": {
               "version_added": "44",
-              "partial_implementation": true,
-              "notes": "<code>auto</code> value is only supported on macOS and Android."
+              "prefix": "-webkit-"
             },
             "opera_android": {
               "prefix": "-webkit-",

--- a/css/properties/hyphenate-character.json
+++ b/css/properties/hyphenate-character.json
@@ -1,0 +1,70 @@
+{
+  "css": {
+    "properties": {
+      "hyphenate-character": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/hyphenate-character",
+          "spec_url": "https://drafts.csswg.org/css-text-4/#propdef-hyphenate-character",
+          "support": {
+            "chrome": {
+              "prefix": "-webkit-",
+              "version_added": "45"
+            },
+            "chrome_android": {
+              "prefix": "-webkit-",
+              "version_added": "45"
+            },
+            "edge": {
+              "prefix": "-webkit-",
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.hyphenate-character.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "44",
+              "partial_implementation": true,
+              "notes": "<code>auto</code> value is only supported on macOS and Android."
+            },
+            "opera_android": {
+              "prefix": "-webkit-",
+              "version_added": "32"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "prefix": "-webkit-",
+              "version_added": "5.0"
+            },
+            "webview_android": {
+              "prefix": "-webkit-",
+              "version_added": "45"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
FF97 adds support for the CSS `hyphenate-character` property https://bugzilla.mozilla.org/show_bug.cgi?id=1746187 behind a preference. I've added that for FF97, but not for FF97 on android.

Now Chrome supports this with a -webkit extension, so I added that as well. BUT I am not sure exactly what versions to put. 
I found it works fine to specify a value (`=`) say for back to Chrome 45, but in Chrome 44 the CSS doesn't seem to understand the "=" char - so the rendered character appears as a box. In other words it isn't clear if it doesn't work or if = just doesn't work.

![image](https://user-images.githubusercontent.com/5368500/148724761-5420f02d-ea9d-40cf-95b5-5e91eac8cf64.png)

Anyway, Safari has the same problem on current versions as the very old chrome, so I put that as false.

I just extended the other things to match chrome versions if appropriate. 

Thoughts on next steps?

Rest of work for this can be tracked in  https://github.com/mdn/content/issues/11596

@ddbeck Would appreciate your advice on this one.