### PR TITLE
Add a note of URL Constructor in Chrome under MacOS

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -123,7 +123,8 @@
           "description": "<code>URL()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "19"
+              "version_added": "19",
+              "notes": "Under MacOS, Chrome failed to construct URL with given <code>file://</code>."
             },
             "chrome_android": {
               "version_added": "25"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Recently, I found that Chrome had different behaviours when constructing URL with following patter:

```js
new URL('file:///C:/test.png') // => OK
new URL('file://C:/test.png') // => Throw Error: Invalid URL
```

In Windows, both are ok.

#### Polyfill

A possible workaround: https://github.com/aleen42/core-web/blob/main/lib/stable/URL/index.js
