### PR TITLE
Add support for Error cause in Edge

### DIFF
--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -233,7 +233,7 @@
                   "version_added": "1.13"
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "93"
                 },
                 "firefox": {
                   "version_added": "91"
@@ -288,7 +288,7 @@
                 "version_added": "1.13"
               },
               "edge": {
-                "version_added": false
+                "version_added": "93"
               },
               "firefox": {
                 "version_added": "91"


### PR DESCRIPTION
#### Summary
Updated Error.json since Error.cause will be supported by Edge.

#### Test results and supporting details
Typed this in Edge DevTools console:

Edge 92

<img width="506" alt="edge92_error_cause" src="https://user-images.githubusercontent.com/15973671/155865269-fdf69081-2c29-4d65-9728-40ed9ef12b1d.png">

Edge 93

<img width="501" alt="edge93_error_cause" src="https://user-images.githubusercontent.com/15973671/155865278-f8fd6ba9-4982-48f5-9606-6e6f7c917c05.png">

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
Fixes #14989 

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
