### PR TITLE
Adapt api.Document.onpointerlock[change/error] to new events structure

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -7226,130 +7226,6 @@
           }
         }
       },
-      "onpointerlockchange": {
-        "__compat": {
-          "spec_url": "https://w3c.github.io/pointerlock/#dom-document-onpointerlockchange",
-          "support": {
-            "chrome": {
-              "version_added": "36"
-            },
-            "chrome_android": {
-              "version_added": "36"
-            },
-            "edge": {
-              "version_added": "13"
-            },
-            "firefox": [
-              {
-                "version_added": "50"
-              },
-              {
-                "version_added": "14",
-                "version_removed": "50",
-                "alternative_name": "onmozpointerlockchange"
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "50"
-              },
-              {
-                "version_added": "14",
-                "version_removed": "50",
-                "alternative_name": "onmozpointerlockchange"
-              }
-            ],
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "23"
-            },
-            "opera_android": {
-              "version_added": "24"
-            },
-            "safari": {
-              "version_added": "10.1"
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "3.0"
-            },
-            "webview_android": {
-              "version_added": "37"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onpointerlockerror": {
-        "__compat": {
-          "spec_url": "https://w3c.github.io/pointerlock/#dom-document-onpointerlockerror",
-          "support": {
-            "chrome": {
-              "version_added": "36"
-            },
-            "chrome_android": {
-              "version_added": "36"
-            },
-            "edge": {
-              "version_added": "13"
-            },
-            "firefox": [
-              {
-                "version_added": "50"
-              },
-              {
-                "version_added": "14",
-                "version_removed": "50",
-                "alternative_name": "onmozpointerlockerror"
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "50"
-              },
-              {
-                "version_added": "14",
-                "version_removed": "50",
-                "alternative_name": "onmozpointerlockerror"
-              }
-            ],
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "23"
-            },
-            "opera_android": {
-              "version_added": "24"
-            },
-            "safari": {
-              "version_added": "10.1"
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "3.0"
-            },
-            "webview_android": {
-              "version_added": "37"
-            }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "onvisibilitychange": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/onvisibilitychange",
@@ -8160,11 +8036,14 @@
         "__compat": {
           "description": "<code>pointerlockchange</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/pointerlockchange_event",
-          "spec_url": "https://w3c.github.io/pointerlock/#pointerlockchange-and-pointerlockerror-events",
+          "spec_url": [
+            "https://w3c.github.io/pointerlock/#pointerlockchange-and-pointerlockerror-events",
+            "https://w3c.github.io/pointerlock/#dom-document-onpointerlockchange"
+          ],
           "support": {
             "chrome": [
               {
-                "version_added": "45"
+                "version_added": "36"
               },
               {
                 "version_added": "22",
@@ -8174,7 +8053,7 @@
             ],
             "chrome_android": [
               {
-                "version_added": "45"
+                "version_added": "36"
               },
               {
                 "version_added": "25",
@@ -8210,7 +8089,7 @@
             },
             "opera": [
               {
-                "version_added": "32"
+                "version_added": "23"
               },
               {
                 "version_added": "15",
@@ -8220,7 +8099,7 @@
             ],
             "opera_android": [
               {
-                "version_added": "32"
+                "version_added": "24"
               },
               {
                 "version_added": "14",
@@ -8236,7 +8115,7 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": "5.0"
+                "version_added": "3.0"
               },
               {
                 "prefix": "webkit",
@@ -8246,7 +8125,7 @@
             ],
             "webview_android": [
               {
-                "version_added": "45"
+                "version_added": "37"
               },
               {
                 "version_added": "≤37",
@@ -8266,11 +8145,14 @@
         "__compat": {
           "description": "<code>pointerlockerror</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/pointerlockerror_event",
-          "spec_url": "https://w3c.github.io/pointerlock/#pointerlockchange-and-pointerlockerror-events",
+          "spec_url": [
+            "https://w3c.github.io/pointerlock/#pointerlockchange-and-pointerlockerror-events",
+            "https://w3c.github.io/pointerlock/#dom-document-onpointerlockerror"
+          ],
           "support": {
             "chrome": [
               {
-                "version_added": "45"
+                "version_added": "36"
               },
               {
                 "version_added": "22",
@@ -8280,7 +8162,7 @@
             ],
             "chrome_android": [
               {
-                "version_added": "45"
+                "version_added": "36"
               },
               {
                 "version_added": "25",
@@ -8316,7 +8198,7 @@
             },
             "opera": [
               {
-                "version_added": "32"
+                "version_added": "23"
               },
               {
                 "version_added": "15",
@@ -8326,7 +8208,7 @@
             ],
             "opera_android": [
               {
-                "version_added": "32"
+                "version_added": "24"
               },
               {
                 "version_added": "14",
@@ -8342,7 +8224,7 @@
             },
             "samsunginternet_android": [
               {
-                "version_added": "5.0"
+                "version_added": "3.0"
               },
               {
                 "prefix": "webkit",
@@ -8352,7 +8234,7 @@
             ],
             "webview_android": [
               {
-                "version_added": "45"
+                "version_added": "37"
               },
               {
                 "version_added": "≤37",


### PR DESCRIPTION
This PR adapts the pointerlockchange and pointerlockerror event of the Document API to conform to the new events structure.

The data for Chromium was updated to adhere to the event handler data's changes in #6836.  Prefixed data was left alone.
