### PR TITLE
Updates edge to version 99

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -182,19 +182,26 @@
         "98": {
           "release_date": "2022-02-03",
           "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-980110843-february-3",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "98"
         },
         "99": {
-          "status": "beta",
+          "release_date": "2022-03-03",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-990115030-march-3",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "99"
         },
         "100": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "100"
+        },
+        "101": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "101"
         }
       }
     }


### PR DESCRIPTION
Hello everyone!

I updated Edge browser to version 99, according to this [release note](https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-990115030-march-3).

Fixes #15270.

:)