### PR TITLE
Add Safari 15 support for multi-keyword display values

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -798,10 +798,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "15"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
#### Summary
Safari 15 added support for multi-keyword `display` values.

#### Test results and supporting details
See: [Release Notes for Safari Technology Preview 125](https://webkit.org/blog/11680/release-notes-for-safari-technology-preview-125/) included in  [New WebKit Features in Safari 15](https://webkit.org/blog/11989/new-webkit-features-in-safari-15/) listed under the "Availability" section.