### PR TITLE
Adapt api.MediaDevices.ondevicechange to new events structure

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -52,7 +52,10 @@
         "__compat": {
           "description": "<code>devicechange</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDevices/devicechange_event",
-          "spec_url": "https://w3c.github.io/mediacapture-main/#event-mediadevices-devicechange",
+          "spec_url": [
+            "https://w3c.github.io/mediacapture-main/#event-mediadevices-devicechange",
+            "https://w3c.github.io/mediacapture-main/#dom-mediadevices-ondevicechange"
+          ],
           "support": {
             "chrome": {
               "version_added": "57"
@@ -449,55 +452,6 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        }
-      },
-      "ondevicechange": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaDevices/ondevicechange",
-          "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediadevices-ondevicechange",
-          "support": {
-            "chrome": {
-              "version_added": "57"
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "52"
-            },
-            "firefox_android": {
-              "version_added": "52"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "34"
-            },
-            "opera_android": {
-              "version_added": "34"
-            },
-            "safari": {
-              "version_added": "11"
-            },
-            "safari_ios": {
-              "version_added": "11"
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
           }
         }
       },


### PR DESCRIPTION
This PR adapts the devicechange event of the MediaDevices API to conform to the new events structure.
