### PR TITLE
Update note wording for TextDecoder/TextEncoder NodeJS availability

### DIFF
--- a/api/TextDecoder.json
+++ b/api/TextDecoder.json
@@ -47,7 +47,7 @@
             {
               "version_added": "8.3.0",
               "partial_implementation": true,
-              "notes": "Exported from the <code>util</code> module but not globally available."
+              "notes": "Available as a part of the <code>util</code> module."
             }
           ],
           "opera": {
@@ -192,7 +192,7 @@
               },
               {
                 "version_added": "8.3.0",
-                "notes": "Exported from the <code>util</code> module but not globally available."
+                "notes": "Available as a part of the <code>util</code> module."
               }
             ],
             "opera": {

--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -33,7 +33,7 @@
             {
               "version_added": "8.3.0",
               "partial_implementation": true,
-              "notes": "Exported from the <code>util</code> module but not globally available."
+              "notes": "Available as a part of the <code>util</code> module."
             }
           ],
           "opera": {
@@ -94,7 +94,7 @@
               },
               {
                 "version_added": "8.3.0",
-                "notes": "Exported from the <code>util</code> module but not globally available."
+                "notes": "Available as a part of the <code>util</code> module."
               }
             ],
             "opera": {


### PR DESCRIPTION
This PR updates the wording for the notes in `TextDecoder` and `TextEncoder` describing that the APIs are exported from a separate module.  The current notes are slightly confusing and do not describe the difference in usage too well.  This PR aims to simplify the notes.
