### PR TITLE
FF98 WebVR support disabled by default

### DIFF
--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -275,7 +275,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -236,11 +236,23 @@
             ],
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -107,7 +107,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         },
@@ -1679,7 +1679,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -70,11 +70,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -1642,11 +1654,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],

--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -130,7 +130,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -211,7 +212,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -292,7 +294,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -373,7 +376,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -454,7 +458,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -535,7 +540,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -616,7 +622,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -697,7 +704,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -778,7 +786,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -846,7 +855,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -926,7 +936,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -1007,7 +1018,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -1136,7 +1148,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -1217,7 +1230,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -1298,7 +1312,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -1379,7 +1394,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -1460,7 +1476,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -1541,7 +1558,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -1622,7 +1640,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false

--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -28,16 +28,29 @@
           },
           "firefox": [
             {
+              "version_added": "98",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.vr.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            {
               "version_added": "55",
+              "version_removed": "98",
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
               "version_added": "64",
+              "version_removed": "98",
               "notes": "macOS support was enabled in Firefox 64."
             }
           ],
           "firefox_android": {
-            "version_added": "55"
+            "version_added": "55",
+            "version_removed": "98"
           },
           "ie": {
             "version_added": false
@@ -64,7 +77,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": true,
+          "standard_track": false,
           "deprecated": true
         }
       },
@@ -96,11 +109,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -132,7 +157,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -165,11 +190,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -201,7 +238,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -234,11 +271,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -270,7 +319,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -303,11 +352,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -339,7 +400,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -372,11 +433,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -408,7 +481,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -441,11 +514,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -477,7 +562,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -510,11 +595,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -546,7 +643,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -579,11 +676,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -615,7 +724,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -648,11 +757,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -684,7 +805,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -704,11 +825,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -772,11 +905,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -808,7 +953,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -841,11 +986,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -877,7 +1034,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -958,11 +1115,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -994,7 +1163,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -1027,11 +1196,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -1063,7 +1244,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -1096,11 +1277,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -1132,7 +1325,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -1165,11 +1358,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -1201,7 +1406,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -1234,11 +1439,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -1270,7 +1487,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -1303,11 +1520,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -1339,7 +1568,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -1372,11 +1601,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -1408,7 +1649,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -28,16 +28,29 @@
           },
           "firefox": [
             {
+              "version_added": "98",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.vr.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            {
               "version_added": "55",
+              "version_removed": "98",
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
               "version_added": "64",
+              "version_removed": "98",
               "notes": "macOS support was enabled in Firefox 64."
             }
           ],
           "firefox_android": {
-            "version_added": "55"
+            "version_added": "55",
+            "version_removed": "98"
           },
           "ie": {
             "version_added": false
@@ -96,11 +109,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -165,11 +190,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -234,11 +271,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -303,11 +352,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -372,11 +433,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],

--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -64,7 +64,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": true,
+          "standard_track": false,
           "deprecated": true
         }
       },
@@ -132,7 +132,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -201,7 +201,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -270,7 +270,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -339,7 +339,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -408,7 +408,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -130,7 +130,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -211,7 +212,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -292,7 +294,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -373,7 +376,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -454,7 +458,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -64,7 +64,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": true,
+          "standard_track": false,
           "deprecated": true
         }
       },
@@ -133,7 +133,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -202,7 +202,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -271,7 +271,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -131,7 +131,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -212,7 +213,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -293,7 +295,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -28,16 +28,29 @@
           },
           "firefox": [
             {
+              "version_added": "98",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.vr.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            {
               "version_added": "55",
+              "version_removed": "98",
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
               "version_added": "64",
+              "version_removed": "98",
               "notes": "macOS support was enabled in Firefox 64."
             }
           ],
           "firefox_android": {
-            "version_added": "55"
+            "version_added": "55",
+            "version_removed": "98"
           },
           "ie": {
             "version_added": false
@@ -97,11 +110,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -166,11 +191,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -235,11 +272,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -130,7 +130,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -198,7 +199,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -265,7 +267,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -345,7 +348,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -474,7 +478,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -603,7 +608,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -64,7 +64,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": true,
+          "standard_track": false,
           "deprecated": true
         }
       },
@@ -132,7 +132,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -311,7 +311,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -428,7 +428,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -545,7 +545,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -28,16 +28,29 @@
           },
           "firefox": [
             {
+              "version_added": "98",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.vr.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            {
               "version_added": "55",
+              "version_removed": "98",
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
               "version_added": "64",
+              "version_removed": "98",
               "notes": "macOS support was enabled in Firefox 64."
             }
           ],
           "firefox_android": {
-            "version_added": "55"
+            "version_added": "55",
+            "version_removed": "98"
           },
           "ie": {
             "version_added": false
@@ -96,11 +109,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -152,11 +177,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -207,11 +244,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -275,11 +324,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -392,11 +453,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -509,11 +582,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -28,16 +28,29 @@
           },
           "firefox": [
             {
+              "version_added": "98",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.vr.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            {
               "version_added": "55",
+              "version_removed": "98",
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
               "version_added": "64",
+              "version_removed": "98",
               "notes": "macOS support was enabled in Firefox 64."
             }
           ],
           "firefox_android": {
-            "version_added": "55"
+            "version_added": "55",
+            "version_removed": "98"
           },
           "ie": {
             "version_added": false
@@ -145,11 +158,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -214,11 +239,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -283,11 +320,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -352,11 +401,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -179,7 +179,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -260,7 +261,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -341,7 +343,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -422,7 +425,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -64,7 +64,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": true,
+          "standard_track": false,
           "deprecated": true
         }
       },
@@ -181,7 +181,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -250,7 +250,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -319,7 +319,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -388,7 +388,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -64,7 +64,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": true,
+          "standard_track": false,
           "deprecated": true
         }
       },
@@ -133,7 +133,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -202,7 +202,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -271,7 +271,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -340,7 +340,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -409,7 +409,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -478,7 +478,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -547,7 +547,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -28,16 +28,29 @@
           },
           "firefox": [
             {
+              "version_added": "98",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.vr.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            {
               "version_added": "55",
+              "version_removed": "98",
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
               "version_added": "64",
+              "version_removed": "98",
               "notes": "macOS support was enabled in Firefox 64."
             }
           ],
           "firefox_android": {
-            "version_added": "55"
+            "version_added": "55",
+            "version_removed": "98"
           },
           "ie": {
             "version_added": false
@@ -97,11 +110,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -166,11 +191,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -235,11 +272,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -304,11 +353,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -373,11 +434,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -442,11 +515,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -511,11 +596,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -131,7 +131,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -212,7 +213,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -293,7 +295,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -374,7 +377,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -455,7 +459,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -536,7 +541,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -617,7 +623,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -130,7 +130,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -211,7 +212,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -388,7 +390,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -469,7 +472,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -550,7 +554,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -631,7 +636,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -64,7 +64,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": true,
+          "standard_track": false,
           "deprecated": true
         }
       },
@@ -132,7 +132,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -201,7 +201,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -366,7 +366,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -435,7 +435,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -504,7 +504,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -573,7 +573,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -28,16 +28,29 @@
           },
           "firefox": [
             {
+              "version_added": "98",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.vr.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            {
               "version_added": "55",
+              "version_removed": "98",
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
               "version_added": "64",
+              "version_removed": "98",
               "notes": "macOS support was enabled in Firefox 64."
             }
           ],
           "firefox_android": {
-            "version_added": "55"
+            "version_added": "55",
+            "version_removed": "98"
           },
           "ie": {
             "version_added": false
@@ -96,11 +109,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -165,11 +190,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -330,11 +367,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -399,11 +448,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -468,11 +529,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -537,11 +610,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -64,7 +64,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": true,
+          "standard_track": false,
           "deprecated": true
         }
       },
@@ -132,7 +132,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -201,7 +201,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -270,7 +270,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -28,16 +28,29 @@
           },
           "firefox": [
             {
+              "version_added": "98",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.vr.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            {
               "version_added": "55",
+              "version_removed": "98",
               "notes": "Windows support was enabled in Firefox 55."
             },
             {
               "version_added": "64",
+              "version_removed": "98",
               "notes": "macOS support was enabled in Firefox 64."
             }
           ],
           "firefox_android": {
-            "version_added": "55"
+            "version_added": "55",
+            "version_removed": "98"
           },
           "ie": {
             "version_added": false
@@ -96,11 +109,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -165,11 +190,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -234,11 +271,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -130,7 +130,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -211,7 +212,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false
@@ -292,7 +294,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false

--- a/api/Window.json
+++ b/api/Window.json
@@ -4974,7 +4974,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -5023,7 +5023,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -5088,7 +5088,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -5144,7 +5144,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -5213,7 +5213,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -5262,7 +5262,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -5311,7 +5311,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -5360,7 +5360,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -5430,7 +5430,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -10012,7 +10012,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -10062,7 +10062,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -10128,7 +10128,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -10184,7 +10184,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -10254,7 +10254,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -10304,7 +10304,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -10354,7 +10354,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -10404,7 +10404,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -10473,7 +10473,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/Window.json
+++ b/api/Window.json
@@ -4939,11 +4939,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -5051,11 +5063,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -5109,11 +5133,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -5176,11 +5212,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -5393,11 +5441,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -9977,11 +10037,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -10091,11 +10163,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -10149,11 +10233,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -10217,11 +10313,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],
@@ -10436,11 +10544,23 @@
             },
             "firefox": [
               {
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.vr.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "55",
+                "version_removed": "98",
                 "notes": "Windows support was enabled in Firefox 55."
               },
               {
                 "version_added": "64",
+                "version_removed": "98",
                 "notes": "macOS support was enabled in Firefox 64."
               }
             ],


### PR DESCRIPTION
WebVR has been disabled by default in FF98 - https://bugzilla.mozilla.org/show_bug.cgi?id=1750902 . Other docs work for this in https://github.com/mdn/content/issues/12582

So Web VR is apparently out of the standards, superseded by WebXR. It was implemented in Chrome Android until v80 and then removed. It is still marked as supported in Samsung Internet. It was implemented on FF in Windows and MacOS from around v55/64, but only on nightly and dev for other platforms.
This change turns it off by default on all platforms. 

I have made the changes just to [VRDisplay](https://developer.mozilla.org/en-US/docs/Web/API/VRDisplay). Once we confirm the right approach I'll role them out widely for the API within this same PR. 

@ddbeck There are questions inline to test changes. 
MAIN question is whether you would instead delete this and all associated MDN documents? I am assuming you don't want to because this will still be supported on Samsung internet.

