### PR TITLE
Add note about safari's event restrictions

### DIFF
--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -396,7 +396,7 @@
             },
             "safari": {
               "version_added": "13.1",
-              "notes": "Must be called within user gesture event handlers like pointerdown or pointerup"
+              "notes": "Must be called within user gesture event handlers such as <code>pointerdown</code> or <code>pointerup</code>."
             },
             "safari_ios": {
               "version_added": "13.4"

--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -399,7 +399,8 @@
               "notes": "Must be called within user gesture event handlers such as <code>pointerdown</code> or <code>pointerup</code>."
             },
             "safari_ios": {
-              "version_added": "13.4"
+              "version_added": "13.4",
+              "notes": "Must be called within user gesture event handlers such as <code>pointerdown</code> or <code>pointerup</code>."
             },
             "samsunginternet_android": {
               "version_added": "9.0"

--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -395,7 +395,8 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": "13.1"
+              "version_added": "13.1",
+              "notes": "Must be called within user gesture event handlers like pointerdown or pointerup"
             },
             "safari_ios": {
               "version_added": "13.4"


### PR DESCRIPTION
#### Summary
Safari will not allow calling from an HTMLSelectElement's change event, Firefox and Chrome do allow it.

#### Test results and supporting details

- https://webkit.org/blog/10247/new-webkit-features-in-safari-13-1/

Testing within an iFrame is disallowed by all vendors, hence making a straight forward reproduction is difficult.

```ts
 const input = document.querySelector(
    '#myForm select[name="turtles"]'
  ) as HTMLSelectElement
  if (input === null) throw new Error('input element missing')

  input.addEventListener('change', (event: any) => {
    if (typeof event.target.value !== 'string')
      throw new error('Selection is not a string')
  navigator.clipboard
    .writeText('Tuhtles')
    .then(() => {
      console.log('wrote to clipboard')
    })
    .catch((e) => {
      console.log('Writing to clipboard failed.')
    })
  })
```

#### Related issues

- https://developer.apple.com/forums/thread/691873
