### PR TITLE
Added Safari 15.4 support for SubmitEvent.submitter

### DIFF
--- a/api/SubmitEvent.json
+++ b/api/SubmitEvent.json
@@ -129,7 +129,7 @@
             },
             "safari": [
               {
-                "version_added": "preview"
+                "version_added": "15.4"
               },
               {
                 "version_added": "15",
@@ -137,11 +137,16 @@
                 "notes": "Property is not set for <code>&lt;button&gt;</code> elements. See <a href='https://webkit.org/b/229660'>bug 229660</a>."
               }
             ],
-            "safari_ios": {
-              "version_added": "15",
-              "partial_implementation": true,
-              "notes": "Property is not set for <code>&lt;button&gt;</code> elements. See <a href='https://webkit.org/b/229660'>bug 229660</a>."
-            },
+            "safari_ios": [
+              {
+                "version_added": "15.4"
+              },
+              {
+                "version_added": "15",
+                "partial_implementation": true,
+                "notes": "Property is not set for <code>&lt;button&gt;</code> elements. See <a href='https://webkit.org/b/229660'>bug 229660</a>."
+              }
+            ],
             "samsunginternet_android": {
               "version_added": "13.0"
             },


### PR DESCRIPTION
#### Summary
Safari 15.4 beta supports the SubmitEvent.submitter property.

#### Test results and supporting details
See [SubmitEvent.submitter property isn't set for `<button type="submit">`](https://github.com/WebKit/WebKit/commit/e4bb8ddfa1f95761b3a858cb37991323932bffd0) 