### PR TITLE
Adapt `ApplicationCache` to the new event structure

### DIFF
--- a/api/ApplicationCache.json
+++ b/api/ApplicationCache.json
@@ -474,59 +474,6 @@
           }
         }
       },
-      "updateready_event": {
-        "__compat": {
-          "description": "<code>updateready</code> event",
-          "support": {
-            "chrome": {
-              "version_added": "5",
-              "version_removed": "85"
-            },
-            "chrome_android": {
-              "version_added": "18",
-              "version_removed": "85"
-            },
-            "edge": {
-              "version_added": "12",
-              "version_removed": "86"
-            },
-            "firefox": {
-              "version_added": "3"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
-            "ie": {
-              "version_added": "10"
-            },
-            "opera": {
-              "version_added": "15",
-              "version_removed": "71"
-            },
-            "opera_android": {
-              "version_added": "14",
-              "version_removed": "60"
-            },
-            "safari": {
-              "version_added": "4"
-            },
-            "safari_ios": {
-              "version_added": "3"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.0"
-            },
-            "webview_android": {
-              "version_added": "≤37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "status": {
         "__compat": {
           "support": {
@@ -661,6 +608,59 @@
             },
             "opera_android": {
               "version_added": "≤12.1",
+              "version_removed": "60"
+            },
+            "safari": {
+              "version_added": "4"
+            },
+            "safari_ios": {
+              "version_added": "3"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
+      "updateready_event": {
+        "__compat": {
+          "description": "<code>updateready</code> event",
+          "support": {
+            "chrome": {
+              "version_added": "5",
+              "version_removed": "85"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "85"
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "86"
+            },
+            "firefox": {
+              "version_added": "3"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": "10"
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "71"
+            },
+            "opera_android": {
+              "version_added": "14",
               "version_removed": "60"
             },
             "safari": {

--- a/api/ApplicationCache.json
+++ b/api/ApplicationCache.json
@@ -103,8 +103,9 @@
           }
         }
       },
-      "oncached": {
+      "cached_event": {
         "__compat": {
+          "description": "<code>cached</code> event",
           "support": {
             "chrome": {
               "version_added": "5",
@@ -155,8 +156,9 @@
           }
         }
       },
-      "onchecking": {
+      "checking_event": {
         "__compat": {
+          "description": "<code>checking</code> event",
           "support": {
             "chrome": {
               "version_added": "5",
@@ -207,8 +209,9 @@
           }
         }
       },
-      "ondownloading": {
+      "downloading_event": {
         "__compat": {
+          "description": "<code>downloading</code> event",
           "support": {
             "chrome": {
               "version_added": "5",
@@ -259,8 +262,9 @@
           }
         }
       },
-      "onerror": {
+      "error_event": {
         "__compat": {
+          "description": "<code>error</code> event",
           "support": {
             "chrome": {
               "version_added": "5",
@@ -311,8 +315,9 @@
           }
         }
       },
-      "onnoupdate": {
+      "noupdate_event": {
         "__compat": {
+          "description": "<code>noupdate</code> event",
           "support": {
             "chrome": {
               "version_added": "5",
@@ -363,8 +368,9 @@
           }
         }
       },
-      "onobsolete": {
+      "obsolete_event": {
         "__compat": {
+          "description": "<code>obsolete</code> event",
           "support": {
             "chrome": {
               "version_added": "5",
@@ -415,8 +421,9 @@
           }
         }
       },
-      "onprogress": {
+      "progress_event": {
         "__compat": {
+          "description": "<code>progress</code> event",
           "support": {
             "chrome": {
               "version_added": "5",
@@ -467,8 +474,9 @@
           }
         }
       },
-      "onupdateready": {
+      "updateready_event": {
         "__compat": {
+          "description": "<code>updateready</code> event",
           "support": {
             "chrome": {
               "version_added": "5",


### PR DESCRIPTION
This PR updates the event handler properties of the `ApplicationCache` API to conform to the new events structure.  Part of work for #14578.

Note: there is no corresponding content PR because this API does not have any written documentation.
