### PR TITLE
Remove api.HTMLBodyElement.orientationchange event

### DIFF
--- a/api/HTMLBodyElement.json
+++ b/api/HTMLBodyElement.json
@@ -240,8 +240,9 @@
           }
         }
       },
-      "onorientationchange": {
+      "orientationchange_event": {
         "__compat": {
+          "description": "<code>orientationchange</code> event",
           "support": {
             "chrome": {
               "version_added": false

--- a/api/HTMLBodyElement.json
+++ b/api/HTMLBodyElement.json
@@ -240,54 +240,6 @@
           }
         }
       },
-      "orientationchange_event": {
-        "__compat": {
-          "description": "<code>orientationchange</code> event",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": "18"
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": "≤14"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": "≤3"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.0"
-            },
-            "webview_android": {
-              "version_added": "≤37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
-      },
       "text": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLBodyElement/text",


### PR DESCRIPTION
This PR adapts the orientationchange event of the HTMLBodyElement API to conform to the new events structure.

Note: there are no MDN pages associated with these events, so there will be no corresponding content PR. Any broken MDN URLs in BCD have been removed.
