### PR TITLE
Added Safari 15.4 support for VideoColorSpace

### DIFF
--- a/api/VideoColorSpace.json
+++ b/api/VideoColorSpace.json
@@ -30,10 +30,10 @@
             "version_added": "66"
           },
           "safari": {
-            "version_added": false
+            "version_added": "15.4"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "15.4"
           },
           "samsunginternet_android": {
             "version_added": false
@@ -128,10 +128,10 @@
               "version_added": "66"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -177,10 +177,10 @@
               "version_added": "66"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -226,10 +226,10 @@
               "version_added": "66"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -275,10 +275,10 @@
               "version_added": "66"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": false
@@ -324,10 +324,10 @@
               "version_added": "66"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
#### Summary
Safari 15.4 beta supports the VideoColorSpace interface.

#### Test results and supporting details
See [Add an experimental trackConfiguration accessor on AudioTrack & VideoTrack.](https://github.com/WebKit/WebKit/commit/be8fbe2d6510ca07c10e2ef44eebe6c8f52ceecb) 