### PR TITLE
Remove irrelevant Edge flag data for TouchEvent API

### DIFF
--- a/api/TouchEvent.json
+++ b/api/TouchEvent.json
@@ -11,22 +11,9 @@
           "chrome_android": {
             "version_added": "25"
           },
-          "edge": [
-            {
-              "version_added": "79"
-            },
-            {
-              "version_added": "≤18",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Standards Preview",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "edge": {
+            "version_added": "79"
+          },
           "firefox": [
             {
               "version_added": "52"
@@ -137,7 +124,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -193,7 +180,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -249,7 +236,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -305,7 +292,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -361,7 +348,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -417,7 +404,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": [
               {
@@ -473,7 +460,7 @@
               "version_added": "25"
             },
             "edge": {
-              "version_added": "≤18"
+              "version_added": "79"
             },
             "firefox": [
               {


### PR DESCRIPTION
This PR removes irrelevant flag data for Microsoft Edge for the `TouchEvent` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/queengooborg/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
