### PR TITLE
Added Safari 15.4 support for randomUUID

### DIFF
--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -159,10 +159,10 @@
               "version_added": "65"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "16.0"


### PR DESCRIPTION
#### Summary
Safari 15.4 beta supports Crypto.randomUUID()

#### Test results and supporting details
See [Implement Crypto.randomUUID()](https://github.com/WebKit/WebKit/commit/6cbcdb03d5b4d2bd49f7f868f093c44dcd2c9f31) 