### PR TITLE
Add last missing nodejs values for api.*

### DIFF
--- a/api/ByteLengthQueuingStrategy.json
+++ b/api/ByteLengthQueuingStrategy.json
@@ -85,6 +85,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "16.5.0"
+            },
             "opera": {
               "version_added": "46"
             },
@@ -139,6 +142,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "16.5.0"
+            },
             "opera": {
               "version_added": "65"
             },
@@ -190,6 +196,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "16.5.0"
             },
             "opera": {
               "version_added": "39"

--- a/api/CountQueuingStrategy.json
+++ b/api/CountQueuingStrategy.json
@@ -79,6 +79,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "16.5.0"
+            },
             "opera": {
               "version_added": "39"
             },
@@ -130,6 +133,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "16.5.0"
+            },
             "opera": {
               "version_added": "65"
             },
@@ -178,6 +184,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "16.5.0"
             },
             "opera": {
               "version_added": "39"

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -227,6 +227,9 @@
               "ie": {
                 "version_added": false
               },
+              "nodejs": {
+                "version_added": false
+              },
               "opera": {
                 "version_added": false,
                 "notes": "See <a href='https://crbug.com/794548'>Chromium bug 794548</a>."

--- a/api/WritableStreamDefaultController.json
+++ b/api/WritableStreamDefaultController.json
@@ -139,6 +139,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "16.5.0"
+            },
             "opera": {
               "version_added": false
             },


### PR DESCRIPTION
#### Summary

This fixes the last API sections that were missing a nodejs value. By "missing" I mean that the parent entry had a value for nodejs, but some child entries didn't.

#### Test results and supporting details

The three stream-related files (`ByteLengthQueuingStrategy`, `CountQueuingStrategy` and `WritableStreamDefaultController`) have values matching the top-level entry. These are also backed up by the docs at https://nodejs.org/dist/latest-v16.x/docs/api/webstreams.html

`api.Worker.Worker.mime_checks` is irrelevant for Node, so I've set it to `false`, which matches the entry for Deno.

#### Related issues

This is the final part of #13170 (when combined with #14953).