### PR TITLE
Update History pushstate|replacestate note about “unused” param (was “title”)

### DIFF
--- a/api/History.json
+++ b/api/History.json
@@ -296,7 +296,7 @@
         },
         "title_parameter": {
           "__compat": {
-            "description": "Whether the <code>title</code> parameter is used",
+            "description": "Whether the <code>unused</code> parameter is used",
             "support": {
               "chrome": {
                 "version_added": false
@@ -397,7 +397,7 @@
         },
         "title_parameter": {
           "__compat": {
-            "description": "Whether the <code>title</code> parameter is used",
+            "description": "Whether the <code>unused</code> parameter is used",
             "support": {
               "chrome": {
                 "version_added": false

--- a/api/History.json
+++ b/api/History.json
@@ -294,7 +294,7 @@
             "deprecated": false
           }
         },
-        "title_parameter": {
+        "unused_parameter": {
           "__compat": {
             "description": "Whether the <code>unused</code> parameter is used",
             "support": {
@@ -395,7 +395,7 @@
             "deprecated": false
           }
         },
-        "title_parameter": {
+        "unused_parameter": {
           "__compat": {
             "description": "Whether the <code>unused</code> parameter is used",
             "support": {


### PR DESCRIPTION
Related MDN change: https://github.com/mdn/content/pull/13322 • Related spec bug: https://github.com/whatwg/html/pull/6482

Relevant spec sections:

- https://html.spec.whatwg.org/multipage/history.html#dom-history-pushstate
- https://html.spec.whatwg.org/multipage/history.html#dom-history-replacestate
- https://html.spec.whatwg.org/multipage/history.html#dom-history-pushstate-dev
- https://html.spec.whatwg.org/multipage/history.html#dom-history-replacestate-dev