### PR TITLE
Added Safari 15.4 MediaCapabilities support updates

### DIFF
--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -155,10 +155,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": false

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -589,10 +589,10 @@
               "version_added": "54"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "12.0"


### PR DESCRIPTION
#### Summary
Safari 15.4 beta supports encodingInfo for WebRTC and is now exposed to Workers.

#### Test results and supporting details
See [Add support for WebRTC media capabilities](https://github.com/WebKit/WebKit/commit/d7dbb2cc95fd59dc4edf120c17419a8a1c1bce1d)
Also see [Expose MediaCapabilities to Workers](https://github.com/WebKit/WebKit/commit/4ff9c98e316aab9fbb610a0bf3c7cdae51f8d999)