### PR TITLE
Adapt api.HIDDevice.oninputreport to new events structure

### DIFF
--- a/api/HIDDevice.json
+++ b/api/HIDDevice.json
@@ -146,9 +146,10 @@
           }
         }
       },
-      "oninputreport": {
+      "inputreport_event": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HIDDevice/oninputreport",
+          "description": "<code>inputreport</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HIDDevice/inputreport_event",
           "spec_url": "https://wicg.github.io/webhid/#dom-hiddevice-oninputreport",
           "support": {
             "chrome": {


### PR DESCRIPTION
This PR adapts the inputreport event of the HIDDevice API to conform to the new events structure.
