### PR TITLE
Adapt RTCDataChannel API to new events structure

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -149,7 +149,10 @@
       "bufferedamountlow_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel/bufferedamountlow_event",
-          "spec_url": "https://w3c.github.io/webrtc-pc/#event-datachannel-bufferedamountlow",
+          "spec_url": [
+            "https://w3c.github.io/webrtc-pc/#event-datachannel-bufferedamountlow",
+            "https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel-onbufferedamountlow"
+          ],
           "description": "<code>bufferedamountlow</code> event",
           "support": {
             "chrome": {
@@ -749,62 +752,6 @@
             },
             "webview_android": {
               "version_added": "4.4"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onbufferedamountlow": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel/onbufferedamountlow",
-          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel-onbufferedamountlow",
-          "support": {
-            "chrome": {
-              "version_added": "46",
-              "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
-            },
-            "chrome_android": {
-              "version_added": "46",
-              "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
-            },
-            "edge": {
-              "version_added": "79",
-              "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
-            },
-            "firefox": {
-              "version_added": "44"
-            },
-            "firefox_android": {
-              "version_added": "44"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "33",
-              "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
-            },
-            "opera_android": {
-              "version_added": "33",
-              "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
-            },
-            "safari": {
-              "version_added": "11"
-            },
-            "safari_ios": {
-              "version_added": "11"
-            },
-            "samsunginternet_android": {
-              "version_added": "5.0",
-              "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
-            },
-            "webview_android": {
-              "version_added": "46",
-              "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
             }
           },
           "status": {

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -304,7 +304,10 @@
       "close_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel/close_event",
-          "spec_url": "https://w3c.github.io/webrtc-pc/#event-datachannel-close",
+          "spec_url": [
+            "https://w3c.github.io/webrtc-pc/#event-datachannel-close",
+            "https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel-onclose"
+          ],
           "description": "<code>close</code> event",
           "support": {
             "chrome": {
@@ -351,10 +354,66 @@
           }
         }
       },
+      "closing_event": {
+        "__compat": {
+          "description": "<code>closing</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel/closing_event",
+          "spec_url": [
+            "https://w3c.github.io/webrtc-pc/#event-datachannel-closing",
+            "https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel-onclosing"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "81"
+            },
+            "chrome_android": {
+              "version_added": "81"
+            },
+            "edge": {
+              "version_added": "81"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "68"
+            },
+            "opera_android": {
+              "version_added": "58"
+            },
+            "safari": {
+              "version_added": "15.4"
+            },
+            "safari_ios": {
+              "version_added": "15.4"
+            },
+            "samsunginternet_android": {
+              "version_added": "13.0"
+            },
+            "webview_android": {
+              "version_added": "81"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "error_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel/error_event",
-          "spec_url": "https://w3c.github.io/webrtc-pc/#event-datachannel-error",
+          "spec_url": [
+            "https://w3c.github.io/webrtc-pc/#event-datachannel-error",
+            "https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel-onerror"
+          ],
           "description": "<code>error</code> event",
           "support": {
             "chrome": {
@@ -600,7 +659,10 @@
       "message_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel/message_event",
-          "spec_url": "https://w3c.github.io/webrtc-pc/#event-datachannel-message",
+          "spec_url": [
+            "https://w3c.github.io/webrtc-pc/#event-datachannel-message",
+            "https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel-onmessage"
+          ],
           "description": "<code>message</code> event",
           "support": {
             "chrome": {
@@ -752,255 +814,13 @@
           }
         }
       },
-      "onclose": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel/onclose",
-          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel-onclose",
-          "support": {
-            "chrome": {
-              "version_added": "24"
-            },
-            "chrome_android": {
-              "version_added": "25"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "22"
-            },
-            "firefox_android": {
-              "version_added": "22"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "15"
-            },
-            "opera_android": {
-              "version_added": "14"
-            },
-            "safari": {
-              "version_added": "11"
-            },
-            "safari_ios": {
-              "version_added": "11"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.5"
-            },
-            "webview_android": {
-              "version_added": "≤37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onclosing": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel/onclosing",
-          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel-onclosing",
-          "support": {
-            "chrome": {
-              "version_added": "81"
-            },
-            "chrome_android": {
-              "version_added": "81"
-            },
-            "edge": {
-              "version_added": "81"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "68"
-            },
-            "opera_android": {
-              "version_added": "58"
-            },
-            "safari": {
-              "version_added": "15.4"
-            },
-            "safari_ios": {
-              "version_added": "15.4"
-            },
-            "samsunginternet_android": {
-              "version_added": "13.0"
-            },
-            "webview_android": {
-              "version_added": "81"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onerror": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel/onerror",
-          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel-onerror",
-          "support": {
-            "chrome": {
-              "version_added": "24"
-            },
-            "chrome_android": {
-              "version_added": "25"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "22"
-            },
-            "firefox_android": {
-              "version_added": "22"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "15"
-            },
-            "opera_android": {
-              "version_added": "14"
-            },
-            "safari": {
-              "version_added": "11"
-            },
-            "safari_ios": {
-              "version_added": "11"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.5"
-            },
-            "webview_android": {
-              "version_added": "≤37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onmessage": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel/onmessage",
-          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel-onmessage",
-          "support": {
-            "chrome": {
-              "version_added": "24"
-            },
-            "chrome_android": {
-              "version_added": "25"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "22"
-            },
-            "firefox_android": {
-              "version_added": "22"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "15"
-            },
-            "opera_android": {
-              "version_added": "14"
-            },
-            "safari": {
-              "version_added": "11"
-            },
-            "safari_ios": {
-              "version_added": "11"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.5"
-            },
-            "webview_android": {
-              "version_added": "≤37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onopen": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel/onopen",
-          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel-onopen",
-          "support": {
-            "chrome": {
-              "version_added": "24"
-            },
-            "chrome_android": {
-              "version_added": "25"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "22"
-            },
-            "firefox_android": {
-              "version_added": "22"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "15"
-            },
-            "opera_android": {
-              "version_added": "14"
-            },
-            "safari": {
-              "version_added": "11"
-            },
-            "safari_ios": {
-              "version_added": "11"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.5"
-            },
-            "webview_android": {
-              "version_added": "≤37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "open_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel/open_event",
-          "spec_url": "https://w3c.github.io/webrtc-pc/#event-datachannel-open",
+          "spec_url": [
+            "https://w3c.github.io/webrtc-pc/#event-datachannel-open",
+            "https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel-onopen"
+          ],
           "description": "<code>open</code> event",
           "support": {
             "chrome": {


### PR DESCRIPTION
This PR adapts the RTCDataChannel API to conform to the new events structure.
