### PR TITLE
FF99 WebMIDI API released

### DIFF
--- a/api/MIDIAccess.json
+++ b/api/MIDIAccess.json
@@ -14,16 +14,22 @@
           "edge": {
             "version_added": "79"
           },
-          "firefox": {
-            "version_added": "97",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.webmidi.enabled",
-                "value_to_set": "true"
-              }
-            ]
-          },
+          "firefox": [
+            {
+              "version_added": "99"
+            },
+            {
+              "version_added": "97",
+              "version_removed": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
             "version_added": false
           },
@@ -69,16 +75,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -125,16 +137,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -181,16 +199,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -237,16 +261,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -293,16 +323,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },

--- a/api/MIDIAccess.json
+++ b/api/MIDIAccess.json
@@ -56,7 +56,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -117,7 +117,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -241,7 +241,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -303,7 +303,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -365,7 +365,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/MIDIConnectionEvent.json
+++ b/api/MIDIConnectionEvent.json
@@ -118,7 +118,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -180,7 +180,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }

--- a/api/MIDIConnectionEvent.json
+++ b/api/MIDIConnectionEvent.json
@@ -14,16 +14,22 @@
           "edge": {
             "version_added": "79"
           },
-          "firefox": {
-            "version_added": "97",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.webmidi.enabled",
-                "value_to_set": "true"
-              }
-            ]
-          },
+          "firefox": [
+            {
+              "version_added": "99"
+            },
+            {
+              "version_added": "97",
+              "version_removed": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
             "version_added": false
           },
@@ -70,16 +76,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -126,16 +138,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },

--- a/api/MIDIInput.json
+++ b/api/MIDIInput.json
@@ -56,7 +56,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -117,7 +117,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/MIDIInput.json
+++ b/api/MIDIInput.json
@@ -14,16 +14,22 @@
           "edge": {
             "version_added": "79"
           },
-          "firefox": {
-            "version_added": "97",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.webmidi.enabled",
-                "value_to_set": "true"
-              }
-            ]
-          },
+          "firefox": [
+            {
+              "version_added": "99"
+            },
+            {
+              "version_added": "97",
+              "version_removed": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
             "version_added": false
           },
@@ -69,16 +75,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -125,16 +137,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },

--- a/api/MIDIInputMap.json
+++ b/api/MIDIInputMap.json
@@ -14,16 +14,22 @@
           "edge": {
             "version_added": "79"
           },
-          "firefox": {
-            "version_added": "97",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.webmidi.enabled",
-                "value_to_set": "true"
-              }
-            ]
-          },
+          "firefox": [
+            {
+              "version_added": "99"
+            },
+            {
+              "version_added": "97",
+              "version_removed": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
             "version_added": false
           },
@@ -67,16 +73,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -121,16 +133,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -175,16 +193,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -229,16 +253,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -283,16 +313,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -337,16 +373,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -391,16 +433,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },

--- a/api/MIDIInputMap.json
+++ b/api/MIDIInputMap.json
@@ -56,7 +56,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }

--- a/api/MIDIMessageEvent.json
+++ b/api/MIDIMessageEvent.json
@@ -14,16 +14,22 @@
           "edge": {
             "version_added": "79"
           },
-          "firefox": {
-            "version_added": "97",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.webmidi.enabled",
-                "value_to_set": "true"
-              }
-            ]
-          },
+          "firefox": [
+            {
+              "version_added": "99"
+            },
+            {
+              "version_added": "97",
+              "version_removed": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
             "version_added": false
           },
@@ -70,16 +76,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -126,16 +138,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },

--- a/api/MIDIMessageEvent.json
+++ b/api/MIDIMessageEvent.json
@@ -56,7 +56,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -118,7 +118,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -180,7 +180,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/MIDIOutput.json
+++ b/api/MIDIOutput.json
@@ -14,16 +14,22 @@
           "edge": {
             "version_added": "79"
           },
-          "firefox": {
-            "version_added": "97",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.webmidi.enabled",
-                "value_to_set": "true"
-              }
-            ]
-          },
+         "firefox": [
+            {
+              "version_added": "99"
+            },
+            {
+              "version_added": "97",
+              "version_removed": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
             "version_added": false
           },
@@ -70,16 +76,22 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -126,16 +138,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },

--- a/api/MIDIOutput.json
+++ b/api/MIDIOutput.json
@@ -14,7 +14,7 @@
           "edge": {
             "version_added": "79"
           },
-         "firefox": [
+          "firefox": [
             {
               "version_added": "99"
             },
@@ -56,7 +56,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -118,7 +118,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -180,7 +180,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/MIDIOutputMap.json
+++ b/api/MIDIOutputMap.json
@@ -14,16 +14,22 @@
           "edge": {
             "version_added": "79"
           },
-          "firefox": {
-            "version_added": "97",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.webmidi.enabled",
-                "value_to_set": "true"
-              }
-            ]
-          },
+          "firefox": [
+            {
+              "version_added": "99"
+            },
+            {
+              "version_added": "97",
+              "version_removed": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
             "version_added": false
           },
@@ -67,16 +73,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -121,16 +133,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -175,16 +193,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -229,16 +253,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -283,16 +313,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -337,16 +373,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -391,16 +433,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },

--- a/api/MIDIOutputMap.json
+++ b/api/MIDIOutputMap.json
@@ -56,7 +56,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }

--- a/api/MIDIPort.json
+++ b/api/MIDIPort.json
@@ -117,7 +117,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -179,7 +179,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -241,7 +241,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -303,7 +303,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -365,7 +365,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -489,7 +489,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -551,7 +551,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -613,7 +613,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -675,7 +675,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -737,7 +737,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/MIDIPort.json
+++ b/api/MIDIPort.json
@@ -14,16 +14,22 @@
           "edge": {
             "version_added": "79"
           },
-          "firefox": {
-            "version_added": "97",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.webmidi.enabled",
-                "value_to_set": "true"
-              }
-            ]
-          },
+          "firefox": [
+            {
+              "version_added": "99"
+            },
+            {
+              "version_added": "97",
+              "version_removed": "99",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
             "version_added": false
           },
@@ -69,16 +75,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -125,16 +137,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -181,16 +199,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -237,16 +261,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -293,16 +323,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -349,16 +385,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -405,16 +447,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -461,16 +509,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -517,16 +571,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -573,16 +633,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -629,16 +695,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4818,16 +4818,22 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "99",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.webmidi.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },


### PR DESCRIPTION
Web MIDI API ships by preference switch in FF99: https://bugzilla.mozilla.org/show_bug.cgi?id=1752906. 

This PR updates all the features with release version. Also this makes the API no longer experimental. Other docs work tracked in https://github.com/mdn/content/issues/12792#issuecomment-1031105153