### PR TITLE
Update the CSS attr() function spec URL

### DIFF
--- a/css/types/attr.json
+++ b/css/types/attr.json
@@ -4,7 +4,7 @@
       "attr": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/attr()",
-          "spec_url": "https://drafts.csswg.org/css-values/#attr-notation",
+          "spec_url": "https://drafts.csswg.org/css-values-5/#attr-notation",
           "description": "<code>attr()</code>",
           "support": {
             "chrome": {


### PR DESCRIPTION
`attr()` is no longer in the css-values (level 4) spec; it was moved to the css-values-5 spec.

https://drafts.csswg.org/css-values/#changes-recent
> Deferred toggle() and attr() to Level 5.