### PR TITLE
Fixed protocol_handlers typo

### DIFF
--- a/html/manifest/protocol_handlers.json
+++ b/html/manifest/protocol_handlers.json
@@ -1,9 +1,9 @@
 {
   "html": {
     "manifest": {
-      "protocol_handler": {
+      "protocol_handlers": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/protocol_handler",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/protocol_handlers",
           "spec_url": "https://wicg.github.io/manifest-incubations/#protocol_handlers-member",
           "support": {
             "chrome": {


### PR DESCRIPTION
#### Summary

The Web Apps Manifest member name is: `protocol_handlers` with an S at the end.
So I'm fixing a couple of typos in the JSON file, including the link to the corresponding MDN page.