### PR TITLE
Update Safari support for Web App Manifest

### DIFF
--- a/html/manifest/categories.json
+++ b/html/manifest/categories.json
@@ -34,7 +34,7 @@
               "version_added": null
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "15.0"

--- a/html/manifest/dir.json
+++ b/html/manifest/dir.json
@@ -34,7 +34,7 @@
               "version_added": null
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null

--- a/html/manifest/icons.json
+++ b/html/manifest/icons.json
@@ -42,8 +42,8 @@
               "version_added": null
             },
             "safari_ios": {
-              "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/183937'>bug 183937</a>."
+              "version_added": "15.4",
+              "notes": "Only used when no <code>apple-touch-icon</code> is present with <code>\"purpose\": \"any\"</code> or no <code>\"purpose\"</code> key."
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/html/manifest/related_applications.json
+++ b/html/manifest/related_applications.json
@@ -34,7 +34,7 @@
               "version_added": null
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": null

--- a/html/manifest/theme_color.json
+++ b/html/manifest/theme_color.json
@@ -42,7 +42,7 @@
               "version_added": null
             },
             "safari_ios": {
-              "version_added": null
+              "version_added": "15"
             },
             "samsunginternet_android": {
               "version_added": "5.0"


### PR DESCRIPTION
#### Summary
Includes accurate Safari data for Web App Manifest support.

#### Test results and supporting details
Internal code review with Safari engineering.
