### PR TITLE
Opera Android 67 is released

### DIFF
--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -364,12 +364,13 @@
         },
         "66": {
           "release_date": "2021-12-15",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "94"
         },
         "67": {
-          "status": "beta",
+          "release_date": "2022-01-31",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "96"
         }


### PR DESCRIPTION
This PR updates our data to reflect that Opera Android 67 is released.  The release date comes from UpToDown: https://opera-browser.en.uptodown.com/android/versions
