### PR TITLE
WEBGL_debug_renderer_info - FF deprecated

### DIFF
--- a/api/WEBGL_debug_renderer_info.json
+++ b/api/WEBGL_debug_renderer_info.json
@@ -15,10 +15,12 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "53"
+            "version_added": "53",
+            "notes": "Deprecated, and may be removed in a future release (see <a href='https://bugzil.la/1722782'>bug 1722782</a>)."
           },
           "firefox_android": {
-            "version_added": "53"
+            "version_added": "53",
+            "notes": "Deprecated, and may be removed in a future release (see <a href='https://bugzil.la/1722782'>bug 1722782</a>)."
           },
           "ie": {
             "version_added": "11"


### PR DESCRIPTION
From FF92, if you use `[WEBGL_debug_renderer_info](https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_debug_renderer_info) Firefox (only) displays a console warning:

> "`WEBGL_debug_renderer_info` is deprecated in Firefox and will be removed".

The API exposes information that can be used for fingerprinting. While the whole extension can be killed using `privacy.resistFingerprinting` the idea was that a safer sanitized API be added. Attempt was made to do that using preference in in https://bugzilla.mozilla.org/show_bug.cgi?id=1722113 but got rolled back and this note added in https://bugzilla.mozilla.org/show_bug.cgi?id=1722782.
According to https://bugzilla.mozilla.org/show_bug.cgi?id=1722782#c10 it is not clear how this will proceed.

Upshot though is that there is a warning from the console about this, which we should indicate here too. 

Fixes https://github.com/mdn/content/issues/12689