### PR TITLE
Update firefox to version 96

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -687,27 +687,28 @@
         "95": {
           "release_date": "2021-12-07",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/95",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "95"
         },
         "96": {
           "release_date": "2022-01-11",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/96",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "96"
         },
         "97": {
           "release_date": "2022-02-08",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/97",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "97"
         },
         "98": {
           "release_date": "2022-03-08",
-          "status": "planned",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/98",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "98"
         }

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -553,27 +553,28 @@
         "95": {
           "release_date": "2021-12-07",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/95",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "95"
         },
         "96": {
           "release_date": "2022-01-11",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/96",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "96"
         },
         "97": {
           "release_date": "2022-02-08",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/97",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "97"
         },
         "98": {
           "release_date": "2022-03-08",
-          "status": "planned",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/98",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "98"
         }


### PR DESCRIPTION
A new version of firefox was released today.

Just updating the `browsers/firefox.json` and `browsers/firefox_android.json` files.

Fixes #14504.