### PR TITLE
Updates opera browser to version 83

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -629,19 +629,26 @@
         "82": {
           "release_date": "2021-12-02",
           "release_notes": "https://blogs.opera.com/desktop/2021/12/opera-82/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "96"
         },
         "83": {
-          "status": "beta",
+          "release_date": "2022-01-19",
+          "release_notes": "https://blogs.opera.com/desktop/2022/01/opera-83/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "97"
         },
         "84": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "98"
+        },
+        "85": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "99"
         }
       }
     }


### PR DESCRIPTION
Hi everyone!

According to this [release note](https://blogs.opera.com/desktop/2022/01/opera-83/), Opera has updated to version 83.

Fixes #14616.