### PR TITLE
Update a bunch of css-conditional spec URLs

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -1501,7 +1501,7 @@
       "supports": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/supports",
-          "spec_url": "https://drafts.csswg.org/css-conditional/#ref-for-dom-css-supports",
+          "spec_url": "https://drafts.csswg.org/css-conditional-3/#ref-for-dom-css-supports",
           "support": {
             "chrome": [
               {

--- a/api/CSSConditionRule.json
+++ b/api/CSSConditionRule.json
@@ -3,7 +3,7 @@
     "CSSConditionRule": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSConditionRule",
-        "spec_url": "https://drafts.csswg.org/css-conditional/#the-cssconditionrule-interface",
+        "spec_url": "https://drafts.csswg.org/css-conditional-3/#the-cssconditionrule-interface",
         "support": {
           "chrome": {
             "version_added": "56"
@@ -51,7 +51,7 @@
       "conditionText": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSConditionRule/conditionText",
-          "spec_url": "https://drafts.csswg.org/css-conditional/#dom-cssconditionrule-conditiontext",
+          "spec_url": "https://drafts.csswg.org/css-conditional-3/#dom-cssconditionrule-conditiontext",
           "support": {
             "chrome": {
               "version_added": "56"

--- a/api/CSSMediaRule.json
+++ b/api/CSSMediaRule.json
@@ -3,7 +3,7 @@
     "CSSMediaRule": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMediaRule",
-        "spec_url": "https://drafts.csswg.org/css-conditional/#the-cssmediarule-interface",
+        "spec_url": "https://drafts.csswg.org/css-conditional-3/#the-cssmediarule-interface",
         "support": {
           "chrome": {
             "version_added": "1"
@@ -53,7 +53,7 @@
       "media": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMediaRule/media",
-          "spec_url": "https://drafts.csswg.org/css-conditional/#dom-cssmediarule-media",
+          "spec_url": "https://drafts.csswg.org/css-conditional-3/#dom-cssmediarule-media",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/CSSSupportsRule.json
+++ b/api/CSSSupportsRule.json
@@ -3,7 +3,7 @@
     "CSSSupportsRule": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSSupportsRule",
-        "spec_url": "https://drafts.csswg.org/css-conditional/#the-csssupportsrule-interface",
+        "spec_url": "https://drafts.csswg.org/css-conditional-3/#the-csssupportsrule-interface",
         "support": {
           "chrome": {
             "version_added": "28"

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media",
           "spec_url": [
             "https://drafts.csswg.org/mediaqueries/#media-descriptor-table",
-            "https://drafts.csswg.org/css-conditional/#at-media"
+            "https://drafts.csswg.org/css-conditional-3/#at-media"
           ],
           "support": {
             "chrome": {

--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -7,7 +7,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@supports",
           "spec_url": [
             "https://drafts.csswg.org/css-conditional-4/#at-supports-ext",
-            "https://drafts.csswg.org/css-conditional/#at-supports"
+            "https://drafts.csswg.org/css-conditional-3/#at-supports"
           ],
           "support": {
             "chrome": {


### PR DESCRIPTION
These URLs were all part of the Level 3 spec, which used to be the unversioned `css-conditional` spec — but the unversioned `css-conditional` spec is now the Level 4 spec, which doesn’t contain the targets in these URLs.