### PR TITLE
Added Safari 15.4 autofocus attribute support

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -583,16 +583,26 @@
                 "notes": "Supported for <code>HTMLButtonElement</code>, <code>HTMLInputElement</code>, <code>HTMLSelectElement</code>, and <code>HTMLTextAreaElement</code>."
               }
             ],
-            "safari": {
-              "version_added": "4",
-              "partial_implementation": true,
-              "notes": "Supported for <code>HTMLButtonElement</code>, <code>HTMLInputElement</code>, <code>HTMLSelectElement</code>, and <code>HTMLTextAreaElement</code>."
-            },
-            "safari_ios": {
-              "version_added": "3.2",
-              "partial_implementation": true,
-              "notes": "Supported for <code>HTMLButtonElement</code>, <code>HTMLInputElement</code>, <code>HTMLSelectElement</code>, and <code>HTMLTextAreaElement</code>."
-            },
+            "safari": [
+              {
+                "version_added": "15.4"
+              },
+              {
+                "version_added": "4",
+                "partial_implementation": true,
+                "notes": "Supported for <code>HTMLButtonElement</code>, <code>HTMLInputElement</code>, <code>HTMLSelectElement</code>, and <code>HTMLTextAreaElement</code>."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "15.4"
+              },
+              {
+                "version_added": "3.2",
+                "partial_implementation": true,
+                "notes": "Supported for <code>HTMLButtonElement</code>, <code>HTMLInputElement</code>, <code>HTMLSelectElement</code>, and <code>HTMLTextAreaElement</code>."
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "12.0"
@@ -2124,12 +2134,12 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": "10",
+              "version_added": "15.4",
               "partial_implementation": true,
               "notes": "The property is defined only for its useful elements: <code>&lt;link&gt;</code>, <code>&lt;script&gt;</code>, and <code>&lt;style&gt;</code>; it is undefined for all other elements."
             },
             "safari_ios": {
-              "version_added": "10",
+              "version_added": "15.4",
               "partial_implementation": true,
               "notes": "The property is defined only for its useful elements: <code>&lt;link&gt;</code>, <code>&lt;script&gt;</code>, and <code>&lt;style&gt;</code>; it is undefined for all other elements."
             },

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2134,12 +2134,12 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": "15.4",
+              "version_added": "10",
               "partial_implementation": true,
               "notes": "The property is defined only for its useful elements: <code>&lt;link&gt;</code>, <code>&lt;script&gt;</code>, and <code>&lt;style&gt;</code>; it is undefined for all other elements."
             },
             "safari_ios": {
-              "version_added": "15.4",
+              "version_added": "10",
               "partial_implementation": true,
               "notes": "The property is defined only for its useful elements: <code>&lt;link&gt;</code>, <code>&lt;script&gt;</code>, and <code>&lt;style&gt;</code>; it is undefined for all other elements."
             },

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -471,10 +471,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": "15.4"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "15.4"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "8.0"

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -77,10 +77,10 @@
               "version_added": "57"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "12.0"
@@ -471,10 +471,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
#### Summary
Safari 15.4 beta supports the autofocus attribute

#### Test results and supporting details
See [Implement new autofocus behavior](https://github.com/WebKit/WebKit/commit/04121307d367f18294594257e49265758e196716) 