### PR TITLE
Make more workflow runs reachable by `diff-features`

### DIFF
--- a/scripts/diff-features.js
+++ b/scripts/diff-features.js
@@ -68,7 +68,7 @@ function getEnumerationFromGithub(ref) {
     encoding: 'utf-8',
   }).trim();
   const workflowRun = execSync(
-    `gh api /repos/:owner/:repo/actions/workflows/${ENUMERATE_WORKFLOW}/runs --jq '.workflow_runs[] | select(.head_sha=="${hash}") | .id'`,
+    `gh api /repos/:owner/:repo/actions/workflows/${ENUMERATE_WORKFLOW}/runs?per_page=100 --jq '.workflow_runs[] | select(.head_sha=="${hash}") | .id'`,
     {
       encoding: 'utf-8',
     },


### PR DESCRIPTION
#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

This increases the number of workflow runs that can provide pre-computed feature lists to `scripts/diff-features.js`.

#### Test results and supporting details

`scripts/diff-features.js` can fetch artifacts from GitHub but, by default, it can only get the 30 most recent runs of the workflow, causing it to fall back to computing the diffs directly more often than necessary. This change increases the number of workflow runs returned by the GitHub API. It saves several minutes on a typical set of runs for a BCD release.
