### PR TITLE
Updates chrome to version 99

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -680,21 +680,28 @@
         "98": {
           "release_date": "2022-02-01",
           "release_notes": "https://chromereleases.googleblog.com/2022/02/stable-channel-update-for-desktop.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "98"
         },
         "99": {
           "release_date": "2022-03-01",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2022/03/stable-channel-update-for-desktop.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "99"
         },
         "100": {
           "release_date": "2022-03-29",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "100"
+        },
+        "101": {
+          "release_date": "2022-04-26",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "101"
         }
       }
     }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -516,21 +516,28 @@
         "98": {
           "release_date": "2022-02-01",
           "release_notes": "https://chromereleases.googleblog.com/2022/02/chrome-for-android-update.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "98"
         },
         "99": {
           "release_date": "2022-03-01",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2022/03/chrome-for-android-update.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "99"
         },
         "100": {
           "release_date": "2022-03-29",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "100"
+        },
+        "101": {
+          "release_date": "2022-04-26",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "101"
         }
       }
     }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -481,21 +481,28 @@
         "98": {
           "release_date": "2022-02-01",
           "release_notes": "https://chromereleases.googleblog.com/2022/02/chrome-for-android-update.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "98"
         },
         "99": {
           "release_date": "2022-03-01",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2022/03/chrome-for-android-update.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "99"
         },
         "100": {
           "release_date": "2022-03-29",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "100"
+        },
+        "101": {
+          "release_date": "2022-04-26",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "101"
         }
       }
     }


### PR DESCRIPTION
Chrome has updated to version 99.

According to https://chromiumdash.appspot.com/schedule, the release date of Chrome 101 is 26/04/2022.

Fixes #15220.