### PR TITLE
grammar: template_literal_revision not experimental anymore

### DIFF
--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -986,7 +986,6 @@
               }
             },
             "status": {
-              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -986,6 +986,7 @@
               }
             },
             "status": {
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
#### Summary
Removed the tag experimental for template_literal_revision as it is included in es2018.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

see more in my other PR:
https://github.com/mdn/content/pull/12885
