### PR TITLE
Adapt api.SharedWorker.onerror to new events structure

### DIFF
--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -209,9 +209,10 @@
           }
         }
       },
-      "onerror": {
+      "error_event": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SharedWorker/onerror",
+          "description": "<code>error</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SharedWorker/error_event",
           "spec_url": "https://html.spec.whatwg.org/multipage/workers.html#handler-abstractworker-onerror",
           "support": {
             "chrome": {


### PR DESCRIPTION
This PR adapts the error event of the SharedWorker API to conform to the new events structure.
