### PR TITLE
Fix Safari data for the browser.tabs.onreplaced event

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -3101,10 +3101,10 @@
                 "version_added": true
               },
               "safari": {
-                "version_added": "14"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "15"
+                "version_added": false
               }
             }
           }


### PR DESCRIPTION
#### Summary
Safari doesn't actually support the `browser.tabs.onreplaced` event.

#### Test results and supporting details
Data provided by the Safari engineering team.