### PR TITLE
Set Chrome 98 as current

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -673,21 +673,28 @@
         "97": {
           "release_date": "2022-01-04",
           "release_notes": "https://chromereleases.googleblog.com/2022/01/stable-channel-update-for-desktop.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "97"
         },
         "98": {
           "release_date": "2022-02-01",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2022/02/stable-channel-update-for-desktop.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "98"
         },
         "99": {
           "release_date": "2022-03-01",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "99"
+        },
+        "100": {
+          "release_date": "2022-03-29",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "100"
         }
       }
     }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -509,21 +509,28 @@
         "97": {
           "release_date": "2022-01-04",
           "release_notes": "https://chromereleases.googleblog.com/2022/01/chrome-for-android-update.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "97"
         },
         "98": {
           "release_date": "2022-02-01",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2022/02/chrome-for-android-update.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "98"
         },
         "99": {
           "release_date": "2022-03-01",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "99"
+        },
+        "100": {
+          "release_date": "2022-03-29",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "100"
         }
       }
     }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -474,21 +474,28 @@
         "97": {
           "release_date": "2022-01-04",
           "release_notes": "https://chromereleases.googleblog.com/2022/01/chrome-for-android-update.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "97"
         },
         "98": {
           "release_date": "2022-02-01",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2022/02/chrome-for-android-update.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "98"
         },
         "99": {
           "release_date": "2022-03-01",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "99"
+        },
+        "100": {
+          "release_date": "2022-03-29",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "100"
         }
       }
     }


### PR DESCRIPTION
Chrome has updated to version 98.

According to https://chromiumdash.appspot.com/schedule, the release date of Chrome 100 is 29/03/2022.

Fixes #14794.