### PR TITLE
Add Safari referrerpolicy attribute support

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -537,10 +537,10 @@
                 "version_added": "41"
               },
               "safari": {
-                "version_added": "11.1"
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14"
               },
               "samsunginternet_android": {
                 "version_added": "7.2"

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -792,10 +792,10 @@
                 "version_added": "41"
               },
               "safari": {
-                "version_added": "11.1"
+                "version_added": "13"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "13"
               },
               "samsunginternet_android": {
                 "version_added": "7.2"

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -795,10 +795,10 @@
                 "version_added": "41"
               },
               "safari": {
-                "version_added": "11.1"
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14"
               },
               "samsunginternet_android": {
                 "version_added": "7.2"

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -651,10 +651,10 @@
                 "version_added": "41"
               },
               "safari": {
-                "version_added": "11.1"
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14"
               },
               "samsunginternet_android": {
                 "version_added": "7.2"

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -369,10 +369,10 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": false
+                "version_added": "13.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "13.4"
               },
               "samsunginternet_android": {
                 "version_added": "10.0"

--- a/svg/elements/a.json
+++ b/svg/elements/a.json
@@ -281,10 +281,10 @@
                 "version_added": "41"
               },
               "safari": {
-                "version_added": "11.1"
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14"
               },
               "samsunginternet_android": {
                 "version_added": "7.2"


### PR DESCRIPTION
Adds Safari version support data for the following:

`html.elements.a.referrerpolicy` and `svg.elements.a.referrerpolicy`:
- https://github.com/WebKit/WebKit/commit/77bc94ad764dc86aace599147418c1dd15224744 (Safari 14/iOS 14)

`html.elements.script.referrerpolicy`:
- https://github.com/WebKit/WebKit/commit/40aaa446945eb80302b4d7e3b52a10db6c025e7e (Safari 13.1/iOS 13.4)

`html.elements.iframe.referrerpolicy`:
- https://github.com/WebKit/WebKit/commit/3a5f1c05c98ec018fd25f51e3454c8dc12e80c62 (Safari 13/iOS 13)

`html.elements.img.referrerpolicy`:
- https://github.com/WebKit/WebKit/commit/85a8b6970d3e8468c10daab808abd749b9dde41f (Safari 14/iOS 14)
 
`html.elements.link.referrerpolicy`:
- https://github.com/WebKit/WebKit/commit/c7dbe22bb1bfb8e9c8d3f3cfff74b9d687c7c23f (Safari 14/iOS 14)
