### PR TITLE
Add mdn_url and spec_url for api.HTMLInputElement.reportValidity

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1658,6 +1658,8 @@
       },
       "reportValidity": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLInputElement/reportValidity",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-reportvalidity-dev",
           "support": {
             "chrome": {
               "version_added": "40"


### PR DESCRIPTION
Add mdn_url and spec_url for HTMLInputElement reportValidity

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Adding `spec_url` and `mdn_url` for the `reportValidity` method of the `HTMLInputElement` interface.
<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details
I ensured that the links being added are valid and that it is possible to navigate to them.
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Supporting WHATWG spec:
- https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-reportvalidity
- https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-reportvalidity-dev

MDN web docs page about the content being added in this PR:
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/reportValidity

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #14669 

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
