### PR TITLE
Adapt BaseAudioContext API to new events structure

### DIFF
--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -1383,55 +1383,6 @@
           }
         }
       },
-      "onstatechange": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/onstatechange",
-          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-onstatechange",
-          "support": {
-            "chrome": {
-              "version_added": "41"
-            },
-            "chrome_android": {
-              "version_added": "41"
-            },
-            "edge": {
-              "version_added": "14"
-            },
-            "firefox": {
-              "version_added": "40"
-            },
-            "firefox_android": {
-              "version_added": "40"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "28"
-            },
-            "opera_android": {
-              "version_added": "28"
-            },
-            "safari": {
-              "version_added": "9"
-            },
-            "safari_ios": {
-              "version_added": "9"
-            },
-            "samsunginternet_android": {
-              "version_added": "4.0"
-            },
-            "webview_android": {
-              "version_added": "41"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "sampleRate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/sampleRate",
@@ -1485,6 +1436,56 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/state",
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-state",
+          "support": {
+            "chrome": {
+              "version_added": "41"
+            },
+            "chrome_android": {
+              "version_added": "41"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "40"
+            },
+            "firefox_android": {
+              "version_added": "40"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "28"
+            },
+            "opera_android": {
+              "version_added": "28"
+            },
+            "safari": {
+              "version_added": "9"
+            },
+            "safari_ios": {
+              "version_added": "9"
+            },
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "41"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "statechange_event": {
+        "__compat": {
+          "description": "<code>statechange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/statechange_event",
+          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-onstatechange",
           "support": {
             "chrome": {
               "version_added": "41"


### PR DESCRIPTION
This PR adapts the BaseAudioContext API to conform to the new events structure.  Part of work for #14578.
