### PR TITLE
Fixed macOS version in Safari note for tabs.detectLanguage

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -2049,7 +2049,7 @@
               "safari": {
                 "version_added": "14",
                 "notes": [
-                  "Will return <code>und</code> (undefined language) for OS lower than 10.16.",
+                  "Will return <code>und</code> (undefined language) for OS lower than 11.",
                   "Locale identifier will include the country code more often."
                 ]
               },


### PR DESCRIPTION
#### Summary
Fixes the note for Safari support in `browser.tabs.detectLanguage` to use the correct macOS version.
