### PR TITLE
Update the spec link of `Element`'s `contextmenu` event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2160,7 +2160,7 @@
       "contextmenu_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/contextmenu_event",
-          "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-contextmenu",
+          "spec_url": "https://w3c.github.io/uievents/#event-type-contextmenu",
           "description": "<code>contextmenu</code> event",
           "support": {
             "chrome": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
The `contextmenu` event used to be defined by the HTML spec, but it is now defined in the UI Events spec.

#### Test results and supporting details
N/A

#### Related issues
whatwg/html#7505
