### PR TITLE
Add support for HTMLInputElement showPicker() in Opera

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2213,7 +2213,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "85"
             },
             "opera_android": {
               "version_added": false


### PR DESCRIPTION
#### Summary
Updated HTMLScriptElement.json since HTMLInputElement.showPicker() will be supported by Opera.

#### Test results and supporting details
Typed this in Opera DevTools console:

Opera 84

<img width="537" alt="image" src="https://user-images.githubusercontent.com/15973671/154828390-316b4b90-8cdd-42b8-93ee-0c3933ab55a2.png">

Opera 85

<img width="443" alt="image" src="https://user-images.githubusercontent.com/15973671/154828406-79be6c18-cdc8-4bc7-ac5f-176750b63f45.png">

#### Related issues
Fixes #15054 

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
