### PR TITLE
Added Safari 15.4 support for BroadcastChannel

### DIFF
--- a/api/BroadcastChannel.json
+++ b/api/BroadcastChannel.json
@@ -47,10 +47,10 @@
             "version_added": "41"
           },
           "safari": {
-            "version_added": "preview"
+            "version_added": "15.4"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "15.4"
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -102,10 +102,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -157,10 +157,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -213,10 +213,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -269,11 +269,10 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/171216'>bug 171216</a>."
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -325,10 +324,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -380,10 +379,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -435,10 +434,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false,
+              "version_added": "15.4",
               "notes": "See <a href='https://webkit.org/b/171216'>bug 171216</a>."
             },
             "samsunginternet_android": {
@@ -491,10 +490,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "6.0"

--- a/api/BroadcastChannel.json
+++ b/api/BroadcastChannel.json
@@ -269,10 +269,12 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": "15.4"
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/171216'>bug 171216</a>."
             },
             "safari_ios": {
-              "version_added": "15.4"
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/171216'>bug 171216</a>."
             },
             "samsunginternet_android": {
               "version_added": "8.0"
@@ -434,10 +436,11 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": "15.4"
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/171216'>bug 171216</a>."
             },
             "safari_ios": {
-              "version_added": "15.4",
+              "version_added": false,
               "notes": "See <a href='https://webkit.org/b/171216'>bug 171216</a>."
             },
             "samsunginternet_android": {


### PR DESCRIPTION
#### Summary
Safari 15.4 beta supports BroadcastChannel

#### Test results and supporting details
See [Safari 15.4 Beta Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes) 