### PR TITLE
Added Safari 15.4 updates for worker support

### DIFF
--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -541,10 +541,10 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "10.0"
@@ -589,10 +589,10 @@
               "version_added": "54"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "12.0"

--- a/api/_globals/reportError.json
+++ b/api/_globals/reportError.json
@@ -35,10 +35,10 @@
             "version_added": "67"
           },
           "safari": {
-            "version_added": "preview"
+            "version_added": "15.4"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "15.4"
           },
           "samsunginternet_android": {
             "version_added": false

--- a/api/_globals/structuredClone.json
+++ b/api/_globals/structuredClone.json
@@ -48,10 +48,10 @@
             "version_added": false
           },
           "safari": {
-            "version_added": "preview"
+            "version_added": "15.4"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "15.4"
           },
           "samsunginternet_android": {
             "version_added": false


### PR DESCRIPTION
#### Summary
Safari 15.4 beta adds new worker support.

#### Test results and supporting details
See:
- [Implement self.reportError()](https://github.com/WebKit/WebKit/commit/b238783cb4843739f3f6f373659dedfc2b0c905e)
- [Make Web Lock API work across multiple WebProcesses](https://github.com/WebKit/WebKit/commit/19aa86e94cf65018474a75bb74b6763a29478943)
- [Implement self.structuredClone()](https://github.com/WebKit/WebKit/commit/8e3c0a95c7a906f305436216657466660e32c814)