### PR TITLE
Adapt api.RTCSctpTransport.onstatechange to new events structure

### DIFF
--- a/api/RTCSctpTransport.json
+++ b/api/RTCSctpTransport.json
@@ -150,9 +150,10 @@
           }
         }
       },
-      "onstatechange": {
+      "state": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCSctpTransport/onstatechange",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCSctpTransport/state",
+          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcsctptransport-state",
           "support": {
             "chrome": {
               "version_added": "76"
@@ -200,10 +201,9 @@
           }
         }
       },
-      "state": {
+      "statechange_event": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCSctpTransport/state",
-          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcsctptransport-state",
+          "description": "<code>statechange</code> event",
           "support": {
             "chrome": {
               "version_added": "76"


### PR DESCRIPTION
This PR adapts the statechange event of the RTCSctpTransport API to conform to the new events structure.

Note: there are no MDN pages associated with these events, so there will be no corresponding content PR. Any broken MDN URLs in BCD have been removed.
