### PR TITLE
CSS counters() - Changed the version of WebView Android to 37 from 1 (#15208)

### DIFF
--- a/css/properties/counter-increment.json
+++ b/css/properties/counter-increment.json
@@ -40,7 +40,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "1"
             }
           },
           "status": {

--- a/css/properties/counter-reset.json
+++ b/css/properties/counter-reset.json
@@ -40,7 +40,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "1"
             }
           },
           "status": {

--- a/css/types/counter.json
+++ b/css/types/counter.json
@@ -41,7 +41,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "1"
             }
           },
           "status": {

--- a/css/types/counters.json
+++ b/css/types/counters.json
@@ -41,7 +41,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "1"
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/types/counters.json
+++ b/css/types/counters.json
@@ -41,7 +41,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
It aligned the version of WebView Android with other initial properties of the CSS counter.

#### Test results and supporting details
see #15208

see also counter() (not counters):

https://github.com/mdn/browser-compat-data/blob/main/css/types/counter.json#L43-L45

#### Related issues
Fixes #15208

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
