### PR TITLE
FF97 @scroll-timeline is behind a preference

### DIFF
--- a/css/at-rules/scroll-timeline.json
+++ b/css/at-rules/scroll-timeline.json
@@ -17,10 +17,17 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "97"
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.scroll-linked-animations.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
-              "version_added": "97"
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -64,10 +71,17 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "97"
+                "version_added": "97",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-linked-animations.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": {
-                "version_added": "97"
+                "version_added": false
               },
               "ie": {
                 "version_added": false
@@ -112,10 +126,17 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "97"
+                "version_added": "97",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-linked-animations.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": {
-                "version_added": "97"
+                "version_added": false
               },
               "ie": {
                 "version_added": false
@@ -160,10 +181,17 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "97"
+                "version_added": "97",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-linked-animations.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": {
-                "version_added": "97"
+                "version_added": false
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
This fixes up the update in #14662

So the story is that FF94 added parser but not render behaviour for @scroll-timeline in https://bugzilla.mozilla.org/show_bug.cgi?id=1676782 behind a preference `layout.css.scroll-linked-animations.enabled`. The support was finished in https://bugzilla.mozilla.org/show_bug.cgi?id=1676791 - this is **still** behind a preference (not shipped) though this is not obvious from the source.

Upshot, this update puts the feature behind a preference in FF97 (IMO the support in FF94 is "too partial" to even be worth mentioning IMO). It removes the support in FF for android because of that preference.

Associated docs changes in https://github.com/mdn/content/pull/12969

@ddbeck Can you please review this as soon as possible.
