### PR TITLE
Remove irrelevant Safari flag data for Element API

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -680,34 +680,12 @@
             "opera_android": {
               "version_added": "24"
             },
-            "safari": [
-              {
-                "version_added": "13.1"
-              },
-              {
-                "version_added": "11.1",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Web Animations"
-                  }
-                ]
-              }
-            ],
-            "safari_ios": [
-              {
-                "version_added": "13.4"
-              },
-              {
-                "version_added": "11.3",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Web Animations"
-                  }
-                ]
-              }
-            ],
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "13.4"
+            },
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -3362,38 +3340,12 @@
                 ]
               }
             ],
-            "safari": [
-              {
-                "version_added": "13.1"
-              },
-              {
-                "version_added": "11.1",
-                "partial_implementation": true,
-                "notes": "Does not support the <code>subtree</code> option.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Web Animations"
-                  }
-                ]
-              }
-            ],
-            "safari_ios": [
-              {
-                "version_added": "13.4"
-              },
-              {
-                "version_added": "11.3",
-                "partial_implementation": true,
-                "notes": "Does not support the <code>subtree</code> option.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Web Animations"
-                  }
-                ]
-              }
-            ],
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "13.4"
+            },
             "samsunginternet_android": {
               "version_added": "14.0"
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Safari (Desktop and iOS/iPadOS) for the `Element` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/queengooborg/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
