### PR TITLE
Added Safari 15.4 support for requestVideoFrameCallback

### DIFF
--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -125,10 +125,10 @@
               "version_added": "59"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -998,10 +998,10 @@
               "version_added": "59"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "13.0"


### PR DESCRIPTION
#### Summary
Safari 15.4 beta supports the requestVideoFrameCallback API

#### Test results and supporting details
See [Add support for requestVideoFrameCallback API and MediaStreamTrack-based backend support](https://github.com/WebKit/WebKit/commit/7c25a92b395059d113a0bbbe7da565bff0b2e6a0) 