### PR TITLE
Adapt api.SharedWorkerGlobalScope.onconnect to new events structure

### DIFF
--- a/api/SharedWorkerGlobalScope.json
+++ b/api/SharedWorkerGlobalScope.json
@@ -149,7 +149,10 @@
         "__compat": {
           "description": "<code>connect</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SharedWorkerGlobalScope/connect_event",
-          "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-workerglobalscope-connect",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/indices.html#event-workerglobalscope-connect",
+            "https://html.spec.whatwg.org/multipage/workers.html#handler-sharedworkerglobalscope-onconnect"
+          ],
           "support": {
             "chrome": {
               "version_added": "4"
@@ -201,55 +204,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SharedWorkerGlobalScope/name",
           "spec_url": "https://html.spec.whatwg.org/multipage/workers.html#dom-sharedworkerglobalscope-name-dev",
-          "support": {
-            "chrome": {
-              "version_added": "4"
-            },
-            "chrome_android": {
-              "version_added": "18"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": "29"
-            },
-            "firefox_android": {
-              "version_added": "29"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "10.6"
-            },
-            "opera_android": {
-              "version_added": "11"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "1.0"
-            },
-            "webview_android": {
-              "version_added": "4.4"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "onconnect": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SharedWorkerGlobalScope/onconnect",
-          "spec_url": "https://html.spec.whatwg.org/multipage/workers.html#handler-sharedworkerglobalscope-onconnect",
           "support": {
             "chrome": {
               "version_added": "4"


### PR DESCRIPTION
This PR adapts the connect event of the SharedWorkerGlobalScope API to conform to the new events structure.
