### PR TITLE
Add Safari 15.4 JavaScript feature support

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -147,10 +147,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "preview"
+                "version_added": "15.4"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "samsunginternet_android": {
                 "version_added": "16.0"
@@ -675,10 +675,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -730,10 +730,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -1014,10 +1014,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "preview"
+                "version_added": "15.4"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "samsunginternet_android": {
                 "version_added": false

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -203,10 +203,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "preview"
+                "version_added": "15.4"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "samsunginternet_android": {
                 "version_added": "16.0"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -146,10 +146,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "preview"
+                "version_added": "15.4"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "samsunginternet_android": {
                 "version_added": "16.0"
@@ -805,10 +805,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "samsunginternet_android": {
                 "version_added": false
@@ -860,10 +860,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
#### Summary
Safari 15.4 beta supports new JavaScript features:
- `Array.at`, `Array.findlast`, `Array.findLastIndex`
- `TypedArray.at`, `TypedArray.findlast`, `TypedArray.findLastIndex`
- `Object.hasOwn`
- `String.at`

#### Test results and supporting details
See [Safari 15.4 Beta Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes) 