### PR TITLE
Complete nodejs data for Performance

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -1458,7 +1458,7 @@
               "version_added": "9"
             },
             "nodejs": {
-              "version_added": false
+              "version_added": "16.1.0"
             },
             "opera": {
               "version_added": false

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -337,6 +337,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "71"
             },
@@ -827,6 +830,9 @@
               "version_added": false
             },
             "ie": {
+              "version_added": false
+            },
+            "nodejs": {
               "version_added": false
             },
             "opera": {

--- a/api/PerformanceEntry.json
+++ b/api/PerformanceEntry.json
@@ -118,7 +118,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": null
+              "version_added": "8.5.0"
             },
             "opera": {
               "version_added": "15"

--- a/api/PerformanceMark.json
+++ b/api/PerformanceMark.json
@@ -79,6 +79,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "16.0.0"
+            },
             "opera": {
               "version_added": "63"
             },
@@ -128,6 +131,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "16.0.0"
             },
             "opera": {
               "version_added": "63"

--- a/api/PerformanceMeasure.json
+++ b/api/PerformanceMeasure.json
@@ -78,6 +78,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "16.0.0"
+            },
             "opera": {
               "version_added": "65"
             },

--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -81,7 +81,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": null
+              "version_added": "8.5.0"
             },
             "opera": {
               "version_added": "39"
@@ -342,7 +342,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": null
+              "version_added": "10.5.0"
             },
             "opera": {
               "version_added": "49"


### PR DESCRIPTION
#### Summary

This fills in the `null` and missing nodejs versions for these entries:

- `api.Performance.eventCounts`
- `api.Performance.measureUserAgentSpecificMemory`
- `api.PerformanceEntry.duration`
- `api.PerformanceMark.PerformanceMark`
- `api.PerformanceMark.detail`
- `api.PerformanceMeasure.detail`
- `api.PerformanceObserver.PerformanceObserver`
- `api.PerformanceObserver.worker_support`

Additionally, support for `api.Performance.toJSON` was added in Node 16.1.0, so I've updated that entry as well.

#### Test results and supporting details

* Most of the data comes from the "history" section of each API in [the documentation](https://nodejs.org/dist/latest-v16.x/docs/api/perf_hooks.html)
* Local testing was done to verify the results. The `PerformanceMark` constructor is not listed in the official documentation, but can be imported from the `perf_hooks` module from v16.0.0 onwards.
* Worker support in general was added to Node in 10.5.0, which is the version we list for other APIs' `worker_support` entries.

#### Related issues

Part of #13170