### PR TITLE
Add missing StyleMedia API

### DIFF
--- a/api/StyleMedia.json
+++ b/api/StyleMedia.json
@@ -77,7 +77,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -124,7 +124,7 @@
               "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "4"
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/StyleMedia.json
+++ b/api/StyleMedia.json
@@ -31,7 +31,7 @@
             "version_added": "5"
           },
           "safari_ios": {
-            "version_added": "5"
+            "version_added": "4"
           },
           "samsunginternet_android": {
             "version_added": "1.0"

--- a/api/StyleMedia.json
+++ b/api/StyleMedia.json
@@ -42,8 +42,8 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
-          "deprecated": false
+          "standard_track": false,
+          "deprecated": true
         }
       },
       "matchMedium": {
@@ -88,8 +88,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -135,8 +135,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }

--- a/api/StyleMedia.json
+++ b/api/StyleMedia.json
@@ -1,0 +1,145 @@
+{
+  "api": {
+    "StyleMedia": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "6"
+          },
+          "chrome_android": {
+            "version_added": "18"
+          },
+          "edge": {
+            "version_added": "12"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": "9"
+          },
+          "opera": {
+            "version_added": "15"
+          },
+          "opera_android": {
+            "version_added": "14"
+          },
+          "safari": {
+            "version_added": "5"
+          },
+          "safari_ios": {
+            "version_added": "5"
+          },
+          "samsunginternet_android": {
+            "version_added": "1.0"
+          },
+          "webview_android": {
+            "version_added": "≤37"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "matchMedium": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "6"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "5"
+            },
+            "safari_ios": {
+              "version_added": "5"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "type": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "6"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "5"
+            },
+            "safari_ios": {
+              "version_added": "5"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `StyleMedia` API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v5.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/StyleMedia

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
