### PR TITLE
Add Safari 15.4 beta browser for macOS and iOS

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -189,6 +189,11 @@
           "status": "current",
           "engine": "WebKit",
           "engine_version": "612.3.6"
+        },
+        "15.4": {
+          "status": "beta",
+          "engine": "WebKit",
+          "engine_version": "613"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -160,6 +160,11 @@
           "status": "current",
           "engine": "WebKit",
           "engine_version": "612.3.6"
+        },
+        "15.4": {
+          "status": "beta",
+          "engine": "WebKit",
+          "engine_version": "613"
         }
       }
     }


### PR DESCRIPTION
#### Summary
Adds Safari 15.4 browser as a beta on macOS and iOS.

#### Test results and supporting details
See [Safari 15.4 Beta Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes)