### PR TITLE
Adapt api.Screen.onorientationchange to new events structure

### DIFF
--- a/api/Screen.json
+++ b/api/Screen.json
@@ -688,7 +688,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/Screen.json
+++ b/api/Screen.json
@@ -570,58 +570,6 @@
           }
         }
       },
-      "onorientationchange": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Screen/onorientationchange",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": "12",
-              "alternative_name": "onmsorientationchange",
-              "version_removed": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": "14",
-              "alternative_name": "onmozorientationchange"
-            },
-            "ie": {
-              "version_added": "11",
-              "alternative_name": "onmsorientationchange"
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
-      },
       "orientation": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Screen/orientation",
@@ -689,6 +637,59 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        }
+      },
+      "orientationchange_event": {
+        "__compat": {
+          "description": "<code>orientationchange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Screen/orientationchange_event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "12",
+              "alternative_name": "msorientationchange",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "14",
+              "alternative_name": "mozorientationchange"
+            },
+            "ie": {
+              "version_added": "11",
+              "alternative_name": "msorientationchange"
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
This PR adapts the orientationchange event of the Screen API to conform to the new events structure.
