### PR TITLE
Default support for hyphenate-character from FF98

### DIFF
--- a/css/properties/hyphenate-character.json
+++ b/css/properties/hyphenate-character.json
@@ -18,18 +18,23 @@
               "prefix": "-webkit-",
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.hyphenate-character.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "98"
+              },
+              {
+                "version_added": "97",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.hyphenate-character.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "98"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
In FF98, the `layout.css.hyphenate-character.enabled` preference is set to true by default.

Updated [browser compat data](https://developer.mozilla.org/en-US/docs/Web/CSS/hyphenate-character#browser_compatibility) to reflect default support for hyphenate-character from FF98.



#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://bugzilla.mozilla.org/show_bug.cgi?id=1751024




#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Other related doc updates for this: https://github.com/mdn/content/issues/12580
