### PR TITLE
Complete nodejs data on worker support

### DIFF
--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -985,7 +985,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": null
+              "version_added": "15.0.0"
             },
             "opera": {
               "version_added": "24"

--- a/api/_globals/atob.json
+++ b/api/_globals/atob.json
@@ -91,6 +91,9 @@
             "ie": {
               "version_added": "10"
             },
+            "nodejs": {
+              "version_added": "16.0.0"
+            },
             "opera": {
               "version_added": "17"
             },

--- a/api/_globals/btoa.json
+++ b/api/_globals/btoa.json
@@ -79,6 +79,9 @@
             "ie": {
               "version_added": "10"
             },
+            "nodejs": {
+              "version_added": "16.0.0"
+            },
             "opera": {
               "version_added": "17"
             },

--- a/api/_globals/queueMicrotask.json
+++ b/api/_globals/queueMicrotask.json
@@ -79,6 +79,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "11.0.0"
+            },
             "opera": {
               "version_added": "58"
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR adds real values for Node.js for these entries:

- `api.atob.worker_support`
- `api.btoa.worker_support`
- `api.queueMicrotask.worker_support`
- `api.SubtleCrypto.worker_support`

#### Test results and supporting details

Worker support was added to Node.js in 10.5.0 ([changelog](https://nodejs.org/en/blog/release/v10.5.0/), [docs](https://nodejs.org/api/worker_threads.html#class-worker)), but these APIs were added in later versions. So the version in which these APIs became available in workers coincides with the version of adding these APIs to Node.js

#### Related issues

Part of #13170.
