### PR TITLE
Fixed CSS features with support on Safari 7 and Safari on iOS 7

### DIFF
--- a/css/properties/image-rendering.json
+++ b/css/properties/image-rendering.json
@@ -93,14 +93,24 @@
                 "alternative_name": "-webkit-optimize-contrast",
                 "version_added": "14"
               },
-              "safari": {
-                "alternative_name": "-webkit-optimize-contrast",
-                "version_added": "6"
-              },
-              "safari_ios": {
-                "alternative_name": "-webkit-optimize-contrast",
-                "version_added": "6"
-              },
+              "safari": [
+                {
+                  "version_added": "7"
+                },
+                {
+                  "alternative_name": "-webkit-optimize-contrast",
+                  "version_added": "6"
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "7"
+                },
+                {
+                  "alternative_name": "-webkit-optimize-contrast",
+                  "version_added": "6"
+                }
+              ],
               "samsunginternet_android": {
                 "alternative_name": "-webkit-optimize-contrast",
                 "version_added": "1.0"

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -86,10 +86,10 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": false
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": "1.5"

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -100,10 +100,10 @@
                 "notes": "Opera uses <code>auto</code> as the initial value for <code>min-width</code>."
               },
               "safari": {
-                "version_added": false
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": "1.5",

--- a/css/properties/text-orientation.json
+++ b/css/properties/text-orientation.json
@@ -134,10 +134,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "7"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "7"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
#### Summary
Fix CSS features with Safari 7 and Safari on iOS 7 support, including:

- `css.properties.image-rendering.crisp-edges`
- `css.properties.min-height.auto`
- `css.properties.min-width.auto`
- `css.properties.text-orientation.sideways`

#### Test results and supporting details
For `css.properties.image-rendering.crisp-edges` see: 
- https://github.com/WebKit/WebKit/commit/31e3ae4099568fbdc594a95d9de4f7c226a8ded0
- https://trac.webkit.org/export/289061/webkit/tags/Safari-537.51.1/Source/WebCore/ChangeLog-2013-04-24 (use find on page: `crisp-edges`)

For `css.properties.min-height.auto` and `css.properties.min-width.auto` see:
- https://github.com/WebKit/WebKit/commit/b1eec614d75acbd9d741d496220becc1f09bb0c3
- https://trac.webkit.org/export/289061/webkit/tags/Safari-537.51.1/Source/WebCore/ChangeLog-2012-10-02 (use find on page: `min-height:auto`)

For `css.properties.text-orientation.sideways` see:
- https://github.com/WebKit/WebKit/commit/57ac98ab83779204b70a971d09788502613e63ee
- https://trac.webkit.org/export/289061/webkit/tags/Safari-537.51.1/Source/WebCore/ChangeLog-2013-04-24 (use find on page: `sideways`)
 
