### PR TITLE
Change all web-animations spec URLs to web-animations-1

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -3,7 +3,7 @@
     "Animation": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation",
-        "spec_url": "https://drafts.csswg.org/web-animations/#the-animation-interface",
+        "spec_url": "https://drafts.csswg.org/web-animations-1/#the-animation-interface",
         "support": {
           "chrome": [
             {
@@ -72,7 +72,7 @@
       "Animation": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/Animation",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-animation",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-animation",
           "description": "<code>Animation()</code> constructor",
           "support": {
             "chrome": {
@@ -122,7 +122,7 @@
       "cancel": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/cancel",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-cancel",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-cancel",
           "support": {
             "chrome": {
               "version_added": "39"
@@ -171,7 +171,7 @@
       "commitStyles": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/commitStyles",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-commitstyles",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-commitstyles",
           "support": {
             "chrome": {
               "version_added": "84"
@@ -220,7 +220,7 @@
       "currentTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/currentTime",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-currenttime",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-currenttime",
           "support": {
             "chrome": {
               "version_added": "39"
@@ -269,7 +269,7 @@
       "effect": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/effect",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-effect",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-effect",
           "support": {
             "chrome": {
               "version_added": "75"
@@ -318,7 +318,7 @@
       "finish": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/finish",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-finish",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-finish",
           "support": {
             "chrome": {
               "version_added": "39"
@@ -367,7 +367,7 @@
       "finished": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/finished",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-finished",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-finished",
           "support": {
             "chrome": {
               "version_added": "84"
@@ -416,7 +416,7 @@
       "id": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/id",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-id",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-id",
           "support": {
             "chrome": {
               "version_added": "50"
@@ -465,7 +465,7 @@
       "oncancel": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/oncancel",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-oncancel",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-oncancel",
           "support": {
             "chrome": {
               "version_added": "50"
@@ -514,7 +514,7 @@
       "onfinish": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/onfinish",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-onfinish",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-onfinish",
           "support": {
             "chrome": {
               "version_added": "39"
@@ -563,7 +563,7 @@
       "onremove": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/onremove",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-onremove",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-onremove",
           "support": {
             "chrome": {
               "version_added": "84"
@@ -612,7 +612,7 @@
       "pause": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/pause",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-pause",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-pause",
           "support": {
             "chrome": {
               "version_added": "39"
@@ -661,7 +661,7 @@
       "pending": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/pending",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-pending",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-pending",
           "support": {
             "chrome": {
               "version_added": "76"
@@ -712,7 +712,7 @@
       "persist": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/persist",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-persist",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-persist",
           "support": {
             "chrome": {
               "version_added": "84"
@@ -761,7 +761,7 @@
       "play": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/play",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-play",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-play",
           "support": {
             "chrome": {
               "version_added": "39"
@@ -810,7 +810,7 @@
       "playbackRate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/playbackRate",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-playbackrate",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-playbackrate",
           "support": {
             "chrome": {
               "version_added": "39"
@@ -859,7 +859,7 @@
       "playState": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/playState",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-playstate",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-playstate",
           "support": {
             "chrome": {
               "version_added": "39",
@@ -916,7 +916,7 @@
       "ready": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/ready",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-ready",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-ready",
           "support": {
             "chrome": {
               "version_added": "84"
@@ -1016,7 +1016,7 @@
       "replaceState": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/replaceState",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-replacestate",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-replacestate",
           "support": {
             "chrome": {
               "version_added": "84"
@@ -1065,7 +1065,7 @@
       "reverse": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/reverse",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-reverse",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-reverse",
           "support": {
             "chrome": {
               "version_added": "39"
@@ -1114,7 +1114,7 @@
       "startTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/startTime",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-starttime",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-starttime",
           "support": {
             "chrome": {
               "version_added": "39"
@@ -1163,7 +1163,7 @@
       "timeline": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/timeline",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-timeline",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-timeline",
           "support": {
             "chrome": {
               "version_added": "84"
@@ -1216,7 +1216,7 @@
       "updatePlaybackRate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation/updatePlaybackRate",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animation-updateplaybackrate",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-updateplaybackrate",
           "support": {
             "chrome": {
               "version_added": "76"

--- a/api/AnimationEffect.json
+++ b/api/AnimationEffect.json
@@ -3,7 +3,7 @@
     "AnimationEffect": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationEffect",
-        "spec_url": "https://drafts.csswg.org/web-animations/#the-animationeffect-interface",
+        "spec_url": "https://drafts.csswg.org/web-animations-1/#the-animationeffect-interface",
         "support": {
           "chrome": {
             "version_added": "75"
@@ -65,7 +65,7 @@
       "getComputedTiming": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationEffect/getComputedTiming",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animationeffect-getcomputedtiming",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animationeffect-getcomputedtiming",
           "support": {
             "chrome": {
               "version_added": "75"
@@ -114,7 +114,7 @@
       "getTiming": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationEffect/getTiming",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animationeffect-gettiming",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animationeffect-gettiming",
           "support": {
             "chrome": {
               "version_added": "75"
@@ -163,7 +163,7 @@
       "updateTiming": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationEffect/updateTiming",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animationeffect-updatetiming",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animationeffect-updatetiming",
           "support": {
             "chrome": {
               "version_added": "75"

--- a/api/AnimationPlaybackEvent.json
+++ b/api/AnimationPlaybackEvent.json
@@ -3,7 +3,7 @@
     "AnimationPlaybackEvent": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationPlaybackEvent",
-        "spec_url": "https://drafts.csswg.org/web-animations/#the-animationplaybackevent-interface",
+        "spec_url": "https://drafts.csswg.org/web-animations-1/#the-animationplaybackevent-interface",
         "support": {
           "chrome": {
             "version_added": "84"
@@ -51,7 +51,7 @@
       "AnimationPlaybackEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationPlaybackEvent/AnimationPlaybackEvent",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animationplaybackevent-animationplaybackevent",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animationplaybackevent-animationplaybackevent",
           "description": "<code>AnimationPlaybackEvent()</code> constructor",
           "support": {
             "chrome": {
@@ -101,7 +101,7 @@
       "currentTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationPlaybackEvent/currentTime",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animationplaybackevent-currenttime",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animationplaybackevent-currenttime",
           "support": {
             "chrome": {
               "version_added": "84"
@@ -150,7 +150,7 @@
       "timelineTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationPlaybackEvent/timelineTime",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animationplaybackevent-timelinetime",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animationplaybackevent-timelinetime",
           "support": {
             "chrome": {
               "version_added": "84"

--- a/api/AnimationTimeline.json
+++ b/api/AnimationTimeline.json
@@ -3,7 +3,7 @@
     "AnimationTimeline": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationTimeline",
-        "spec_url": "https://drafts.csswg.org/web-animations/#the-animationtimeline-interface",
+        "spec_url": "https://drafts.csswg.org/web-animations-1/#the-animationtimeline-interface",
         "support": {
           "chrome": {
             "version_added": "84"
@@ -75,7 +75,7 @@
       "currentTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationTimeline/currentTime",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animationtimeline-currenttime",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animationtimeline-currenttime",
           "support": {
             "chrome": {
               "version_added": "84"

--- a/api/Document.json
+++ b/api/Document.json
@@ -10547,7 +10547,7 @@
       "timeline": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/timeline",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-document-timeline",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-document-timeline",
           "support": {
             "chrome": {
               "version_added": "84"

--- a/api/DocumentTimeline.json
+++ b/api/DocumentTimeline.json
@@ -3,7 +3,7 @@
     "DocumentTimeline": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentTimeline",
-        "spec_url": "https://drafts.csswg.org/web-animations/#the-documenttimeline-interface",
+        "spec_url": "https://drafts.csswg.org/web-animations-1/#the-documenttimeline-interface",
         "support": {
           "chrome": {
             "version_added": "84"
@@ -77,7 +77,7 @@
       "DocumentTimeline": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentTimeline/DocumentTimeline",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-documenttimeline-documenttimeline",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-documenttimeline-documenttimeline",
           "description": "<code>DocumentTimeline()</code> constructor",
           "support": {
             "chrome": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -918,7 +918,7 @@
         "options_iterationComposite_parameter": {
           "__compat": {
             "description": "<code>options.iterationComposite</code> parameter",
-            "spec_url": "https://drafts.csswg.org/web-animations-1-2/#dom-keyframeeffectoptions-iterationcomposite",
+            "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-keyframeeffectoptions-iterationcomposite",
             "support": {
               "chrome": {
                 "version_added": false

--- a/api/Element.json
+++ b/api/Element.json
@@ -654,7 +654,7 @@
       "animate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/animate",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animatable-animate",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animatable-animate",
           "support": {
             "chrome": {
               "version_added": "36"
@@ -777,7 +777,7 @@
         "options_composite_parameter": {
           "__compat": {
             "description": "<code>options.composite</code> parameter",
-            "spec_url": "https://drafts.csswg.org/web-animations/#dom-keyframeeffectoptions-composite",
+            "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-keyframeeffectoptions-composite",
             "support": {
               "chrome": {
                 "version_added": "79",
@@ -869,7 +869,7 @@
         "options_id_parameter": {
           "__compat": {
             "description": "<code>options.id</code> parameter",
-            "spec_url": "https://drafts.csswg.org/web-animations/#dom-keyframeanimationoptions-id",
+            "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-keyframeanimationoptions-id",
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -918,7 +918,7 @@
         "options_iterationComposite_parameter": {
           "__compat": {
             "description": "<code>options.iterationComposite</code> parameter",
-            "spec_url": "https://drafts.csswg.org/web-animations-2/#dom-keyframeeffectoptions-iterationcomposite",
+            "spec_url": "https://drafts.csswg.org/web-animations-1-2/#dom-keyframeeffectoptions-iterationcomposite",
             "support": {
               "chrome": {
                 "version_added": false
@@ -986,7 +986,7 @@
         "options_pseudoElement_parameter": {
           "__compat": {
             "description": "<code>options.pseudoElement</code> parameter",
-            "spec_url": "https://drafts.csswg.org/web-animations/#dom-keyframeeffectoptions-pseudoelement",
+            "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-keyframeeffectoptions-pseudoelement",
             "support": {
               "chrome": {
                 "version_added": "81",
@@ -3109,7 +3109,7 @@
       "getAnimations": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/getAnimations",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-animatable-getanimations",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animatable-getanimations",
           "support": {
             "chrome": [
               {

--- a/api/KeyframeEffect.json
+++ b/api/KeyframeEffect.json
@@ -225,7 +225,7 @@
       "iterationComposite": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyframeEffect/iterationComposite",
-          "spec_url": "https://drafts.csswg.org/web-animations-1-2/#dom-keyframeeffect-iterationcomposite",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-iterationcomposite",
           "support": {
             "chrome": {
               "version_added": false

--- a/api/KeyframeEffect.json
+++ b/api/KeyframeEffect.json
@@ -3,7 +3,7 @@
     "KeyframeEffect": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyframeEffect",
-        "spec_url": "https://drafts.csswg.org/web-animations/#the-keyframeeffect-interface",
+        "spec_url": "https://drafts.csswg.org/web-animations-1/#the-keyframeeffect-interface",
         "support": {
           "chrome": {
             "version_added": "75"
@@ -51,7 +51,7 @@
       "KeyframeEffect": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyframeEffect/KeyframeEffect",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-keyframeeffect-keyframeeffect",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-keyframeeffect",
           "description": "<code>KeyframeEffect()</code> constructor",
           "support": {
             "chrome": {
@@ -101,7 +101,7 @@
       "composite": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyframeEffect/composite",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-keyframeeffect-composite",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-composite",
           "support": {
             "chrome": {
               "version_added": "84"
@@ -176,7 +176,7 @@
       "getKeyframes": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyframeEffect/getKeyframes",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-keyframeeffect-getkeyframes",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-getkeyframes",
           "support": {
             "chrome": {
               "version_added": "84"
@@ -225,7 +225,7 @@
       "iterationComposite": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyframeEffect/iterationComposite",
-          "spec_url": "https://drafts.csswg.org/web-animations-2/#dom-keyframeeffect-iterationcomposite",
+          "spec_url": "https://drafts.csswg.org/web-animations-1-2/#dom-keyframeeffect-iterationcomposite",
           "support": {
             "chrome": {
               "version_added": false
@@ -392,7 +392,7 @@
       "setKeyframes": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyframeEffect/setKeyframes",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-keyframeeffect-setkeyframes",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-setkeyframes",
           "support": {
             "chrome": {
               "version_added": "84"
@@ -441,7 +441,7 @@
       "target": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyframeEffect/target",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-keyframeeffect-target",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-target",
           "support": {
             "chrome": {
               "version_added": "75"

--- a/api/_mixins/DocumentOrShadowRoot__Document.json
+++ b/api/_mixins/DocumentOrShadowRoot__Document.json
@@ -340,7 +340,7 @@
       "getAnimations": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/getAnimations",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-documentorshadowroot-getanimations",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-documentorshadowroot-getanimations",
           "support": {
             "chrome": [
               {

--- a/api/_mixins/DocumentOrShadowRoot__ShadowRoot.json
+++ b/api/_mixins/DocumentOrShadowRoot__ShadowRoot.json
@@ -271,7 +271,7 @@
       "getAnimations": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/getAnimations",
-          "spec_url": "https://drafts.csswg.org/web-animations/#dom-documentorshadowroot-getanimations",
+          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-documentorshadowroot-getanimations",
           "support": {
             "chrome": [
               {


### PR DESCRIPTION
https://drafts.csswg.org/web-animations/ is now the Level 2 spec, marked “Not Ready For Implementation”, and it does not contain many of the targets the Level 1 spec contains. So, switch all URLs to point to the Level 1 spec.