### PR TITLE
Updates edge to version 98

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -175,19 +175,26 @@
         "97": {
           "release_date": "2022-01-06",
           "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-970107255-january-6",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "97"
         },
         "98": {
-          "status": "beta",
+          "release_date": "2022-02-03",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-980110843-february-3",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "98"
         },
         "99": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "99"
+        },
+        "100": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "100"
         }
       }
     }


### PR DESCRIPTION
Hello everyone!

I updated Edge browser to version 98, according to this [release note](https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-980110843-february-3).

Fixes #14832.

:)