### PR TITLE
Split first baseline and last baseline entries

### DIFF
--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -119,7 +119,7 @@
                   "version_added": "57"
                 },
                 "edge": {
-                  "version_added": "79"
+                  "version_added": "≤79"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -156,18 +156,75 @@
               }
             }
           },
-          "first_last_baseline": {
+          "first_baseline": {
             "__compat": {
-              "description": "<code>first baseline</code> and <code>last baseline</code>",
+              "description": "<code>first baseline</code>",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "59"
                 },
                 "chrome_android": {
-                  "version_added": false
+                  "version_added": "59"
                 },
                 "edge": {
+                  "version_added": "≤79"
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": "52"
+                },
+                "ie": {
                   "version_added": false
+                },
+                "opera": {
+                  "version_added": "46"
+                },
+                "opera_android": {
+                  "version_added": "43"
+                },
+                "safari": {
+                  "version_added": "11"
+                },
+                "safari_ios": {
+                  "version_added": "11"
+                },
+                "samsunginternet_android": {
+                  "version_added": "7.0"
+                },
+                "webview_android": {
+                  "version_added": "59"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "last_baseline": {
+            "__compat": {
+              "description": "<code>last baseline</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "59",
+                  "version_removed": "86",
+                  "partial_implementation": true,
+                  "notes": "This value is recognized, but has no effect. See <a href='https://crbug.com/885175'>bug 885175</a>."
+                },
+                "chrome_android": {
+                  "version_added": "59",
+                  "version_removed": "86",
+                  "partial_implementation": true,
+                  "notes": "This value is recognized, but has no effect. See <a href='https://crbug.com/885175'>bug 885175</a>."
+                },
+                "edge": {
+                  "version_added": "≤79",
+                  "version_removed": "86",
+                  "partial_implementation": true,
+                  "notes": "This value is recognized, but has no effect. See <a href='https://crbug.com/885175'>bug 885175</a>."
                 },
                 "firefox": {
                   "version_added": "52"
@@ -185,10 +242,14 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": "11"
+                  "version_added": "11",
+                  "partial_implementation": true,
+                  "notes": "This value is recognized, but has no effect. See <a href='https://webkit.org/b/235005'>bug 235005</a>."
                 },
                 "safari_ios": {
-                  "version_added": "11"
+                  "version_added": "11",
+                  "partial_implementation": true,
+                  "notes": "This value is recognized, but has no effect. See <a href='https://webkit.org/b/235005'>bug 235005</a>."
                 },
                 "samsunginternet_android": {
                   "version_added": false

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -131,9 +131,57 @@
               "deprecated": false
             }
           },
-          "first_last_baseline": {
+          "baseline": {
             "__compat": {
-              "description": "<code>first baseline</code> and <code>last baseline</code>",
+              "description": "<code>baseline</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "21"
+                },
+                "chrome_android": {
+                  "version_added": "25"
+                },
+                "edge": {
+                  "version_added": "≤79"
+                },
+                "firefox": {
+                  "version_added": "28"
+                },
+                "firefox_android": {
+                  "version_added": "28"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "44"
+                },
+                "opera_android": {
+                  "version_added": "43"
+                },
+                "safari": {
+                  "version_added": "7"
+                },
+                "safari_ios": {
+                  "version_added": "7"
+                },
+                "samsunginternet_android": {
+                  "version_added": "7.0"
+                },
+                "webview_android": {
+                  "version_added": "57"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "first_baseline": {
+            "__compat": {
+              "description": "<code>first baseline</code>",
               "support": {
                 "chrome": {
                   "version_added": "59"
@@ -142,13 +190,13 @@
                   "version_added": "59"
                 },
                 "edge": {
-                  "version_added": "79"
+                  "version_added": "≤79"
                 },
                 "firefox": {
-                  "version_added": "45"
+                  "version_added": "52"
                 },
                 "firefox_android": {
-                  "version_added": "45"
+                  "version_added": "52"
                 },
                 "ie": {
                   "version_added": false
@@ -164,6 +212,67 @@
                 },
                 "safari_ios": {
                   "version_added": "11"
+                },
+                "samsunginternet_android": {
+                  "version_added": "7.0"
+                },
+                "webview_android": {
+                  "version_added": "59"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "last_baseline": {
+            "__compat": {
+              "description": "<code>last baseline</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "59",
+                  "version_removed": "86",
+                  "partial_implementation": true,
+                  "notes": "This value is recognized, but has no effect. See <a href='https://crbug.com/885175'>bug 885175</a>."
+                },
+                "chrome_android": {
+                  "version_added": "59",
+                  "version_removed": "86",
+                  "partial_implementation": true,
+                  "notes": "This value is recognized, but has no effect. See <a href='https://crbug.com/885175'>bug 885175</a>."
+                },
+                "edge": {
+                  "version_added": "≤79",
+                  "version_removed": "86",
+                  "partial_implementation": true,
+                  "notes": "This value is recognized, but has no effect. See <a href='https://crbug.com/885175'>bug 885175</a>."
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": "52"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "46"
+                },
+                "opera_android": {
+                  "version_added": "43"
+                },
+                "safari": {
+                  "version_added": "11",
+                  "partial_implementation": true,
+                  "notes": "This value is recognized, but has no effect. See <a href='https://webkit.org/b/235005'>bug 235005</a>."
+                },
+                "safari_ios": {
+                  "version_added": "11",
+                  "partial_implementation": true,
+                  "notes": "This value is recognized, but has no effect. See <a href='https://webkit.org/b/235005'>bug 235005</a>."
                 },
                 "samsunginternet_android": {
                   "version_added": "7.0"

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -135,19 +135,19 @@
               "description": "<code>baseline</code>",
               "support": {
                 "chrome": {
-                  "version_added": "57"
+                  "version_added": "21"
                 },
                 "chrome_android": {
-                  "version_added": "57"
+                  "version_added": "25"
                 },
                 "edge": {
-                  "version_added": "79"
+                  "version_added": "≤79"
                 },
                 "firefox": {
-                  "version_added": "45"
+                  "version_added": "28"
                 },
                 "firefox_android": {
-                  "version_added": "45"
+                  "version_added": "28"
                 },
                 "ie": {
                   "version_added": false
@@ -159,10 +159,10 @@
                   "version_added": "43"
                 },
                 "safari": {
-                  "version_added": "9"
+                  "version_added": "7"
                 },
                 "safari_ios": {
-                  "version_added": "9"
+                  "version_added": "7"
                 },
                 "samsunginternet_android": {
                   "version_added": "7.0"
@@ -178,18 +178,75 @@
               }
             }
           },
-          "first_last_baseline": {
+          "first_baseline": {
             "__compat": {
-              "description": "<code>first baseline</code> and <code>last baseline</code>",
+              "description": "<code>first baseline</code>",
               "support": {
                 "chrome": {
-                  "version_added": "57"
+                  "version_added": "59"
                 },
                 "chrome_android": {
-                  "version_added": "57"
+                  "version_added": "59"
                 },
                 "edge": {
-                  "version_added": "79"
+                  "version_added": "≤79"
+                },
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": "52"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "46"
+                },
+                "opera_android": {
+                  "version_added": "43"
+                },
+                "safari": {
+                  "version_added": "11"
+                },
+                "safari_ios": {
+                  "version_added": "11"
+                },
+                "samsunginternet_android": {
+                  "version_added": "7.0"
+                },
+                "webview_android": {
+                  "version_added": "59"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "last_baseline": {
+            "__compat": {
+              "description": "<code>last baseline</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "59",
+                  "version_removed": "86",
+                  "partial_implementation": true,
+                  "notes": "This value is recognized, but has no effect. See <a href='https://crbug.com/885175'>bug 885175</a>."
+                },
+                "chrome_android": {
+                  "version_added": "59",
+                  "version_removed": "86",
+                  "partial_implementation": true,
+                  "notes": "This value is recognized, but has no effect. See <a href='https://crbug.com/885175'>bug 885175</a>."
+                },
+                "edge": {
+                  "version_added": "≤79",
+                  "version_removed": "86",
+                  "partial_implementation": true,
+                  "notes": "This value is recognized, but has no effect. See <a href='https://crbug.com/885175'>bug 885175</a>."
                 },
                 "firefox": {
                   "version_added": "52"
@@ -207,10 +264,14 @@
                   "version_added": "43"
                 },
                 "safari": {
-                  "version_added": "11.1"
+                  "version_added": "11",
+                  "partial_implementation": true,
+                  "notes": "This value is recognized, but has no effect. See <a href='https://webkit.org/b/235005'>bug 235005</a>."
                 },
                 "safari_ios": {
-                  "version_added": "11.3"
+                  "version_added": "11",
+                  "partial_implementation": true,
+                  "notes": "This value is recognized, but has no effect. See <a href='https://webkit.org/b/235005'>bug 235005</a>."
                 },
                 "samsunginternet_android": {
                   "version_added": "7.0"


### PR DESCRIPTION
The 3 properties `align-content`, `align-items` and `align-self` all
take the 3 values `baseline`, `first baseline` and `last baseline`.
However, support for `last baseline` doesn't match support for
`first baseline`, so the entries need to be split to represent this.

There was no entry for `align-items: baseline`, so add that.

Tests:
http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=9948
http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=9955

The following was found based on testing:

- Chrome 21 got support for `-webkit-align-items: baseline` and
  `-webkit-align-self: baseline`.
- Chrome 29 got support for the unprefixed `align-items: baseline` and
  `align-self: baseline`.
- Chrome 57 got support for `align-content: baseline`.
- Chrome 59 got support for `first baseline` and `last baseline` for all
  3 properties.
- Chrome 86 dropped support for `last baseline` for all 3 properties,
  because it was only recognized but not actually supported. See:
  https://storage.googleapis.com/chromium-find-releases-static/af5.html#af5e59b01391ffa6be2a37d7958df22821a4a18d

- Edge 18 support all 9 combinations of properties and values.

- Firefox 28 had support for `align-items: baseline` and
  `align-self: baseline`. They were supported in Firefox 27 too, but the
  parent feature here is set to 28 so clamp to that.
- Firefox 45 got support for `align-content: baseline`.
- Firefox 52 got support for `first baseline` and `last baseline` for
  all 3 properties.

- Safari 7.1 had support for `-webkit-align-items: baseline` and
  `-webkit-align-self: baseline`, but Safari 6 did not.
- Safari 9.1 had support for `-webkit-align-content: baseline`, but
  Safari 8 did not.
- Safari 11 got support for `first baseline` and `last baseline` for all
  3 properties.

In order to avoid researching when Edge first got support and whether it
was partial, use ≤79 ranges to represent that it could be supported
earlier.