### PR TITLE
Add Safari versions for api.EventTarget.addEventListener.options_signal_parameter

### DIFF
--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -546,10 +546,10 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "15"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "15"
                 },
                 "samsunginternet_android": {
                   "version_added": "15.0"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
This add values for when Safari added support for the signal options parameter.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
Tested at: https://wpt.fyi/results/dom/events/AddEventListenerOptions-signal.any.html?label=master&label=stable&product=safari-15.0%20%2815612.1.29.41.4%29&aligned&q=signal

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Webkit bug: https://bugs.webkit.org/show_bug.cgi?id=218753

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
