### PR TITLE
Update release html dialog which is switch on by default in Firefox 98

### DIFF
--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -14,28 +14,37 @@
           "edge": {
             "version_added": "79"
           },
-          "firefox": {
-            "version_added": "53",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.dialog_element.enabled",
-                "value_to_set": "true"
-              }
-            ],
-            "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-          },
-          "firefox_android": {
-            "version_added": "53",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.dialog_element.enabled",
-                "value_to_set": "true"
-              }
-            ],
-            "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-          },
+          "firefox": [
+            {
+              "version_added": "98"
+            },
+            {
+              "version_added": "53",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.dialog_element.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "firefox_android": [
+            {
+              "version_added": "98"
+            },
+            {
+              "version_added": "53",
+              "version_removed": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.dialog_element.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "ie": {
             "version_added": false
           },
@@ -79,27 +88,23 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "78",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.dialog_element.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "98"
+              },
+              {
+                "version_added": "78",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.dialog_element.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.dialog_element.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
+              "version_added": "98"
             },
             "ie": {
               "version_added": false
@@ -144,28 +149,37 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.dialog_element.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-            },
-            "firefox_android": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.dialog_element.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "98"
+              },
+              {
+                "version_added": "53",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.dialog_element.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "98"
+              },
+              {
+                "version_added": "53",
+                "version_removed": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.dialog_element.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -211,10 +225,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "98"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "98"
             },
             "ie": {
               "version_added": false
@@ -259,28 +273,37 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.dialog_element.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-            },
-            "firefox_android": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.dialog_element.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "98"
+              },
+              {
+                "version_added": "53",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.dialog_element.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "98"
+              },
+              {
+                "version_added": "53",
+                "version_removed": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.dialog_element.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -324,28 +347,37 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.dialog_element.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-            },
-            "firefox_android": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.dialog_element.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "98"
+              },
+              {
+                "version_added": "53",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.dialog_element.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "98"
+              },
+              {
+                "version_added": "53",
+                "version_removed": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.dialog_element.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -389,28 +421,37 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.dialog_element.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-            },
-            "firefox_android": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.dialog_element.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "98"
+              },
+              {
+                "version_added": "53",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.dialog_element.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "98"
+              },
+              {
+                "version_added": "53",
+                "version_removed": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.dialog_element.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -454,28 +495,37 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.dialog_element.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-            },
-            "firefox_android": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.dialog_element.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "98"
+              },
+              {
+                "version_added": "53",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.dialog_element.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "98"
+              },
+              {
+                "version_added": "53",
+                "version_removed": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.dialog_element.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/html/elements/dialog.json
+++ b/html/elements/dialog.json
@@ -15,28 +15,37 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.dialog_element.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-            },
-            "firefox_android": {
-              "version_added": "53",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.dialog_element.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "98"
+              },
+              {
+                "version_added": "53",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.dialog_element.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "98"
+              },
+              {
+                "version_added": "53",
+                "version_removed": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.dialog_element.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -77,28 +86,37 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": {
-                "version_added": "53",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.dialog_element.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-              },
-              "firefox_android": {
-                "version_added": "53",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.dialog_element.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "See <a href='https://bugzil.la/840640'>bug 840640</a>."
-              },
+              "firefox": [
+                {
+                  "version_added": "98"
+                },
+                {
+                  "version_added": "53",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.dialog_element.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "98"
+                },
+                {
+                  "version_added": "53",
+                  "version_removed": "79",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.dialog_element.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
#### Summary
Update release html dialog which is switch on by default in Firefox 98

#### Test results and supporting details
[https://bugzilla.mozilla.org/show_bug.cgi?id=1733536](https://bugzilla.mozilla.org/show_bug.cgi?id=1733536) - the bug which switch on html dialog  by default.
