### PR TITLE
Add Safari 15.4 accent-color property support

### DIFF
--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -84,10 +84,10 @@
               "version_added": "66"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
#### Summary
Safari 15.4 beta supports the CSS accent-color property.

#### Test results and supporting details
See [Safari 15.4 Beta Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes) 