### PR TITLE
SameSite - IE 11 started supporting it on recent Windows 10 (#12535)

### DIFF
--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -170,7 +170,12 @@
                 "version_added": "60"
               },
               "ie": {
-                "version_added": false
+                "version_added": "11",
+                "partial_implementation": true,
+                "notes": [
+                  "Not shipped with the inital release but later with the 2018 June security update (Patch Tuesday) to Windows 10 RS3 (2017 Fall Creators Update) and newer. <a href='https://github.com/MicrosoftEdge/Status/issues/616'>More info</a>.",
+                  "Partial support because only supported in IE 11 on Windows 10 RS3 (2017 Fall Creators Update) and newer, but not in IE 11 on other Windows versions (Windows 7, ...)"
+                ]
               },
               "opera": {
                 "version_added": "39"
@@ -232,7 +237,12 @@
                   "version_added": "60"
                 },
                 "ie": {
-                  "version_added": false
+                  "version_added": "11",
+                  "partial_implementation": true,
+                  "notes": [
+                    "Not shipped with the inital release but later with the 2018 June security update (Patch Tuesday) to Windows 10 RS3 (2017 Fall Creators Update) and newer. <a href='https://github.com/MicrosoftEdge/Status/issues/616'>More info</a>.",
+                    "Partial support because only supported in IE 11 on Windows 10 RS3 (2017 Fall Creators Update) and newer, but not in IE 11 on other Windows versions (Windows 7, ...)"
+                  ]
                 },
                 "opera": {
                   "version_added": "39"
@@ -351,7 +361,12 @@
                   "version_added": "60"
                 },
                 "ie": {
-                  "version_added": false
+                  "version_added": "11",
+                  "partial_implementation": true,
+                  "notes": [
+                    "Not shipped with the inital release but later with the 2018 June security update (Patch Tuesday) to Windows 10 RS3 (2017 Fall Creators Update) and newer. <a href='https://github.com/MicrosoftEdge/Status/issues/616'>More info</a>.",
+                    "Partial support because only supported in IE 11 on Windows 10 RS3 (2017 Fall Creators Update) and newer, but not in IE 11 on other Windows versions (Windows 7, ...)"
+                  ]
                 },
                 "opera": [
                   {
@@ -432,7 +447,12 @@
                   "version_added": "60"
                 },
                 "ie": {
-                  "version_added": false
+                  "version_added": "11",
+                  "partial_implementation": true,
+                  "notes": [
+                    "Not shipped with the inital release but later with the 2018 June security update (Patch Tuesday) to Windows 10 RS3 (2017 Fall Creators Update) and newer. <a href='https://github.com/MicrosoftEdge/Status/issues/616'>More info</a>.",
+                    "Partial support because only supported in IE 11 on Windows 10 RS3 (2017 Fall Creators Update) and newer, but not in IE 11 on other Windows versions (Windows 7, ...)"
+                  ]
                 },
                 "opera": {
                   "version_added": "39"

--- a/http/headers/set-cookie.json
+++ b/http/headers/set-cookie.json
@@ -170,12 +170,7 @@
                 "version_added": "60"
               },
               "ie": {
-                "version_added": "11",
-                "partial_implementation": true,
-                "notes": [
-                  "Not shipped with the inital release but later with the 2018 June security update (Patch Tuesday) to Windows 10 RS3 (2017 Fall Creators Update) and newer. <a href='https://github.com/MicrosoftEdge/Status/issues/616'>More info</a>.",
-                  "Partial support because only supported in IE 11 on Windows 10 RS3 (2017 Fall Creators Update) and newer, but not in IE 11 on other Windows versions (Windows 7, ...)"
-                ]
+                "version_added": "11"
               },
               "opera": {
                 "version_added": "39"
@@ -237,12 +232,7 @@
                   "version_added": "60"
                 },
                 "ie": {
-                  "version_added": "11",
-                  "partial_implementation": true,
-                  "notes": [
-                    "Not shipped with the inital release but later with the 2018 June security update (Patch Tuesday) to Windows 10 RS3 (2017 Fall Creators Update) and newer. <a href='https://github.com/MicrosoftEdge/Status/issues/616'>More info</a>.",
-                    "Partial support because only supported in IE 11 on Windows 10 RS3 (2017 Fall Creators Update) and newer, but not in IE 11 on other Windows versions (Windows 7, ...)"
-                  ]
+                  "version_added": "11"
                 },
                 "opera": {
                   "version_added": "39"
@@ -361,12 +351,7 @@
                   "version_added": "60"
                 },
                 "ie": {
-                  "version_added": "11",
-                  "partial_implementation": true,
-                  "notes": [
-                    "Not shipped with the inital release but later with the 2018 June security update (Patch Tuesday) to Windows 10 RS3 (2017 Fall Creators Update) and newer. <a href='https://github.com/MicrosoftEdge/Status/issues/616'>More info</a>.",
-                    "Partial support because only supported in IE 11 on Windows 10 RS3 (2017 Fall Creators Update) and newer, but not in IE 11 on other Windows versions (Windows 7, ...)"
-                  ]
+                  "version_added": "11"
                 },
                 "opera": [
                   {
@@ -447,12 +432,7 @@
                   "version_added": "60"
                 },
                 "ie": {
-                  "version_added": "11",
-                  "partial_implementation": true,
-                  "notes": [
-                    "Not shipped with the inital release but later with the 2018 June security update (Patch Tuesday) to Windows 10 RS3 (2017 Fall Creators Update) and newer. <a href='https://github.com/MicrosoftEdge/Status/issues/616'>More info</a>.",
-                    "Partial support because only supported in IE 11 on Windows 10 RS3 (2017 Fall Creators Update) and newer, but not in IE 11 on other Windows versions (Windows 7, ...)"
-                  ]
+                  "version_added": "11"
                 },
                 "opera": {
                   "version_added": "39"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
IE 11 started supporting it on recent Windows 10.
The "notes" in IE is reprinted from https://caniuse.com/same-site-cookie-attribute

#### Test results and supporting details
It supports only SameSite attribute, SameSite=Lax, SameSite=None and SameSite=Strict. It not supports Defaults to Lax.

see also #12535 and https://caniuse.com/same-site-cookie-attribute

#### Related issues
Fixes #12535
