### PR TITLE
Adapt api.PresentationConnectionList.onconnectionavailable to new events structure

### DIFF
--- a/api/PresentationConnectionList.json
+++ b/api/PresentationConnectionList.json
@@ -64,9 +64,9 @@
           "deprecated": false
         }
       },
-      "connections": {
+      "connectionavailable_event": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationConnectionList/connections",
+          "description": "<code>connectionavailable</code> event",
           "support": {
             "chrome": {
               "version_added": "59"
@@ -128,9 +128,9 @@
           }
         }
       },
-      "onconnectionavailable": {
+      "connections": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationConnectionList/onconnectionavailable",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationConnectionList/connections",
           "support": {
             "chrome": {
               "version_added": "59"


### PR DESCRIPTION
This PR adapts the connectionavailable event of the PresentationConnectionList API to conform to the new events structure.

Note: there are no MDN pages associated with these events, so there will be no corresponding content PR. Any broken MDN URLs in BCD have been removed.
