### PR TITLE
Firefox 96+ supports hwb()

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -566,10 +566,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": "96"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "96"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1352755