### PR TITLE
Sec-CH-UA-Full-Version-List supported in Chrome 98 et al

### DIFF
--- a/http/headers/sec-ch-ua-full-version-list.json
+++ b/http/headers/sec-ch-ua-full-version-list.json
@@ -1,0 +1,56 @@
+{
+  "http": {
+    "headers": {
+      "Sec-CH-UA-Full-Version-List": {
+        "__compat": {
+          "description": "<code>Sec-CH-UA-Full-Version-List</code> request header",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-CH-UA-Full-Version-List",
+          "spec_url": "https://wicg.github.io/ua-client-hints/#sec-ch-ua-full-version-list",
+          "support": {
+            "chrome": {
+              "version_added": "98"
+            },
+            "chrome_android": {
+              "version_added": "98"
+            },
+            "edge": {
+              "version_added": "98"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "84"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "98"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
See https://chromestatus.com/feature/5703317813460992
This adds version support info for Chrome and associated browsers. 
- MDN docs are already up to date in https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-CH-UA-Full-Version-List
- Easy to test using https://user-agent-client-hints.glitch.me/?uach=Sec-CH-UA-Full-Version&uach=Sec-CH-UA-Full-Version-List

Fixes #14868