### PR TITLE
FF97 CSS basic-shape path() function enabled by default

### DIFF
--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -326,7 +326,7 @@
               ],
               "firefox_android": [
                 {
-                  "version_added": "71"
+                  "version_added": "79"
                 },
                 {
                   "version_added": "64",

--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -315,6 +315,7 @@
                 },
                 {
                   "version_added": "64",
+                  "version_removed": "71",
                   "flags": [
                     {
                       "type": "preference",
@@ -330,6 +331,7 @@
                 },
                 {
                   "version_added": "64",
+                  "version_removed": "79",
                   "flags": [
                     {
                       "type": "preference",

--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -314,7 +314,7 @@
                   "version_added": "71"
                 },
                 {
-                  "version_added": "63",
+                  "version_added": "64",
                   "flags": [
                     {
                       "type": "preference",
@@ -324,16 +324,21 @@
                   ]
                 }
               ],
-              "firefox_android": {
-                "version_added": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.clip-path-path.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox_android": [
+                {
+                  "version_added": "71"
+                },
+                {
+                  "version_added": "64",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.clip-path-path.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -270,46 +270,24 @@
                 "partial_implementation": true,
                 "notes": "Only supported on the <code>offset-path</code> property."
               },
-              "firefox": [
-                {
-                  "version_added": "97",
-                  "partial_implementation": true,
-                  "notes": "It is supported on the <code>d</code> SVG presentation attribute, <code>clip-path</code> and <code>offset-path</code> properties."
-                },
-                {
-                  "version_added": "63",
-                  "version_removed": "97",
-                  "partial_implementation": true,
-                  "notes": "From version 91 it can be used on the <code>d</code> SVG presentation attribute. For earlier versions it is only supported on the <code>clip-path</code> and <code>offset-path</code> properties.",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.clip-path-path.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "97",
-                  "partial_implementation": true,
-                  "notes": "It is supported on the <code>d</code> SVG presentation attribute, <code>clip-path</code> and <code>offset-path</code> properties."
-                },
-                {
-                  "version_added": "63",
-                  "version_removed": "79",
-                  "partial_implementation": true,
-                  "notes": "Only supported on the <code>clip-path</code> and <code>offset-path</code> properties.",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.clip-path-path.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "63",
+                "partial_implementation": true,
+                "notes": [
+                  "From version 63 it is supported on the <code>offset-path</code> property.",
+                  "From version 71 it is supported on the <code>clip-path</code> property (from version 64 to 71 it is supported behind the preference <code>layout.css.clip-path-path.enabled</code>).",
+                  "From version 97 it can be used on the <code>d</code> SVG presentation attribute (from version 91 to 97 it is supported behind the preference <code>layout.css.d-property.enabled</code>)."
+                ]
+              },
+              "firefox_android": {
+                "version_added": "63",
+                "partial_implementation": true,
+                "notes": [
+                  "From version 63 it is supported on the <code>offset-path</code> property.",
+                  "From version 79 it is supported on the <code>clip-path</code> property (from version 64 to 79 it is supported behind the preference <code>layout.css.clip-path-path.enabled</code>).",
+                  "From version 97 it can be used on the <code>d</code> SVG presentation attribute."
+                ]
+              },
               "ie": {
                 "version_added": false
               },

--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -270,24 +270,67 @@
                 "partial_implementation": true,
                 "notes": "Only supported on the <code>offset-path</code> property."
               },
-              "firefox": {
-                "version_added": "63",
-                "partial_implementation": true,
-                "notes": [
-                  "From version 63 it is supported on the <code>offset-path</code> property.",
-                  "From version 71 it is supported on the <code>clip-path</code> property (from version 64 to 71 it is supported behind the preference <code>layout.css.clip-path-path.enabled</code>).",
-                  "From version 97 it can be used on the <code>d</code> SVG presentation attribute (from version 91 to 97 it is supported behind the preference <code>layout.css.d-property.enabled</code>)."
-                ]
-              },
-              "firefox_android": {
-                "version_added": "63",
-                "partial_implementation": true,
-                "notes": [
-                  "From version 63 it is supported on the <code>offset-path</code> property.",
-                  "From version 79 it is supported on the <code>clip-path</code> property (from version 64 to 79 it is supported behind the preference <code>layout.css.clip-path-path.enabled</code>).",
-                  "From version 97 it can be used on the <code>d</code> SVG presentation attribute."
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "63",
+                  "partial_implementation": true,
+                  "notes": [
+                    "From version 97, the <code>d</code> SVG presentation attribute supports <code>path()</code>.",
+                    "From version 71, the <code>clip-path</code> property supports <code>path()</code>.",
+                    "Before version 71, only the <code>offset-path</code> property supports <code>path()</code>."
+                  ]
+                },
+                {
+                  "version_added": "91",
+                  "version_removed": "97",
+                  "partial_implementation": true,
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.d-property.enabled",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "notes": "The <code>d</code> SVG presentation attribute, <code>clip-path</code> CSS property, and <code>offset-path</code> CSS property support <code>path()</code>."
+                },
+                {
+                  "version_added": "64",
+                  "version_removed": "71",
+                  "partial_implementation": true,
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.clip-path-path.enabled",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "notes": "The <code>clip-path</code> and <code>offset-path</code> properties support <code>path()</code>."
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "63",
+                  "partial_implementation": true,
+                  "notes": [
+                    "From version 97, the <code>d</code> SVG presentation attribute supports <code>path()</code>.",
+                    "From version 79, the <code>clip-path</code> property supports <code>path()</code>.",
+                    "Before version 79, only the <code>offset-path</code> property supports <code>path()</code>."
+                  ]
+                },
+                {
+                  "version_added": "64",
+                  "version_removed": "79",
+                  "partial_implementation": true,
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.clip-path-path.enabled",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "notes": "The <code>clip-path</code> and <code>offset-path</code> properties support <code>path()</code>."
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -270,30 +270,46 @@
                 "partial_implementation": true,
                 "notes": "Only supported on the <code>offset-path</code> property."
               },
-              "firefox": {
-                "version_added": "63",
-                "partial_implementation": true,
-                "notes": "Only supported on the <code>clip-path</code> and <code>offset-path</code> properties.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.clip-path-path.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              "firefox_android": {
-                "version_added": "63",
-                "partial_implementation": true,
-                "notes": "Only supported on the <code>clip-path</code> and <code>offset-path</code> properties.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.clip-path-path.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "97",
+                  "partial_implementation": true,
+                  "notes": "It is supported on the <code>d</code> SVG presentation attribute, <code>clip-path</code> and <code>offset-path</code> properties."
+                },
+                {
+                  "version_added": "63",
+                  "version_removed": "97",
+                  "partial_implementation": true,
+                  "notes": "From version 91 it can be used on the <code>d</code> SVG presentation attribute. For earlier versions it is only supported on the <code>clip-path</code> and <code>offset-path</code> properties.",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.clip-path-path.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "97",
+                  "partial_implementation": true,
+                  "notes": "It is supported on the <code>d</code> SVG presentation attribute, <code>clip-path</code> and <code>offset-path</code> properties."
+                },
+                {
+                  "version_added": "63",
+                  "version_removed": "79",
+                  "partial_implementation": true,
+                  "notes": "Only supported on the <code>clip-path</code> and <code>offset-path</code> properties.",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.clip-path-path.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -291,7 +291,7 @@
                       "value_to_set": "true"
                     }
                   ],
-                  "notes": "The <code>d</code> SVG presentation attribute, <code>clip-path</code> CSS property, and <code>offset-path</code> CSS property support <code>path()</code>."
+                  "notes": "With the preference enabled, the <code>d</code> SVG presentation attribute, <code>clip-path</code> CSS property, and <code>offset-path</code> CSS property support <code>path()</code>."
                 },
                 {
                   "version_added": "64",
@@ -304,7 +304,7 @@
                       "value_to_set": "true"
                     }
                   ],
-                  "notes": "The <code>clip-path</code> and <code>offset-path</code> properties support <code>path()</code>."
+                  "notes": "With the preference enabled, the <code>clip-path</code> and <code>offset-path</code> properties support <code>path()</code>."
                 }
               ],
               "firefox_android": [
@@ -328,7 +328,7 @@
                       "value_to_set": "true"
                     }
                   ],
-                  "notes": "The <code>clip-path</code> and <code>offset-path</code> properties support <code>path()</code>."
+                  "notes": "With the preference enabled, the <code>clip-path</code> and <code>offset-path</code> properties support <code>path()</code>."
                 }
               ],
               "ie": {

--- a/svg/elements/path.json
+++ b/svg/elements/path.json
@@ -97,6 +97,7 @@
           },
           "path": {
             "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/path()",
               "description": "<code>path()</code> function can be used to set value in CSS",
               "support": {
                 "chrome": {

--- a/svg/elements/path.json
+++ b/svg/elements/path.json
@@ -94,6 +94,67 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "path": {
+            "__compat": {
+              "description": "<code>path()</code> function can be used to set value in CSS",
+              "support": {
+                "chrome": {
+                  "version_added": "52"
+                },
+                "chrome_android": {
+                  "version_added": "52"
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": [
+                  {
+                    "version_added": "97"
+                  },
+                  {
+                    "version_added": "91",
+                    "version_removed": "97",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "layout.css.d-property.enabled",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
+                "firefox_android": {
+                  "version_added": "97"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "60"
+                },
+                "opera_android": {
+                  "version_added": "51"
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": "6.0"
+                },
+                "webview_android": {
+                  "version_added": "52"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }

--- a/svg/elements/path.json
+++ b/svg/elements/path.json
@@ -98,7 +98,7 @@
           "path": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/path()",
-              "description": "<code>path()</code> function can be used to set value in CSS",
+              "description": "<code>d</code> as CSS property supports <code>path()</code>",
               "support": {
                 "chrome": {
                   "version_added": "52"


### PR DESCRIPTION
FF97 ships the bug [Ship d property and make SVG path d attribute as the presentation attribute](https://bugzilla.mozilla.org/show_bug.cgi?id=1744599) which was implemented behind pref in FF91 https://bugzilla.mozilla.org/show_bug.cgi?id=1340422

My understanding is that essentially this means you can now call `path()` on the `d` property of an SVG path element in CSS. There is a cool little demo here: https://codepen.io/airen/pen/wgNEQo

So what I have done here is for `path()` added a NOTE about the introduction of the feature in FF91 and a new version for FF97 that removes the preference. For FF android the preference does not work from FF79 so I just put that as the end version.

> **NOTE:** I am not 100% certain about the partial implementation, but I will query that separately. This could go in as "no worse". 

> NOTE: Chrome also supports this in CSS now too, so that would have to be tested.

--- 
As a separate PR to follow ...

In addition, I THINK it would be useful to update the [`d` attribute](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d) to indicate that from FF97 it is now a "presentation attribute", which is what allows it to be modified in CSS and set to the [`path()`](https://developer.mozilla.org/en-US/docs/Web/CSS/path()) or `none`. Not sure right way to do this - subfeature "supports_css_path()" or similar. Or would we do this as a "reversed" one - e.g. not_supports_css_path. Note that current chrome does do the right thing.  @ddbeck Advice?

Further, any reason not to add these spec URLs that are currently manually in the page here https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d#specifications ?

