### PR TITLE
Adding Firefox 79 for Android supports for line-break

### DIFF
--- a/css/properties/line-break.json
+++ b/css/properties/line-break.json
@@ -31,7 +31,7 @@
               "version_added": "69"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": [
               {


### PR DESCRIPTION
#### Summary
https://github.com/mdn/browser-compat-data/pull/4646 is added for Firefox desktop, so we should add it for Android version too.

#### Test results and supporting details
Tested on wpt.live.

#### Related issues
- https://github.com/mdn/browser-compat-data/pull/4646
- https://bugzilla.mozilla.org/show_bug.cgi?id=1011369

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
