### PR TITLE
Updates Web Share support in macOS for Edge 93.

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3533,8 +3533,8 @@
               },
               "edge": {
                 "version_added": "89",
-                "partial_implementation": true,
-                "notes": "Not supported on macOS, see <a href='https://crbug.com/1144920'>bug 1144920</a>."
+                "partial_implementation": false,
+                "notes": "Supported in macOS from version 93."
               },
               "firefox": {
                 "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -546,19 +546,31 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/canShare",
           "spec_url": "https://w3c.github.io/web-share/#canshare-data-method",
           "support": {
-            "chrome": {
-              "version_added": "89",
-              "partial_implementation": true,
-              "notes": "Not supported on macOS, see <a href='https://crbug.com/1144920'>bug 1144920</a>."
-            },
+            "chrome": [
+              {
+                "version_added": "93"
+              },
+              {
+                "version_added": "89",
+                "version_removed": "93",
+                "partial_implementation": true,
+                "notes": "Not supported on macOS."
+              }
+            ],
             "chrome_android": {
               "version_added": "75"
             },
-            "edge": {
-              "version_added": "89",
-              "partial_implementation": true,
-              "notes": "Not supported on macOS, see <a href='https://crbug.com/1144920'>bug 1144920</a>."
-            },
+            "edge": [
+              {
+                "version_added": "93"
+              },
+              {
+                "version_added": "89",
+                "version_removed": "93",
+                "partial_implementation": true,
+                "notes": "Not supported on macOS."
+              }
+            ],
             "firefox": {
               "version_added": "96",
               "flags": [
@@ -575,11 +587,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "75",
-              "partial_implementation": true,
-              "notes": "Not supported on macOS, see <a href='https://crbug.com/1144920'>bug 1144920</a>."
-            },
+            "opera": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "75",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Not supported on macOS."
+              }
+            ],
             "opera_android": {
               "version_added": "54"
             },
@@ -3463,19 +3481,31 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/share",
           "spec_url": "https://w3c.github.io/web-share/#share-method",
           "support": {
-            "chrome": {
-              "version_added": "89",
-              "partial_implementation": true,
-              "notes": "Not supported on macOS, see <a href='https://crbug.com/1144920'>bug 1144920</a>."
-            },
+            "chrome": [
+              {
+                "version_added": "93"
+              },
+              {
+                "version_added": "89",
+                "version_removed": "93",
+                "partial_implementation": true,
+                "notes": "Not supported on macOS."
+              }
+            ],
             "chrome_android": {
               "version_added": "61"
             },
-            "edge": {
-              "version_added": "81",
-              "partial_implementation": true,
-              "notes": "Not supported on macOS, see <a href='https://crbug.com/1144920'>bug 1144920</a>."
-            },
+            "edge": [
+              {
+                "version_added": "93"
+              },
+              {
+                "version_added": "89",
+                "version_removed": "93",
+                "partial_implementation": true,
+                "notes": "Not supported on macOS."
+              }
+            ],
             "firefox": {
               "version_added": "71",
               "flags": [
@@ -3493,9 +3523,17 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "75"
-            },
+            "opera": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "75",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "Not supported on macOS."
+              }
+            ],
             "opera_android": {
               "version_added": "48"
             },
@@ -3523,19 +3561,31 @@
             "description": "<code>data.files</code> parameter",
             "spec_url": "https://w3c.github.io/web-share/#dom-sharedata-files",
             "support": {
-              "chrome": {
-                "version_added": "89",
-                "partial_implementation": true,
-                "notes": "Not supported on macOS, see <a href='https://crbug.com/1144920'>bug 1144920</a>."
-              },
+              "chrome": [
+                {
+                  "version_added": "93"
+                },
+                {
+                  "version_added": "89",
+                  "version_removed": "93",
+                  "partial_implementation": true,
+                  "notes": "Not supported on macOS."
+                }
+              ],
               "chrome_android": {
                 "version_added": "76"
               },
-              "edge": {
-                "version_added": "89",
-                "partial_implementation": false,
-                "notes": "Supported in macOS from version 93."
-              },
+              "edge": [
+                {
+                  "version_added": "93"
+                },
+                {
+                  "version_added": "89",
+                  "version_removed": "93",
+                  "partial_implementation": true,
+                  "notes": "Not supported on macOS."
+                }
+              ],
               "firefox": {
                 "version_added": false
               },
@@ -3545,11 +3595,17 @@
               "ie": {
                 "version_added": false
               },
-              "opera": {
-                "version_added": "75",
-                "partial_implementation": true,
-                "notes": "Not supported on macOS, see <a href='https://crbug.com/1144920'>bug 1144920</a>."
-              },
+              "opera": [
+                {
+                  "version_added": "79"
+                },
+                {
+                  "version_added": "75",
+                  "version_removed": "79",
+                  "partial_implementation": true,
+                  "notes": "Not supported on macOS."
+                }
+              ],
               "opera_android": {
                 "version_added": "54"
               },
@@ -3578,19 +3634,31 @@
             "description": "<code>data.text</code> parameter",
             "spec_url": "https://w3c.github.io/web-share/#dom-sharedata-text",
             "support": {
-              "chrome": {
-                "version_added": "89",
-                "partial_implementation": true,
-                "notes": "Not supported on macOS, see <a href='https://crbug.com/1144920'>bug 1144920</a>."
-              },
+              "chrome": [
+                {
+                  "version_added": "93"
+                },
+                {
+                  "version_added": "89",
+                  "version_removed": "93",
+                  "partial_implementation": true,
+                  "notes": "Not supported on macOS."
+                }
+              ],
               "chrome_android": {
                 "version_added": "76"
               },
-              "edge": {
-                "version_added": "89",
-                "partial_implementation": true,
-                "notes": "Not supported on macOS, see <a href='https://crbug.com/1144920'>bug 1144920</a>."
-              },
+              "edge": [
+                {
+                  "version_added": "93"
+                },
+                {
+                  "version_added": "89",
+                  "version_removed": "93",
+                  "partial_implementation": true,
+                  "notes": "Not supported on macOS."
+                }
+              ],
               "firefox": {
                 "version_added": "71"
               },
@@ -3600,11 +3668,17 @@
               "ie": {
                 "version_added": false
               },
-              "opera": {
-                "version_added": "75",
-                "partial_implementation": true,
-                "notes": "Not supported on macOS, see <a href='https://crbug.com/1144920'>bug 1144920</a>."
-              },
+              "opera": [
+                {
+                  "version_added": "79"
+                },
+                {
+                  "version_added": "75",
+                  "version_removed": "79",
+                  "partial_implementation": true,
+                  "notes": "Not supported on macOS."
+                }
+              ],
               "opera_android": {
                 "version_added": "54"
               },


### PR DESCRIPTION
Updates Web Share support in macOS for Edge 93.

#### Summary
Updates Web Share support in macOS for Edge 93.

#### Test results and supporting details
https://docs.microsoft.com/en-gb/microsoft-edge/progressive-web-apps-chromium/whats-new/pwa#support-for-the-share-api-on-macos


