### PR TITLE
Add Safari 15.4 scroll-behavior property support

### DIFF
--- a/css/properties/scroll-behavior.json
+++ b/css/properties/scroll-behavior.json
@@ -32,7 +32,7 @@
             },
             "safari": [
               {
-                "version_added": "preview"
+                "version_added": "15.4"
               },
               {
                 "version_added": "14",
@@ -45,15 +45,20 @@
                 ]
               }
             ],
-            "safari_ios": {
-              "version_added": "14",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "CSSOM View Smooth Scrolling"
-                }
-              ]
-            },
+            "safari_ios": [
+              {
+                "version_added": "15.4"
+              },
+              {
+                "version_added": "14",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "CSSOM View Smooth Scrolling"
+                  }
+                ]
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "8.0"
             },


### PR DESCRIPTION
#### Summary
Safari 15.4 beta supports the CSS scroll-behavior property.

#### Test results and supporting details
See [Safari 15.4 Beta Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes) 