### PR TITLE
Added Safari 15.4 support for ServiceWorker Navigation Preload

### DIFF
--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -280,10 +280,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "7.0"

--- a/api/NavigationPreloadManager.json
+++ b/api/NavigationPreloadManager.json
@@ -32,10 +32,10 @@
             "version_added": "43"
           },
           "safari": {
-            "version_added": false
+            "version_added": "15.4"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "15.4"
           },
           "samsunginternet_android": {
             "version_added": "7.0"
@@ -81,10 +81,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -131,10 +131,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -181,10 +181,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "7.0"
@@ -231,10 +231,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "7.0"

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -378,10 +378,10 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
#### Summary
Safari 15.4 beta supports ServiceWorker Navigation Preload

#### Test results and supporting details
See [Safari 15.4 Beta Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes) 