### PR TITLE
Adapt SVGAnimationElement API to new events structure

### DIFF
--- a/api/SVGAnimationElement.json
+++ b/api/SVGAnimationElement.json
@@ -48,6 +48,56 @@
           "deprecated": false
         }
       },
+      "begin_event": {
+        "__compat": {
+          "description": "<code>begin</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/begin_event",
+          "spec_url": "https://svgwg.org/specs/animations/#__svg__SVGAnimationElement__onbegin",
+          "support": {
+            "chrome": {
+              "version_added": "35"
+            },
+            "chrome_android": {
+              "version_added": "35"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "93"
+            },
+            "firefox_android": {
+              "version_added": "93"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "22"
+            },
+            "opera_android": {
+              "version_added": "22"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
+            "webview_android": {
+              "version_added": "37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "beginElement": {
         "__compat": {
           "support": {
@@ -183,6 +233,56 @@
             },
             "webview_android": {
               "version_added": "4.4.3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "end_event": {
+        "__compat": {
+          "description": "<code>end</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/end_event",
+          "spec_url": "https://svgwg.org/specs/animations/#__svg__SVGAnimationElement__onend",
+          "support": {
+            "chrome": {
+              "version_added": "35"
+            },
+            "chrome_android": {
+              "version_added": "35"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "93"
+            },
+            "firefox_android": {
+              "version_added": "93"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "22"
+            },
+            "opera_android": {
+              "version_added": "22"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
+            "webview_android": {
+              "version_added": "37"
             }
           },
           "status": {
@@ -477,107 +577,10 @@
           }
         }
       },
-      "onbegin": {
+      "repeat_event": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/onbegin",
-          "spec_url": "https://svgwg.org/specs/animations/#__svg__SVGAnimationElement__onbegin",
-          "support": {
-            "chrome": {
-              "version_added": "35"
-            },
-            "chrome_android": {
-              "version_added": "35"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "93"
-            },
-            "firefox_android": {
-              "version_added": "93"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "22"
-            },
-            "opera_android": {
-              "version_added": "22"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "3.0"
-            },
-            "webview_android": {
-              "version_added": "37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onend": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/onend",
-          "spec_url": "https://svgwg.org/specs/animations/#__svg__SVGAnimationElement__onend",
-          "support": {
-            "chrome": {
-              "version_added": "35"
-            },
-            "chrome_android": {
-              "version_added": "35"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "93"
-            },
-            "firefox_android": {
-              "version_added": "93"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "22"
-            },
-            "opera_android": {
-              "version_added": "22"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "3.0"
-            },
-            "webview_android": {
-              "version_added": "37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onrepeat": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/onrepeat",
+          "description": "<code>repeat</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/repeat_event",
           "spec_url": "https://svgwg.org/specs/animations/#__svg__SVGAnimationElement__onrepeat",
           "support": {
             "chrome": {

--- a/api/SVGAnimationElement.json
+++ b/api/SVGAnimationElement.json
@@ -48,70 +48,58 @@
           "deprecated": false
         }
       },
-      "begin_event": {
+      "beginEvent_event": {
         "__compat": {
-          "description": "<code>begin</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/begin_event",
+          "description": "<code>beginEvent</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/beginEvent_event",
           "spec_url": "https://svgwg.org/svg2-draft/interact.html#BeginEvent",
           "support": {
             "chrome": [
               {
                 "version_added": "35",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>."
+                "notes": "The event handler is <code>onbegin</code> for this event."
               },
               {
                 "version_added": "31",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>.",
-                  "The event handler, <code>onbegin</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onbegin</code>, is not supported."
               }
             ],
             "chrome_android": [
               {
                 "version_added": "35",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>."
+                "notes": "The event handler is <code>onbegin</code> for this event."
               },
               {
                 "version_added": "31",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>.",
-                  "The event handler, <code>onbegin</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onbegin</code>, is not supported."
               }
             ],
             "edge": {
               "version_added": "79",
-              "notes": "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>."
+              "notes": "The event handler is <code>onbegin</code> for this event."
             },
             "firefox": [
               {
                 "version_added": "93",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>."
+                "notes": "The event handler is <code>onbegin</code> for this event."
               },
               {
                 "version_added": "6",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>.",
-                  "The event handler, <code>onbegin</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onbegin</code>, is not supported."
               }
             ],
             "firefox_android": [
               {
                 "version_added": "93",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>."
+                "notes": "The event handler is <code>onbegin</code> for this event."
               },
               {
                 "version_added": "6",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>.",
-                  "The event handler, <code>onbegin</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onbegin</code>, is not supported."
               }
             ],
             "ie": {
@@ -120,73 +108,55 @@
             "opera": [
               {
                 "version_added": "22",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>."
+                "notes": "The event handler is <code>onbegin</code> for this event."
               },
               {
                 "version_added": "18",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>.",
-                  "The event handler, <code>onbegin</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onbegin</code>, is not supported."
               }
             ],
             "opera_android": [
               {
                 "version_added": "22",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>."
+                "notes": "The event handler is <code>onbegin</code> for this event."
               },
               {
                 "version_added": "18",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>.",
-                  "The event handler, <code>onbegin</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onbegin</code>, is not supported."
               }
             ],
             "safari": {
               "version_added": "10",
               "partial_implementation": true,
-              "notes": [
-                "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>.",
-                "The event handler, <code>onbegin</code>, is not supported."
-              ]
+              "notes": "The event handler, <code>onbegin</code>, is not supported."
             },
             "safari_ios": {
               "version_added": "10",
               "partial_implementation": true,
-              "notes": [
-                "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>.",
-                "The event handler, <code>onbegin</code>, is not supported."
-              ]
+              "notes": "The event handler, <code>onbegin</code>, is not supported."
             },
             "samsunginternet_android": [
               {
                 "version_added": "3.0",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>."
+                "notes": "The event handler is <code>onbegin</code> for this event."
               },
               {
                 "version_added": "2.0",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>.",
-                  "The event handler, <code>onbegin</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onbegin</code>, is not supported."
               }
             ],
             "webview_android": [
               {
                 "version_added": "37",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>."
+                "notes": "The event handler is <code>onbegin</code> for this event."
               },
               {
                 "version_added": "4.4.3",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>.",
-                  "The event handler, <code>onbegin</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onbegin</code>, is not supported."
               }
             ]
           },
@@ -291,70 +261,58 @@
           }
         }
       },
-      "end_event": {
+      "endEvent_event": {
         "__compat": {
-          "description": "<code>end</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/end_event",
+          "description": "<code>endEvent</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/endEvent_event",
           "spec_url": "https://svgwg.org/svg2-draft/interact.html#EndEvent",
           "support": {
             "chrome": [
               {
                 "version_added": "35",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>."
+                "notes": "The event handler is <code>onend</code> for this event."
               },
               {
                 "version_added": "31",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>.",
-                  "The event handler, <code>onend</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onend</code>, is not supported."
               }
             ],
             "chrome_android": [
               {
                 "version_added": "35",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>."
+                "notes": "The event handler is <code>onend</code> for this event."
               },
               {
                 "version_added": "31",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>.",
-                  "The event handler, <code>onend</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onend</code>, is not supported."
               }
             ],
             "edge": {
               "version_added": "79",
-              "notes": "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>."
+              "notes": "The event handler is <code>onend</code> for this event."
             },
             "firefox": [
               {
                 "version_added": "93",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>."
+                "notes": "The event handler is <code>onend</code> for this event."
               },
               {
                 "version_added": "6",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>.",
-                  "The event handler, <code>onend</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onend</code>, is not supported."
               }
             ],
             "firefox_android": [
               {
                 "version_added": "93",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>."
+                "notes": "The event handler is <code>onend</code> for this event."
               },
               {
                 "version_added": "6",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>.",
-                  "The event handler, <code>onend</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onend</code>, is not supported."
               }
             ],
             "ie": {
@@ -363,73 +321,55 @@
             "opera": [
               {
                 "version_added": "22",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>."
+                "notes": "The event handler is <code>onend</code> for this event."
               },
               {
                 "version_added": "18",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>.",
-                  "The event handler, <code>onend</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onend</code>, is not supported."
               }
             ],
             "opera_android": [
               {
                 "version_added": "22",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>."
+                "notes": "The event handler is <code>onend</code> for this event."
               },
               {
                 "version_added": "18",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>.",
-                  "The event handler, <code>onend</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onend</code>, is not supported."
               }
             ],
             "safari": {
               "version_added": "10",
               "partial_implementation": true,
-              "notes": [
-                "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>.",
-                "The event handler, <code>onend</code>, is not supported."
-              ]
+              "notes": "The event handler, <code>onend</code>, is not supported."
             },
             "safari_ios": {
               "version_added": "10",
               "partial_implementation": true,
-              "notes": [
-                "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>.",
-                "The event handler, <code>onend</code>, is not supported."
-              ]
+              "notes": "The event handler, <code>onend</code>, is not supported."
             },
             "samsunginternet_android": [
               {
                 "version_added": "3.0",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>."
+                "notes": "The event handler is <code>onend</code> for this event."
               },
               {
                 "version_added": "2.0",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>.",
-                  "The event handler, <code>onend</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onend</code>, is not supported."
               }
             ],
             "webview_android": [
               {
                 "version_added": "37",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>."
+                "notes": "The event handler is <code>onend</code> for this event."
               },
               {
                 "version_added": "4.4.3",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>.",
-                  "The event handler, <code>onend</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onend</code>, is not supported."
               }
             ]
           },
@@ -675,70 +615,58 @@
           }
         }
       },
-      "repeat_event": {
+      "repeatEvent_event": {
         "__compat": {
-          "description": "<code>repeat</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/repeat_event",
+          "description": "<code>repeatEvent</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/repeatEvent_event",
           "spec_url": "https://svgwg.org/svg2-draft/interact.html#RepeatEvent",
           "support": {
             "chrome": [
               {
                 "version_added": "35",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>."
+                "notes": "The event handler is <code>onrepeat</code> for this event."
               },
               {
                 "version_added": "31",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>.",
-                  "The event handler, <code>onrepeat</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onrepeat</code>, is not supported."
               }
             ],
             "chrome_android": [
               {
                 "version_added": "35",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>."
+                "notes": "The event handler is <code>onrepeat</code> for this event."
               },
               {
                 "version_added": "31",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>.",
-                  "The event handler, <code>onrepeat</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onrepeat</code>, is not supported."
               }
             ],
             "edge": {
               "version_added": "79",
-              "notes": "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>."
+              "notes": "The event handler is <code>onrepeat</code> for this event."
             },
             "firefox": [
               {
                 "version_added": "93",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>."
+                "notes": "The event handler is <code>onrepeat</code> for this event."
               },
               {
                 "version_added": "6",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>.",
-                  "The event handler, <code>onrepeat</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onrepeat</code>, is not supported."
               }
             ],
             "firefox_android": [
               {
                 "version_added": "93",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>."
+                "notes": "The event handler is <code>onrepeat</code> for this event."
               },
               {
                 "version_added": "6",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>.",
-                  "The event handler, <code>onrepeat</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onrepeat</code>, is not supported."
               }
             ],
             "ie": {
@@ -747,73 +675,55 @@
             "opera": [
               {
                 "version_added": "22",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>."
+                "notes": "The event handler is <code>onrepeat</code> for this event."
               },
               {
                 "version_added": "18",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>.",
-                  "The event handler, <code>onrepeat</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onrepeat</code>, is not supported."
               }
             ],
             "opera_android": [
               {
                 "version_added": "22",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>."
+                "notes": "The event handler is <code>onrepeat</code> for this event."
               },
               {
                 "version_added": "18",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>.",
-                  "The event handler, <code>onrepeat</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onrepeat</code>, is not supported."
               }
             ],
             "safari": {
               "version_added": "10",
               "partial_implementation": true,
-              "notes": [
-                "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>.",
-                "The event handler, <code>onrepeat</code>, is not supported."
-              ]
+              "notes": "The event handler, <code>onrepeat</code>, is not supported."
             },
             "safari_ios": {
               "version_added": "10",
               "partial_implementation": true,
-              "notes": [
-                "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>.",
-                "The event handler, <code>onrepeat</code>, is not supported."
-              ]
+              "notes": "The event handler, <code>onrepeat</code>, is not supported."
             },
             "samsunginternet_android": [
               {
                 "version_added": "3.0",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>."
+                "notes": "The event handler is <code>onrepeat</code> for this event."
               },
               {
                 "version_added": "2.0",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>.",
-                  "The event handler, <code>onrepeat</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onrepeat</code>, is not supported."
               }
             ],
             "webview_android": [
               {
                 "version_added": "37",
-                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>."
+                "notes": "The event handler is <code>onrepeat</code> for this event."
               },
               {
                 "version_added": "4.4.3",
                 "partial_implementation": true,
-                "notes": [
-                  "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>.",
-                  "The event handler, <code>onrepeat</code>, is not supported."
-                ]
+                "notes": "The event handler, <code>onrepeat</code>, is not supported."
               }
             ]
           },

--- a/api/SVGAnimationElement.json
+++ b/api/SVGAnimationElement.json
@@ -48,6 +48,100 @@
           "deprecated": false
         }
       },
+      "beginElement": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "4"
+            },
+            "safari_ios": {
+              "version_added": "3.2"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beginElementAt": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "4"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "4"
+            },
+            "safari_ios": {
+              "version_added": "3.2"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "beginEvent_event": {
         "__compat": {
           "description": "<code>beginEvent</code> event",
@@ -167,7 +261,7 @@
           }
         }
       },
-      "beginElement": {
+      "endElement": {
         "__compat": {
           "support": {
             "chrome": {
@@ -214,7 +308,7 @@
           }
         }
       },
-      "beginElementAt": {
+      "endElementAt": {
         "__compat": {
           "support": {
             "chrome": {
@@ -372,100 +466,6 @@
                 "notes": "The event handler, <code>onend</code>, is not supported."
               }
             ]
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "endElement": {
-        "__compat": {
-          "support": {
-            "chrome": {
-              "version_added": "1"
-            },
-            "chrome_android": {
-              "version_added": "18"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "4"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "≤12.1"
-            },
-            "opera_android": {
-              "version_added": "≤12.1"
-            },
-            "safari": {
-              "version_added": "4"
-            },
-            "safari_ios": {
-              "version_added": "3.2"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.0"
-            },
-            "webview_android": {
-              "version_added": "3"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "endElementAt": {
-        "__compat": {
-          "support": {
-            "chrome": {
-              "version_added": "1"
-            },
-            "chrome_android": {
-              "version_added": "18"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "4"
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "≤12.1"
-            },
-            "opera_android": {
-              "version_added": "≤12.1"
-            },
-            "safari": {
-              "version_added": "4"
-            },
-            "safari_ios": {
-              "version_added": "3.2"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.0"
-            },
-            "webview_android": {
-              "version_added": "3"
-            }
           },
           "status": {
             "experimental": false,

--- a/api/SVGAnimationElement.json
+++ b/api/SVGAnimationElement.json
@@ -52,44 +52,143 @@
         "__compat": {
           "description": "<code>begin</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/begin_event",
-          "spec_url": "https://svgwg.org/specs/animations/#__svg__SVGAnimationElement__onbegin",
+          "spec_url": "https://svgwg.org/svg2-draft/interact.html#BeginEvent",
           "support": {
-            "chrome": {
-              "version_added": "35"
-            },
-            "chrome_android": {
-              "version_added": "35"
-            },
+            "chrome": [
+              {
+                "version_added": "35",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>."
+              },
+              {
+                "version_added": "31",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>.",
+                  "The event handler, <code>onbegin</code>, is not supported."
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "35",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>."
+              },
+              {
+                "version_added": "31",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>.",
+                  "The event handler, <code>onbegin</code>, is not supported."
+                ]
+              }
+            ],
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "notes": "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>."
             },
-            "firefox": {
-              "version_added": "93"
-            },
-            "firefox_android": {
-              "version_added": "93"
-            },
+            "firefox": [
+              {
+                "version_added": "93",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>."
+              },
+              {
+                "version_added": "6",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>.",
+                  "The event handler, <code>onbegin</code>, is not supported."
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "93",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>."
+              },
+              {
+                "version_added": "6",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>.",
+                  "The event handler, <code>onbegin</code>, is not supported."
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "22"
-            },
-            "opera_android": {
-              "version_added": "22"
-            },
+            "opera": [
+              {
+                "version_added": "22",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>."
+              },
+              {
+                "version_added": "18",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>.",
+                  "The event handler, <code>onbegin</code>, is not supported."
+                ]
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "22",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>."
+              },
+              {
+                "version_added": "18",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>.",
+                  "The event handler, <code>onbegin</code>, is not supported."
+                ]
+              }
+            ],
             "safari": {
-              "version_added": false
+              "version_added": "10",
+              "partial_implementation": true,
+              "notes": [
+                "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>.",
+                "The event handler, <code>onbegin</code>, is not supported."
+              ]
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10",
+              "partial_implementation": true,
+              "notes": [
+                "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>.",
+                "The event handler, <code>onbegin</code>, is not supported."
+              ]
             },
-            "samsunginternet_android": {
-              "version_added": "3.0"
-            },
-            "webview_android": {
-              "version_added": "37"
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>."
+              },
+              {
+                "version_added": "2.0",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>.",
+                  "The event handler, <code>onbegin</code>, is not supported."
+                ]
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "37",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>."
+              },
+              {
+                "version_added": "4.4.3",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>beginEvent</code>.",
+                  "The event handler, <code>onbegin</code>, is not supported."
+                ]
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -192,98 +291,147 @@
           }
         }
       },
-      "beginEvent_event": {
-        "__compat": {
-          "description": "<code>beginEvent</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/beginEvent_event",
-          "spec_url": "https://svgwg.org/svg2-draft/interact.html#BeginEvent",
-          "support": {
-            "chrome": {
-              "version_added": "31"
-            },
-            "chrome_android": {
-              "version_added": "31"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "6"
-            },
-            "firefox_android": {
-              "version_added": "6"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "18"
-            },
-            "opera_android": {
-              "version_added": "18"
-            },
-            "safari": {
-              "version_added": "10"
-            },
-            "safari_ios": {
-              "version_added": "10"
-            },
-            "samsunginternet_android": {
-              "version_added": "2.0"
-            },
-            "webview_android": {
-              "version_added": "4.4.3"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "end_event": {
         "__compat": {
           "description": "<code>end</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/end_event",
-          "spec_url": "https://svgwg.org/specs/animations/#__svg__SVGAnimationElement__onend",
+          "spec_url": "https://svgwg.org/svg2-draft/interact.html#EndEvent",
           "support": {
-            "chrome": {
-              "version_added": "35"
-            },
-            "chrome_android": {
-              "version_added": "35"
-            },
+            "chrome": [
+              {
+                "version_added": "35",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>."
+              },
+              {
+                "version_added": "31",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>.",
+                  "The event handler, <code>onend</code>, is not supported."
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "35",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>."
+              },
+              {
+                "version_added": "31",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>.",
+                  "The event handler, <code>onend</code>, is not supported."
+                ]
+              }
+            ],
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "notes": "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>."
             },
-            "firefox": {
-              "version_added": "93"
-            },
-            "firefox_android": {
-              "version_added": "93"
-            },
+            "firefox": [
+              {
+                "version_added": "93",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>."
+              },
+              {
+                "version_added": "6",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>.",
+                  "The event handler, <code>onend</code>, is not supported."
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "93",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>."
+              },
+              {
+                "version_added": "6",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>.",
+                  "The event handler, <code>onend</code>, is not supported."
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "22"
-            },
-            "opera_android": {
-              "version_added": "22"
-            },
+            "opera": [
+              {
+                "version_added": "22",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>."
+              },
+              {
+                "version_added": "18",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>.",
+                  "The event handler, <code>onend</code>, is not supported."
+                ]
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "22",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>."
+              },
+              {
+                "version_added": "18",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>.",
+                  "The event handler, <code>onend</code>, is not supported."
+                ]
+              }
+            ],
             "safari": {
-              "version_added": false
+              "version_added": "10",
+              "partial_implementation": true,
+              "notes": [
+                "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>.",
+                "The event handler, <code>onend</code>, is not supported."
+              ]
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10",
+              "partial_implementation": true,
+              "notes": [
+                "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>.",
+                "The event handler, <code>onend</code>, is not supported."
+              ]
             },
-            "samsunginternet_android": {
-              "version_added": "3.0"
-            },
-            "webview_android": {
-              "version_added": "37"
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>."
+              },
+              {
+                "version_added": "2.0",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>.",
+                  "The event handler, <code>onend</code>, is not supported."
+                ]
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "37",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>."
+              },
+              {
+                "version_added": "4.4.3",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>endEvent</code>.",
+                  "The event handler, <code>onend</code>, is not supported."
+                ]
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -377,56 +525,6 @@
             },
             "webview_android": {
               "version_added": "3"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "endEvent_event": {
-        "__compat": {
-          "description": "<code>endEvent</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/endEvent_event",
-          "spec_url": "https://svgwg.org/svg2-draft/interact.html#EndEvent",
-          "support": {
-            "chrome": {
-              "version_added": "31"
-            },
-            "chrome_android": {
-              "version_added": "31"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "6"
-            },
-            "firefox_android": {
-              "version_added": "6"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "18"
-            },
-            "opera_android": {
-              "version_added": "18"
-            },
-            "safari": {
-              "version_added": "10"
-            },
-            "safari_ios": {
-              "version_added": "10"
-            },
-            "samsunginternet_android": {
-              "version_added": "2.0"
-            },
-            "webview_android": {
-              "version_added": "4.4.3"
             }
           },
           "status": {
@@ -581,94 +679,143 @@
         "__compat": {
           "description": "<code>repeat</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/repeat_event",
-          "spec_url": "https://svgwg.org/specs/animations/#__svg__SVGAnimationElement__onrepeat",
-          "support": {
-            "chrome": {
-              "version_added": "35"
-            },
-            "chrome_android": {
-              "version_added": "35"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "93"
-            },
-            "firefox_android": {
-              "version_added": "93"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "22"
-            },
-            "opera_android": {
-              "version_added": "22"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "3.0"
-            },
-            "webview_android": {
-              "version_added": "37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "repeatEvent_event": {
-        "__compat": {
-          "description": "<code>repeatEvent</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/repeatEvent_event",
           "spec_url": "https://svgwg.org/svg2-draft/interact.html#RepeatEvent",
           "support": {
-            "chrome": {
-              "version_added": "31"
-            },
-            "chrome_android": {
-              "version_added": "31"
-            },
+            "chrome": [
+              {
+                "version_added": "35",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>."
+              },
+              {
+                "version_added": "31",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>.",
+                  "The event handler, <code>onrepeat</code>, is not supported."
+                ]
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "35",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>."
+              },
+              {
+                "version_added": "31",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>.",
+                  "The event handler, <code>onrepeat</code>, is not supported."
+                ]
+              }
+            ],
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "notes": "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>."
             },
-            "firefox": {
-              "version_added": "6"
-            },
-            "firefox_android": {
-              "version_added": "6"
-            },
+            "firefox": [
+              {
+                "version_added": "93",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>."
+              },
+              {
+                "version_added": "6",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>.",
+                  "The event handler, <code>onrepeat</code>, is not supported."
+                ]
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "93",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>."
+              },
+              {
+                "version_added": "6",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>.",
+                  "The event handler, <code>onrepeat</code>, is not supported."
+                ]
+              }
+            ],
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "18"
-            },
-            "opera_android": {
-              "version_added": "18"
-            },
+            "opera": [
+              {
+                "version_added": "22",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>."
+              },
+              {
+                "version_added": "18",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>.",
+                  "The event handler, <code>onrepeat</code>, is not supported."
+                ]
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "22",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>."
+              },
+              {
+                "version_added": "18",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>.",
+                  "The event handler, <code>onrepeat</code>, is not supported."
+                ]
+              }
+            ],
             "safari": {
-              "version_added": false
+              "version_added": "10",
+              "partial_implementation": true,
+              "notes": [
+                "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>.",
+                "The event handler, <code>onrepeat</code>, is not supported."
+              ]
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "10",
+              "partial_implementation": true,
+              "notes": [
+                "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>.",
+                "The event handler, <code>onrepeat</code>, is not supported."
+              ]
             },
-            "samsunginternet_android": {
-              "version_added": "2.0"
-            },
-            "webview_android": {
-              "version_added": "4.4.3"
-            }
+            "samsunginternet_android": [
+              {
+                "version_added": "3.0",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>."
+              },
+              {
+                "version_added": "2.0",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>.",
+                  "The event handler, <code>onrepeat</code>, is not supported."
+                ]
+              }
+            ],
+            "webview_android": [
+              {
+                "version_added": "37",
+                "notes": "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>."
+              },
+              {
+                "version_added": "4.4.3",
+                "partial_implementation": true,
+                "notes": [
+                  "When using the <code>addEventListener()</code> method, the event is called <code>repeatEvent</code>.",
+                  "The event handler, <code>onrepeat</code>, is not supported."
+                ]
+              }
+            ]
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR adapts the SVGAnimationElement API to conform to the new events structure.

Notice: since the event is named `xxxEvent` when using `addEventListener()`, the merge on this one is a special case.  I chose to treat the events as if they're simply called `begin` or `end` rather than `beginEvent` or `endEvent`, and added a note stating that the event is called the latter when using `addEventListener()`.  Please let me know if this seems like the right way to go about this before I proceed with the content updates!