### PR TITLE
Delete api.HTMLFrameSetElement.onstorage

### DIFF
--- a/api/HTMLFrameSetElement.json
+++ b/api/HTMLFrameSetElement.json
@@ -141,54 +141,6 @@
             "deprecated": true
           }
         }
-      },
-      "storage_event": {
-        "__compat": {
-          "description": "<code>storage</code> event",
-          "support": {
-            "chrome": {
-              "version_added": "3"
-            },
-            "chrome_android": {
-              "version_added": "18"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "45"
-            },
-            "firefox_android": {
-              "version_added": "45"
-            },
-            "ie": {
-              "version_added": "9"
-            },
-            "opera": {
-              "version_added": "15"
-            },
-            "opera_android": {
-              "version_added": "14"
-            },
-            "safari": {
-              "version_added": "4"
-            },
-            "safari_ios": {
-              "version_added": "3.2"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.0"
-            },
-            "webview_android": {
-              "version_added": "≤37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
       }
     }
   }

--- a/api/HTMLFrameSetElement.json
+++ b/api/HTMLFrameSetElement.json
@@ -95,53 +95,6 @@
           }
         }
       },
-      "onstorage": {
-        "__compat": {
-          "support": {
-            "chrome": {
-              "version_added": "3"
-            },
-            "chrome_android": {
-              "version_added": "18"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "45"
-            },
-            "firefox_android": {
-              "version_added": "45"
-            },
-            "ie": {
-              "version_added": "9"
-            },
-            "opera": {
-              "version_added": "15"
-            },
-            "opera_android": {
-              "version_added": "14"
-            },
-            "safari": {
-              "version_added": "4"
-            },
-            "safari_ios": {
-              "version_added": "3.2"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.0"
-            },
-            "webview_android": {
-              "version_added": "≤37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
-      },
       "rows": {
         "__compat": {
           "support": {
@@ -180,6 +133,54 @@
             },
             "webview_android": {
               "version_added": "1"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "storage_event": {
+        "__compat": {
+          "description": "<code>storage</code> event",
+          "support": {
+            "chrome": {
+              "version_added": "3"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "45"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "4"
+            },
+            "safari_ios": {
+              "version_added": "3.2"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adapts the storage event of the HTMLFrameSetElement API to conform to the new events structure.  This PR focuses on deleting the `onstorage` entry, leaving the addition of `storage_event` to #15477.