### PR TITLE
Added STP flag data for CSS overflow: clip support

### DIFF
--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -94,7 +94,13 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "preview"
+                "version_added": "preview",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "CSS overflow: clip support"
+                  }
+                ]
               },
               "safari_ios": {
                 "version_added": false


### PR DESCRIPTION
#### Summary
CSS `overflow: clip` support is available in Safari Technology Preview under an Experimental Features flag.

#### Test results and supporting details
See [Release Notes for Safari Technology Preview 131](https://webkit.org/blog/11962/release-notes-for-safari-technology-preview-131/)