### PR TITLE
Use "accepts_flags" hint in browser JSON for linting

### DIFF
--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -25,9 +25,6 @@ const VERSION_RANGE_BROWSERS = {
   webview_android: ['≤37'],
 };
 
-/** @type string[] */
-const FLAGLESS_BROWSERS = ['samsunginternet_android', 'webview_android'];
-
 for (const browser of Object.keys(browsers)) {
   validBrowserVersions[browser] = Object.keys(browsers[browser].releases);
   if (VERSION_RANGE_BROWSERS[browser]) {
@@ -139,7 +136,7 @@ function checkVersions(supportData, relPath, logger) {
           }
         }
         if ('flags' in statement) {
-          if (FLAGLESS_BROWSERS.includes(browser)) {
+          if (browsers[browser].accepts_flags === false) {
             logger.error(
               chalk`{red → {bold ${relPath}} - This browser ({bold ${browser}}) does not support flags, so support cannot be behind a flag for this feature.}`,
             );


### PR DESCRIPTION
This PR is a follow-up to #11286, which added an `accepts_flags` hint to the browser JSON.  This PR updates our lint script to use this property, rather than a hard-coded array.
