### PR TITLE
Fix Safari version for clearLiveSeekableRange

### DIFF
--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -279,7 +279,7 @@
               "version_added": "46"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
               "version_added": "13",


### PR DESCRIPTION
It was introduced here together with setLiveSeekableRanges:
https://trac.webkit.org/changeset/206146/webkit
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=206146

Testing https://mdn-bcd-collector.appspot.com/tests/api/MediaSource
in Safari 10 and 10.1 in Sauce Labs confirms they were added in 10.1.

The data came from https://github.com/mdn/browser-compat-data/pull/7427
which did come from the collector, but even the results at the time support
10.1 as the correct version:
https://raw.githubusercontent.com/foolip/mdn-bcd-results/327933b8a3a402bbb6e880569a2dff104df31698/1.1.3-safari-10.0.1-mac-os-10.11.6-daabd96f93.json
https://raw.githubusercontent.com/foolip/mdn-bcd-results/327933b8a3a402bbb6e880569a2dff104df31698/1.1.3-safari-10.1.2-mac-os-10.12.6-142e4c09c5.json

Possibly the updater script is buggy or the results were manually edited.