### PR TITLE
Adapt BluetoothDevice API events to new structure

### DIFF
--- a/api/BluetoothDevice.json
+++ b/api/BluetoothDevice.json
@@ -143,6 +143,58 @@
           }
         }
       },
+      "gattserverdisconnected_event": {
+        "__compat": {
+          "description": "<code>gattserverdisconnected</code> event",
+          "spec_url": [
+            "https://webbluetoothcg.github.io/web-bluetooth/#eventdef-bluetoothdevice-gattserverdisconnected",
+            "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdeviceeventhandlers-ongattserverdisconnected"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "56"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "id": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothDevice/id",
@@ -237,54 +289,6 @@
           "status": {
             "experimental": true,
             "standard_track": false,
-            "deprecated": false
-          }
-        }
-      },
-      "ongattserverdisconnected": {
-        "__compat": {
-          "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdeviceeventhandlers-ongattserverdisconnected",
-          "support": {
-            "chrome": {
-              "version_added": "56"
-            },
-            "chrome_android": {
-              "version_added": "56"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "43"
-            },
-            "opera_android": {
-              "version_added": "43"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
This PR updates the `gattserverdisconnected` event of the BluetoothDevice API to the new style.  Part of work for #14578.

Note: there is no content PR as the MDN page for this feature has not yet been created.
