### PR TITLE
Fix spec_url of "javascript.operators.right_shift"

### DIFF
--- a/javascript/operators/right_shift.json
+++ b/javascript/operators/right_shift.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Bitwise right shift (<code>a &gt;&gt; b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Right_shift",
-          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-BitwiseORExpression",
+          "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-signed-right-shift-operator",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

The specification URL was linking to the section of the bitwise OR `|` operator,
apparently due to a copy-paste error. The unsigned right shift is correct, see
https://github.com/mdn/browser-compat-data/blob/6f71796dc415c5562e857be2312cc79ed6335422/javascript/operators/unsigned_right_shift.json#L8

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

I tested the URL https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-signed-right-shift-operator that I'm linking, it works.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

I didn't find any - no one seems to have noticed yet.

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
