### PR TITLE
FF98 HTMLElement.outerText - add support and mark as standard

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2552,6 +2552,7 @@
       "outerText": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/outerText",
+          "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#dom-outertext",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -2563,10 +2564,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "98"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "98"
             },
             "ie": {
               "version_added": "5.5"
@@ -2592,7 +2593,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
[`HTMLElement.outerText`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/outerText) became part of the spec in https://github.com/whatwg/html/pull/6653 (Sep. 2021) and can now be found here: https://html.spec.whatwg.org/multipage/dom.html#the-innertext-idl-attribute.

Support was added in FF98 in https://bugzilla.mozilla.org/show_bug.cgi?id=1709790

This adds the FF support statements, adds spec-url links, and adds it as being on the standard track.
