### PR TITLE
Added Safari 15.4 support for the Web Locks API

### DIFF
--- a/api/Lock.json
+++ b/api/Lock.json
@@ -43,10 +43,10 @@
             "version_added": "48"
           },
           "safari": {
-            "version_added": "preview"
+            "version_added": "15.4"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "15.4"
           },
           "samsunginternet_android": {
             "version_added": "10.0"
@@ -104,10 +104,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -166,10 +166,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/api/LockManager.json
+++ b/api/LockManager.json
@@ -43,10 +43,10 @@
             "version_added": "48"
           },
           "safari": {
-            "version_added": "preview"
+            "version_added": "15.4"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "15.4"
           },
           "samsunginternet_android": {
             "version_added": "10.0"
@@ -104,10 +104,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -166,10 +166,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "10.0"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2082,10 +2082,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "10.0"


### PR DESCRIPTION
#### Summary
Safari 15.4 beta supports the Web Locks API

#### Test results and supporting details
See [Turn on Web Locks API support](Turn on Web Locks API support) 