### PR TITLE
Fix nesting of `grid-template-rows: masonry`

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -168,6 +168,62 @@
             }
           }
         },
+        "masonry": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-grid-3/#masonry-layout",
+            "description": "<code>masonry</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "77",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.grid-template-masonry-value.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "minmax": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/minmax()",
@@ -366,63 +422,6 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        }
-      },
-      "masonry": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/CSS_Grid_Layout/Masonry_Layout",
-          "spec_url": "https://drafts.csswg.org/css-grid-3/#masonry-layout",
-          "description": "<code>masonry</code>",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": "77",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.grid-template-masonry-value.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
           }
         }
       }


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

`css.properties.grid-template-rows.masonry` was improperly nested as `css.properties.masonry`. This moves the value to the right place.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

As reported by @GPHemsley in https://github.com/mdn/browser-compat-data/pull/9078#issuecomment-1014064807.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Related to https://github.com/mdn/browser-compat-data/pull/9078 and https://github.com/mdn/browser-compat-data/pull/7249.

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
