### PR TITLE
Fix Safari notes for captureVisibleTab

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1616,14 +1616,14 @@
               "safari": {
                 "notes": [
                   "The default file format is 'jpeg'.",
-                  "<code><all_urls></code> permission is not required to call this."
+                  "<code>&lt;all_urls&gt;</code> permission is not required to call this."
                 ],
                 "version_added": "14"
               },
               "safari_ios": {
                 "notes": [
                   "The default file format is 'jpeg'.",
-                  "<code><all_urls></code> permission is not required to call this."
+                  "<code>&lt;all_urls&gt;</code> permission is not required to call this."
                 ],
                 "version_added": "15"
               }


### PR DESCRIPTION
The notes for Safari on captureVisibleTab are not rendering properly.

There are two notes that show up as:
- The default file format is 'jpeg'.
- permission is not required to call this.

The second note should read:
- `<all_urls>` permission is not required to call this.

