### PR TITLE
FF98 Ship form associated custom elements

### DIFF
--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -128,7 +128,7 @@
                   }
                 ]
               }
-            ]
+            ],
             "firefox_android": {
               "version_added": "98"
             },
@@ -190,7 +190,7 @@
                   }
                 ]
               }
-            ]
+            ],
             "firefox_android": {
               "version_added": "98"
             },
@@ -301,7 +301,7 @@
                   }
                 ]
               }
-            ]
+            ],
             "firefox_android": {
               "version_added": "98"
             },
@@ -607,7 +607,7 @@
                   }
                 ]
               }
-            ]
+            ],
             "firefox_android": {
               "version_added": "98"
             },

--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -113,18 +113,24 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "95",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.formAssociatedCustomElement.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "98"
+              },
+              {
+                "version_added": "95",
+                "version_removed": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.formAssociatedCustomElement.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ]
             "firefox_android": {
-              "version_added": false
+              "version_added": "98"
             },
             "ie": {
               "version_added": false
@@ -169,18 +175,24 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "95",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.formAssociatedCustomElement.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "98"
+              },
+              {
+                "version_added": "95",
+                "version_removed": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.formAssociatedCustomElement.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ]
             "firefox_android": {
-              "version_added": false
+              "version_added": "98"
             },
             "ie": {
               "version_added": false
@@ -274,18 +286,24 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "95",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.formAssociatedCustomElement.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "98"
+              },
+              {
+                "version_added": "95",
+                "version_removed": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.formAssociatedCustomElement.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ]
             "firefox_android": {
-              "version_added": false
+              "version_added": "98"
             },
             "ie": {
               "version_added": false
@@ -574,18 +592,24 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "96",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webcomponents.formAssociatedCustomElement.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "98"
+              },
+              {
+                "version_added": "95",
+                "version_removed": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webcomponents.formAssociatedCustomElement.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ]
             "firefox_android": {
-              "version_added": false
+              "version_added": "98"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
Firefox 98 ships form associated custom elements https://bugzilla.mozilla.org/show_bug.cgi?id=1745378 - essentially turning on `dom.webcomponents.formAssociatedCustomElement.enabled` all the time (this was added to BCD in #13223). This adds the new version for FF and also FF for Android. 

Other docs work for this can be tracked in https://github.com/mdn/content/issues/11969