### PR TITLE
Mark font-variant-alternates as not deprecated

### DIFF
--- a/css/properties/font-variant-alternates.json
+++ b/css/properties/font-variant-alternates.json
@@ -4,6 +4,7 @@
       "font-variant-alternates": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates",
+          "spec_url": "https://drafts.csswg.org/css-fonts/#font-variant-alternates-prop",
           "support": {
             "chrome": {
               "version_added": false,
@@ -47,7 +48,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         },
         "annotation": {
@@ -95,7 +96,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },
@@ -144,7 +145,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },
@@ -193,7 +194,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },
@@ -242,7 +243,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },
@@ -291,7 +292,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },
@@ -340,7 +341,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         }


### PR DESCRIPTION
It's been deprecated since it was added in https://github.com/mdn/browser-compat-data/pull/513,
but shouldn't be. Link the spec to make this clear.