### PR TITLE
Adapt api.PaymentResponse.onpayerdetailchange to new events structure

### DIFF
--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -296,9 +296,10 @@
           }
         }
       },
-      "onpayerdetailchange": {
+      "payerdetailchange_event": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/onpayerdetailchange",
+          "description": "<code>payerdetailchange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/payerdetailchange_event",
           "support": {
             "chrome": {
               "version_added": "78"
@@ -357,80 +358,6 @@
             },
             "samsunginternet_android": {
               "version_added": "12.0"
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
-      "payerdetailchange_event": {
-        "__compat": {
-          "description": "<code>payerdetailchange</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/payerdetailchange_event",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": "55",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "name": "dom.payments.request.supportedRegions",
-                  "type": "preference",
-                  "value_to_set": "A comma-delimited list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
-                }
-              ]
-            },
-            "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "name": "dom.payments.request.supportedRegions",
-                  "type": "preference",
-                  "value_to_set": "A comma-delimited list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
-                }
-              ]
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": "12.1"
-            },
-            "safari_ios": {
-              "version_added": "12.2"
-            },
-            "samsunginternet_android": {
-              "version_added": false
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
This PR adapts the payerdetailchange event of the PaymentResponse API to conform to the new events structure.
