### PR TITLE
Adapt RTCDtlsTransport API to new events structure

### DIFF
--- a/api/RTCDtlsTransport.json
+++ b/api/RTCDtlsTransport.json
@@ -50,6 +50,56 @@
           "deprecated": false
         }
       },
+      "error_event": {
+        "__compat": {
+          "description": "<code>error</code> event",
+          "support": {
+            "chrome": {
+              "version_added": "72"
+            },
+            "chrome_android": {
+              "version_added": "72"
+            },
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "60"
+            },
+            "opera_android": {
+              "version_added": "50"
+            },
+            "safari": {
+              "version_added": "15.4"
+            },
+            "safari_ios": {
+              "version_added": "15.4"
+            },
+            "samsunginternet_android": {
+              "version_added": "11.0"
+            },
+            "webview_android": {
+              "version_added": "72"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getRemoteCertificates": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDtlsTransport/getRemoteCertificates",
@@ -114,107 +164,6 @@
             "edge": {
               "version_added": "15",
               "alternative_name": "transport"
-            },
-            "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
-            },
-            "firefox_android": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "60"
-            },
-            "opera_android": {
-              "version_added": "50"
-            },
-            "safari": {
-              "version_added": "15.4"
-            },
-            "safari_ios": {
-              "version_added": "15.4"
-            },
-            "samsunginternet_android": {
-              "version_added": "11.0"
-            },
-            "webview_android": {
-              "version_added": "72"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onerror": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDtlsTransport/onerror",
-          "support": {
-            "chrome": {
-              "version_added": "72"
-            },
-            "chrome_android": {
-              "version_added": "72"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
-            },
-            "firefox_android": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "60"
-            },
-            "opera_android": {
-              "version_added": "50"
-            },
-            "safari": {
-              "version_added": "15.4"
-            },
-            "safari_ios": {
-              "version_added": "15.4"
-            },
-            "samsunginternet_android": {
-              "version_added": "11.0"
-            },
-            "webview_android": {
-              "version_added": "72"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onstatechange": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDtlsTransport/onstatechange",
-          "support": {
-            "chrome": {
-              "version_added": "72"
-            },
-            "chrome_android": {
-              "version_added": "72"
-            },
-            "edge": {
-              "version_added": "12",
-              "alternative_name": "ondtlsstatechange"
             },
             "firefox": {
               "version_added": false,


### PR DESCRIPTION
This PR adapts the RTCDtlsTransport API to conform to the new events structure.

Note: there are no MDN pages associated with this event, so there will be no corresponding content PR. Any broken MDN URLs in BCD have been removed.
