### PR TITLE
Adapt BroadcastChannel events to the new event structure

### DIFF
--- a/api/BroadcastChannel.json
+++ b/api/BroadcastChannel.json
@@ -180,7 +180,10 @@
         "__compat": {
           "description": "<code>message</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BroadcastChannel/message_event",
-          "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-message",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/indices.html#event-message",
+            "https://html.spec.whatwg.org/multipage/web-messaging.html#handler-broadcastchannel-onmessage"
+          ],
           "support": {
             "chrome": {
               "version_added": "54"
@@ -236,7 +239,10 @@
         "__compat": {
           "description": "<code>messageerror</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BroadcastChannel/messageerror_event",
-          "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-messageerror",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/indices.html#event-messageerror",
+            "https://html.spec.whatwg.org/multipage/web-messaging.html#handler-broadcastchannel-onmessageerror"
+          ],
           "support": {
             "chrome": {
               "version_added": "60"
@@ -336,118 +342,6 @@
             },
             "webview_android": {
               "version_added": "54"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onmessage": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BroadcastChannel/onmessage",
-          "spec_url": "https://html.spec.whatwg.org/multipage/web-messaging.html#handler-broadcastchannel-onmessage",
-          "support": {
-            "chrome": {
-              "version_added": "54"
-            },
-            "chrome_android": {
-              "version_added": "54"
-            },
-            "deno": {
-              "version_added": "1.11"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "38"
-            },
-            "firefox_android": {
-              "version_added": "38"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "nodejs": {
-              "version_added": "15.4.0"
-            },
-            "opera": {
-              "version_added": "41"
-            },
-            "opera_android": {
-              "version_added": "41"
-            },
-            "safari": {
-              "version_added": "15.4"
-            },
-            "safari_ios": {
-              "version_added": "15.4"
-            },
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
-            "webview_android": {
-              "version_added": "54"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onmessageerror": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BroadcastChannel/onmessageerror",
-          "spec_url": "https://html.spec.whatwg.org/multipage/web-messaging.html#handler-broadcastchannel-onmessageerror",
-          "support": {
-            "chrome": {
-              "version_added": "60"
-            },
-            "chrome_android": {
-              "version_added": "60"
-            },
-            "deno": {
-              "version_added": "1.11"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "57"
-            },
-            "firefox_android": {
-              "version_added": "57"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "nodejs": {
-              "version_added": "15.4.0"
-            },
-            "opera": {
-              "version_added": "47"
-            },
-            "opera_android": {
-              "version_added": "44"
-            },
-            "safari": {
-              "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/171216'>bug 171216</a>."
-            },
-            "safari_ios": {
-              "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/171216'>bug 171216</a>."
-            },
-            "samsunginternet_android": {
-              "version_added": "8.0"
-            },
-            "webview_android": {
-              "version_added": "60"
             }
           },
           "status": {


### PR DESCRIPTION
Part of #14578.

Per the new guideline: https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#dom-events-eventname_event

Content work: mdn/content#12982