### PR TITLE
FF96 Same-Site - lax changes reverted

### DIFF
--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -273,38 +273,19 @@
                 "edge": {
                   "version_added": "86"
                 },
-                "firefox": [
-                  {
-                    "version_added": "96"
-                  },
-                  {
-                    "version_added": "69",
-                    "version_removed": "96",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "network.cookie.sameSite.laxByDefault",
-                        "value_to_set": "true"
-                      }
-                    ]
-                  }
-                ],
-                "firefox_android": [
-                  {
-                    "version_added": "96"
-                  },
-                  {
-                    "version_added": "79",
-                    "version_removed": "96",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "network.cookie.sameSite.laxByDefault",
-                        "value_to_set": "true"
-                      }
-                    ]
-                  }
-                ],
+                "firefox": {
+                  "version_added": "69",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "network.cookie.sameSite.laxByDefault",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
                 "ie": {
                   "version_added": false
                 },
@@ -531,38 +512,19 @@
                     ]
                   }
                 ],
-                "firefox": [
-                  {
-                    "version_added": "96"
-                  },
-                  {
-                    "version_added": "79",
-                    "version_removed": "96",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "network.cookie.sameSite.schemeful",
-                        "value_to_set": "true"
-                      }
-                    ]
-                  }
-                ],
-                "firefox_android": [
-                  {
-                    "version_added": "96"
-                  },
-                  {
-                    "version_added": "79",
-                    "version_removed": "96",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "network.cookie.sameSite.schemeful",
-                        "value_to_set": "true"
-                      }
-                    ]
-                  }
-                ],
+                "firefox": {
+                  "version_added": "79",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "network.cookie.sameSite.schemeful",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
                 "ie": {
                   "version_added": false
                 },
@@ -618,38 +580,19 @@
                 "edge": {
                   "version_added": "86"
                 },
-                "firefox": [
-                  {
-                    "version_added": "96"
-                  },
-                  {
-                    "version_added": "69",
-                    "version_removed": "96",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "network.cookie.sameSite.noneRequiresSecure",
-                        "value_to_set": "true"
-                      }
-                    ]
-                  }
-                ],
-                "firefox_android": [
-                  {
-                    "version_added": "96"
-                  },
-                  {
-                    "version_added": "79",
-                    "version_removed": "96",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "network.cookie.sameSite.noneRequiresSecure",
-                        "value_to_set": "true"
-                      }
-                    ]
-                  }
-                ],
+                "firefox": {
+                  "version_added": "69",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "network.cookie.sameSite.noneRequiresSecure",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
                 "ie": {
                   "version_added": false
                 },


### PR DESCRIPTION
This reverts the relevant FF96 samesite changes that were added in #13840 (it is not a complete reversion, because the updates in that PR affected other browsers, and also fixed some data errors, and those changes are retained).

This is confirmed by https://bugzilla.mozilla.org/show_bug.cgi?id=1750264#c9

Related docs changes can be tracked in https://github.com/mdn/content/issues/12224