### PR TITLE
Remove "Streaming response body" compat data

### DIFF
--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -222,13 +222,7 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": "64",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "javascript.options.streams"
-                }
-              ]
+              "version_added": "65",
             },
             "firefox_android": {
               "version_added": false

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -222,7 +222,7 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": "65",
+              "version_added": "65"
             },
             "firefox_android": {
               "version_added": false

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -205,57 +205,6 @@
           }
         }
       },
-      "streaming_response_body": {
-        "__compat": {
-          "description": "Streaming response body",
-          "support": {
-            "chrome": {
-              "version_added": "43"
-            },
-            "chrome_android": {
-              "version_added": "43"
-            },
-            "deno": {
-              "version_added": "1.0"
-            },
-            "edge": {
-              "version_added": "14"
-            },
-            "firefox": {
-              "version_added": "65"
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "29"
-            },
-            "opera_android": {
-              "version_added": "30"
-            },
-            "safari": {
-              "version_added": "10.1"
-            },
-            "safari_ios": {
-              "version_added": "10.3"
-            },
-            "samsunginternet_android": {
-              "version_added": "4.0"
-            },
-            "webview_android": {
-              "version_added": "43"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "worker_support": {
         "__compat": {
           "description": "Available in workers",


### PR DESCRIPTION
I think this must be referring to Response.body, which should be supported since 65: https://developer.mozilla.org/en-US/docs/Web/API/Response/body.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
"Streaming response body" feature of fetch is supported in Firefox

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/65
> Readable Streams have been enabled by default


#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
