### PR TITLE
Add Safari 15.4 support for ResizeObserverSize

### DIFF
--- a/api/ResizeObserverEntry.json
+++ b/api/ResizeObserverEntry.json
@@ -78,10 +78,10 @@
               "version_added": "60"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "14.0"
@@ -143,10 +143,10 @@
               "version_added": "60"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "14.0"

--- a/api/ResizeObserverSize.json
+++ b/api/ResizeObserverSize.json
@@ -30,10 +30,10 @@
             "version_added": "60"
           },
           "safari": {
-            "version_added": false
+            "version_added": "15.4"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "15.4"
           },
           "samsunginternet_android": {
             "version_added": "14.0"
@@ -78,10 +78,10 @@
               "version_added": "60"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "14.0"
@@ -127,10 +127,10 @@
               "version_added": "60"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "14.0"


### PR DESCRIPTION
#### Summary
Safari 15.4 beta supports ResizeObserverSize along with `borderBoxSize` and `contentBoxSize` of ResizeObserverEntry.

#### Test results and supporting details
See [Implement the borderBoxSize/contentBoxSize parts of ResizeObserver](https://github.com/WebKit/WebKit/commit/7425eefe3f7068d356077c39f230dd6098583163)