### PR TITLE
Corrected Safari 15.4 support for the FileSystem API

### DIFF
--- a/api/FileSystemHandle.json
+++ b/api/FileSystemHandle.json
@@ -225,7 +225,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -274,7 +274,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false

--- a/api/FileSystemWritableFileStream.json
+++ b/api/FileSystemWritableFileStream.json
@@ -30,7 +30,7 @@
             "version_added": false
           },
           "safari": {
-            "version_added": "preview"
+            "version_added": false
           },
           "safari_ios": {
             "version_added": false
@@ -78,7 +78,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -127,7 +127,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -176,7 +176,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false

--- a/api/StorageManager.json
+++ b/api/StorageManager.json
@@ -78,7 +78,7 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
#### Summary
Fixed Safari/Safari Technology Preview support information for FileSystemHandle, FileSystemWritableFileStream and StorageManager.

#### Test results and supporting details
See [Safari 15.4 Beta Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes) 