### PR TITLE
Add yarn.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __enumerating__*/
 *.log
 /node_modules/
 build/
+yarn.lock


### PR DESCRIPTION
This adds `yarn.lock` to the `.gitignore` so that it doesn't accidentally get included in commits (yarn works, but is not the supported package manager). As discussed @ddbeck 