### PR TITLE
Add nodejs version for api.TextEncoder.encodeInto

### DIFF
--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -205,7 +205,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": null
+              "version_added": "12.11.0"
             },
             "opera": {
               "version_added": "62"


### PR DESCRIPTION
#### Summary

This PR adds the real value for Node.js for the `encodeInto` member of the `TextEncoder` API.

#### Test results and supporting details

Changelog: https://nodejs.org/en/blog/release/v12.11.0/

> Add encodeInto to TextEncoder

#### Related issues

Part of #13170.
