### PR TITLE
Update Chromium versions for api.AbortSignal.reason

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -284,16 +284,16 @@
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-abortsignal-reason①",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "98"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "98"
             },
             "deno": {
               "version_added": "1.16"
             },
             "edge": {
-              "version_added": false
+              "version_added": "98"
             },
             "firefox": {
               "version_added": "97"
@@ -323,7 +323,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "98"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `reason` member of the `AbortSignal` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v5.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AbortSignal/reason

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
