### PR TITLE
Add data for `:local-link` css selector

### DIFF
--- a/css/selectors/local-link.json
+++ b/css/selectors/local-link.json
@@ -1,0 +1,58 @@
+{
+  "css": {
+    "selectors": {
+      "local-link": {
+        "__compat": {
+          "description": "<code>:local-link</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:local-link",
+          "spec_url": "https://drafts.csswg.org/selectors/#local-link-pseudo",
+          "support": {
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1654861'>bug 1654861</a>."
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1654861'>bug 1654861</a>."
+            },
+            "edge": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Added spec URL and  browser data for the `:local-link` CSS selector.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
I'm not aware of any applicable tests. Although, I did use the JSON schema when adding the data.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
- [No WebKit support](https://webkit.org/status/#specification-css-selectors-level-4)
- [Open Firefox bug](https://bugzil.la/1654861)
- [Relevant Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=747818)
- [Edge status page](https://developer.microsoft.com/en-us/microsoft-edge/status/cssselectorslevel4/)
- For Internet Explorer, I put `version_added` as `null`. Though other browsers don't supports this feature, so I can take a guess....

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Closes #13029

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
