### PR TITLE
Set ESR status on correct version

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -442,7 +442,7 @@
         "60": {
           "release_date": "2018-05-09",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/60",
-          "status": "esr",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "60"
         },
@@ -659,7 +659,7 @@
         "91": {
           "release_date": "2021-08-10",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/91",
-          "status": "retired",
+          "status": "esr",
           "engine": "Gecko",
           "engine_version": "91"
         },


### PR DESCRIPTION
Firefox 60 isn't ESR anymore, it's Firefox 91 those days