### PR TITLE
Document upcoming DOM changes streams in Firefox 99

### DIFF
--- a/api/ReadableByteStreamController.json
+++ b/api/ReadableByteStreamController.json
@@ -26,7 +26,14 @@
             "version_added": "89"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "99",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.streams.byte_streams.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": {
             "version_added": false
@@ -84,7 +91,14 @@
               "version_added": "89"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.byte_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -139,7 +153,14 @@
               "version_added": "89"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.byte_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -194,7 +215,14 @@
               "version_added": "89"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.byte_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -249,7 +277,14 @@
               "version_added": "89"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.byte_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -304,7 +339,14 @@
               "version_added": "89"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.byte_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/api/ReadableStreamBYOBReader.json
+++ b/api/ReadableStreamBYOBReader.json
@@ -18,8 +18,14 @@
             "version_added": "89"
           },
           "firefox": {
-            "version_added": false,
-            "notes": "See <a href='https://bugzil.la/1604037'>bug 1604037</a>."
+            "version_added": "99",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.streams.byte_streams.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": {
             "version_added": false
@@ -78,8 +84,14 @@
               "version_added": "89"
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1604037'>bug 1604037</a>."
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.byte_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -134,8 +146,14 @@
               "version_added": "89"
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1604037'>bug 1604037</a>."
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.byte_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -190,8 +208,14 @@
               "version_added": "89"
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1604037'>bug 1604037</a>."
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.byte_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -246,8 +270,14 @@
               "version_added": "89"
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1604037'>bug 1604037</a>."
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.byte_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/api/ReadableStreamBYOBRequest.json
+++ b/api/ReadableStreamBYOBRequest.json
@@ -18,7 +18,14 @@
             "version_added": "89"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "99",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.streams.byte_streams.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": {
             "version_added": false
@@ -76,7 +83,14 @@
               "version_added": "89"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.byte_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -131,7 +145,14 @@
               "version_added": "89"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.byte_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -186,7 +207,14 @@
               "version_added": "89"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.byte_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/api/WritableStream.json
+++ b/api/WritableStream.json
@@ -18,7 +18,14 @@
             "version_added": "16"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "99",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.streams.writable_streams.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": {
             "version_added": false
@@ -77,7 +84,14 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.writable_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -132,7 +146,14 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.writable_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -185,7 +206,14 @@
               "version_added": "81"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.writable_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -240,7 +268,14 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.writable_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -295,7 +330,14 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.writable_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/api/WritableStreamDefaultController.json
+++ b/api/WritableStreamDefaultController.json
@@ -18,7 +18,14 @@
             "version_added": "16"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "99",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.streams.writable_streams.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": {
             "version_added": false
@@ -76,7 +83,14 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.writable_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -131,7 +145,14 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.writable_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false

--- a/api/WritableStreamDefaultWriter.json
+++ b/api/WritableStreamDefaultWriter.json
@@ -18,7 +18,14 @@
             "version_added": "16"
           },
           "firefox": {
-            "version_added": false
+            "version_added": "99",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.streams.writable_streams.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": {
             "version_added": false
@@ -77,7 +84,14 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.writable_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -132,7 +146,14 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.writable_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -187,7 +208,14 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.writable_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -242,7 +270,14 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.writable_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -297,7 +332,14 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.writable_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -352,7 +394,14 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.writable_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -407,7 +456,14 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.writable_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false
@@ -462,7 +518,14 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.writable_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Firefox 99 is expected to add support for new DOM stream API behind a pref.


#### Test results and supporting details
- [Searchfox search](https://searchfox.org/mozilla-central/search?q=dom.streams.writable_streams.enabled) for `dom.streams.writable_streams.enabled`
- [Searchfox search](https://searchfox.org/mozilla-central/search?q=dom.streams.byte_streams.enabled) for `dom.streams.byte_streams.enabled`

#### Related issues
[Implement WritableStream](https://bugzilla.mozilla.org/show_bug.cgi?id=1735664)

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
