### PR TITLE
Mark support for additional -webkit-prefixed properties in Edge 12

### DIFF
--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -39,9 +39,15 @@
                   "version_added": "25"
                 }
               ],
-              "edge": {
-                "version_added": "12"
-              },
+              "edge": [
+                {
+                  "version_added": "12"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "12"
+                }
+              ],
               "firefox": [
                 {
                   "version_added": "20",

--- a/css/properties/animation-delay.json
+++ b/css/properties/animation-delay.json
@@ -24,9 +24,15 @@
                 "version_added": "18"
               }
             ],
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "16",

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -12,7 +12,6 @@
               },
               {
                 "version_added": "1",
-                "version_removed": "64",
                 "prefix": "-webkit-",
                 "notes": "Chrome accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
@@ -23,14 +22,20 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "64",
                 "prefix": "-webkit-",
                 "notes": "Chrome accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12",
+                "notes": "Since Edge 79, accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
+              }
+            ],
             "firefox": [
               {
                 "version_added": "4"
@@ -66,7 +71,6 @@
               },
               {
                 "version_added": "15",
-                "version_removed": "51",
                 "prefix": "-webkit-",
                 "notes": "Opera accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
@@ -77,7 +81,6 @@
               },
               {
                 "version_added": "14",
-                "version_removed": "47",
                 "prefix": "-webkit-",
                 "notes": "Opera accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
@@ -99,8 +102,7 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "1.0",
-                "version_removed": "9.0",
-                "notes": "Chrome accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "Samsung Internet accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
             "webview_android": [
@@ -109,7 +111,6 @@
               },
               {
                 "version_added": "≤37",
-                "version_removed": "64",
                 "prefix": "-webkit-",
                 "notes": "WebView accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }

--- a/css/properties/background-origin.json
+++ b/css/properties/background-origin.json
@@ -12,7 +12,6 @@
               },
               {
                 "version_added": "1",
-                "version_removed": "64",
                 "prefix": "-webkit-",
                 "notes": "Chrome accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
@@ -23,14 +22,20 @@
               },
               {
                 "version_added": "18",
-                "version_removed": "64",
                 "prefix": "-webkit-",
                 "notes": "Chrome accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12",
+                "notes": "Since Edge 79, accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
+              }
+            ],
             "firefox": [
               {
                 "version_added": "4"
@@ -66,7 +71,6 @@
               },
               {
                 "version_added": "15",
-                "version_removed": "51",
                 "prefix": "-webkit-",
                 "notes": "Opera accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
@@ -77,7 +81,6 @@
               },
               {
                 "version_added": "14",
-                "version_removed": "47",
                 "prefix": "-webkit-",
                 "notes": "Opera accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
@@ -109,8 +112,7 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "1.0",
-                "version_removed": "9.0",
-                "notes": "Chrome accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
+                "notes": "Samsung Internet accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
             "webview_android": [
@@ -119,7 +121,6 @@
               },
               {
                 "version_added": "4",
-                "version_removed": "64",
                 "prefix": "-webkit-",
                 "notes": "WebView accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }

--- a/css/properties/background-size.json
+++ b/css/properties/background-size.json
@@ -26,9 +26,15 @@
                 "notes": "WebKit-based browsers originally implemented an older draft of CSS3 <code>background-size</code> in which an omitted second value is treated as duplicating the first value; this draft does not include the <code>contain</code> or <code>cover</code> keywords."
               }
             ],
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "4"


### PR DESCRIPTION
This is based on these tests in Edge 13, 18 and 79:
http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=9958
http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=9956

That support was in Edge 12 can be seen in Web API Confluence:
http://web-confluence.appspot.com/#!/catalog?releases=%5B%22Edge_12.10240_Windows_10.0%22%5D&q=%22CSSStyleDeclaration%23webkit%22

The notes and removal versions from background-clip and
background-origin had some errors, so fix that to carefully capture that
Edge supports the keyword aliases from Edge 79 but not in Edge 12-18.