### PR TITLE
Add WebAssembly exception handling with Safari data

### DIFF
--- a/javascript/builtins/webassembly/Exception.json
+++ b/javascript/builtins/webassembly/Exception.json
@@ -60,7 +60,7 @@
             "__compat": {
               "description": "<code>Exception()</code> constructor",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/Exception",
-              "spec_url": "https://webassembly.github.io/exception-handling/js-api/index.html#runtime-exceptions",
+              "spec_url": "https://webassembly.github.io/exception-handling/js-api/index.html#dom-exception-exception",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -115,7 +115,7 @@
           "getArg": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/getArg",
-              "spec_url": "https://webassembly.github.io/exception-handling/js-api/index.html#runtime-exceptions",
+              "spec_url": "https://webassembly.github.io/exception-handling/js-api/index.html#dom-exception-getarg",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -170,7 +170,7 @@
           "is": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/is",
-              "spec_url": "https://webassembly.github.io/exception-handling/js-api/index.html#runtime-exceptions",
+              "spec_url": "https://webassembly.github.io/exception-handling/js-api/index.html#dom-exception-is",
               "support": {
                 "chrome": {
                   "version_added": false

--- a/javascript/builtins/webassembly/Exception.json
+++ b/javascript/builtins/webassembly/Exception.json
@@ -1,0 +1,229 @@
+{
+  "javascript": {
+    "builtins": {
+      "WebAssembly": {
+        "Exception": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception",
+            "spec_url": "https://webassembly.github.io/exception-handling/js-api/index.html#runtime-exceptions",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "15.2"
+              },
+              "safari_ios": {
+                "version_added": "15.2"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "Exception": {
+            "__compat": {
+              "description": "<code>Exception()</code> constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/Exception",
+              "spec_url": "https://webassembly.github.io/exception-handling/js-api/index.html#runtime-exceptions",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "deno": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": "15.2"
+                },
+                "safari_ios": {
+                  "version_added": "15.2"
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "getArg": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/getArg",
+              "spec_url": "https://webassembly.github.io/exception-handling/js-api/index.html#runtime-exceptions",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "deno": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": "15.2"
+                },
+                "safari_ios": {
+                  "version_added": "15.2"
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "is": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/is",
+              "spec_url": "https://webassembly.github.io/exception-handling/js-api/index.html#runtime-exceptions",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "deno": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": "15.2"
+                },
+                "safari_ios": {
+                  "version_added": "15.2"
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/javascript/builtins/webassembly/Tag.json
+++ b/javascript/builtins/webassembly/Tag.json
@@ -60,7 +60,7 @@
             "__compat": {
               "description": "<code>Tag()</code> constructor",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag/Tag",
-              "spec_url": "https://webassembly.github.io/exception-handling/js-api/index.html#tags",
+              "spec_url": "https://webassembly.github.io/exception-handling/js-api/index.html#dom-tag-tag",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -115,7 +115,7 @@
           "type": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag/type",
-              "spec_url": "https://webassembly.github.io/exception-handling/js-api/index.html#tags",
+              "spec_url": "https://webassembly.github.io/exception-handling/js-api/index.html#dom-tag-type",
               "support": {
                 "chrome": {
                   "version_added": false

--- a/javascript/builtins/webassembly/Tag.json
+++ b/javascript/builtins/webassembly/Tag.json
@@ -1,0 +1,174 @@
+{
+  "javascript": {
+    "builtins": {
+      "WebAssembly": {
+        "Tag": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag",
+            "spec_url": "https://webassembly.github.io/exception-handling/js-api/index.html#tags",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "15.2"
+              },
+              "safari_ios": {
+                "version_added": "15.2"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "Tag": {
+            "__compat": {
+              "description": "<code>Tag()</code> constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag/Tag",
+              "spec_url": "https://webassembly.github.io/exception-handling/js-api/index.html#tags",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "deno": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": "15.2"
+                },
+                "safari_ios": {
+                  "version_added": "15.2"
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "type": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag/type",
+              "spec_url": "https://webassembly.github.io/exception-handling/js-api/index.html#tags",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "deno": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": "15.2"
+                },
+                "safari_ios": {
+                  "version_added": "15.2"
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### Summary
Adds builtins for `WebAssembly.Exception` and `WebAssembly.Tag` for WASM exception handling.

#### Test results and supporting details
See [Safari 15.2 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15_2-release-notes)

