### PR TITLE
Add support for self.structuredClone() in Chromium Based Browsers

### DIFF
--- a/api/_globals/structuredClone.json
+++ b/api/_globals/structuredClone.json
@@ -6,10 +6,10 @@
         "spec_url": "https://html.spec.whatwg.org/multipage/structured-data.html#dom-structuredclone",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "98"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "98"
           },
           "deno": [
             {
@@ -27,7 +27,7 @@
             }
           ],
           "edge": {
-            "version_added": false
+            "version_added": "98"
           },
           "firefox": {
             "version_added": "94"
@@ -42,7 +42,7 @@
             "version_added": "17.0.0"
           },
           "opera": {
-            "version_added": false
+            "version_added": "84"
           },
           "opera_android": {
             "version_added": false
@@ -57,7 +57,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "98"
           }
         },
         "status": {


### PR DESCRIPTION
#### Summary
Updated structuredClone.json since self.structuredClone() is now supported by Chromium Based Browsers.

#### Test results and supporting details
https://chromestatus.com/feature/5630001077551104

#### Related issues
Fixes #14885
Fixes #14867
