### PR TITLE
Added Safari 15.4 support for lazy loading images

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -669,12 +669,10 @@
               "version_added": "55"
             },
             "safari": {
-              "version_added": "15.4",
-              "notes": "See <a href='https://webkit.org/b/196698'>bug 196698</a>."
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": "15.4",
-              "notes": "See <a href='https://webkit.org/b/196698'>bug 196698</a>."
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "12.0"

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -669,11 +669,11 @@
               "version_added": "55"
             },
             "safari": {
-              "version_added": false,
+              "version_added": "15.4",
               "notes": "See <a href='https://webkit.org/b/196698'>bug 196698</a>."
             },
             "safari_ios": {
-              "version_added": false,
+              "version_added": "15.4",
               "notes": "See <a href='https://webkit.org/b/196698'>bug 196698</a>."
             },
             "samsunginternet_android": {

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -607,11 +607,10 @@
                 "version_added": "55"
               },
               "safari": {
-                "version_added": "preview"
+                "version_added": "15.4"
               },
               "safari_ios": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/196698'>bug 196698</a>."
+                "version_added": "15.4"
               },
               "samsunginternet_android": {
                 "version_added": "12.0"


### PR DESCRIPTION
#### Summary
Safari 15.4 beta supports lazy loading images

#### Test results and supporting details
See [Safari 15.4 Beta Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes) 