### PR TITLE
Firefox 97 `SVGPathElement.getPathSegAtLength()` behind pref

### DIFF
--- a/api/SVGPathElement.json
+++ b/api/SVGPathElement.json
@@ -1127,12 +1127,38 @@
               "version_added": "12",
               "version_removed": "79"
             },
-            "firefox": {
-              "version_added": "1.5"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
+            "firefox": [
+              {
+                "version_added": "97",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.svg.pathSeg.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+              "version_added": "1.5",
+              "version_removed": "97"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "97",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.svg.pathSeg.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+              "version_added": "4",
+              "version_removed": "97"
+              }
+            ],
             "ie": {
               "version_added": "9"
             },

--- a/api/SVGPathElement.json
+++ b/api/SVGPathElement.json
@@ -1143,22 +1143,10 @@
                 "version_removed": "97"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.svg.pathSeg.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "4",
-                "version_removed": "97"
-              }
-            ],
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "97"
+            },
             "ie": {
               "version_added": "9"
             },

--- a/api/SVGPathElement.json
+++ b/api/SVGPathElement.json
@@ -1139,8 +1139,8 @@
                 ]
               },
               {
-              "version_added": "1.5",
-              "version_removed": "97"
+                "version_added": "1.5",
+                "version_removed": "97"
               }
             ],
             "firefox_android": [
@@ -1155,8 +1155,8 @@
                 ]
               },
               {
-              "version_added": "4",
-              "version_removed": "97"
+                "version_added": "4",
+                "version_removed": "97"
               }
             ],
             "ie": {


### PR DESCRIPTION
FF97 puts some SVGPathX.. elements behind a preference in [bug 1388931](https://bugzilla.mozilla.org/show_bug.cgi?id=1388931) on path to removal. 

This just adds pref to existing [SVGPathElement.getPathSegAtLength()](https://developer.mozilla.org/en-US/docs/Web/API/SVGPathElement). The other elements that are also behind pref are `SVGPathSegList` (including `.numberOfItems`, `getItem()` and `length`) and `SVGAnimatedPathData` `.pathSegList` and `.animatedPathSegList`. These are not in MDN or BCD - I have chosen not to add them as this API is clearly "on the way out".

Other docs work for this can be tracked in https://github.com/mdn/content/issues/11597#issuecomment-1009447802
