### PR TITLE
Added Safari 15 support for Private class fields 'in'

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -575,10 +575,10 @@
               "version_added": "64"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15"
             },
             "samsunginternet_android": {
               "version_added": "16.0"


### PR DESCRIPTION
#### Summary
Private class fields with "in" is already supported in Safari 15.0.

#### Test results and supporting details
Verification provided by a WebKit JavaScriptCore engineer.