### PR TITLE
Require real values for Firefox Android for api/

### DIFF
--- a/test/linter/test-real-values.js
+++ b/test/linter/test-real-values.js
@@ -28,19 +28,7 @@ const blockMany = [
 
 /** @type {Record<string, string[]>} */
 const blockList = {
-  api: [
-    'chrome',
-    'chrome_android',
-    'edge',
-    'firefox',
-    'ie',
-    'opera',
-    'opera_android',
-    'safari',
-    'safari_ios',
-    'samsunginternet_android',
-    'webview_android',
-  ],
+  api: blockMany,
   css: blockMany,
   html: [],
   http: [],


### PR DESCRIPTION
This PR updates the linter to require real values for Firefox Android for all API data -- the last browser for the API folder!
