### PR TITLE
Mirror Firefox -> Firefox Android WebGL data

### DIFF
--- a/api/ANGLE_instanced_arrays.json
+++ b/api/ANGLE_instanced_arrays.json
@@ -18,7 +18,7 @@
             "version_added": "47"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "47"
           },
           "ie": {
             "version_added": "11"
@@ -66,7 +66,7 @@
               "version_added": "47"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "ie": {
               "version_added": "11"
@@ -115,7 +115,7 @@
               "version_added": "47"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "ie": {
               "version_added": "11"
@@ -164,7 +164,7 @@
               "version_added": "47"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "47"
             },
             "ie": {
               "version_added": "11"

--- a/api/EXT_blend_minmax.json
+++ b/api/EXT_blend_minmax.json
@@ -26,7 +26,7 @@
             }
           ],
           "firefox_android": {
-            "version_added": null
+            "version_added": "35"
           },
           "ie": {
             "version_added": false

--- a/api/EXT_color_buffer_float.json
+++ b/api/EXT_color_buffer_float.json
@@ -18,7 +18,7 @@
             "version_added": "49"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "49"
           },
           "ie": {
             "version_added": false

--- a/api/EXT_color_buffer_half_float.json
+++ b/api/EXT_color_buffer_half_float.json
@@ -26,7 +26,7 @@
             }
           ],
           "firefox_android": {
-            "version_added": null
+            "version_added": "36"
           },
           "ie": {
             "version_added": false

--- a/api/EXT_float_blend.json
+++ b/api/EXT_float_blend.json
@@ -19,7 +19,7 @@
             "version_added": "67"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "67"
           },
           "ie": {
             "version_added": false

--- a/api/EXT_frag_depth.json
+++ b/api/EXT_frag_depth.json
@@ -19,7 +19,7 @@
             "version_added": "47"
           },
           "firefox_android": {
-            "version_added": "47"
+            "version_added": false
           },
           "ie": {
             "version_added": false

--- a/api/EXT_sRGB.json
+++ b/api/EXT_sRGB.json
@@ -26,7 +26,7 @@
             }
           ],
           "firefox_android": {
-            "version_added": null
+            "version_added": "28"
           },
           "ie": {
             "version_added": false

--- a/api/EXT_shader_texture_lod.json
+++ b/api/EXT_shader_texture_lod.json
@@ -19,7 +19,7 @@
             "version_added": "47"
           },
           "firefox_android": {
-            "version_added": "47"
+            "version_added": false
           },
           "ie": {
             "version_added": false

--- a/api/OES_element_index_uint.json
+++ b/api/OES_element_index_uint.json
@@ -18,7 +18,7 @@
             "version_added": "24"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "24"
           },
           "ie": {
             "version_added": "11"

--- a/api/OES_fbo_render_mipmap.json
+++ b/api/OES_fbo_render_mipmap.json
@@ -30,7 +30,7 @@
             }
           ],
           "firefox_android": {
-            "version_added": false
+            "version_added": "79"
           },
           "ie": {
             "version_added": false

--- a/api/OES_standard_derivatives.json
+++ b/api/OES_standard_derivatives.json
@@ -18,7 +18,7 @@
             "version_added": "10"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "10"
           },
           "ie": {
             "version_added": "11"

--- a/api/OES_texture_float.json
+++ b/api/OES_texture_float.json
@@ -18,7 +18,7 @@
             "version_added": "6"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "6"
           },
           "ie": {
             "version_added": "11"

--- a/api/OES_texture_float_linear.json
+++ b/api/OES_texture_float_linear.json
@@ -18,7 +18,7 @@
             "version_added": "24"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "24"
           },
           "ie": {
             "version_added": "11"

--- a/api/OES_texture_half_float.json
+++ b/api/OES_texture_half_float.json
@@ -18,7 +18,7 @@
             "version_added": "29"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "29"
           },
           "ie": {
             "version_added": false

--- a/api/OES_texture_half_float_linear.json
+++ b/api/OES_texture_half_float_linear.json
@@ -18,7 +18,7 @@
             "version_added": "30"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false

--- a/api/OES_vertex_array_object.json
+++ b/api/OES_vertex_array_object.json
@@ -18,7 +18,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "25"
           },
           "ie": {
             "version_added": false
@@ -66,7 +66,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -115,7 +115,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -164,7 +164,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "25"
             },
             "ie": {
               "version_added": false
@@ -213,7 +213,7 @@
               "version_added": "25"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": "25"
             },
             "ie": {
               "version_added": false

--- a/api/OVR_multiview2.json
+++ b/api/OVR_multiview2.json
@@ -35,7 +35,7 @@
             "version_added": "71"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "79"
           },
           "ie": {
             "version_added": false
@@ -113,7 +113,7 @@
               "version_added": "71"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false

--- a/api/WEBGL_color_buffer_float.json
+++ b/api/WEBGL_color_buffer_float.json
@@ -18,7 +18,7 @@
             "version_added": "30"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "30"
           },
           "ie": {
             "version_added": false

--- a/api/WEBGL_compressed_texture_etc.json
+++ b/api/WEBGL_compressed_texture_etc.json
@@ -18,7 +18,7 @@
             "version_added": "51"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "51"
           },
           "ie": {
             "version_added": false

--- a/api/WEBGL_compressed_texture_etc1.json
+++ b/api/WEBGL_compressed_texture_etc1.json
@@ -18,7 +18,7 @@
             "version_added": "30"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "30"
           },
           "ie": {
             "version_added": false

--- a/api/WEBGL_compressed_texture_pvrtc.json
+++ b/api/WEBGL_compressed_texture_pvrtc.json
@@ -17,16 +17,9 @@
           "firefox": {
             "version_added": false
           },
-          "firefox_android": [
-            {
-              "version_added": "18"
-            },
-            {
-              "prefix": "MOZ_",
-              "version_added": true,
-              "version_removed": "58"
-            }
-          ],
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },

--- a/api/WEBGL_compressed_texture_s3tc.json
+++ b/api/WEBGL_compressed_texture_s3tc.json
@@ -32,7 +32,7 @@
             }
           ],
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": "11"

--- a/api/WEBGL_compressed_texture_s3tc_srgb.json
+++ b/api/WEBGL_compressed_texture_s3tc_srgb.json
@@ -18,7 +18,7 @@
             "version_added": "55"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false

--- a/api/WEBGL_debug_renderer_info.json
+++ b/api/WEBGL_debug_renderer_info.json
@@ -18,7 +18,7 @@
             "version_added": "53"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "53"
           },
           "ie": {
             "version_added": "11"

--- a/api/WEBGL_debug_shaders.json
+++ b/api/WEBGL_debug_shaders.json
@@ -26,7 +26,7 @@
             "notes": "The extension is activated by default to privileged contexts (chrome context)."
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -82,7 +82,7 @@
               "notes": "The extension is activated by default to privileged contexts (chrome context)."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/WEBGL_draw_buffers.json
+++ b/api/WEBGL_draw_buffers.json
@@ -18,7 +18,7 @@
             "version_added": "28"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -66,7 +66,7 @@
               "version_added": "28"
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/WEBGL_lose_context.json
+++ b/api/WEBGL_lose_context.json
@@ -36,9 +36,16 @@
               "version_removed": "58"
             }
           ],
-          "firefox_android": {
-            "version_added": null
-          },
+          "firefox_android": [
+            {
+              "version_added": "22"
+            },
+            {
+              "prefix": "MOZ_",
+              "version_added": "19",
+              "version_removed": "58"
+            }
+          ],
           "ie": {
             "version_added": false
           },
@@ -115,9 +122,16 @@
                 "version_removed": "58"
               }
             ],
-            "firefox_android": {
-              "version_added": null
-            },
+            "firefox_android": [
+              {
+                "version_added": "22"
+              },
+              {
+                "prefix": "MOZ_",
+                "version_added": "19",
+                "version_removed": "58"
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -171,9 +185,16 @@
                 "version_removed": "58"
               }
             ],
-            "firefox_android": {
-              "version_added": null
-            },
+            "firefox_android": [
+              {
+                "version_added": "22"
+              },
+              {
+                "prefix": "MOZ_",
+                "version_added": "19",
+                "version_removed": "58"
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/WebGLActiveInfo.json
+++ b/api/WebGLActiveInfo.json
@@ -18,7 +18,7 @@
             "version_added": "4"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "11"
@@ -66,7 +66,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -115,7 +115,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -164,7 +164,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"

--- a/api/WebGLBuffer.json
+++ b/api/WebGLBuffer.json
@@ -18,7 +18,7 @@
             "version_added": "4"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "11"

--- a/api/WebGLFramebuffer.json
+++ b/api/WebGLFramebuffer.json
@@ -18,7 +18,7 @@
             "version_added": "4"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "11"

--- a/api/WebGLProgram.json
+++ b/api/WebGLProgram.json
@@ -18,7 +18,7 @@
             "version_added": "4"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "11"

--- a/api/WebGLRenderbuffer.json
+++ b/api/WebGLRenderbuffer.json
@@ -18,7 +18,7 @@
             "version_added": "4"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "11"

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -19,7 +19,7 @@
             "version_added": "4"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "11",
@@ -68,7 +68,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -117,7 +117,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -166,7 +166,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -218,7 +218,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -317,7 +317,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -413,7 +413,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -465,7 +465,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -561,7 +561,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -610,7 +610,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -706,7 +706,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -802,7 +802,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -851,7 +851,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -898,7 +898,7 @@
                 "version_added": "79"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "79"
               },
               "ie": {
                 "version_added": false
@@ -948,7 +948,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -1044,7 +1044,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -1140,7 +1140,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -1246,7 +1246,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -1342,7 +1342,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -1391,7 +1391,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -1440,7 +1440,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -1489,7 +1489,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -1538,7 +1538,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -1643,7 +1643,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -1692,7 +1692,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -1739,7 +1739,7 @@
                 "version_added": "79"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "79"
               },
               "ie": {
                 "version_added": false
@@ -1836,7 +1836,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -1929,7 +1929,7 @@
                   "version_added": "79"
                 },
                 "firefox_android": {
-                  "version_added": null
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -1980,7 +1980,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -2029,7 +2029,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -2078,7 +2078,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -2127,7 +2127,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -2176,7 +2176,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -2225,7 +2225,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -2274,7 +2274,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -2323,7 +2323,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -2372,7 +2372,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -2421,7 +2421,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -2470,7 +2470,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -2519,7 +2519,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -2568,7 +2568,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -2617,7 +2617,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -2666,7 +2666,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -2715,7 +2715,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -2764,7 +2764,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -2813,7 +2813,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -2862,7 +2862,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -2911,7 +2911,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -2960,7 +2960,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -3009,7 +3009,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -3058,7 +3058,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -3107,7 +3107,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -3156,7 +3156,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -3205,7 +3205,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -3254,7 +3254,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -3303,7 +3303,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -3352,7 +3352,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -3401,7 +3401,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -3497,7 +3497,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -3593,7 +3593,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -3642,7 +3642,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -3738,7 +3738,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -3787,7 +3787,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -3836,7 +3836,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -3885,7 +3885,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -3937,7 +3937,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -4033,7 +4033,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -4082,7 +4082,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -4131,7 +4131,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -4183,7 +4183,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -4282,7 +4282,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -4331,7 +4331,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -4383,7 +4383,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -4482,7 +4482,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -4578,7 +4578,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -4627,7 +4627,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -4676,7 +4676,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -4725,7 +4725,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -4774,7 +4774,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -4826,7 +4826,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -4925,7 +4925,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -5021,7 +5021,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -5073,7 +5073,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -5169,7 +5169,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -5218,7 +5218,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -5267,7 +5267,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -5316,7 +5316,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -5368,7 +5368,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -5464,7 +5464,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -5513,7 +5513,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -5562,7 +5562,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -5611,7 +5611,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -5660,7 +5660,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -5759,7 +5759,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -5861,7 +5861,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -5957,7 +5957,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -6006,7 +6006,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -6099,7 +6099,7 @@
                   "version_added": "79"
                 },
                 "firefox_android": {
-                  "version_added": null
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -6153,7 +6153,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -6249,7 +6249,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -6298,7 +6298,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -6347,7 +6347,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -6396,7 +6396,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -6445,7 +6445,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -6494,7 +6494,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -6543,7 +6543,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -6592,7 +6592,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -6641,7 +6641,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -6693,7 +6693,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -6786,7 +6786,7 @@
                   "version_added": "79"
                 },
                 "firefox_android": {
-                  "version_added": null
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -6840,7 +6840,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -6939,7 +6939,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -7038,7 +7038,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -7131,7 +7131,7 @@
                   "version_added": "79"
                 },
                 "firefox_android": {
-                  "version_added": null
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -7182,7 +7182,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -7231,7 +7231,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -7280,7 +7280,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -7329,7 +7329,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -7378,7 +7378,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -7427,7 +7427,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -7476,7 +7476,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -7525,7 +7525,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -7574,7 +7574,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -7623,7 +7623,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -7672,7 +7672,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -7721,7 +7721,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -7770,7 +7770,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -7819,7 +7819,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -7868,7 +7868,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -7917,7 +7917,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -7966,7 +7966,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -8059,7 +8059,7 @@
                   "version_added": "79"
                 },
                 "firefox_android": {
-                  "version_added": null
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -8110,7 +8110,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -8203,7 +8203,7 @@
                   "version_added": "79"
                 },
                 "firefox_android": {
-                  "version_added": null
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -8254,7 +8254,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -8347,7 +8347,7 @@
                   "version_added": "79"
                 },
                 "firefox_android": {
-                  "version_added": null
+                  "version_added": "79"
                 },
                 "ie": {
                   "version_added": false
@@ -8398,7 +8398,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -8447,7 +8447,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -8496,7 +8496,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -8545,7 +8545,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -8592,7 +8592,7 @@
                 "version_added": "79"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "79"
               },
               "ie": {
                 "version_added": false
@@ -8642,7 +8642,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -8691,7 +8691,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -8738,7 +8738,7 @@
                 "version_added": "79"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "79"
               },
               "ie": {
                 "version_added": false
@@ -8788,7 +8788,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -8837,7 +8837,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -8884,7 +8884,7 @@
                 "version_added": "79"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "79"
               },
               "ie": {
                 "version_added": false
@@ -8934,7 +8934,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -8983,7 +8983,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -9030,7 +9030,7 @@
                 "version_added": "79"
               },
               "firefox_android": {
-                "version_added": null
+                "version_added": "79"
               },
               "ie": {
                 "version_added": false
@@ -9080,7 +9080,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -9129,7 +9129,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"

--- a/api/WebGLShader.json
+++ b/api/WebGLShader.json
@@ -18,7 +18,7 @@
             "version_added": "4"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "11"

--- a/api/WebGLShaderPrecisionFormat.json
+++ b/api/WebGLShaderPrecisionFormat.json
@@ -18,7 +18,7 @@
             "version_added": "4"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "11"
@@ -66,7 +66,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -115,7 +115,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"
@@ -164,7 +164,7 @@
               "version_added": "4"
             },
             "firefox_android": {
-              "version_added": true
+              "version_added": "4"
             },
             "ie": {
               "version_added": "11"

--- a/api/WebGLTexture.json
+++ b/api/WebGLTexture.json
@@ -18,7 +18,7 @@
             "version_added": "4"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "11"

--- a/api/WebGLUniformLocation.json
+++ b/api/WebGLUniformLocation.json
@@ -18,7 +18,7 @@
             "version_added": "4"
           },
           "firefox_android": {
-            "version_added": true
+            "version_added": "4"
           },
           "ie": {
             "version_added": "11"

--- a/api/WebGLVertexArrayObjectOES.json
+++ b/api/WebGLVertexArrayObjectOES.json
@@ -18,7 +18,7 @@
             "version_added": "25"
           },
           "firefox_android": {
-            "version_added": null
+            "version_added": "25"
           },
           "ie": {
             "version_added": false


### PR DESCRIPTION
This PR adds real values to Firefox Android for the WebGL data.  The data is verified using the mdn-bcd-collector project to check for support, and then version numbers come from mirroring the data.

I found a [bug that includes a commen](https://bugzilla.mozilla.org/show_bug.cgi?id=647802#c3)t talking about a WebGL feature bugging out in Firefox 4 beta.  Based upon this comment, I believe that WebGL support was introduced to Firefox Android since the very beginning.
