### PR TITLE
Fixed Safari URL API support

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -159,16 +159,26 @@
             "opera_android": {
               "version_added": "14"
             },
-            "safari": {
-              "version_added": "6",
-              "partial_implementation": true,
-              "notes": "In Safari 14 and earlier, calling the <code>URL</code> constructor with a base URL whose value is <code>undefined</code> causes Safari to throw a <code>TypeError</code>; see <a href='https://webkit.org/b/216841'>WebKit bug 216841</a>."
-            },
-            "safari_ios": {
-              "version_added": "6",
-              "partial_implementation": true,
-              "notes": "In Safari 14 and earlier, calling the <code>URL</code> constructor with a base URL whose value is <code>undefined</code> causes Safari to throw a <code>TypeError</code>; see <a href='https://webkit.org/b/216841'>WebKit bug 216841</a>."
-            },
+            "safari": [
+              {
+                "version_added": "14.1"
+              },
+              {
+                "version_added": "6",
+                "partial_implementation": true,
+                "notes": "In Safari 14 and earlier, calling the <code>URL</code> constructor with a base URL whose value is <code>undefined</code> causes Safari to throw a <code>TypeError</code>; see <a href='https://webkit.org/b/216841'>WebKit bug 216841</a>."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "14.5"
+              },
+              {
+                "version_added": "6",
+                "partial_implementation": true,
+                "notes": "In Safari 14 and earlier, calling the <code>URL</code> constructor with a base URL whose value is <code>undefined</code> causes Safari to throw a <code>TypeError</code>; see <a href='https://webkit.org/b/216841'>WebKit bug 216841</a>."
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "1.5"
             },


### PR DESCRIPTION
#### Summary
Fix Safari URL API support

#### Test results and supporting details
Data submitted by a Apple WebKit engineer.

See also https://trac.webkit.org/changeset/266010/webkit