### PR TITLE
Add Safari 15.2 support for colorSpace in ImageData

### DIFF
--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -127,10 +127,10 @@
               "version_added": "65"
             },
             "safari": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.2"
             },
             "samsunginternet_android": {
               "version_added": false


### PR DESCRIPTION
#### Summary
Safari 15.2 supports colorSpace in ImageData.

#### Test results and supporting details
See [Add support for creating/accessing/setting non-sRGB ImageData via canvas](https://github.com/WebKit/WebKit/commit/92aae0e646b118b43c0249c5147ae09d92648284)