### PR TITLE
Add nodejs for fetch

### DIFF
--- a/api/Headers.json
+++ b/api/Headers.json
@@ -26,6 +26,15 @@
           "ie": {
             "version_added": false
           },
+          "nodejs": {
+            "version_added": "17.5.0",
+            "flags": [
+              {
+                "name": "--experimental-fetch",
+                "type": "runtime_flag"
+              }
+            ]
+          },
           "opera": {
             "version_added": "29"
           },

--- a/api/Headers.json
+++ b/api/Headers.json
@@ -26,15 +26,20 @@
           "ie": {
             "version_added": false
           },
-          "nodejs": {
-            "version_added": "17.5.0",
-            "flags": [
-              {
-                "name": "--experimental-fetch",
-                "type": "runtime_flag"
-              }
-            ]
-          },
+          "nodejs": [
+            {
+              "version_added": "18.0.0"
+            },
+            {
+              "version_added": "17.5.0",
+              "flags": [
+                {
+                  "name": "--experimental-fetch",
+                  "type": "runtime_flag"
+                }
+              ]
+            }
+          ],
           "opera": {
             "version_added": "29"
           },

--- a/api/Request.json
+++ b/api/Request.json
@@ -42,15 +42,20 @@
           "ie": {
             "version_added": false
           },
-          "nodejs": {
-            "version_added": "17.5.0",
-            "flags": [
-              {
-                "name": "--experimental-fetch",
-                "type": "runtime_flag"
-              }
-            ]
-          },
+          "nodejs": [
+            {
+              "version_added": "18.0.0"
+            },
+            {
+              "version_added": "17.5.0",
+              "flags": [
+                {
+                  "name": "--experimental-fetch",
+                  "type": "runtime_flag"
+                }
+              ]
+            }
+          ],
           "opera": [
             {
               "version_added": "29"

--- a/api/Request.json
+++ b/api/Request.json
@@ -42,6 +42,15 @@
           "ie": {
             "version_added": false
           },
+          "nodejs": {
+            "version_added": "17.5.0",
+            "flags": [
+              {
+                "name": "--experimental-fetch",
+                "type": "runtime_flag"
+              }
+            ]
+          },
           "opera": [
             {
               "version_added": "29"

--- a/api/Response.json
+++ b/api/Response.json
@@ -42,15 +42,20 @@
           "ie": {
             "version_added": false
           },
-          "nodejs": {
-            "version_added": "17.5.0",
-            "flags": [
-              {
-                "name": "--experimental-fetch",
-                "type": "runtime_flag"
-              }
-            ]
-          },
+          "nodejs": [
+            {
+              "version_added": "18.0.0"
+            },
+            {
+              "version_added": "17.5.0",
+              "flags": [
+                {
+                  "name": "--experimental-fetch",
+                  "type": "runtime_flag"
+                }
+              ]
+            }
+          ],
           "opera": [
             {
               "version_added": "29"

--- a/api/Response.json
+++ b/api/Response.json
@@ -42,6 +42,15 @@
           "ie": {
             "version_added": false
           },
+          "nodejs": {
+            "version_added": "17.5.0",
+            "flags": [
+              {
+                "name": "--experimental-fetch",
+                "type": "runtime_flag"
+              }
+            ]
+          },
           "opera": [
             {
               "version_added": "29"

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -27,6 +27,15 @@
           "ie": {
             "version_added": false
           },
+          "nodejs": {
+            "version_added": "17.5.0",
+            "flags": [
+              {
+                "name": "--experimental-fetch",
+                "type": "runtime_flag"
+              }
+            ]
+          },
           "opera": {
             "version_added": "29"
           },

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -27,15 +27,20 @@
           "ie": {
             "version_added": false
           },
-          "nodejs": {
-            "version_added": "17.5.0",
-            "flags": [
-              {
-                "name": "--experimental-fetch",
-                "type": "runtime_flag"
-              }
-            ]
-          },
+          "nodejs": [
+            {
+              "version_added": "18.0.0"
+            },
+            {
+              "version_added": "17.5.0",
+              "flags": [
+                {
+                  "name": "--experimental-fetch",
+                  "type": "runtime_flag"
+                }
+              ]
+            }
+          ],
           "opera": {
             "version_added": "29"
           },

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -366,6 +366,13 @@
           "status": "current",
           "engine": "V8",
           "engine_version": "9.6"
+        },
+        "17.5.0": {
+          "release_date": "2022-02-10",
+          "release_notes": "https://nodejs.org/en/blog/release/v17.5.0/",
+          "status": "current",
+          "engine": "V8",
+          "engine_version": "9.6"
         }
       }
     }

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -370,7 +370,7 @@
         "17.5.0": {
           "release_date": "2022-02-10",
           "release_notes": "https://nodejs.org/en/blog/release/v17.5.0/",
-          "status": "current",
+          "status": "esr",
           "engine": "V8",
           "engine_version": "9.6"
         },

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -373,6 +373,13 @@
           "status": "current",
           "engine": "V8",
           "engine_version": "9.6"
+        },
+        "18.0.0": {
+          "release_date": "2022-04-19",
+          "release_notes": "https://nodejs.org/en/blog/release/v18.0.0/",
+          "status": "current",
+          "engine": "V8",
+          "engine_version": "10.1"
         }
       }
     }

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -363,7 +363,7 @@
         "17.3.0": {
           "release_date": "2021-12-17",
           "release_notes": "https://nodejs.org/en/blog/release/v17.3.0/",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "9.6"
         },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Node.js has started supporting `fetch()` with the `--experimental-fetch` flag since version 17.5.0.
https://nodejs.org/en/blog/release/v17.5.0/

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
