### PR TITLE
Adapt HID API to new events structure

### DIFF
--- a/api/HID.json
+++ b/api/HID.json
@@ -48,58 +48,9 @@
           "deprecated": false
         }
       },
-      "getDevices": {
+      "connect_event": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HID/getDevices",
-          "spec_url": "https://wicg.github.io/webhid/#dom-hid-getdevices",
-          "support": {
-            "chrome": {
-              "version_added": "89"
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": "89"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "75"
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onconnect": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HID/onconnect",
+          "description": "<code>connect</code> event",
           "spec_url": "https://wicg.github.io/webhid/#dom-hid-onconnect",
           "support": {
             "chrome": {
@@ -146,10 +97,59 @@
           }
         }
       },
-      "ondisconnect": {
+      "disconnect_event": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HID/ondisconnect",
+          "description": "<code>disconnect</code> event",
           "spec_url": "https://wicg.github.io/webhid/#dom-hid-ondisconnect",
+          "support": {
+            "chrome": {
+              "version_added": "89"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "89"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "75"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getDevices": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HID/getDevices",
+          "spec_url": "https://wicg.github.io/webhid/#dom-hid-getdevices",
           "support": {
             "chrome": {
               "version_added": "89"


### PR DESCRIPTION
This PR adapts the HID API to conform to the new events structure.

Note: there are no MDN pages associated with this event, so there will be no corresponding content PR. Any broken MDN URLs in BCD have been removed.
