### PR TITLE
FF97 WebMidi support - desktop

### DIFF
--- a/api/MIDIAccess.json
+++ b/api/MIDIAccess.json
@@ -15,7 +15,14 @@
             "version_added": "79"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "97",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.webmidi.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": {
             "version_added": false
@@ -63,7 +70,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -112,7 +126,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -161,7 +182,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -210,7 +238,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -259,7 +294,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/api/MIDIConnectionEvent.json
+++ b/api/MIDIConnectionEvent.json
@@ -15,7 +15,14 @@
             "version_added": "79"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "97",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.webmidi.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": {
             "version_added": false
@@ -64,7 +71,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -113,7 +127,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/api/MIDIInput.json
+++ b/api/MIDIInput.json
@@ -15,7 +15,14 @@
             "version_added": "79"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "97",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.webmidi.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": {
             "version_added": false
@@ -63,7 +70,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -112,7 +126,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/api/MIDIInputMap.json
+++ b/api/MIDIInputMap.json
@@ -15,7 +15,14 @@
             "version_added": "79"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "97",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.webmidi.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": {
             "version_added": false

--- a/api/MIDIInputMap.json
+++ b/api/MIDIInputMap.json
@@ -68,7 +68,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -115,7 +122,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -162,7 +176,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -209,7 +230,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -256,7 +284,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -303,7 +338,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -350,7 +392,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/api/MIDIMessageEvent.json
+++ b/api/MIDIMessageEvent.json
@@ -15,7 +15,14 @@
             "version_added": "79"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "97",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.webmidi.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": {
             "version_added": false
@@ -64,7 +71,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -113,7 +127,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/api/MIDIOutput.json
+++ b/api/MIDIOutput.json
@@ -15,7 +15,14 @@
             "version_added": "79"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "97",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.webmidi.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": {
             "version_added": false
@@ -64,7 +71,14 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -113,7 +127,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/api/MIDIOutputMap.json
+++ b/api/MIDIOutputMap.json
@@ -15,7 +15,14 @@
             "version_added": "79"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "97",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.webmidi.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": {
             "version_added": false
@@ -61,7 +68,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -108,7 +122,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -155,7 +176,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -202,7 +230,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -249,7 +284,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -296,7 +338,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -343,7 +392,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/api/MIDIPort.json
+++ b/api/MIDIPort.json
@@ -15,7 +15,14 @@
             "version_added": "79"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "97",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.webmidi.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": {
             "version_added": false
@@ -63,7 +70,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -112,7 +126,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -161,7 +182,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -210,7 +238,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -259,7 +294,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -308,7 +350,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -357,7 +406,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -406,7 +462,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -455,7 +518,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -504,7 +574,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -553,7 +630,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
FF97 added support for [WebMidi API](https://developer.mozilla.org/en-US/docs/Web/API/Web_MIDI_API) backends for desktop platforms in https://bugzilla.mozilla.org/show_bug.cgi?id=836897 behind a preference: Linux, MacOS, Windows.
(Android does not have a backend yet, but is by definition `false` for support because of the preference). 

This just updates [MIDIInputMap](https://developer.mozilla.org/en-US/docs/Web/API/MIDIInputMap) - I will roll out to other parts if this is agreed good.

@ddbeck There are a few nuances. 
- The API consists of a front end and platform-specific backends. The front end including preference has been around since FF60 according to browserstack. This allows you to read files and output to "local synth" (your computer speakers) - e.g. run this kind of page: https://blog.karimratib.me/demos/sheetplayer/. 
  - This is not considered "real" midi by the team (see https://bugzilla.mozilla.org/show_bug.cgi?id=836897#c119) - it is referred to as a "dummy implementation". It doesn't look all that dummy to me, but I guess that is the team's call. 
  - My concern is that someone trying this on FF60 to 97 will see the preference, and see that they can call the API. So they will think we got BCD wrong. **Should we perhaps add another note**: "From version 60 to version 96 a dummy implementation is provided; you can call the API but not route MIDI to an output"?
- There are two other prefs which we can ignore for BCD:
  - `dom.webmidi.gated` causes the Web MIDI implementation to be gated by a new add-on based security policy. But this is on by default from this first real version 97, so IMO does not need to be mentioned.
  - `midi.tested` enables some behavior required for testing - can be ignored.
