### PR TITLE
Add cookieStoreId to userScripts.register

### DIFF
--- a/webextensions/api/userScripts.json
+++ b/webextensions/api/userScripts.json
@@ -122,6 +122,33 @@
             }
           }
         },
+        "cookieStoreId": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "97"
+              },
+              "firefox_android": {
+                "version_added": "97"
+              },
+              "opera": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "register": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/register",

--- a/webextensions/api/userScripts.json
+++ b/webextensions/api/userScripts.json
@@ -132,10 +132,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "97"
+                "version_added": "98"
               },
               "firefox_android": {
-                "version_added": "97"
+                "version_added": "98"
               },
               "opera": {
                 "version_added": false


### PR DESCRIPTION
#### Summary
Adds details of `cookieStoreId` to `userScripts.register`. Addresses browser compatibility data requirements for [bug 1738567](https://bugzilla.mozilla.org/show_bug.cgi?id=1738567)

#### Test results and supporting details
Ran `npm test` with no errors.

#### Related issues
MDN documentation changes made in PR [13259](https://github.com/mdn/content/pull/13259)