### PR TITLE
Deno 1.18 release

### DIFF
--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -131,9 +131,16 @@
         },
         "1.18": {
           "release_date": "2022-01-20",
-          "status": "nightly",
+          "release_notes": "https://github.com/denoland/deno/releases/tag/v1.18.0",
+          "status": "current",
           "engine": "V8",
           "engine_version": "9.8"
+        },
+        "1.19": {
+          "release_date": "2022-02-17",
+          "status": "nightly",
+          "engine": "V8",
+          "engine_version": "9.9"
         }
       }
     }


### PR DESCRIPTION
#### Summary

Deno 1.18 is releasing today.
