### PR TITLE
Show Safari also supports Atomics (gated by COOP/COEP)

### DIFF
--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -105,14 +105,26 @@
             "opera_android": {
               "version_added": false
             },
-            "safari": {
-              "version_added": "10.1",
-              "version_removed": "11.1"
-            },
-            "safari_ios": {
-              "version_added": "10.3",
-              "version_removed": "11.3"
-            },
+            "safari": [
+              {
+                "version_added": "15.2",
+                "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+              },
+              {
+                "version_added": "10.1",
+                "version_removed": "11.1"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "15.2",
+                "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+              },
+              {
+                "version_added": "10.3",
+                "version_removed": "11.3"
+              }
+            ],
             "samsunginternet_android": {
               "version_added": false,
               "notes": "Chrome disabled <code>SharedArrayBuffer</code> on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
@@ -428,14 +440,26 @@
               "opera_android": {
                 "version_added": false
               },
-              "safari": {
-                "version_added": "10.1",
-                "version_removed": "11.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3",
-                "version_removed": "11.3"
-              },
+              "safari": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.1",
+                  "version_removed": "11.1"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.3",
+                  "version_removed": "11.3"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": false,
                 "notes": "Chrome disabled <code>SharedArrayBuffer</code> on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
@@ -557,14 +581,26 @@
               "opera_android": {
                 "version_added": false
               },
-              "safari": {
-                "version_added": "10.1",
-                "version_removed": "11.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3",
-                "version_removed": "11.3"
-              },
+              "safari": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.1",
+                  "version_removed": "11.1"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.3",
+                  "version_removed": "11.3"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": false,
                 "notes": "Chrome disabled <code>SharedArrayBuffer</code> on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
@@ -686,14 +722,26 @@
               "opera_android": {
                 "version_added": false
               },
-              "safari": {
-                "version_added": "10.1",
-                "version_removed": "11.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3",
-                "version_removed": "11.3"
-              },
+              "safari": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.1",
+                  "version_removed": "11.1"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.3",
+                  "version_removed": "11.3"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": false,
                 "notes": "Chrome disabled <code>SharedArrayBuffer</code> on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
@@ -815,14 +863,26 @@
               "opera_android": {
                 "version_added": false
               },
-              "safari": {
-                "version_added": "10.1",
-                "version_removed": "11.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3",
-                "version_removed": "11.3"
-              },
+              "safari": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.1",
+                  "version_removed": "11.1"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.3",
+                  "version_removed": "11.3"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": false,
                 "notes": "Chrome disabled <code>SharedArrayBuffer</code> on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
@@ -944,14 +1004,26 @@
               "opera_android": {
                 "version_added": false
               },
-              "safari": {
-                "version_added": "10.1",
-                "version_removed": "11.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3",
-                "version_removed": "11.3"
-              },
+              "safari": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.1",
+                  "version_removed": "11.1"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.3",
+                  "version_removed": "11.3"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": false,
                 "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
@@ -1119,15 +1191,27 @@
               "opera_android": {
                 "version_added": false
               },
-              "safari": {
-                "version_added": "10.1",
-                "version_removed": "11.1",
-                "alternative_name": "wake"
-              },
-              "safari_ios": {
-                "version_added": "10.3",
-                "version_removed": "11.3"
-              },
+              "safari": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.1",
+                  "version_removed": "11.1",
+                  "alternative_name": "wake"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.3",
+                  "version_removed": "11.3"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": false,
                 "alternative_name": "wake",
@@ -1251,14 +1335,26 @@
               "opera_android": {
                 "version_added": false
               },
-              "safari": {
-                "version_added": "10.1",
-                "version_removed": "11.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3",
-                "version_removed": "11.3"
-              },
+              "safari": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.1",
+                  "version_removed": "11.1"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.3",
+                  "version_removed": "11.3"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": false,
                 "notes": "Chrome disabled <code>SharedArrayBuffer</code> on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
@@ -1380,14 +1476,26 @@
               "opera_android": {
                 "version_added": false
               },
-              "safari": {
-                "version_added": "10.1",
-                "version_removed": "11.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3",
-                "version_removed": "11.3"
-              },
+              "safari": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.1",
+                  "version_removed": "11.1"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.3",
+                  "version_removed": "11.3"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": false,
                 "notes": "Chrome disabled <code>SharedArrayBuffer</code> on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
@@ -1509,14 +1617,26 @@
               "opera_android": {
                 "version_added": false
               },
-              "safari": {
-                "version_added": "10.1",
-                "version_removed": "11.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3",
-                "version_removed": "11.3"
-              },
+              "safari": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.1",
+                  "version_removed": "11.1"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.3",
+                  "version_removed": "11.3"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": false,
                 "notes": "Chrome disabled SharedArrayBuffer on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
@@ -1664,14 +1784,26 @@
               "opera_android": {
                 "version_added": false
               },
-              "safari": {
-                "version_added": "10.1",
-                "version_removed": "11.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3",
-                "version_removed": "11.3"
-              },
+              "safari": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.1",
+                  "version_removed": "11.1"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.3",
+                  "version_removed": "11.3"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": false,
                 "notes": "Chrome disabled <code>SharedArrayBuffer</code> on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
@@ -1793,14 +1925,26 @@
               "opera_android": {
                 "version_added": false
               },
-              "safari": {
-                "version_added": "10.1",
-                "version_removed": "11.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3",
-                "version_removed": "11.3"
-              },
+              "safari": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.1",
+                  "version_removed": "11.1"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.3",
+                  "version_removed": "11.3"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": false,
                 "notes": "Chrome disabled <code>SharedArrayBuffer</code> on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."

--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -287,14 +287,26 @@
               "opera_android": {
                 "version_added": false
               },
-              "safari": {
-                "version_added": "10.1",
-                "version_removed": "11.1"
-              },
-              "safari_ios": {
-                "version_added": "10.3",
-                "version_removed": "11.3"
-              },
+              "safari": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.1",
+                  "version_removed": "11"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "15.2",
+                  "notes": "Like <code>SharedArrayBuffer</code>, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.3",
+                  "version_removed": "11.3"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": false,
                 "notes": "Chrome disabled <code>SharedArrayBuffer</code> on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."

--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -306,7 +306,7 @@
                 },
                 {
                   "version_added": "10.1",
-                  "version_removed": "11"
+                  "version_removed": "11.1"
                 }
               ],
               "safari_ios": [


### PR DESCRIPTION
#### Summary

In Safari version 15.2, Safari re-enabled `SharedArrayBuffer` but they also re-enabled `Atomics` but it was not mentioned in the release notes.

On top of that, `Atomics.wake` appears to have been renamed to `Atomics.notify` in line with other browsers and the spec that changed. https://github.com/tc39/ecma262/pull/1220

#### Test results and supporting details

I've tested it myself in MacOS Safari 15.2. Note that other browsers support `Atomics` all the time, regardless of COOP/COEP headers but in Safari 15.2 `Atomics` is not defined unless in a cross-origin isolated context (if `SharedArrayBuffer` works, it also works).

I've built a little testing site with the cross-origin headers set correctly: https://atomics-browser-test.web.app/

Code is here: https://github.com/katharosada/atomics-test

I don't have a device with iOS but friends have reported the testing site is all green if on Safari 15.2 and the 15.3 public beta.

#### Supporting information

I've tried to follow the paper trail as best I can to figure out why it wasn't mentioned in the release notes.

Release notes for Safari 15.2 say that `SharedArrayBuffer` is enabled but do not mention `Atomics`: https://developer.apple.com/documentation/safari-release-notes/safari-15_2-release-notes 

However, preview release notes for past versions clearly state that `Atomics` are enabled under the same feature flag: `JSC_useSharedArrayBuffer`. See: https://developer.apple.com/safari/technology-preview/release-notes/ 

And the release notes that describe enabling `SharedArrayBuffer` do so by enabling the JSC flag - as outlined in the linked changeset: https://trac.webkit.org/changeset/281832/webkit/

#### Related issues

https://github.com/mdn/browser-compat-data/pull/14056