### PR TITLE
Add support for HTMLScriptElement.supports() in Chromium Based Browsers

### DIFF
--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -527,13 +527,13 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#dom-script-supports",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "97"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "97"
             },
             "edge": {
-              "version_added": false
+              "version_added": "97"
             },
             "firefox": {
               "version_added": "94"
@@ -545,7 +545,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "83"
             },
             "opera_android": {
               "version_added": false
@@ -560,7 +560,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "97"
             }
           },
           "status": {


### PR DESCRIPTION
#### Summary
Updated HTMLScriptElement.json since HTMLScriptElement.supports() is now supported by Chromium Based Browsers.

#### Test results and supporting details
https://chromestatus.com/feature/5712146835963904

#### Related issues
Fixes #14752
