### PR TITLE
Adapt BatteryManager events to the new event structure

### DIFF
--- a/api/BatteryManager.json
+++ b/api/BatteryManager.json
@@ -101,6 +101,61 @@
           }
         }
       },
+      "chargingchange_event": {
+        "__compat": {
+          "description": "<code>chargingchange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingchange_event",
+          "spec_url": [
+            "https://w3c.github.io/battery/#ref-for-dfn-chargingchange-1",
+            "https://w3c.github.io/battery/#dom-batterymanager-onchargingchange"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "38"
+            },
+            "chrome_android": {
+              "version_added": "38"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "43",
+              "version_removed": "52"
+            },
+            "firefox_android": {
+              "version_added": "43",
+              "version_removed": "52"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "25"
+            },
+            "opera_android": {
+              "version_added": "25"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
+            "webview_android": {
+              "version_added": "38"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "chargingTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingTime",
@@ -176,6 +231,61 @@
                 "notes": "Always equal to <code>0</code> or <code>Infinity</code>."
               }
             ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "chargingtimechange_event": {
+        "__compat": {
+          "description": "<code>chargingtimechange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BatteryManager/chargingtimechange_event",
+          "spec_url": [
+            "https://w3c.github.io/battery/#ref-for-dfn-chargingtimechange-1",
+            "https://w3c.github.io/battery/#dom-batterymanager-onchargingtimechange"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "38"
+            },
+            "chrome_android": {
+              "version_added": "38"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "43",
+              "version_removed": "52"
+            },
+            "firefox_android": {
+              "version_added": "43",
+              "version_removed": "52"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "25"
+            },
+            "opera_android": {
+              "version_added": "25"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
+            "webview_android": {
+              "version_added": "38"
+            }
           },
           "status": {
             "experimental": false,
@@ -267,6 +377,61 @@
           }
         }
       },
+      "dischargingtimechange_event": {
+        "__compat": {
+          "description": "<code>dischargingtimechange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BatteryManager/dischargingtimechange_event",
+          "spec_url": [
+            "https://w3c.github.io/battery/#ref-for-dfn-dischargingtimechange-1",
+            "https://w3c.github.io/battery/#dom-batterymanager-ondischargingtimechange"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "38"
+            },
+            "chrome_android": {
+              "version_added": "38"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "43",
+              "version_removed": "52"
+            },
+            "firefox_android": {
+              "version_added": "43",
+              "version_removed": "52"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "25"
+            },
+            "opera_android": {
+              "version_added": "25"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
+            "webview_android": {
+              "version_added": "38"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "level": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BatteryManager/level",
@@ -318,163 +483,14 @@
           }
         }
       },
-      "onchargingchange": {
+      "levelchange_event": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BatteryManager/onchargingchange",
-          "spec_url": "https://w3c.github.io/battery/#dom-batterymanager-onchargingchange",
-          "support": {
-            "chrome": {
-              "version_added": "38"
-            },
-            "chrome_android": {
-              "version_added": "38"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "43",
-              "version_removed": "52"
-            },
-            "firefox_android": {
-              "version_added": "43",
-              "version_removed": "52"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "25"
-            },
-            "opera_android": {
-              "version_added": "25"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "3.0"
-            },
-            "webview_android": {
-              "version_added": "38"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onchargingtimechange": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BatteryManager/onchargingtimechange",
-          "spec_url": "https://w3c.github.io/battery/#dom-batterymanager-onchargingtimechange",
-          "support": {
-            "chrome": {
-              "version_added": "38"
-            },
-            "chrome_android": {
-              "version_added": "38"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "43",
-              "version_removed": "52"
-            },
-            "firefox_android": {
-              "version_added": "43",
-              "version_removed": "52"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "25"
-            },
-            "opera_android": {
-              "version_added": "25"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "3.0"
-            },
-            "webview_android": {
-              "version_added": "38"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "ondischargingtimechange": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BatteryManager/ondischargingtimechange",
-          "spec_url": "https://w3c.github.io/battery/#dom-batterymanager-ondischargingtimechange",
-          "support": {
-            "chrome": {
-              "version_added": "38"
-            },
-            "chrome_android": {
-              "version_added": "38"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "43",
-              "version_removed": "52"
-            },
-            "firefox_android": {
-              "version_added": "43",
-              "version_removed": "52"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "25"
-            },
-            "opera_android": {
-              "version_added": "25"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "3.0"
-            },
-            "webview_android": {
-              "version_added": "38"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onlevelchange": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BatteryManager/onlevelchange",
-          "spec_url": "https://w3c.github.io/battery/#dom-batterymanager-onlevelchange",
+          "description": "<code>levelchange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BatteryManager/levelchange_event",
+          "spec_url": [
+            "https://w3c.github.io/battery/#ref-for-dfn-levelchange-1",
+            "https://w3c.github.io/battery/#dom-batterymanager-onlevelchange"
+          ],
           "support": {
             "chrome": {
               "version_added": "38"


### PR DESCRIPTION
Part of https://github.com/mdn/browser-compat-data/issues/14578.

Per the new guideline: https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#dom-events-eventname_event

4 events: `chargingchange_event`, `chargingtimechange_event`, `dischargingtimechange_event` and `levelchange_event`.

Only cases where `onXYZ` exists, but not `XYZ_event`.

Move `onXYZ` to non-existing`XYZ_event`:
- [x] Rename `onXYZ` to `XYZ_event`
- [x] Change `mdn_url` to new MDN page
- [x] Add description before `mdn_url`: `"description": "<code>XYZ</code> event",`
- [x] Add second entry to `spec_url`
- [x] Run `npm run fix` to fix sort (if needed)
- [x] Run `npm test`to check all is fine
- [x] Open PR with name of events.
- [x] Add link to related content PR
- [x] Add "needs content update" label if content PR has not been merged.
- [x] Update description of #14578 so that it points to this PR


Content work: https://github.com/mdn/content/pull/13021