### PR TITLE
FF97 navigator.requestMIDIAccess() supported behind flag

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3183,6 +3183,8 @@
       },
       "requestMIDIAccess": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/requestMIDIAccess",
+          "spec_url": "https://webaudio.github.io/web-midi-api/#dom-navigator-requestmidiaccess",
           "support": {
             "chrome": {
               "version_added": "43"
@@ -3194,7 +3196,14 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
FF97 adds support for the web midi API behind a flag. Most of the work was done in #14874. This updates the compatibility for `navigator.requestMIDIAccess()` which was accidentally omitted. Note, this also add the spec_url and MDN path to docs (which will be added in https://github.com/mdn/content/pull/13212).

Other docs work on this can be tracked in #12792
