### PR TITLE
Complete nodejs data for EventTarget

### DIFF
--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -428,7 +428,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": "42"
@@ -482,7 +482,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "opera": {
                   "version_added": "60"


### PR DESCRIPTION
#### Summary

This PR adds the last missing real values for Node.js for the `EventTarget` API.

#### Test results and supporting details

[The documentation](https://nodejs.org/docs/latest-v16.x/api/events.html#eventtargetaddeventlistenertype-listener-options) says that `options.passive` is `false` by default without notes about any special cases. I also looked at the [changelogs](https://github.com/nodejs/node/tree/master/doc/changelogs) and didn't find any notes about `options.passive`.

#### Related issues

Part of #13170.
