### PR TITLE
FF98 registerProtcolHandler() supports ftp, sftp, ftps

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4260,7 +4260,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         }

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3022,6 +3022,54 @@
             "deprecated": false
           }
         },
+        "scheme_parameter_bitcoin": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>bitcoin</code>",
+            "support": {
+              "chrome": {
+                "version_added": "28"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "2"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "scheme_parameter_ftp": {
           "__compat": {
             "description": "<code>scheme</code> parameter supports <code>ftp</code>",
@@ -3118,6 +3166,102 @@
             }
           }
         },
+        "scheme_parameter_geo": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>geo</code>",
+            "support": {
+              "chrome": {
+                "version_added": "30"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "2"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "17"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_im": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>im</code>",
+            "support": {
+              "chrome": {
+                "version_added": "30"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "2"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "17"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "scheme_parameter_irc": {
           "__compat": {
             "description": "<code>scheme</code> parameter supports <code>irc</code>",
@@ -3142,6 +3286,102 @@
               },
               "opera": {
                 "version_added": "11.6"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_ircs": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>ircs</code>",
+            "support": {
+              "chrome": {
+                "version_added": "30"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "2"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "17"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_magnet": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>magnet</code>",
+            "support": {
+              "chrome": {
+                "version_added": "30"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "2"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "17"
               },
               "opera_android": {
                 "version_added": false
@@ -3406,6 +3646,54 @@
             }
           }
         },
+        "scheme_parameter_openpgp4fpr": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>openpgp4fpr</code>",
+            "support": {
+              "chrome": {
+                "version_added": "42"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "2"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "29"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "scheme_parameter_sftp": {
           "__compat": {
             "description": "<code>scheme</code> parameter supports <code>sftp</code>",
@@ -3454,6 +3742,54 @@
             }
           }
         },
+        "scheme_parameter_sip": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>sip</code>",
+            "support": {
+              "chrome": {
+                "version_added": "30"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "2"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "17"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "scheme_parameter_sms": {
           "__compat": {
             "description": "<code>scheme</code> parameter supports <code>news</code>",
@@ -3478,6 +3814,102 @@
               },
               "opera": {
                 "version_added": "11.6"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_smsto": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>smsto</code>",
+            "support": {
+              "chrome": {
+                "version_added": "26"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "2"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_ssh": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>ssh</code>",
+            "support": {
+              "chrome": {
+                "version_added": "41"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "2"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "28"
               },
               "opera_android": {
                 "version_added": false
@@ -3622,6 +4054,102 @@
               },
               "opera": {
                 "version_added": "11.6"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_wtai": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>wtai</code>",
+            "support": {
+              "chrome": {
+                "version_added": "31"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "2"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "18"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_xmpp": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>xmpp</code>",
+            "support": {
+              "chrome": {
+                "version_added": "30"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "2"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "17"
               },
               "opera_android": {
                 "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2984,9 +2984,7 @@
             },
             "edge": {
               "version_added": "79",
-              "notes": [
-                "Allowed schemes include <code>mailto</code>, <code>mms</code>, <code>nntp</code>, <code>rtsp</code>, and <code>webcal</code>. Custom protocols must be prefixed with <code>web+</code>.",
-              ]
+              "notes": "Allowed schemes include <code>mailto</code>, <code>mms</code>, <code>nntp</code>, <code>rtsp</code>, and <code>webcal</code>. Custom protocols must be prefixed with <code>web+</code>."
             },
             "firefox": {
               "version_added": "2",
@@ -3024,105 +3022,9 @@
             "deprecated": false
           }
         },
-        "title_parameter_required": {
-          "__compat": {
-            "description": "Obsolete <code>title</code> parameter required",
-            "support": {
-              "chrome": {
-                "version_added": "13"
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": "79"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "11.6"
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "scheme_parameter_ftp": {
           "__compat": {
             "description": "<code>scheme</code> parameter supports <code>ftp</code>",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "98"
-              },
-              "firefox_android": {
-                "version_added": "98"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "scheme_parameter_sftp": {
-          "__compat": {
-            "description": "<code>scheme</code> parameter supports <code>sftp</code>",
             "support": {
               "chrome": {
                 "version_added": false
@@ -3264,6 +3166,54 @@
             }
           }
         },
+        "scheme_parameter_sftp": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>sftp</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "98"
+              },
+              "firefox_android": {
+                "version_added": "98"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "secure_context_required": {
           "__compat": {
             "description": "Secure context required",
@@ -3288,6 +3238,54 @@
               },
               "opera": {
                 "version_added": "67"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "title_parameter_required": {
+          "__compat": {
+            "description": "Obsolete <code>title</code> parameter required",
+            "support": {
+              "chrome": {
+                "version_added": "13"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "11.6"
               },
               "opera_android": {
                 "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2974,25 +2974,19 @@
           "support": {
             "chrome": {
               "version_added": "13",
-              "notes": [
-                "Allowed schemes include <code>mailto</code>, <code>mms</code>, <code>nntp</code>, <code>rtsp</code>, and <code>webcal</code>. Custom protocols must be prefixed with <code>web+</code>.",
-                "From Chrome 77, the URL parameter only accepts <code>http</code> or <code>https</code> URLs."
-              ]
+              "notes": "From Chrome 77, the URL parameter only accepts <code>http</code> or <code>https</code> URLs."
             },
             "chrome_android": {
               "version_added": false
             },
             "edge": {
-              "version_added": "79",
-              "notes": "Allowed schemes include <code>mailto</code>, <code>mms</code>, <code>nntp</code>, <code>rtsp</code>, and <code>webcal</code>. Custom protocols must be prefixed with <code>web+</code>."
+              "version_added": "79"
             },
             "firefox": {
-              "version_added": "2",
-              "notes": "Firefox tracks the safelisted schemes listed in the specification are supported and the custom scheme protocol format."
+              "version_added": "2"
             },
             "firefox_android": {
-              "version_added": "4",
-              "notes": "Firefox tracks the safelisted schemes listed in the specification are supported and the custom scheme protocol format."
+              "version_added": "4"
             },
             "ie": {
               "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3118,6 +3118,54 @@
             }
           }
         },
+        "scheme_parameter_irc": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>irc</code>",
+            "support": {
+              "chrome": {
+                "version_added": "15"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "2"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "11.6"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "scheme_parameter_mailto": {
           "__compat": {
             "description": "<code>scheme</code> parameter supports <code>mailto</code>",
@@ -3262,6 +3310,54 @@
             }
           }
         },
+        "scheme_parameter_news": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>news</code>",
+            "support": {
+              "chrome": {
+                "version_added": "13"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "2"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "11.6"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "scheme_parameter_nntp": {
           "__compat": {
             "description": "<code>scheme</code> parameter supports <code>nntp</code>",
@@ -3334,6 +3430,150 @@
               },
               "opera": {
                 "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_sms": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>news</code>",
+            "support": {
+              "chrome": {
+                "version_added": "13"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "2"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "11.6"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_tel": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>news</code>",
+            "support": {
+              "chrome": {
+                "version_added": "13"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "2"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "11.6"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_urn": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>news</code>",
+            "support": {
+              "chrome": {
+                "version_added": "13"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "2"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "11.6"
               },
               "opera_android": {
                 "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3106,7 +3106,7 @@
               }
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -3154,7 +3154,7 @@
               }
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -3730,7 +3730,7 @@
               }
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -4218,7 +4218,7 @@
         },
         "title_parameter_required": {
           "__compat": {
-            "description": "Obsolete <code>title</code> parameter required",
+            "description": "<code>title</code> parameter required",
             "support": {
               "chrome": {
                 "version_added": "13"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2976,8 +2976,7 @@
               "version_added": "13",
               "notes": [
                 "Allowed schemes include <code>mailto</code>, <code>mms</code>, <code>nntp</code>, <code>rtsp</code>, and <code>webcal</code>. Custom protocols must be prefixed with <code>web+</code>.",
-                "From Chrome 77, the URL parameter only accepts <code>http</code> or <code>https</code> URLs.",
-                "The obsolete <code>title</code> parameter is required."
+                "From Chrome 77, the URL parameter only accepts <code>http</code> or <code>https</code> URLs."
               ]
             },
             "chrome_android": {
@@ -2987,7 +2986,6 @@
               "version_added": "79",
               "notes": [
                 "Allowed schemes include <code>mailto</code>, <code>mms</code>, <code>nntp</code>, <code>rtsp</code>, and <code>webcal</code>. Custom protocols must be prefixed with <code>web+</code>.",
-                "The obsolete <code>title</code> parameter is required."
               ]
             },
             "firefox": {
@@ -3002,8 +3000,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "11.6",
-              "notes": "The obsolete <code>title</code> parameter is required."
+              "version_added": "11.6"
             },
             "opera_android": {
               "version_added": false
@@ -3025,6 +3022,54 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "title_parameter_required": {
+          "__compat": {
+            "description": "Obsolete <code>title</code> parameter required",
+            "support": {
+              "chrome": {
+                "version_added": "13"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "11.6"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         },
         "scheme_parameter_ftp": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2992,11 +2992,11 @@
             },
             "firefox": {
               "version_added": "2",
-              "notes": "Firefox 98 adds support for new safelisted schemes: <code>ftp</code>, <code>sftp</code>, <code>ftps</code>. All other safelisted schemes listed in the specification are supported, as is the custom scheme protocol format."
+              "notes": "Firefox tracks the safelisted schemes listed in the specification are supported and the custom scheme protocol format."
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "Firefox 98 adds support for new safelisted schemes: <code>ftp</code>, <code>sftp</code>, <code>ftps</code>. All other safelisted schemes listed in the specification are supported, as is the custom scheme protocol format."
+              "notes": "Firefox tracks the safelisted schemes listed in the specification are supported and the custom scheme protocol format."
             },
             "ie": {
               "version_added": false
@@ -3025,6 +3025,198 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "scheme_parameter_ftp": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>ftp</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "98"
+              },
+              "firefox_android": {
+                "version_added": "98"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_sftp": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>sftp</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "98"
+              },
+              "firefox_android": {
+                "version_added": "98"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_ftps": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>ftps</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "98"
+              },
+              "firefox_android": {
+                "version_added": "98"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_matrix": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>matrix</code>",
+            "support": {
+              "chrome": {
+                "version_added": "92"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "92"
+              },
+              "firefox": {
+                "version_added": "90"
+              },
+              "firefox_android": {
+                "version_added": "90"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "78"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         },
         "secure_context_required": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2991,10 +2991,12 @@
               ]
             },
             "firefox": {
-              "version_added": "2"
+              "version_added": "2",
+              "notes": "Firefox 98 adds support for new safelisted schemes: <code>ftp</code>, <code>sftp</code>, <code>ftps</code>."
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "Firefox 98 adds support for new safelisted schemes: <code>ftp</code>, <code>sftp</code>, <code>ftps</code>."
             },
             "ie": {
               "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3064,6 +3064,246 @@
             }
           }
         },
+        "scheme_parameter_cabal": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>cabal</code>",
+            "support": {
+              "chrome": {
+                "version_added": "86"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "86"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "72"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_dat": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>dat</code>",
+            "support": {
+              "chrome": {
+                "version_added": "86"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "86"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "72"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_did": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>did</code>",
+            "support": {
+              "chrome": {
+                "version_added": "86"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "86"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "72"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_dweb": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>dweb</code>",
+            "support": {
+              "chrome": {
+                "version_added": "86"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "86"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "72"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_etherium": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>etherium</code>",
+            "support": {
+              "chrome": {
+                "version_added": "86"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "86"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "72"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
         "scheme_parameter_ftp": {
           "__compat": {
             "description": "<code>scheme</code> parameter supports <code>ftp</code>",
@@ -3208,6 +3448,54 @@
             }
           }
         },
+        "scheme_parameter_hyper": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>hyper</code>",
+            "support": {
+              "chrome": {
+                "version_added": "86"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "86"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "72"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
         "scheme_parameter_im": {
           "__compat": {
             "description": "<code>scheme</code> parameter supports <code>im</code>",
@@ -3252,6 +3540,102 @@
             "status": {
               "experimental": false,
               "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_ipfs": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>ipfs</code>",
+            "support": {
+              "chrome": {
+                "version_added": "86"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "86"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "72"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_ipns": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>ipns</code>",
+            "support": {
+              "chrome": {
+                "version_added": "86"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "86"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "72"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
               "deprecated": false
             }
           }
@@ -3880,6 +4264,54 @@
             }
           }
         },
+        "scheme_parameter_ssb": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>ssb</code>",
+            "support": {
+              "chrome": {
+                "version_added": "86"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "86"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "72"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
         "scheme_parameter_ssh": {
           "__compat": {
             "description": "<code>scheme</code> parameter supports <code>ssh</code>",
@@ -4164,438 +4596,6 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "scheme_parameter_cabal": {
-          "__compat": {
-            "description": "<code>scheme</code> parameter supports <code>cabal</code>",
-            "support": {
-              "chrome": {
-                "version_added": "86"
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": "86"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "72"
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": false,
-              "deprecated": false
-            }
-          }
-        },
-        "scheme_parameter_dat": {
-          "__compat": {
-            "description": "<code>scheme</code> parameter supports <code>dat</code>",
-            "support": {
-              "chrome": {
-                "version_added": "86"
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": "86"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "72"
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": false,
-              "deprecated": false
-            }
-          }
-        },
-        "scheme_parameter_did": {
-          "__compat": {
-            "description": "<code>scheme</code> parameter supports <code>did</code>",
-            "support": {
-              "chrome": {
-                "version_added": "86"
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": "86"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "72"
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": false,
-              "deprecated": false
-            }
-          }
-        },
-        "scheme_parameter_dweb": {
-          "__compat": {
-            "description": "<code>scheme</code> parameter supports <code>dweb</code>",
-            "support": {
-              "chrome": {
-                "version_added": "86"
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": "86"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "72"
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": false,
-              "deprecated": false
-            }
-          }
-        },
-        "scheme_parameter_etherium": {
-          "__compat": {
-            "description": "<code>scheme</code> parameter supports <code>etherium</code>",
-            "support": {
-              "chrome": {
-                "version_added": "86"
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": "86"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "72"
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": false,
-              "deprecated": false
-            }
-          }
-        },
-        "scheme_parameter_hyper": {
-          "__compat": {
-            "description": "<code>scheme</code> parameter supports <code>hyper</code>",
-            "support": {
-              "chrome": {
-                "version_added": "86"
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": "86"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "72"
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": false,
-              "deprecated": false
-            }
-          }
-        },
-        "scheme_parameter_ipfs": {
-          "__compat": {
-            "description": "<code>scheme</code> parameter supports <code>ipfs</code>",
-            "support": {
-              "chrome": {
-                "version_added": "86"
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": "86"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "72"
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": false,
-              "deprecated": false
-            }
-          }
-        },
-        "scheme_parameter_ipns": {
-          "__compat": {
-            "description": "<code>scheme</code> parameter supports <code>ipns</code>",
-            "support": {
-              "chrome": {
-                "version_added": "86"
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": "86"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "72"
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": false,
-              "deprecated": false
-            }
-          }
-        },
-        "scheme_parameter_ssb": {
-          "__compat": {
-            "description": "<code>scheme</code> parameter supports <code>ssb</code>",
-            "support": {
-              "chrome": {
-                "version_added": "86"
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": "86"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "72"
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": false,
               "deprecated": false
             }
           }

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3118,6 +3118,54 @@
             }
           }
         },
+        "scheme_parameter_mailto": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>mailto</code>",
+            "support": {
+              "chrome": {
+                "version_added": "13"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "2"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "11.6"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "scheme_parameter_matrix": {
           "__compat": {
             "description": "<code>scheme</code> parameter supports <code>matrix</code>",
@@ -3166,6 +3214,102 @@
             }
           }
         },
+        "scheme_parameter_mms": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>mms</code>",
+            "support": {
+              "chrome": {
+                "version_added": "13"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "2"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "11.6"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_nntp": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>nntp</code>",
+            "support": {
+              "chrome": {
+                "version_added": "13"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "2"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "11.6"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "scheme_parameter_sftp": {
           "__compat": {
             "description": "<code>scheme</code> parameter supports <code>sftp</code>",
@@ -3190,6 +3334,54 @@
               },
               "opera": {
                 "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_webcal": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>webcal</code>",
+            "support": {
+              "chrome": {
+                "version_added": "13"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "2"
+              },
+              "firefox_android": {
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "11.6"
               },
               "opera_android": {
                 "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2992,11 +2992,11 @@
             },
             "firefox": {
               "version_added": "2",
-              "notes": "Firefox 98 adds support for new safelisted schemes: <code>ftp</code>, <code>sftp</code>, <code>ftps</code>."
+              "notes": "Firefox 98 adds support for new safelisted schemes: <code>ftp</code>, <code>sftp</code>, <code>ftps</code>. All other safelisted schemes listed in the specification are supported, as is the custom scheme protocol format."
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "Firefox 98 adds support for new safelisted schemes: <code>ftp</code>, <code>sftp</code>, <code>ftps</code>."
+              "notes": "Firefox 98 adds support for new safelisted schemes: <code>ftp</code>, <code>sftp</code>, <code>ftps</code>. All other safelisted schemes listed in the specification are supported, as is the custom scheme protocol format."
             },
             "ie": {
               "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4168,6 +4168,438 @@
             }
           }
         },
+        "scheme_parameter_cabal": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>cabal</code>",
+            "support": {
+              "chrome": {
+                "version_added": "86"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "86"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "72"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_dat": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>dat</code>",
+            "support": {
+              "chrome": {
+                "version_added": "86"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "86"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "72"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_did": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>did</code>",
+            "support": {
+              "chrome": {
+                "version_added": "86"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "86"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "72"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_dweb": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>dweb</code>",
+            "support": {
+              "chrome": {
+                "version_added": "86"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "86"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "72"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_etherium": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>etherium</code>",
+            "support": {
+              "chrome": {
+                "version_added": "86"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "86"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "72"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_hyper": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>hyper</code>",
+            "support": {
+              "chrome": {
+                "version_added": "86"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "86"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "72"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_ipfs": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>ipfs</code>",
+            "support": {
+              "chrome": {
+                "version_added": "86"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "86"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "72"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_ipns": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>ipns</code>",
+            "support": {
+              "chrome": {
+                "version_added": "86"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "86"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "72"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "scheme_parameter_ssb": {
+          "__compat": {
+            "description": "<code>scheme</code> parameter supports <code>ssb</code>",
+            "support": {
+              "chrome": {
+                "version_added": "86"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "86"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "72"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
         "secure_context_required": {
           "__compat": {
             "description": "Secure context required",


### PR DESCRIPTION
FF98 adds support for new protocols in [navigator.registerProtcolHandler()](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler): `ftp`, `sftp`, `ftps` - https://bugzilla.mozilla.org/show_bug.cgi?id=1705202

This adds information about the new addition as a NOTE. @ddbeck not sure if this is right approach - please see note inline