### PR TITLE
Adapt BackgroundFetchRegistration events to new structure

### DIFF
--- a/api/BackgroundFetchRegistration.json
+++ b/api/BackgroundFetchRegistration.json
@@ -395,7 +395,7 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchRegistration/progress_event",
           "description": "<code>progress</code> event",
-          "spec_url": "https://wicg.github.io/background-fetch/#eventdef-backgroundfetchregistration-progress",
+          "spec_url": "https://wicg.github.io/background-fetch/#background-fetch-registration-events",
           "support": {
             "chrome": {
               "version_added": "74"

--- a/api/BackgroundFetchRegistration.json
+++ b/api/BackgroundFetchRegistration.json
@@ -391,10 +391,11 @@
           }
         }
       },
-      "onprogress": {
+      "progress_event": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchRegistration/onprogress",
-          "spec_url": "https://wicg.github.io/background-fetch/#dom-backgroundfetchregistration-onprogress",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BackgroundFetchRegistration/progress_event",
+          "description": "<code>progress</code> event",
+          "spec_url": "https://wicg.github.io/background-fetch/#eventdef-backgroundfetchregistration-progress",
           "support": {
             "chrome": {
               "version_added": "74"


### PR DESCRIPTION
Per the new events guideline (Part of #14578).

Content work: mdn/content#12851