### PR TITLE
Adapt api.AudioWorkletNode.processorerror_event to new events structure

### DIFF
--- a/api/AudioWorkletNode.json
+++ b/api/AudioWorkletNode.json
@@ -98,55 +98,6 @@
           }
         }
       },
-      "onprocessorerror": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/onprocessorerror",
-          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audioworkletnode-onprocessorerror",
-          "support": {
-            "chrome": {
-              "version_added": "66"
-            },
-            "chrome_android": {
-              "version_added": "66"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "76"
-            },
-            "firefox_android": {
-              "version_added": "79"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "53"
-            },
-            "opera_android": {
-              "version_added": "47"
-            },
-            "safari": {
-              "version_added": "14.1"
-            },
-            "safari_ios": {
-              "version_added": "14.5"
-            },
-            "samsunginternet_android": {
-              "version_added": "9.0"
-            },
-            "webview_android": {
-              "version_added": "66"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "parameters": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/parameters",
@@ -249,6 +200,7 @@
         "__compat": {
           "description": "<code>processorerror</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioWorkletNode/processorerror_event",
+          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audioworkletnode-onprocessorerror",
           "support": {
             "chrome": {
               "version_added": "66"


### PR DESCRIPTION
This PR adapts the processorerror event of the AudioWorkletNode API to conform to the new events structure.  Part of work for #14578.
