### PR TITLE
add chrome & edge 98 to structuredClone compat data

### DIFF
--- a/api/_globals/structuredClone.json
+++ b/api/_globals/structuredClone.json
@@ -6,7 +6,7 @@
         "spec_url": "https://html.spec.whatwg.org/multipage/structured-data.html#dom-structuredclone",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "98"
           },
           "chrome_android": {
             "version_added": false
@@ -27,7 +27,7 @@
             }
           ],
           "edge": {
-            "version_added": false
+            "version_added": "98"
           },
           "firefox": {
             "version_added": "94"
@@ -71,7 +71,7 @@
           "description": "Available in workers",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "98"
             },
             "chrome_android": {
               "version_added": false
@@ -80,7 +80,7 @@
               "version_added": true
             },
             "edge": {
-              "version_added": false
+              "version_added": "98"
             },
             "firefox": {
               "version_added": "94"

--- a/api/_globals/structuredClone.json
+++ b/api/_globals/structuredClone.json
@@ -9,7 +9,7 @@
             "version_added": "98"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "98"
           },
           "deno": [
             {
@@ -74,7 +74,7 @@
               "version_added": "98"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "98"
             },
             "deno": {
               "version_added": true


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

`structuredClone` works in Edge and Chrome starting in version 98.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

##### Screenshots

Chrome 98:
![image](https://user-images.githubusercontent.com/5100938/153531846-f6231888-8c6d-43cb-8f04-b55ab3f2d08e.png)

Chrome 97:

![image](https://user-images.githubusercontent.com/5100938/153531889-af6aa9f5-0e81-418d-b013-329809c241f8.png)

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
##### Supporting Links

<https://chromestatus.com/feature/5630001077551104>
<https://bugs.chromium.org/p/chromium/issues/detail?id=1233571>
<https://chromium.googlesource.com/chromium/src/+/705ed55d9127eb057b50b3764def13c6277f1970>
<https://groups.google.com/a/chromium.org/g/blink-dev/c/qerisCd3Qmo>

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Fixes #14501
Fixes #14867