### PR TITLE
Mark remove_filling_animation supported in Chromium

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -968,15 +968,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation#Automatically_removing_filling_animations",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "Currently Chrome Canary only"
+              "version_added": "84"
             },
             "chrome_android": {
-              "version_added": false,
-              "notes": "Currently Chrome Canary only"
+              "version_added": "84"
             },
             "edge": {
-              "version_added": false
+              "version_added": "84"
             },
             "firefox": {
               "version_added": "75"
@@ -988,10 +986,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "70"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "safari": {
               "version_added": "13.1"
@@ -1000,10 +998,10 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "14.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "84"
             }
           },
           "status": {


### PR DESCRIPTION
This was implemented in Chromium 81:
https://storage.googleapis.com/chromium-find-releases-static/e26.html#e26d3044c41ff8e863789d8e982bf046d375256f

But it was part of the Web Animations API, shipped in 84:
https://storage.googleapis.com/chromium-find-releases-static/9cd.html#9cdcb106b0bcfee75cf3e94576fd48c055cc4bd6