### PR TITLE
Updates opera browser to version 84

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -636,19 +636,26 @@
         "83": {
           "release_date": "2022-01-19",
           "release_notes": "https://blogs.opera.com/desktop/2022/01/opera-83/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "97"
         },
         "84": {
-          "status": "beta",
+          "release_date": "2022-02-16",
+          "release_notes": "https://blogs.opera.com/desktop/2022/02/opera-84/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "98"
         },
         "85": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "99"
+        },
+        "86": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "100"
         }
       }
     }


### PR DESCRIPTION
Hello all!

According to this [release note](https://blogs.opera.com/desktop/2022/02/opera-84/), Opera has updated to version 84.

Fixes #15076.