### PR TITLE
Adapt api.IdleDetector.onchange to new events structure

### DIFF
--- a/api/IdleDetector.json
+++ b/api/IdleDetector.json
@@ -98,9 +98,10 @@
           }
         }
       },
-      "onchange": {
+      "change_event": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/onchange",
+          "description": "<code>change</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/change_event",
           "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector-onchange",
           "support": {
             "chrome": {


### PR DESCRIPTION
This PR adapts the change event of the IdleDetector API to conform to the new events structure.
