### PR TITLE
Update Navigator.json

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3473,8 +3473,8 @@
             },
             "edge": {
               "version_added": "81",
-              "partial_implementation": true,
-              "notes": "Not supported on macOS, see <a href='https://crbug.com/1144920'>bug 1144920</a>."
+              "partial_implementation": false,
+              "notes": "Supported in macOS from version 83."
             },
             "firefox": {
               "version_added": "71",


### PR DESCRIPTION
Updates Web Share support on Edge from v83.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Updates Web Share support on Edge from v83.

#### Test results and supporting details

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://docs.microsoft.com/en-gb/microsoft-edge/progressive-web-apps-chromium/whats-new/pwa#support-for-the-share-api-on-macos

#### Related issues
Fixes bug https://bugs.chromium.org/p/chromium/issues/detail?id=1144920 on Microsoft Edge. 

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
