### PR TITLE
Adapt api.PresentationAvailability.onchange to new events structure

### DIFF
--- a/api/PresentationAvailability.json
+++ b/api/PresentationAvailability.json
@@ -64,9 +64,10 @@
           "deprecated": false
         }
       },
-      "onchange": {
+      "change_event": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationAvailability/onchange",
+          "description": "<code>change</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationAvailability/change_event",
           "spec_url": "https://w3c.github.io/presentation-api/#dom-presentationavailability-onchange",
           "support": {
             "chrome": {


### PR DESCRIPTION
This PR adapts the change event of the PresentationAvailability API to conform to the new events structure.
