### PR TITLE
fix: Safari has content-length as CORS safelisted

### DIFF
--- a/http/headers/content-length.json
+++ b/http/headers/content-length.json
@@ -69,7 +69,7 @@
                 "version_added": "87"
               },
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "opera": {
                 "version_added": "63"
@@ -78,10 +78,10 @@
                 "version_added": "54"
               },
               "safari": {
-                "version_added": false
+                "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "12.2"
               },
               "samsunginternet_android": {
                 "version_added": "12.0"


### PR DESCRIPTION
The ticket on webkit: https://bugs.webkit.org/show_bug.cgi?id=185473

I tested on IE and it is no safelisted.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Safari has content-length as CORS safelisted response header since version 12.1.
IE has not.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
POC: https://github.com/jeremad/content-length-cors-poc

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://bugs.webkit.org/show_bug.cgi?id=185473

#### Related issues

Closes: #15007
