### PR TITLE
Add sub-feature versions on setLocalDescription & setRemoteDescription.

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -3662,7 +3662,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "66"
+                "version_added": "67"
               },
               "opera_android": {
                 "version_added": "66"

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -3510,16 +3510,16 @@
                 "version_added": "75"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "ie": {
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "64"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "66"
               },
               "safari": {
                 "version_added": "14.1"
@@ -3639,54 +3639,6 @@
             "deprecated": false
           }
         },
-        "description_parameter_optional": {
-          "__compat": {
-            "description": "<code>description</code> parameter is optional",
-            "support": {
-              "chrome": {
-                "version_added": "80"
-              },
-              "chrome_android": {
-                "version_added": "80"
-              },
-              "edge": {
-                "version_added": "80"
-              },
-              "firefox": {
-                "version_added": "75"
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": "13.0"
-              },
-              "webview_android": {
-                "version_added": "80"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "implicit_rollback": {
           "__compat": {
             "description": "Implicit rollback",
@@ -3704,19 +3656,19 @@
                 "version_added": "70"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "ie": {
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "66"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "66"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": {
                 "version_added": false

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -3668,7 +3668,7 @@
                 "version_added": "66"
               },
               "safari": {
-                "version_added": "15.4"
+                "version_added": "preview"
               },
               "safari_ios": {
                 "version_added": false


### PR DESCRIPTION
#### Summary
- Add more supported versions to setLocalDescription's optional description parameter feature
- Add more supported versions to setRemoteDescription's implicit rollback feature
- Remove setRemoteDescription's optional description parameter feature, which is not a thing.

#### Test results and supporting details
- SLD optional description test: https://jsfiddle.net/jib1/yxbLvjm6/
  - Firefox for Android 79: would normally track desktop, except for 69-78 gap until Fenix [was released](https://en.wikipedia.org/wiki/Firefox_for_Android#History) in 79
  - Opera 64: earliest version I tested, but probably near when it was added.
  - Opera 66 for Android: earliest version I tested.
- SRD implicit rollback test: https://jsfiddle.net/jib1/hmgdu1rz/
  - SRD description argument is not optional [spec](https://www.w3.org/TR/webrtc/#idl-def-rtcpeerconnection).
  - Firefox for Android 79: would normally track desktop, except for 68-78 gap until Fenix was released in 79
  - Opera 67: Confirmed not working in 66 but working in 67.
  - Opera 66 for Android: earliest version I tested.
  - Safari 15.4: Confirmed not working in Safari 15.3 but working in 15.4 (Safari Tech Preview).