### PR TITLE
Remove irrelevant Chromium flag data for api.ServiceWorkerRegistration.paymentManager

### DIFF
--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -451,36 +451,12 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/paymentManager",
           "support": {
-            "chrome": [
-              {
-                "version_added": "70"
-              },
-              {
-                "version_added": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#service-worker-payment-apps",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "70"
-              },
-              {
-                "version_added": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#service-worker-payment-apps",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "70"
+            },
+            "chrome_android": {
+              "version_added": "70"
+            },
             "edge": {
               "version_added": "79"
             },
@@ -493,21 +469,9 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "57"
-              },
-              {
-                "version_added": "43",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#service-worker-payment-apps",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "opera": {
+              "version_added": "57"
+            },
             "opera_android": {
               "version_added": "49"
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `paymentManager` member of the `ServiceWorkerRegistration` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/queengooborg/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
