### PR TITLE
Update for...in support for Internet Explorer

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1032,7 +1032,7 @@
               "version_added": "4"
             },
             "ie": {
-              "version_added": "6"
+              "version_added": "3"
             },
             "nodejs": {
               "version_added": "0.10.0"


### PR DESCRIPTION
Update for...in support for Internet Explorer to show 3 not 6 as for...in has been supported since JScript 1.0.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
The for..in loop has been supported since JScript 1.0 in IE 3.0. This updates the statements compat data to reflect that.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

Test case on Internet Explorer 3.0 on Windows 95:

```html
<html>

<body>

<script>

var obj = new Object();
obj.a = '1';
obj.b = '2';
obj.c = '3';

var values = '';

for (var k in obj) {
  values += k + ': ' + obj[k] + ' ';
}

alert(values);

</script>

</body>

</html>
```

This can be tested in a modern browser by using the Windows 95 v86 demo created by copy.sh: https://copy.sh/v86/?profile=windows95 and creating an index.html file on the Desktop with the above contents.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
I could not find docs directly for IE3.0, but did find for...in support in docs as early as IE 4:
https://archive.org/details/microsoftinterne00micr/page/432/mode/2up (see `Control Flow`)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #15048

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
