### PR TITLE
Adding details for runtime.getFrameId

### DIFF
--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -513,6 +513,34 @@
             }
           }
         },
+        "getFrameId": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getFrameId",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "96"
+              },
+              "firefox_android": {
+                "version_added": "96"
+              },
+              "opera": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "getManifest": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getManifest",


### PR DESCRIPTION
#### Summary
Adds details for runtime.getFrameId

#### Test results and supporting details
`npm test` reported all tests passed

#### Related issues
Adds details requested in [Bug 1733104](https://bugzilla.mozilla.org/show_bug.cgi?id=1733104) Consider allowing retrieval of frameId from <iframe> elements
