### PR TITLE
Add nodejs version 16.1.0 details

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -297,6 +297,13 @@
           "engine": "V8",
           "engine_version": "9.0"
         },
+        "16.1.0": {
+          "release_date": "2021-05-04",
+          "release_notes": "https://nodejs.org/en/blog/release/v16.1.0/",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "9.0"
+        },
         "16.4.0": {
           "release_date": "2021-06-23",
           "release_notes": "https://nodejs.org/en/blog/release/v16.4.0/",


### PR DESCRIPTION
#### Summary

Adds Node 16.1 to the release data. This is required due to the [changelog entry](https://nodejs.org/en/blog/release/v16.1.0/):

```
[4711f57cf2] - perf_hooks: add toJSON to performance class (Yash Ladha) #37771
```

#### Related issues

Fixes the linting error on #14666.