### PR TITLE
Update support data for forgiving selector lists in is/where for Safari

### DIFF
--- a/css/selectors/is.json
+++ b/css/selectors/is.json
@@ -222,10 +222,10 @@
                 "version_added": "63"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14"
               },
               "samsunginternet_android": {
                 "version_added": "15.0"

--- a/css/selectors/where.json
+++ b/css/selectors/where.json
@@ -119,10 +119,10 @@
                 "version_added": "63"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14"
               },
               "samsunginternet_android": {
                 "version_added": "15.0"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Safari has supported forgiving selector lists in is/where since version 14

#### Test results and supporting details
Fixed and resolved bug report: https://bugs.webkit.org/show_bug.cgi?id=217814

#### Related issues
n/a
