### PR TITLE
FF99 Navigator.requestMIDIAccess() - add secure context subfeature

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4858,6 +4858,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "secure_context_required": {
+          "__compat": {
+            "description": "Secure context required",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "99"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "scheduling": {


### PR DESCRIPTION
FF99 adds secure context to [`Navigator.requestMIDIAccess()`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/requestMIDIAccess) in https://bugzilla.mozilla.org/show_bug.cgi?id=1757153

All the other browsers  are set to false. Note that this might have been added to [chromium here in M77](https://chromestatus.com/feature/5138066234671104). I am querying, but [indications](https://groups.google.com/a/chromium.org/g/blink-dev/c/_2XZt3yInCI/m/tk-f_vPwAQAJ) seems to be that there might just be a console warning.

Related docs work tracked in https://github.com/mdn/content/issues/12792#issuecomment-1031105153