### PR TITLE
Update <img loading> support for Firefox Android

### DIFF
--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -595,8 +595,7 @@
                 "version_added": "75"
               },
               "firefox_android": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1542784'>bug 1542784</a>."
+                "version_added": "79"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
#### Summary
Gecko 75+ suppoorts loading attribute, so Firefox 79+ for Android supports it.

#### Test results and supporting details
- https://github.com/mdn/browser-compat-data/pull/5759 for Firefox desktop
- https://bugzilla.mozilla.org/show_bug.cgi?id=1542784 for BMO link

#### Related issues
Fixes #13105.
