### PR TITLE
Adapt api.MediaKeySession.onkeystatuseschange to new events structure

### DIFF
--- a/api/MediaKeySession.json
+++ b/api/MediaKeySession.json
@@ -299,12 +299,28 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaKeySession/keystatuseschange_event",
           "spec_url": "https://w3c.github.io/encrypted-media/#dom-mediakeysession-onkeystatuseschange",
           "support": {
-            "chrome": {
-              "version_added": "55"
-            },
-            "chrome_android": {
-              "version_added": "55"
-            },
+            "chrome": [
+              {
+                "version_added": "55"
+              },
+              {
+                "version_added": "42",
+                "version_removed": "55",
+                "partial_implementation": true,
+                "notes": "The <code>onkeystatuseschange</code> event handler property is not supported."
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "55"
+              },
+              {
+                "version_added": "42",
+                "version_removed": "55",
+                "partial_implementation": true,
+                "notes": "The <code>onkeystatuseschange</code> event handler property is not supported."
+              }
+            ],
             "edge": {
               "version_added": "79"
             },
@@ -317,24 +333,56 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "42"
-            },
-            "opera_android": {
-              "version_added": "42"
-            },
+            "opera": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "29",
+                "version_removed": "42",
+                "partial_implementation": true,
+                "notes": "The <code>onkeystatuseschange</code> event handler property is not supported."
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "42"
+              },
+              {
+                "version_added": "29",
+                "version_removed": "42",
+                "partial_implementation": true,
+                "notes": "The <code>onkeystatuseschange</code> event handler property is not supported."
+              }
+            ],
             "safari": {
               "version_added": "12.1"
             },
             "safari_ios": {
               "version_added": "12.2"
             },
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
-            "webview_android": {
-              "version_added": "43"
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "6.0"
+              },
+              {
+                "version_added": "4.0",
+                "version_removed": "6.0",
+                "partial_implementation": true,
+                "notes": "The <code>onkeystatuseschange</code> event handler property is not supported."
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "55"
+              },
+              {
+                "version_added": "43",
+                "version_removed": "55",
+                "partial_implementation": true,
+                "notes": "The <code>onkeystatuseschange</code> event handler property is not supported."
+              }
+            ]
           },
           "status": {
             "experimental": true,

--- a/api/MediaKeySession.json
+++ b/api/MediaKeySession.json
@@ -293,6 +293,56 @@
           }
         }
       },
+      "keystatuseschange_event": {
+        "__compat": {
+          "description": "<code>keystatuseschange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaKeySession/keystatuseschange_event",
+          "spec_url": "https://w3c.github.io/encrypted-media/#dom-mediakeysession-onkeystatuseschange",
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "55"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "52"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "42"
+            },
+            "opera_android": {
+              "version_added": "42"
+            },
+            "safari": {
+              "version_added": "12.1"
+            },
+            "safari_ios": {
+              "version_added": "12.2"
+            },
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": {
+              "version_added": "43"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "load": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaKeySession/load",
@@ -330,55 +380,6 @@
             },
             "samsunginternet_android": {
               "version_added": "4.0"
-            },
-            "webview_android": {
-              "version_added": "43"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onkeystatuseschange": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaKeySession/onkeystatuseschange",
-          "spec_url": "https://w3c.github.io/encrypted-media/#dom-mediakeysession-onkeystatuseschange",
-          "support": {
-            "chrome": {
-              "version_added": "55"
-            },
-            "chrome_android": {
-              "version_added": "55"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "52"
-            },
-            "firefox_android": {
-              "version_added": "52"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "42"
-            },
-            "opera_android": {
-              "version_added": "42"
-            },
-            "safari": {
-              "version_added": "12.1"
-            },
-            "safari_ios": {
-              "version_added": "12.2"
-            },
-            "samsunginternet_android": {
-              "version_added": "6.0"
             },
             "webview_android": {
               "version_added": "43"


### PR DESCRIPTION
This PR adapts the keystatuseschange event of the MediaKeySession API to conform to the new events structure.
