### PR TITLE
Add some spec URLs for SVG features lacking them

### DIFF
--- a/svg/elements/a.json
+++ b/svg/elements/a.json
@@ -350,6 +350,8 @@
         },
         "target": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/target",
+            "spec_url": "https://svgwg.org/svg2-draft/linking.html#AElementTargetAttribute",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/svg/elements/altGlyph.json
+++ b/svg/elements/altGlyph.json
@@ -147,6 +147,11 @@
         },
         "format": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/format",
+            "spec_url": [
+              "https://www.w3.org/TR/SVG11/text.html#GlyphRefElementFormatAttribute",
+              "https://www.w3.org/TR/SVG11/text.html#AltGlyphElementFormatAttribute"
+            ],
             "support": {
               "chrome": {
                 "version_added": null
@@ -194,6 +199,11 @@
         },
         "glyphRef": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/glyphRef",
+            "spec_url": [
+              "https://www.w3.org/TR/SVG11/text.html#GlyphRefElementGlyphRefAttribute",
+              "https://www.w3.org/TR/SVG11/text.html#AltGlyphElementGlyphRefAttribute"
+            ],
             "support": {
               "chrome": {
                 "version_added": null

--- a/svg/elements/animate.json
+++ b/svg/elements/animate.json
@@ -145,6 +145,8 @@
         },
         "dur": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/dur",
+            "spec_url": "https://svgwg.org/specs/animations/#DurAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -192,6 +194,8 @@
         },
         "from": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/from",
+            "spec_url": "https://svgwg.org/specs/animations/#FromAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -239,6 +243,8 @@
         },
         "repeatCount": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/repeatCount",
+            "spec_url": "https://svgwg.org/specs/animations/#RepeatCountAttribute",
             "support": {
               "chrome": {
                 "version_added": null

--- a/svg/elements/animateMotion.json
+++ b/svg/elements/animateMotion.json
@@ -98,6 +98,8 @@
         },
         "keyPoints": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/keyPoints",
+            "spec_url": "https://svgwg.org/specs/animations/#KeyPointsAttribute",
             "support": {
               "chrome": {
                 "version_added": null

--- a/svg/elements/feBlend.json
+++ b/svg/elements/feBlend.json
@@ -145,6 +145,8 @@
         },
         "mode": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/mode",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-feblend-mode",
             "support": {
               "chrome": {
                 "version_added": true

--- a/svg/elements/feComposite.json
+++ b/svg/elements/feComposite.json
@@ -147,6 +147,8 @@
         },
         "k1": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/k1",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-fecomposite-k1",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -194,6 +196,8 @@
         },
         "k2": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/k2",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-fecomposite-k2",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -241,6 +245,8 @@
         },
         "k3": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/k3",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-fecomposite-k3",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -288,6 +294,8 @@
         },
         "k4": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/k4",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-fecomposite-k4",
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/svg/elements/feDisplacementMap.json
+++ b/svg/elements/feDisplacementMap.json
@@ -145,6 +145,8 @@
         },
         "scale": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/scale",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-fedisplacementmap-scale",
             "support": {
               "chrome": {
                 "version_added": true
@@ -192,6 +194,8 @@
         },
         "xChannelSelector": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/xChannelSelector",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-fedisplacementmap-xchannelselector",
             "support": {
               "chrome": {
                 "version_added": null
@@ -239,6 +243,8 @@
         },
         "yChannelSelector": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/yChannelSelector",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-fedisplacementmap-ychannelselector",
             "support": {
               "chrome": {
                 "version_added": null

--- a/svg/elements/feGaussianBlur.json
+++ b/svg/elements/feGaussianBlur.json
@@ -145,6 +145,8 @@
         },
         "stdDeviation": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/stdDeviation",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-fegaussianblur-stddeviation",
             "support": {
               "chrome": {
                 "version_added": true

--- a/svg/elements/feMorphology.json
+++ b/svg/elements/feMorphology.json
@@ -193,6 +193,8 @@
         },
         "radius": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/radius",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-femorphology-radius",
             "support": {
               "chrome": {
                 "version_added": true

--- a/svg/elements/feSpecularLighting.json
+++ b/svg/elements/feSpecularLighting.json
@@ -145,6 +145,8 @@
         },
         "specularConstant": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/specularConstant",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-fespecularlighting-specularconstant",
             "support": {
               "chrome": {
                 "version_added": true

--- a/svg/elements/feSpotLight.json
+++ b/svg/elements/feSpotLight.json
@@ -51,6 +51,8 @@
         },
         "limitingConeAngle": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/limitingConeAngle",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-fespotlight-limitingconeangle",
             "support": {
               "chrome": {
                 "version_added": true
@@ -98,6 +100,8 @@
         },
         "pointsAtX": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/pointsAtX",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-fespotlight-pointsatx",
             "support": {
               "chrome": {
                 "version_added": true
@@ -145,6 +149,8 @@
         },
         "pointsAtY": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/pointsAtY",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-fespotlight-pointsaty",
             "support": {
               "chrome": {
                 "version_added": true
@@ -192,6 +198,8 @@
         },
         "pointsAtZ": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/pointsAtZ",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-fespotlight-pointsatz",
             "support": {
               "chrome": {
                 "version_added": true

--- a/svg/elements/font-face-format.json
+++ b/svg/elements/font-face-format.json
@@ -51,6 +51,8 @@
         },
         "string": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/string",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontFaceFormatElementStringAttribute",
             "support": {
               "chrome": {
                 "version_added": null

--- a/svg/elements/font.json
+++ b/svg/elements/font.json
@@ -71,6 +71,11 @@
         },
         "horiz-adv-x": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/horiz-adv-x",
+            "spec_url": [
+              "https://www.w3.org/TR/SVG11/fonts.html#GlyphElementHorizAdvXAttribute",
+              "https://www.w3.org/TR/SVG11/fonts.html#FontElementHorizAdvXAttribute"
+            ],
             "support": {
               "chrome": {
                 "version_added": false
@@ -118,6 +123,8 @@
         },
         "horiz-origin-x": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/horiz-origin-x",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontElementHorizOriginXAttribute",
             "support": {
               "chrome": {
                 "version_added": false
@@ -165,6 +172,8 @@
         },
         "horiz-origin-y": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/horiz-origin-y",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontElementHorizOriginYAttribute",
             "support": {
               "chrome": {
                 "version_added": false
@@ -212,6 +221,11 @@
         },
         "vert-adv-y": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/vert-adv-y",
+            "spec_url": [
+              "https://www.w3.org/TR/SVG11/fonts.html#GlyphElementVertAdvYAttribute",
+              "https://www.w3.org/TR/SVG11/fonts.html#FontElementVertAdvYAttribute"
+            ],
             "support": {
               "chrome": {
                 "version_added": false
@@ -259,6 +273,8 @@
         },
         "vert-origin-x": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/vert-origin-x",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontElementVertOriginXAttribute",
             "support": {
               "chrome": {
                 "version_added": false
@@ -306,6 +322,8 @@
         },
         "vert-origin-y": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/vert-origin-y",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#FontElementVertOriginYAttribute",
             "support": {
               "chrome": {
                 "version_added": false

--- a/svg/elements/glyph.json
+++ b/svg/elements/glyph.json
@@ -51,6 +51,8 @@
         },
         "arabic-form": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/arabic-form",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#GlyphElementArabicFormAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -145,6 +147,8 @@
         },
         "glyph-name": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/glyph-name",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#GlyphElementGlyphNameAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -286,6 +290,8 @@
         },
         "orientation": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/orientation",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#GlyphElementOrientationAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -333,6 +339,8 @@
         },
         "unicode": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/unicode",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#GlyphElementUnicodeAttribute",
             "support": {
               "chrome": {
                 "version_added": null

--- a/svg/elements/hkern.json
+++ b/svg/elements/hkern.json
@@ -51,6 +51,8 @@
         },
         "g1": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/g1",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#HKernElementG1Attribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -98,6 +100,8 @@
         },
         "g2": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/g2",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#HKernElementG2Attribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -145,6 +149,8 @@
         },
         "k": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/k",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#HKernElementKAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -192,6 +198,8 @@
         },
         "u1": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/u1",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#HKernElementU1Attribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -239,6 +247,8 @@
         },
         "u2": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/u2",
+            "spec_url": "https://www.w3.org/TR/SVG11/fonts.html#HKernElementU2Attribute",
             "support": {
               "chrome": {
                 "version_added": null

--- a/svg/elements/linearGradient.json
+++ b/svg/elements/linearGradient.json
@@ -51,6 +51,12 @@
         },
         "gradientTransform": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/gradientTransform",
+            "spec_url": [
+              "https://drafts.csswg.org/css-transforms/#typedef-transform-list",
+              "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementGradientTransformAttribute",
+              "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementGradientTransformAttribute"
+            ],
             "support": {
               "chrome": {
                 "version_added": null

--- a/svg/elements/marker.json
+++ b/svg/elements/marker.json
@@ -51,6 +51,8 @@
         },
         "markerHeight": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/markerHeight",
+            "spec_url": "https://svgwg.org/svg2-draft/painting.html#MarkerHeightAttribute",
             "support": {
               "chrome": {
                 "version_added": true
@@ -98,6 +100,8 @@
         },
         "markerUnits": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/markerUnits",
+            "spec_url": "https://svgwg.org/svg2-draft/painting.html#MarkerUnitsAttribute",
             "support": {
               "chrome": {
                 "version_added": true
@@ -145,6 +149,8 @@
         },
         "markerWidth": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/markerWidth",
+            "spec_url": "https://svgwg.org/svg2-draft/painting.html#MarkerWidthAttribute",
             "support": {
               "chrome": {
                 "version_added": true
@@ -192,6 +198,8 @@
         },
         "orient": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/orient",
+            "spec_url": "https://svgwg.org/svg2-draft/painting.html#OrientAttribute",
             "support": {
               "chrome": {
                 "version_added": true

--- a/svg/elements/mask.json
+++ b/svg/elements/mask.json
@@ -98,6 +98,8 @@
         },
         "maskContentUnits": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/maskContentUnits",
+            "spec_url": "https://drafts.fxtf.org/css-masking-1/#element-attrdef-mask-maskcontentunits",
             "support": {
               "chrome": {
                 "version_added": null
@@ -145,6 +147,8 @@
         },
         "maskUnits": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/maskUnits",
+            "spec_url": "https://drafts.fxtf.org/css-masking-1/#element-attrdef-mask-maskunits",
             "support": {
               "chrome": {
                 "version_added": null

--- a/svg/elements/pattern.json
+++ b/svg/elements/pattern.json
@@ -145,6 +145,8 @@
         },
         "patternContentUnits": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/patternContentUnits",
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#PatternElementPatternContentUnitsAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -192,6 +194,8 @@
         },
         "patternTransform": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/patternTransform",
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#PatternElementPatternTransformAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -239,6 +243,8 @@
         },
         "patternUnits": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/patternUnits",
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#PatternElementPatternUnitsAttribute",
             "support": {
               "chrome": {
                 "version_added": null

--- a/svg/elements/radialGradient.json
+++ b/svg/elements/radialGradient.json
@@ -145,6 +145,8 @@
         },
         "fr": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/fr",
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementFRAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -192,6 +194,8 @@
         },
         "fx": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/fx",
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementFXAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -239,6 +243,8 @@
         },
         "fy": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/fy",
+            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementFYAttribute",
             "support": {
               "chrome": {
                 "version_added": null

--- a/svg/elements/style.json
+++ b/svg/elements/style.json
@@ -51,6 +51,8 @@
         },
         "media": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/media",
+            "spec_url": "https://svgwg.org/svg2-draft/styling.html#StyleElementMediaAttribute",
             "support": {
               "chrome": {
                 "version_added": null

--- a/svg/elements/svg.json
+++ b/svg/elements/svg.json
@@ -98,6 +98,8 @@
         },
         "contentScriptType": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/contentScriptType",
+            "spec_url": "https://www.w3.org/TR/SVG11/script.html#ContentScriptTypeAttribute",
             "support": {
               "chrome": {
                 "version_added": false
@@ -145,6 +147,8 @@
         },
         "contentStyleType": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/contentStyleType",
+            "spec_url": "https://www.w3.org/TR/SVG11/styling.html#ContentStyleTypeAttribute",
             "support": {
               "chrome": {
                 "version_added": false
@@ -286,6 +290,8 @@
         },
         "version": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/version",
+            "spec_url": "https://www.w3.org/TR/SVG11/struct.html#SVGElementVersionAttribute",
             "support": {
               "chrome": {
                 "version_added": true
@@ -521,6 +527,8 @@
         },
         "zoomAndPan": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/zoomAndPan",
+            "spec_url": "https://www.w3.org/TR/SVG11/interact.html#ZoomAndPanAttribute",
             "support": {
               "chrome": {
                 "version_added": true

--- a/svg/elements/textPath.json
+++ b/svg/elements/textPath.json
@@ -155,6 +155,8 @@
         },
         "side": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/side",
+            "spec_url": "https://svgwg.org/svg2-draft/text.html#TextPathElementSideAttribute",
             "support": {
               "chrome": {
                 "version_added": false
@@ -202,6 +204,8 @@
         },
         "spacing": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/spacing",
+            "spec_url": "https://svgwg.org/svg2-draft/text.html#TextPathElementSpacingAttribute",
             "support": {
               "chrome": {
                 "version_added": null
@@ -249,6 +253,8 @@
         },
         "startOffset": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/startOffset",
+            "spec_url": "https://svgwg.org/svg2-draft/text.html#TextPathElementStartOffsetAttribute",
             "support": {
               "chrome": {
                 "version_added": true

--- a/svg/elements/view.json
+++ b/svg/elements/view.json
@@ -145,6 +145,8 @@
         },
         "viewTarget": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/viewTarget",
+            "spec_url": "https://www.w3.org/TR/SVG11/linking.html#ViewElementViewTargetAttribute",
             "support": {
               "chrome": {
                 "version_added": null


### PR DESCRIPTION
Related: https://github.com/mdn/content/pull/13265#discussion_r814480265 • Related: https://github.com/mdn/content/issues/13126

This has are two separate commits: 96a4fcdb6 for the non-obsolete features, and 4a46c9422 for the obsolete features (which are only in the SVG 1.1 spec but not in the SVG2 spec).