### PR TITLE
Change Firefox version number supporting scrollbar-gutter

### DIFF
--- a/css/properties/scrollbar-gutter.json
+++ b/css/properties/scrollbar-gutter.json
@@ -40,12 +40,10 @@
               "version_added": "94"
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1715112'>bug 1715112</a>."
+              "version_added": "97"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1715112'>bug 1715112</a>."
+              "version_added": "97"
             },
             "ie": {
               "version_added": false
@@ -72,7 +70,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
scrollbar-gutter is shipped in Firefox 97 in
https://bugzilla.mozilla.org/show_bug.cgi?id=1715112