### PR TITLE
Added Safari 15.4 support for unprefixed CSS properties

### DIFF
--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -91,7 +91,7 @@
             ],
             "safari": [
               {
-                "version_added": "preview"
+                "version_added": "15.4"
               },
               {
                 "version_added": "3",
@@ -99,11 +99,16 @@
                 "prefix": "-webkit-"
               }
             ],
-            "safari_ios": {
-              "version_added": "1",
-              "partial_implementation": true,
-              "prefix": "-webkit-"
-            },
+            "safari_ios": [
+              {
+                "version_added": "15.4"
+              },
+              {
+                "version_added": "1",
+                "partial_implementation": true,
+                "prefix": "-webkit-"
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "14.0"
@@ -159,10 +164,10 @@
                 "version_added": "59"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "samsunginternet_android": {
                 "version_added": "13.0"

--- a/css/properties/backface-visibility.json
+++ b/css/properties/backface-visibility.json
@@ -82,17 +82,22 @@
             ],
             "safari": [
               {
-                "version_added": "preview"
+                "version_added": "15.4"
               },
               {
                 "prefix": "-webkit-",
                 "version_added": "5.1"
               }
             ],
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": "5"
-            },
+            "safari_ios": [
+              {
+                "version_added": "15.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "5"
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "3.0"

--- a/css/properties/color-adjust.json
+++ b/css/properties/color-adjust.json
@@ -39,10 +39,15 @@
               "version_added": "6",
               "alternative_name": "-webkit-print-color-adjust"
             },
-            "safari_ios": {
-              "version_added": "6",
-              "alternative_name": "-webkit-print-color-adjust"
-            },
+            "safari_ios": [
+              {
+                "version_added": "15.4"
+              },
+              {
+                "version_added": "6",
+                "alternative_name": "-webkit-print-color-adjust"
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "5.0",
               "alternative_name": "-webkit-print-color-adjust"

--- a/css/properties/mask-clip.json
+++ b/css/properties/mask-clip.json
@@ -35,14 +35,24 @@
               "prefix": "-webkit-",
               "version_added": "14"
             },
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": "4"
-            },
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": "3.2"
-            },
+            "safari": [
+              {
+                "version_added": "15.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "4"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "15.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3.2"
+              }
+            ],
             "samsunginternet_android": {
               "prefix": "-webkit-",
               "version_added": "1.0"

--- a/css/properties/mask-composite.json
+++ b/css/properties/mask-composite.json
@@ -36,11 +36,11 @@
               "notes": "See also <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-composite'><code>-webkit-mask-composite</code></a> for a similar non-standard property that uses different keywords."
             },
             "safari": {
-              "version_added": false,
+              "version_added": "15.4",
               "notes": "See also <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-composite'><code>-webkit-mask-composite</code></a> for a similar non-standard property that uses different keywords."
             },
             "safari_ios": {
-              "version_added": false,
+              "version_added": "15.4",
               "notes": "See also <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-composite'><code>-webkit-mask-composite</code></a> for a similar non-standard property that uses different keywords."
             },
             "samsunginternet_android": {

--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -43,16 +43,26 @@
               "prefix": "-webkit-",
               "version_added": "14"
             },
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": "4",
-              "notes": "Initially, Safari supported only <code>-webkit-</code> prefixed values for gradients (such as <code>-webkit-linear-gradient()</code>). Later, support for unprefixed values was added."
-            },
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": "3.2",
-              "notes": "Initially, Safari supported only <code>-webkit-</code> prefixed values for gradients (such as <code>-webkit-linear-gradient()</code>). Later, support for unprefixed values was added."
-            },
+            "safari": [
+              {
+                "version_added": "15.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "4",
+                "notes": "Initially, Safari supported only <code>-webkit-</code> prefixed values for gradients (such as <code>-webkit-linear-gradient()</code>). Later, support for unprefixed values was added."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "15.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3.2",
+                "notes": "Initially, Safari supported only <code>-webkit-</code> prefixed values for gradients (such as <code>-webkit-linear-gradient()</code>). Later, support for unprefixed values was added."
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "1.0",
               "prefix": "-webkit-"

--- a/css/properties/mask-mode.json
+++ b/css/properties/mask-mode.json
@@ -31,10 +31,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/css/properties/mask-origin.json
+++ b/css/properties/mask-origin.json
@@ -40,16 +40,26 @@
               "version_added": "14",
               "notes": "The <code>margin-box</code> value is unsupported."
             },
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": "4",
-              "notes": "The <code>margin-box</code> value is unsupported."
-            },
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": "3.2",
-              "notes": "The <code>margin-box</code> value is unsupported."
-            },
+            "safari": [
+              {
+                "version_added": "15.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "4",
+                "notes": "The <code>margin-box</code> value is unsupported."
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "15.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3.2",
+                "notes": "The <code>margin-box</code> value is unsupported."
+              }
+            ],
             "samsunginternet_android": {
               "prefix": "-webkit-",
               "version_added": "1.0",

--- a/css/properties/mask-position.json
+++ b/css/properties/mask-position.json
@@ -41,14 +41,24 @@
               "prefix": "-webkit-",
               "version_added": "14"
             },
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": "3.1"
-            },
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": "2"
-            },
+            "safari": [
+              {
+                "version_added": "15.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3.1"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "15.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "2"
+              }
+            ],
             "samsunginternet_android": {
               "prefix": "-webkit-",
               "version_added": "1.0"

--- a/css/properties/mask-repeat.json
+++ b/css/properties/mask-repeat.json
@@ -41,14 +41,24 @@
               "prefix": "-webkit-",
               "version_added": "14"
             },
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": "3.1"
-            },
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": "2"
-            },
+            "safari": [
+              {
+                "version_added": "15.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "3.1"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "15.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "2"
+              }
+            ],
             "samsunginternet_android": {
               "prefix": "-webkit-",
               "version_added": "1.0"

--- a/css/properties/mask-size.json
+++ b/css/properties/mask-size.json
@@ -41,14 +41,24 @@
               "prefix": "-webkit-",
               "version_added": "14"
             },
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": "4"
-            },
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": "2"
-            },
+            "safari": [
+              {
+                "version_added": "15.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "4"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "15.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "2"
+              }
+            ],
             "samsunginternet_android": {
               "prefix": "-webkit-",
               "version_added": "1.0"

--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -79,12 +79,17 @@
               "version_added": "5.1",
               "notes": "This property was initially named <code>-webkit-text-combine</code> according to a <a href='http://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine'>2011 version of the CSS3 Writing Modes specification</a>, supporting the values <code>none</code> and <code>horizontal</code> without <code>digits</code>."
             },
-            "safari_ios": {
-              "partial_implementation": true,
-              "alternative_name": "-webkit-text-combine",
-              "version_added": "5",
-              "notes": "This property was initially named <code>-webkit-text-combine</code> according to a <a href='http://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine'>2011 version of the CSS3 Writing Modes specification</a>, supporting the values <code>none</code> and <code>horizontal</code> without <code>digits</code>."
-            },
+            "safari_ios": [
+              {
+                "version_added": "15.4"
+              },
+              {
+                "partial_implementation": true,
+                "alternative_name": "-webkit-text-combine",
+                "version_added": "5",
+                "notes": "This property was initially named <code>-webkit-text-combine</code> according to a <a href='http://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine'>2011 version of the CSS3 Writing Modes specification</a>, supporting the values <code>none</code> and <code>horizontal</code> without <code>digits</code>."
+              }
+            ],
             "samsunginternet_android": [
               {
                 "version_added": "5.0"


### PR DESCRIPTION
#### Summary
Safari 15.4 beta supports new unprefixed properties

#### Test results and supporting details
See [Safari 15.4 Beta Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes) 