### PR TITLE
Adapt CookieStore change event to new structure

### DIFF
--- a/api/CookieStore.json
+++ b/api/CookieStore.json
@@ -52,6 +52,58 @@
           "deprecated": false
         }
       },
+      "change_event": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CookieStore/change_event",
+          "spec_url": [
+            "https://wicg.github.io/cookie-store/#intro-monitor",
+            "https://wicg.github.io/cookie-store/#dom-cookiestore-onchange"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "87"
+            },
+            "chrome_android": {
+              "version_added": "87"
+            },
+            "edge": {
+              "version_added": "87"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "73"
+            },
+            "opera_android": {
+              "version_added": "62"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "14.0"
+            },
+            "webview_android": {
+              "version_added": "87"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "delete": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CookieStore/delete",
@@ -154,55 +206,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CookieStore/getAll",
           "spec_url": "https://wicg.github.io/cookie-store/#dom-cookiestore-getall",
-          "support": {
-            "chrome": {
-              "version_added": "87"
-            },
-            "chrome_android": {
-              "version_added": "87"
-            },
-            "edge": {
-              "version_added": "87"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "73"
-            },
-            "opera_android": {
-              "version_added": "62"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "14.0"
-            },
-            "webview_android": {
-              "version_added": "87"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onchange": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CookieStore/onchange",
-          "spec_url": "https://wicg.github.io/cookie-store/#dom-cookiestore-onchange",
           "support": {
             "chrome": {
               "version_added": "87"

--- a/api/CookieStore.json
+++ b/api/CookieStore.json
@@ -54,6 +54,7 @@
       },
       "change_event": {
         "__compat": {
+          "description": "<code>change</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CookieStore/change_event",
           "spec_url": [
             "https://wicg.github.io/cookie-store/#intro-monitor",


### PR DESCRIPTION
This PR updates the `change` event of the CookieStore API to conform to the new format.  Part of work for #14578.

Content PR: https://github.com/mdn/content/pull/12913
