### PR TITLE
Fixed Safari support versions for JavaScript/Wasm

### DIFF
--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -266,7 +266,7 @@
               },
               "safari": [
                 {
-                  "version_added": "preview",
+                  "version_added": "15.2",
                   "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
                 },
                 {
@@ -274,10 +274,16 @@
                   "version_removed": "11"
                 }
               ],
-              "safari_ios": {
-                "version_added": "10.3",
-                "version_removed": "11"
-              },
+              "safari_ios": [
+                {
+                  "version_added": "15.2",
+                  "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.3",
+                  "version_removed": "11"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": "15.0",
                 "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
@@ -410,7 +416,7 @@
               },
               "safari": [
                 {
-                  "version_added": "preview",
+                  "version_added": "15.2",
                   "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
                 },
                 {
@@ -418,10 +424,16 @@
                   "version_removed": "11"
                 }
               ],
-              "safari_ios": {
-                "version_added": "10.3",
-                "version_removed": "11"
-              },
+              "safari_ios": [
+                {
+                  "version_added": "15.2",
+                  "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.3",
+                  "version_removed": "11"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": "15.0",
                 "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
@@ -554,7 +566,7 @@
               },
               "safari": [
                 {
-                  "version_added": "preview",
+                  "version_added": "15.2",
                   "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
                 },
                 {
@@ -562,10 +574,16 @@
                   "version_removed": "11"
                 }
               ],
-              "safari_ios": {
-                "version_added": "10.3",
-                "version_removed": "11"
-              },
+              "safari_ios": [
+                {
+                  "version_added": "15.2",
+                  "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
+                },
+                {
+                  "version_added": "10.3",
+                  "version_removed": "11"
+                }
+              ],
               "samsunginternet_android": {
                 "version_added": "15.0",
                 "notes": "<code>SharedArrayBuffer</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."

--- a/javascript/builtins/webassembly/Memory.json
+++ b/javascript/builtins/webassembly/Memory.json
@@ -157,10 +157,12 @@
                     "version_added": false
                   },
                   "safari": {
-                    "version_added": false
+                    "version_added": "15.2",
+                    "notes": "Shared <code>WebAssembly.Memory</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
                   },
                   "safari_ios": {
-                    "version_added": false
+                    "version_added": "15.2",
+                    "notes": "Shared <code>WebAssembly.Memory</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
                   },
                   "samsunginternet_android": {
                     "version_added": false

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -273,10 +273,10 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "11.0"

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -864,10 +864,10 @@
                 "version_added": "51"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14.5"
               },
               "samsunginternet_android": {
                 "version_added": "11.0"


### PR DESCRIPTION
#### Summary
Includes corrected version support for Safari across several JavaScript/Wasm features.

#### Test results and supporting details
This data was provided by a WebKit JSC engineer.

For some supporting details see: [Safari 15.2 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15_2-release-notes)