### PR TITLE
Add Safari 15.4 support for more CSS length types

### DIFF
--- a/css/types/length.json
+++ b/css/types/length.json
@@ -275,11 +275,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/195176'>bug 195176</a>."
+                "version_added": "15.4"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -473,11 +472,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/159801'>bug 159801</a>."
+                "version_added": "15.4"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -573,11 +571,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/159801'>bug 159801</a>."
+                "version_added": "15.4"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
#### Summary
Safari 15.4 beta supports `ic`, `vb`, and `vi` units.

#### Test results and supporting details
See [Safari 15.4 Beta Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes) 