### PR TITLE
Added Safari 15.4 support for externally_connectable:matches

### DIFF
--- a/webextensions/manifest/externally_connectable.json
+++ b/webextensions/manifest/externally_connectable.json
@@ -22,7 +22,12 @@
               "version_added": true
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4",
+              "notes": "Safari only supports the 'matches' attribute."
+            },
+            "safari_ios": {
+              "version_added": "15.4",
+              "notes": "Safari only supports the 'matches' attribute."
             }
           }
         }


### PR DESCRIPTION
#### Summary
Safari 15.4 beta supports externally_connectable:matches

#### Test results and supporting details
See [Safari 15.4 Beta Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes) 