### PR TITLE
Add Cloudflare Workers to MDN compat table

### DIFF
--- a/api/AbortController.json
+++ b/api/AbortController.json
@@ -11,6 +11,9 @@
           "chrome_android": {
             "version_added": "66"
           },
+          "cloudflare_workers": {
+            "version_added": "2021-09-24"
+          },
           "deno": {
             "version_added": "1.0"
           },
@@ -79,6 +82,9 @@
             },
             "chrome_android": {
               "version_added": "66"
+            },
+            "cloudflare_workers": {
+              "version_added": "2021-09-24"
             },
             "deno": {
               "version_added": "1.0"
@@ -149,6 +155,9 @@
             "chrome_android": {
               "version_added": "66"
             },
+            "cloudflare_workers": {
+              "version_added": "2021-09-24"
+            },
             "deno": {
               "version_added": "1.0"
             },
@@ -217,6 +226,9 @@
             },
             "chrome_android": {
               "version_added": "66"
+            },
+            "cloudflare_workers": {
+              "version_added": "2021-09-24"
             },
             "deno": {
               "version_added": "1.0"

--- a/api/AbortController.json
+++ b/api/AbortController.json
@@ -12,7 +12,7 @@
             "version_added": "66"
           },
           "cloudflare_workers": {
-            "version_added": "2021-09-24"
+            "version_added": "2021.09.24"
           },
           "deno": {
             "version_added": "1.0"
@@ -84,7 +84,7 @@
               "version_added": "66"
             },
             "cloudflare_workers": {
-              "version_added": "2021-09-24"
+              "version_added": "2021.09.24"
             },
             "deno": {
               "version_added": "1.0"
@@ -156,7 +156,7 @@
               "version_added": "66"
             },
             "cloudflare_workers": {
-              "version_added": "2021-09-24"
+              "version_added": "2021.09.24"
             },
             "deno": {
               "version_added": "1.0"
@@ -228,7 +228,7 @@
               "version_added": "66"
             },
             "cloudflare_workers": {
-              "version_added": "2021-09-24"
+              "version_added": "2021.09.24"
             },
             "deno": {
               "version_added": "1.0"

--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -12,7 +12,7 @@
             "version_added": "66"
           },
           "cloudflare_workers": {
-            "version_added": "2021-09-24"
+            "version_added": "2021.09.24"
           },
           "deno": {
             "version_added": "1.0"
@@ -69,7 +69,7 @@
               "version_added": "93"
             },
             "cloudflare_workers": {
-              "version_added": "2021-09-24"
+              "version_added": "2021.09.24"
             },
             "deno": {
               "version_added": "1.9"
@@ -126,7 +126,7 @@
                 "version_added": false
               },
               "cloudflare_workers": {
-                "version_added": "2021-09-24"
+                "version_added": "2021.09.24"
               },
               "deno": {
                 "version_added": "1.16"
@@ -186,7 +186,7 @@
               "version_added": "66"
             },
             "cloudflare_workers": {
-              "version_added": "2021-09-24"
+              "version_added": "2021.09.24"
             },
             "deno": {
               "version_added": "1.0"
@@ -244,7 +244,7 @@
               "version_added": "66"
             },
             "cloudflare_workers": {
-              "version_added": "2021-09-24"
+              "version_added": "2021.09.24"
             },
             "deno": {
               "version_added": "1.0"
@@ -302,7 +302,7 @@
               "version_added": "66"
             },
             "cloudflare_workers": {
-              "version_added": "2021-09-24"
+              "version_added": "2021.09.24"
             },
             "deno": {
               "version_added": "1.0"
@@ -360,7 +360,7 @@
               "version_added": false
             },
             "cloudflare_workers": {
-              "version_added": "2021-09-24"
+              "version_added": "2021.09.24"
             },
             "deno": {
               "version_added": "1.16"
@@ -418,7 +418,7 @@
               "version_added": false
             },
             "cloudflare_workers": {
-              "version_added": "2021-09-24"
+              "version_added": "2021.09.24"
             },
             "deno": {
               "version_added": "1.17"

--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -11,6 +11,9 @@
           "chrome_android": {
             "version_added": "66"
           },
+          "cloudflare_workers": {
+            "version_added": "2021-09-24"
+          },
           "deno": {
             "version_added": "1.0"
           },
@@ -65,6 +68,9 @@
             "chrome_android": {
               "version_added": "93"
             },
+            "cloudflare_workers": {
+              "version_added": "2021-09-24"
+            },
             "deno": {
               "version_added": "1.9"
             },
@@ -118,6 +124,9 @@
               },
               "chrome_android": {
                 "version_added": false
+              },
+              "cloudflare_workers": {
+                "version_added": "2021-09-24"
               },
               "deno": {
                 "version_added": "1.16"
@@ -176,6 +185,9 @@
             "chrome_android": {
               "version_added": "66"
             },
+            "cloudflare_workers": {
+              "version_added": "2021-09-24"
+            },
             "deno": {
               "version_added": "1.0"
             },
@@ -230,6 +242,9 @@
             },
             "chrome_android": {
               "version_added": "66"
+            },
+            "cloudflare_workers": {
+              "version_added": "2021-09-24"
             },
             "deno": {
               "version_added": "1.0"
@@ -286,6 +301,9 @@
             "chrome_android": {
               "version_added": "66"
             },
+            "cloudflare_workers": {
+              "version_added": "2021-09-24"
+            },
             "deno": {
               "version_added": "1.0"
             },
@@ -341,6 +359,9 @@
             "chrome_android": {
               "version_added": false
             },
+            "cloudflare_workers": {
+              "version_added": "2021-09-24"
+            },
             "deno": {
               "version_added": "1.16"
             },
@@ -395,6 +416,9 @@
             },
             "chrome_android": {
               "version_added": false
+            },
+            "cloudflare_workers": {
+              "version_added": "2021-09-24"
             },
             "deno": {
               "version_added": "1.17"

--- a/browsers/cloudflare_workers.json
+++ b/browsers/cloudflare_workers.json
@@ -3,12 +3,19 @@
       "cloudflare_workers": {
         "name": "Cloudflare Workers",
         "releases": {
-          "1/7/2022": {
+          "2022.01.07": {
             "release_date": "2022-01-07",
             "release_notes": "https://developers.cloudflare.com/workers/platform/changelog#172022",
             "status": "current",
             "engine": "V8",
             "engine_version": "9.7"
+          },
+          "2021.09.24": {
+            "release_date": "2021-09-24",
+            "release_notes": "https://developers.cloudflare.com/workers/platform/changelog#172022",
+            "status": "retired",
+            "engine": "V8",
+            "engine_version": "9.4"
           }
         }
       }

--- a/browsers/cloudflare_workers.json
+++ b/browsers/cloudflare_workers.json
@@ -1,0 +1,17 @@
+{
+    "browsers": {
+      "cloudflare_workers": {
+        "name": "Cloudflare Workers",
+        "releases": {
+          "1/7/2022": {
+            "release_date": "2022-01-07",
+            "release_notes": "https://developers.cloudflare.com/workers/platform/changelog#172022",
+            "status": "current",
+            "engine": "V8",
+            "engine_version": "9.7"
+          }
+        }
+      }
+    }
+  }
+  

--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -8,6 +8,7 @@
       "properties": {
         "chrome": { "$ref": "#/definitions/browser_statement" },
         "chrome_android": { "$ref": "#/definitions/browser_statement" },
+        "cloudflare_workers": { "$ref": "#/definitions/browser_statement" },
         "deno": { "$ref": "#/definitions/browser_statement" },
         "edge": { "$ref": "#/definitions/browser_statement" },
         "firefox": { "$ref": "#/definitions/browser_statement" },

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -118,6 +118,7 @@ The currently accepted browser identifiers should be declared in alphabetical or
 
 - `chrome`, Google Chrome (on desktops)
 - `chrome_android`, Google Chrome (on Android)
+- `cloudflare_workers`, Cloudflare Workers runtime built on Chrome's V8 JavaScript engine
 - `deno`, Deno JavaScript runtime built on Chrome's V8 JavaScript engine
 - `edge`, Microsoft Edge (on Windows), based on the EdgeHTML version (before version 79), and later on the Chromium version
 - `firefox`, Mozilla Firefox (on desktops)

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -152,6 +152,7 @@
         "enum": [
           "chrome",
           "chrome_android",
+          "cloudflare_workers",
           "deno",
           "edge",
           "firefox",

--- a/test/linter/test-browsers.js
+++ b/test/linter/test-browsers.js
@@ -18,7 +18,7 @@ const browsers = {
     'samsunginternet_android',
     'webview_android',
   ],
-  server: ['nodejs', 'deno'],
+  server: ['nodejs', 'deno', 'cloudflare_workers'],
   'webextensions-desktop': ['chrome', 'edge', 'firefox', 'opera', 'safari'],
   'webextensions-mobile': ['firefox_android', 'safari_ios'],
 };
@@ -126,6 +126,7 @@ function testBrowsers(filename) {
   if (category === 'api') {
     displayBrowsers.push('nodejs');
     displayBrowsers.push('deno');
+    displayBrowsers.push('cloudflare_workers');
   }
   if (category === 'javascript') {
     displayBrowsers.push(...browsers['server']);

--- a/types.d.ts
+++ b/types.d.ts
@@ -7,6 +7,7 @@
 export type BrowserNames =
   | 'chrome'
   | 'chrome_android'
+  | 'cloudflare_workers'
   | 'deno'
   | 'edge'
   | 'firefox'


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Hi folks!

I'm hoping you'll consider adding the Cloudflare Workers runtime to the server compatibility list. Like Node.js and Deno, the Cloudflare Workers runtime uses Google's v8 engine. We have been hard at work adding support for standard APIs and think MDN would be a great resource for people to check on our progress.

I followed along with the Deno PR and thought this would make a good start adding support for two fully-support APIs.

#### Note

I wanted to note that, if you all feel we'd make a good fit, we'd open PRs for all of the APIs that we support. We don't just support `AbortController` and `AbortSignal`!