### PR TITLE
Add Safari 15.4 support for text-decoration-skip-ink

### DIFF
--- a/css/properties/text-decoration-skip-ink.json
+++ b/css/properties/text-decoration-skip-ink.json
@@ -31,10 +31,10 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "9.0"


### PR DESCRIPTION
#### Summary
Safari 15.4 beta supports the `text-decoration-skip-ink` CSS property.

#### Test results and supporting details
See [Safari 15.4 Beta Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes) 