### PR TITLE
Mark animation* events supported since Firefox 5

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -655,10 +655,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "firefox_android": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "ie": {
               "version_added": "10"
@@ -705,10 +705,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "firefox_android": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "ie": {
               "version_added": "10"
@@ -755,10 +755,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "firefox_android": {
-              "version_added": "6"
+              "version_added": "5"
             },
             "ie": {
               "version_added": "10"


### PR DESCRIPTION
This is to match the AnimationEvent interface change:
https://github.com/mdn/browser-compat-data/pull/14174

CSS animations are mentinoed in the Firefox 5 release notes:
https://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-us/firefox/5.0/releasenotes/

This has not been verified by testing.