### PR TITLE
Add bcd for Intl.NumberFormat.options_signDisplay_parameter.negative

### DIFF
--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -403,6 +403,60 @@
                   "standard_track": true,
                   "deprecated": false
                 }
+              },
+              "negative": {
+                "__compat": {
+                  "description": "<code>negative</code> value",
+                  "support": {
+                    "chrome": {
+                      "version_added": false
+                    },
+                    "chrome_android": {
+                      "version_added": false
+                    },
+                    "deno": {
+                      "version_added": false
+                    },
+                    "edge": {
+                      "version_added": false
+                    },
+                    "firefox": {
+                      "version_added": "93"
+                    },
+                    "firefox_android": {
+                      "version_added": "93"
+                    },
+                    "ie": {
+                      "version_added": false
+                    },
+                    "nodejs": {
+                      "version_added": false
+                    },
+                    "opera": {
+                      "version_added": false
+                    },
+                    "opera_android": {
+                      "version_added": false
+                    },
+                    "safari": {
+                      "version_added": false
+                    },
+                    "safari_ios": {
+                      "version_added": false
+                    },
+                    "samsunginternet_android": {
+                      "version_added": false
+                    },
+                    "webview_android": {
+                      "version_added": false
+                    }
+                  },
+                  "status": {
+                    "experimental": true,
+                    "standard_track": true,
+                    "deprecated": false
+                  }
+                }
               }
             },
             "options_unit_parameter": {


### PR DESCRIPTION
NumberFormat v3 is partially implemented in Gecko, but not in Chromium.

This adds bcd the `negative` parameter value. See mdn/content#13230 that fixes the content part and mdn/content#13045 where this has been reported.

Enabling of Unified NumberFormat on Firefox 78: https://bugzilla.mozilla.org/show_bug.cgi?id=1633836
Enabling of NumberFormat v3 on Firefox 93: https://bugzilla.mozilla.org/show_bug.cgi?id=1648137

There is likely more work to be done for NumberFormat v3 but this fixes what has been reported on mdn/content.