### PR TITLE
Adapt AudioScheduledSourceNode ended event to new structure

### DIFF
--- a/api/AudioScheduledSourceNode.json
+++ b/api/AudioScheduledSourceNode.json
@@ -186,55 +186,6 @@
           }
         }
       },
-      "onended": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioScheduledSourceNode/onended",
-          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audioscheduledsourcenode-onended",
-          "support": {
-            "chrome": {
-              "version_added": "30"
-            },
-            "chrome_android": {
-              "version_added": "30"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "25"
-            },
-            "firefox_android": {
-              "version_added": "25"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "17"
-            },
-            "opera_android": {
-              "version_added": "18"
-            },
-            "safari": {
-              "version_added": "7"
-            },
-            "safari_ios": {
-              "version_added": "7"
-            },
-            "samsunginternet_android": {
-              "version_added": "2.0"
-            },
-            "webview_android": {
-              "version_added": "≤37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "start": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioScheduledSourceNode/start",


### PR DESCRIPTION
This PR adapts the `ended` event of the AudioScheduledSourceNode API to the new guidelines.  Part of work for #14578.
