### PR TITLE
Add Safari 15.4 support for CSS Cascade Layers

### DIFF
--- a/css/at-rules/layer.json
+++ b/css/at-rules/layer.json
@@ -50,12 +50,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false,
-              "notes": "See WebKit <a href='https://webkit.org/b/220779'>bug 220779</a>."
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false,
-              "notes": "See WebKit <a href='https://webkit.org/b/220779'>bug 220779</a>."
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
#### Summary
Safari 15.4 beta supports CSS Cascade Layers

#### Test results and supporting details
See [Safari 15.4 Beta Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes)