### PR TITLE
Adapt Bluetooth API events to new structure

### DIFF
--- a/api/Bluetooth.json
+++ b/api/Bluetooth.json
@@ -94,6 +94,59 @@
           "deprecated": false
         }
       },
+      "availabilitychanged_event": {
+        "__compat": {
+          "description": "<code>availabilitychanged</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Bluetooth/availabilitychanged_event",
+          "spec_url": [
+            "https://webbluetoothcg.github.io/web-bluetooth/#eventdef-bluetooth-availabilitychanged",
+            "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-onavailabilitychanged"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "56"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "getAvailability": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Bluetooth/getAvailability",
@@ -208,55 +261,6 @@
             },
             "samsunginternet_android": {
               "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": false,
-            "deprecated": false
-          }
-        }
-      },
-      "onavailabilitychanged": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Bluetooth/onavailabilitychanged",
-          "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#bluetooth",
-          "support": {
-            "chrome": {
-              "version_added": "56"
-            },
-            "chrome_android": {
-              "version_added": "56"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "43"
-            },
-            "opera_android": {
-              "version_added": "43"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
This PR updates the events of the Bluetooth API to conform to the new events structure.  Part of work for #14578.

Note: the spec URL was replaced as it was a generic URL that didn't correlate with the event itself.

Content PR: https://github.com/mdn/content/pull/13034