### PR TITLE
Add Safari 15.4 support for CSS Contaimment

### DIFF
--- a/css/properties/contain.json
+++ b/css/properties/contain.json
@@ -52,10 +52,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/css/properties/content-visibility.json
+++ b/css/properties/content-visibility.json
@@ -31,10 +31,10 @@
               "version_added": "60"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "14.0"


### PR DESCRIPTION
#### Summary
Safari 15.4 beta supports CSS Containment

#### Test results and supporting details
See [Safari 15.4 Beta Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes) 