### PR TITLE
Adapt api.Document.onfreeze to new events structure

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -5193,6 +5193,54 @@
           }
         }
       },
+      "freeze_event": {
+        "__compat": {
+          "description": "<code>freeze</code> event",
+          "support": {
+            "chrome": {
+              "version_added": "68"
+            },
+            "chrome_android": {
+              "version_added": "68"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "55"
+            },
+            "opera_android": {
+              "version_added": "48"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "10.0"
+            },
+            "webview_android": {
+              "version_added": "68"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "fullscreen": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/fullscreen",
@@ -7175,54 +7223,6 @@
             "experimental": false,
             "standard_track": false,
             "deprecated": true
-          }
-        }
-      },
-      "onfreeze": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/onfreeze",
-          "support": {
-            "chrome": {
-              "version_added": "68"
-            },
-            "chrome_android": {
-              "version_added": "68"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "55"
-            },
-            "opera_android": {
-              "version_added": "48"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "10.0"
-            },
-            "webview_android": {
-              "version_added": "68"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
           }
         }
       },


### PR DESCRIPTION
This PR adapts the freeze event of the Document API to conform to the new events structure.

Note: the MDN URL is removed and there is no content PR because the page does not exist.
