### PR TITLE
Add specs for svg.elements.path.d

### DIFF
--- a/svg/elements/path.json
+++ b/svg/elements/path.json
@@ -51,6 +51,12 @@
         },
         "d": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/d",
+            "spec_url": [
+              "https://svgwg.org/svg2-draft/paths.html#DProperty",
+              "https://www.w3.org/TR/SVG11/fonts.html#GlyphElementDAttribute",
+              "https://www.w3.org/TR/SVG11/paths.html#DAttribute"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"


### PR DESCRIPTION
Adds specs for svg.elements.path.d from this page: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d#specifications