### PR TITLE
Update Safari URLSearchParam delete support

### DIFF
--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -370,16 +370,26 @@
             "opera_android": {
               "version_added": "36"
             },
-            "safari": {
-              "version_added": "10.1",
-              "partial_implementation": true,
-              "notes": "Removing a non-existent query parameter doesn't remove <code>?</code> from the URL. See <a href='https://webkit.org/b/193022'>bug 193022</a>."
-            },
-            "safari_ios": {
-              "version_added": "10.3",
-              "partial_implementation": true,
-              "notes": "Removing a non-existent query parameter doesn't remove <code>?</code> from the URL. See <a href='https://webkit.org/b/193022'>bug 193022</a>."
-            },
+            "safari": [
+              {
+                "version_added": "14"
+              },
+              {
+                "version_added": "10.1",
+                "partial_implementation": true,
+                "notes": "Removing a non-existent query parameter doesn't remove <code>?</code> from the URL. See <a href='https://webkit.org/b/193022'>bug 193022</a>."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14"
+              },
+              {
+                "version_added": "10.3",
+                "partial_implementation": true,
+                "notes": "Removing a non-existent query parameter doesn't remove <code>?</code> from the URL. See <a href='https://webkit.org/b/193022'>bug 193022</a>."
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "5.0"
             },


### PR DESCRIPTION
#### Summary
Update Safari delete support for URLSearchParam

#### Test results and supporting details
Data provided by a JavaScriptCore engineer on the Apple WebKit team.

See also: https://trac.webkit.org/changeset/261399/webkit