### PR TITLE
Deno 1.19 supports (De)CompressionStream

### DIFF
--- a/api/CompressionStream.json
+++ b/api/CompressionStream.json
@@ -11,6 +11,9 @@
           "chrome_android": {
             "version_added": "80"
           },
+          "deno": {
+            "version_added": "1.19"
+          },
           "edge": {
             "version_added": "80"
           },
@@ -59,6 +62,9 @@
             },
             "chrome_android": {
               "version_added": "80"
+            },
+            "deno": {
+              "version_added": "1.19"
             },
             "edge": {
               "version_added": "80"
@@ -112,6 +118,9 @@
             "chrome_android": {
               "version_added": "80"
             },
+            "deno": {
+              "version_added": "1.19"
+            },
             "edge": {
               "version_added": "80"
             },
@@ -163,6 +172,9 @@
             },
             "chrome_android": {
               "version_added": "80"
+            },
+            "deno": {
+              "version_added": "1.19"
             },
             "edge": {
               "version_added": "80"

--- a/api/DecompressionStream.json
+++ b/api/DecompressionStream.json
@@ -12,7 +12,7 @@
             "version_added": "80"
           },
           "deno": {
-            "version_added": false
+            "version_added": "1.19"
           },
           "edge": {
             "version_added": "80"
@@ -64,7 +64,7 @@
               "version_added": "80"
             },
             "deno": {
-              "version_added": false
+              "version_added": "1.19"
             },
             "edge": {
               "version_added": "80"
@@ -119,7 +119,7 @@
               "version_added": "80"
             },
             "deno": {
-              "version_added": false
+              "version_added": "1.19"
             },
             "edge": {
               "version_added": "80"
@@ -174,7 +174,7 @@
               "version_added": "80"
             },
             "deno": {
-              "version_added": false
+              "version_added": "1.19"
             },
             "edge": {
               "version_added": "80"


### PR DESCRIPTION
https://github.com/denoland/deno/commit/30ddf436d0d48ce0f9238f1728bc83aa4c6dddad

We're shipping this in 1.19, due to be released on Thursday.
