### PR TITLE
Fix Chalk expression

### DIFF
--- a/test/linter/test-real-values.js
+++ b/test/linter/test-real-values.js
@@ -68,7 +68,7 @@ function checkRealValues(supportData, blockList, relPath, logger) {
         }
         if ([true, null].includes(statement.version_removed)) {
           logger.error(
-            chalk`{red → {bold ${relPath}} - {bold ${browser}} no longer accepts} {bold ${statement.version_removed}} as a value}`,
+            chalk`{red → {bold ${relPath}} - {bold ${browser}} no longer accepts {bold ${statement.version_removed}} as a value}`,
           );
         }
       }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Fix Chalk expression

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
Prior to this commit this expression has an extra `}` which causes Chalk to throw:
```
chalk`{red → {bold ${relPath}} - {bold ${browser}} no longer accepts} {bold ${statement.version_removed}} as a value}`,
                                                                    ^
```
Removing this `}` makes chalk print actual error properly. Also, this PR makes lines 71 and 66 consistent.
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
