### PR TITLE
Add nodejs version for api.TextDecoder.TextDecoder

### DIFF
--- a/api/TextDecoder.json
+++ b/api/TextDecoder.json
@@ -116,9 +116,15 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": null
-            },
+            "nodejs": [
+              {
+                "version_added": "11.0.0"
+              },
+              {
+                "version_added": "8.3.0",
+                "notes": "Exported from the <code>util</code> module but not globally available."
+              }
+            ],
             "opera": {
               "version_added": "25"
             },


### PR DESCRIPTION
#### Summary

This PR adds the real value for Node.js for the `TextDecoder` constructor.

#### Test results and supporting details

Changelog for adding: https://nodejs.org/en/blog/release/v8.3.0/

> The WHATWG Encoding Standard (TextDecoder and TextEncoder) has been implemented as an experimental feature

Changelog for making the API global: https://nodejs.org/en/blog/release/v11.0.0/

> The WHATWG TextEncoder and TextDecoder are now globals

History section in the documentation: https://nodejs.org/docs/latest-v16.x/api/util.html#new-textdecoderencoding-options

#### Related issues

Part of #13170.
