### PR TITLE
Fix structure of `dump()` data

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1880,28 +1880,40 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "1.5",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "browser.dom.window.dump.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "By default, this method exists and can be called, but does nothing unless enabled in the browser's preferences."
-            },
-            "firefox_android": {
-              "version_added": "4",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "browser.dom.window.dump.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "By default, this method exists and can be called, but does nothing unless enabled in the browser's preferences."
-            },
+            "firefox": [
+              {
+                "version_added": "1.5",
+                "partial_implementation": true,
+                "notes": "By default, this method exists and can be called, but does nothing unless enabled in the browser's preferences."
+              },
+              {
+                "version_added": "1.5",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "browser.dom.window.dump.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "4",
+                "partial_implementation": true,
+                "notes": "By default, this method exists and can be called, but does nothing unless enabled in the browser's preferences."
+              },
+              {
+                "version_added": "4",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "browser.dom.window.dump.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -67,28 +67,40 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "3.5",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "browser.dom.window.dump.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "By default, this method exists and can be called, but does nothing unless enabled in the browser's preferences."
-            },
-            "firefox_android": {
-              "version_added": "4",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "browser.dom.window.dump.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "By default, this method exists and can be called, but does nothing unless enabled in the browser's preferences."
-            },
+            "firefox": [
+              {
+                "version_added": "3.5",
+                "partial_implementation": true,
+                "notes": "By default, this method exists and can be called, but does nothing unless enabled in the browser's preferences."
+              },
+              {
+                "version_added": "3.5",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "browser.dom.window.dump.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "4",
+                "partial_implementation": true,
+                "notes": "By default, this method exists and can be called, but does nothing unless enabled in the browser's preferences."
+              },
+              {
+                "version_added": "4",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "browser.dom.window.dump.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Show unflagged existence of `dump()` (i.e., that `"dump" in window` is `true`), which is implied by the existing notes.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Post-merge suggestions for https://github.com/mdn/browser-compat-data/pull/15014 by @wbamberg.


<!-- ✅ After submitting, review the results of the "Checks" tab! -->
