### PR TITLE
Added Safari 15.4 support for highWaterMark

### DIFF
--- a/api/ByteLengthQueuingStrategy.json
+++ b/api/ByteLengthQueuingStrategy.json
@@ -146,10 +146,10 @@
               "version_added": "56"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "12.0"

--- a/api/CountQueuingStrategy.json
+++ b/api/CountQueuingStrategy.json
@@ -137,10 +137,10 @@
               "version_added": "56"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "12.0"


### PR DESCRIPTION
#### Summary
Safari 15.4 beta supports highWaterMark.

#### Test results and supporting details
See [`highWaterMark` should be a readonly WebIDL attribute of queuing strategies](https://github.com/WebKit/WebKit/commit/45e43a5086dad6a82a4ad192e1c314611f692312)