### PR TITLE
@layer removed from behind a pref in FF

### DIFF
--- a/css/at-rules/layer.json
+++ b/css/at-rules/layer.json
@@ -18,28 +18,40 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "94",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.cascade-layers.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See Firefox <a href='https://bugzil.la/1699217'>bug 1699217</a>."
-            },
-            "firefox_android": {
-              "version_added": "94",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.cascade-layers.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "See Firefox <a href='https://bugzil.la/1699217'>bug 1699217</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "97"
+              },
+              {
+                "version_added": "94",
+                "version_removed": "97",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.cascade-layers.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See Firefox <a href='https://bugzil.la/1699217'>bug 1699217</a>."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "97",
+              },
+              {
+                "version_added": "94",
+                "version_removed": "97",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.cascade-layers.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "See Firefox <a href='https://bugzil.la/1699217'>bug 1699217</a>."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/at-rules/layer.json
+++ b/css/at-rules/layer.json
@@ -35,23 +35,9 @@
                 "notes": "See Firefox <a href='https://bugzil.la/1699217'>bug 1699217</a>."
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "97"
-              },
-              {
-                "version_added": "94",
-                "version_removed": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.cascade-layers.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "See Firefox <a href='https://bugzil.la/1699217'>bug 1699217</a>."
-              }
-            ],
+            "firefox_android": {
+              "version_added": "97"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/at-rules/layer.json
+++ b/css/at-rules/layer.json
@@ -37,7 +37,7 @@
             ],
             "firefox_android": [
               {
-                "version_added": "97",
+                "version_added": "97"
               },
               {
                 "version_added": "94",


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

@layer is now available by default in FF97

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

~Weirdly done this through gh ui because tests are failing locally and I can't see why - interested to see what happens here~ found it, switching contexts helped

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

see https://bugzilla.mozilla.org/show_bug.cgi?id=1699215

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Part of https://github.com/mdn/content/issues/9369

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
