### PR TITLE
Remove nodejs stability notes from Performance APIs

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -33,10 +33,7 @@
           },
           "nodejs": {
             "version_added": "8.5.0",
-            "notes": [
-              "Stability: Experimental",
-              "Exported from the <code>perf_hooks</code> module"
-            ],
+            "notes": "Exported from the <code>perf_hooks</code> module",
             "partial_implementation": true
           },
           "opera": {

--- a/api/PerformanceEntry.json
+++ b/api/PerformanceEntry.json
@@ -39,8 +39,7 @@
             "version_added": "10"
           },
           "nodejs": {
-            "version_added": "8.5.0",
-            "notes": "Stability: Experimental"
+            "version_added": "8.5.0"
           },
           "opera": [
             {

--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -25,10 +25,7 @@
           },
           "nodejs": {
             "version_added": "8.5.0",
-            "notes": [
-              "Stability: Experimental",
-              "Exported from the <code>perf_hooks</code> module"
-            ],
+            "notes": "Exported from the <code>perf_hooks</code> module",
             "partial_implementation": true
           },
           "opera": {

--- a/api/PerformanceObserverEntryList.json
+++ b/api/PerformanceObserverEntryList.json
@@ -24,8 +24,7 @@
             "version_added": false
           },
           "nodejs": {
-            "version_added": "8.5.0",
-            "notes": "Stability: Experimental"
+            "version_added": "8.5.0"
           },
           "opera": {
             "version_added": "39"


### PR DESCRIPTION
#### Summary

Removed the `"Stability: Experimental"` notes for NodeJS in Performance-related files. As discussed in #14988, the `perf_hooks` module was marked "Stable" in version 12.16.0. We don't track the internal NodeJS module stability details anywhere else.

#### Test results and supporting details

[NodeJS 12.16.0 release notes](https://nodejs.org/en/blog/release/v12.16.0/)

> Performance Hooks are no longer experimental
>
> The `perf_hooks` module is now considered a stable API.

#### Related issues

Fixes #14988 