### PR TITLE
Add a note of `Option` before IE 10

### DIFF
--- a/api/HTMLOptionElement.json
+++ b/api/HTMLOptionElement.json
@@ -70,7 +70,8 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "5.5"
+              "version_added": "5.5",
+              "notes": "Before Internet Explorer 9, the <code>outerHTML</code> of elements lose their text when constructing with <code>new Option()</code>."
             },
             "opera": {
               "version_added": "≤12.1"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

To describe the behaviour of elements constructed with `Option` before IE10, the `outerHTML` of which should miss the text.

#### Test results and supporting details

I have tested under IE8 / IE9 with the following snippet:

```js
console.log(new Option('text', 'value').outerHTML); // => "<OPTION value=value></OPTION>"
```

And the standard behaviour should be:

```js
console.log(new Option('text', 'value').outerHTML); // => "<option value="value">text</option>"
```
