### PR TITLE
Safari 15 supports the :autofill pseudo-selector

### DIFF
--- a/css/selectors/autofill.json
+++ b/css/selectors/autofill.json
@@ -70,17 +70,22 @@
             },
             "safari": [
               {
-                "version_added": "preview"
+                "version_added": "15"
               },
               {
                 "version_added": "3",
                 "prefix": "-webkit-"
               }
             ],
-            "safari_ios": {
-              "version_added": "1",
-              "prefix": "-webkit-"
-            },
+            "safari_ios": [
+              {
+                "version_added": "15"
+              },
+              {
+                "version_added": "1",
+                "prefix": "-webkit-"
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "1.0",
               "prefix": "-webkit-"


### PR DESCRIPTION
#### Summary
Fixes Safari version support for the unprefixed :autofill pseudo-selector.

#### Test results and supporting details
See the following:
- [New WebKit Features in Safari 15](https://webkit.org/blog/11989/new-webkit-features-in-safari-15/)
- [Release Notes for Safari Technology Preview 129](https://webkit.org/blog/11951/release-notes-for-safari-technology-preview-129/)
- [Changeset 279457 in webkit](https://trac.webkit.org/changeset/279457/webkit) 