### PR TITLE
Fix the iterationComposite spec URLs

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -918,7 +918,7 @@
         "options_iterationComposite_parameter": {
           "__compat": {
             "description": "<code>options.iterationComposite</code> parameter",
-            "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-keyframeeffectoptions-iterationcomposite",
+            "spec_url": "https://drafts.csswg.org/web-animations-2/#dom-keyframeeffectoptions-iterationcomposite",
             "support": {
               "chrome": {
                 "version_added": false

--- a/api/KeyframeEffect.json
+++ b/api/KeyframeEffect.json
@@ -225,7 +225,7 @@
       "iterationComposite": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyframeEffect/iterationComposite",
-          "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-iterationcomposite",
+          "spec_url": "https://drafts.csswg.org/web-animations-2/#dom-keyframeeffect-iterationcomposite",
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
This is follow-up to https://github.com/mdn/browser-compat-data/pull/14610. These targets are in the Level 2 spec but not in the Level 1 spec.