### PR TITLE
Adapt api.ScreenOrientation.onchange to new events structure

### DIFF
--- a/api/ScreenOrientation.json
+++ b/api/ScreenOrientation.json
@@ -100,7 +100,6 @@
       "change_event": {
         "__compat": {
           "description": "<code>change</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScreenOrientation/change_event",
           "spec_url": "https://w3c.github.io/screen-orientation/#dom-screenorientation-onchange",
           "support": {
             "chrome": {

--- a/api/ScreenOrientation.json
+++ b/api/ScreenOrientation.json
@@ -97,6 +97,56 @@
           }
         }
       },
+      "change_event": {
+        "__compat": {
+          "description": "<code>change</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScreenOrientation/change_event",
+          "spec_url": "https://w3c.github.io/screen-orientation/#dom-screenorientation-onchange",
+          "support": {
+            "chrome": {
+              "version_added": "38"
+            },
+            "chrome_android": {
+              "version_added": "38"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "43"
+            },
+            "firefox_android": {
+              "version_added": "43"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "25"
+            },
+            "opera_android": {
+              "version_added": "25"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "3.0"
+            },
+            "webview_android": {
+              "version_added": "38"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "lock": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScreenOrientation/lock",
@@ -139,55 +189,6 @@
               "version_added": "25",
               "partial_implementation": true,
               "notes": "Always throws <code>NotSupportedError</code>."
-            },
-            "opera_android": {
-              "version_added": "25"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "3.0"
-            },
-            "webview_android": {
-              "version_added": "38"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onchange": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScreenOrientation/onchange",
-          "spec_url": "https://w3c.github.io/screen-orientation/#dom-screenorientation-onchange",
-          "support": {
-            "chrome": {
-              "version_added": "38"
-            },
-            "chrome_android": {
-              "version_added": "38"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "43"
-            },
-            "firefox_android": {
-              "version_added": "43"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "25"
             },
             "opera_android": {
               "version_added": "25"


### PR DESCRIPTION
This PR adapts the change event of the ScreenOrientation API to conform to the new events structure.
