### PR TITLE
Deno 1.19 is released

### DIFF
--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -138,9 +138,16 @@
         },
         "1.19": {
           "release_date": "2022-02-17",
-          "status": "nightly",
+          "release_notes": "https://github.com/denoland/deno/releases/tag/v1.19.0",
+          "status": "current",
           "engine": "V8",
           "engine_version": "9.9"
+        },
+        "1.20": {
+          "release_date": "2022-03-17",
+          "status": "nightly",
+          "engine": "V8",
+          "engine_version": "10.0"
         }
       }
     }


### PR DESCRIPTION
We're not actually releasing until Thursday, but the new features are pretty much locked in now.
