### PR TITLE
Update BCD for dump()

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1867,6 +1867,70 @@
           }
         }
       },
+      "dump": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/dump",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "1.5",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "browser.dom.window.dump.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "By default, this method exists and can be called, but does nothing unless enabled in the browser's preferences."
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "browser.dom.window.dump.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "By default, this method exists and can be called, but does nothing unless enabled in the browser's preferences."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "error_event": {
         "__compat": {
           "description": "<code>error</code> event",

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -68,10 +68,26 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "3.5",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "browser.dom.window.dump.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "By default, this method exists and can be called, but does nothing unless enabled in the browser's preferences."
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "4",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "browser.dom.window.dump.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "By default, this method exists and can be called, but does nothing unless enabled in the browser's preferences."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
I'm updating the pages for https://developer.mozilla.org/en-US/docs/Web/API/Window/dump and https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/dump , and this is for the BCD.

I'm pretty sure window.dump() is supported from very early on in Firefox, because this bug: https://bugzilla.mozilla.org/show_bug.cgi?id=359433 refers to it in 2006. So 1.5 seems plausible: https://en.wikipedia.org/wiki/Firefox_early_version_history#Firefox_1.5.

I've also tested that it is supported in workers, when the pref is set.