### PR TITLE
Adapt api.RTCDTMFSender.ontonechange to new events structure

### DIFF
--- a/api/RTCDTMFSender.json
+++ b/api/RTCDTMFSender.json
@@ -145,55 +145,6 @@
           }
         }
       },
-      "ontonechange": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDTMFSender/ontonechange",
-          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcdtmfsender-ontonechange",
-          "support": {
-            "chrome": {
-              "version_added": "27"
-            },
-            "chrome_android": {
-              "version_added": "27"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "52"
-            },
-            "firefox_android": {
-              "version_added": "52"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "15"
-            },
-            "opera_android": {
-              "version_added": "14"
-            },
-            "safari": {
-              "version_added": "13.1"
-            },
-            "safari_ios": {
-              "version_added": "13.4"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.5"
-            },
-            "webview_android": {
-              "version_added": "≤37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "toneBuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDTMFSender/toneBuffer",


### PR DESCRIPTION
This PR adapts the tonechange event of the RTCDTMFSender API to conform to the new events structure.
