### PR TITLE
Firefox does not support HTTP header Expect-CT

### DIFF
--- a/http/headers/expect-ct.json
+++ b/http/headers/expect-ct.json
@@ -17,10 +17,12 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1281469'>bug 1281469</a>."
             },
             "firefox_android": {
-              "version_added": null
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1281469'>bug 1281469</a>."
             },
             "ie": {
               "version_added": null


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Update BCD to show that Firefox does not support HTTP header Expect-CT.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
[See bug 1281469](https://bugzil.la/1281469).

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
None.
<!-- ✅ After submitting, review the results of the "Checks" tab! -->
