### PR TITLE
Adapt PresentationConnection API to new events structure

### DIFF
--- a/api/PresentationConnection.json
+++ b/api/PresentationConnection.json
@@ -194,6 +194,134 @@
           }
         }
       },
+      "close_event": {
+        "__compat": {
+          "description": "<code>close</code> event",
+          "support": {
+            "chrome": {
+              "version_added": "50"
+            },
+            "chrome_android": {
+              "version_added": "50"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "51",
+              "version_removed": "88",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.presentation.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "51",
+              "version_removed": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.presentation.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "37"
+            },
+            "opera_android": {
+              "version_added": "37"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "connect_event": {
+        "__compat": {
+          "description": "<code>connect</code> event",
+          "support": {
+            "chrome": {
+              "version_added": "50"
+            },
+            "chrome_android": {
+              "version_added": "50"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "51",
+              "version_removed": "88",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.presentation.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "51",
+              "version_removed": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.presentation.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "37"
+            },
+            "opera_android": {
+              "version_added": "37"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "id": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationConnection/id",
@@ -259,137 +387,9 @@
           }
         }
       },
-      "onclose": {
+      "message_event": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationConnection/onclose",
-          "support": {
-            "chrome": {
-              "version_added": "50"
-            },
-            "chrome_android": {
-              "version_added": "50"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "51",
-              "version_removed": "88",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "37"
-            },
-            "opera_android": {
-              "version_added": "37"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onconnect": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationConnection/onconnect",
-          "support": {
-            "chrome": {
-              "version_added": "50"
-            },
-            "chrome_android": {
-              "version_added": "50"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "51",
-              "version_removed": "88",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "37"
-            },
-            "opera_android": {
-              "version_added": "37"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onmessage": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationConnection/onmessage",
+          "description": "<code>message</code> event",
           "support": {
             "chrome": {
               "version_added": "47"
@@ -430,70 +430,6 @@
             },
             "opera_android": {
               "version_added": "34"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "5.0"
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onterminate": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationConnection/onterminate",
-          "support": {
-            "chrome": {
-              "version_added": "50"
-            },
-            "chrome_android": {
-              "version_added": "50"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "51",
-              "version_removed": "88",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "37"
-            },
-            "opera_android": {
-              "version_added": "37"
             },
             "safari": {
               "version_added": false
@@ -689,6 +625,70 @@
             },
             "opera_android": {
               "version_added": "35"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "5.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "terminate_event": {
+        "__compat": {
+          "description": "<code>terminate</code> event",
+          "support": {
+            "chrome": {
+              "version_added": "50"
+            },
+            "chrome_android": {
+              "version_added": "50"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "51",
+              "version_removed": "88",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.presentation.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": {
+              "version_added": "51",
+              "version_removed": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.presentation.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "37"
+            },
+            "opera_android": {
+              "version_added": "37"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR adapts the PresentationConnection API to conform to the new events structure.

Note: there are no MDN pages associated with this event, so there will be no corresponding content PR. Any broken MDN URLs in BCD have been removed.
