### PR TITLE
Add Safari 15.4 support for Dialog element and ::backdrop

### DIFF
--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -46,10 +46,10 @@
             "version_added": "24"
           },
           "safari": {
-            "version_added": false
+            "version_added": "15.4"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "15.4"
           },
           "samsunginternet_android": {
             "version_added": "3.0"
@@ -111,10 +111,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -176,10 +176,10 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -226,10 +226,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -291,10 +291,10 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -356,10 +356,10 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -421,10 +421,10 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -486,10 +486,10 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "3.0"

--- a/css/selectors/backdrop.json
+++ b/css/selectors/backdrop.json
@@ -69,10 +69,10 @@
               }
             ],
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": [
               {
@@ -128,10 +128,10 @@
                 "version_added": "19"
               },
               "safari": {
-                "version_added": "preview"
+                "version_added": "15.4"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "samsunginternet_android": {
                 "version_added": "2.0"

--- a/html/elements/dialog.json
+++ b/html/elements/dialog.json
@@ -47,10 +47,10 @@
               "version_added": "24"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -109,10 +109,10 @@
                 "version_added": "24"
               },
               "safari": {
-                "version_added": "preview"
+                "version_added": "15.4"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "samsunginternet_android": {
                 "version_added": "3.0"


### PR DESCRIPTION
#### Summary
Safari 15.4 beta supports the `<dialog>` element and the CSS `::backdrop` selector.

#### Test results and supporting details
See [Safari 15.4 Beta Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes) 