### PR TITLE
Updates firefox to version 97

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -694,23 +694,30 @@
         "96": {
           "release_date": "2022-01-11",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/96",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "96"
         },
         "97": {
           "release_date": "2022-02-08",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/97",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "97"
         },
         "98": {
           "release_date": "2022-03-08",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/98",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "98"
+        },
+        "99": {
+          "release_date": "2022-04-05",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/99",
+          "status": "nightly",
+          "engine": "Gecko",
+          "engine_version": "99"
         }
       }
     }

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -560,23 +560,30 @@
         "96": {
           "release_date": "2022-01-11",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/96",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "96"
         },
         "97": {
           "release_date": "2022-02-08",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/97",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "97"
         },
         "98": {
           "release_date": "2022-03-08",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/98",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "98"
+        },
+        "99": {
+          "release_date": "2022-04-05",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/99",
+          "status": "nightly",
+          "engine": "Gecko",
+          "engine_version": "99"
         }
       }
     }


### PR DESCRIPTION
Hello everyone!

I updated Firefox browser to version 97, according to [this release note](https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/97).

Fixes #14893.

 😉