### PR TITLE
Add Safari 15.4 support for :has()

### DIFF
--- a/css/selectors/has.json
+++ b/css/selectors/has.json
@@ -36,10 +36,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
#### Summary
Safari 15.4 beta supports :has() in CSS

#### Test results and supporting details
See [Safari 15.4 Beta Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes) 