### PR TITLE
offset-anchor

### DIFF
--- a/css/properties/offset-anchor.json
+++ b/css/properties/offset-anchor.json
@@ -32,7 +32,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": "72"
+              "version_added": "79"
             },
             "ie": {
               "version_added": false

--- a/css/properties/offset-anchor.json
+++ b/css/properties/offset-anchor.json
@@ -7,13 +7,13 @@
           "spec_url": "https://drafts.fxtf.org/motion/#offset-anchor-property",
           "support": {
             "chrome": {
-              "version_added": "79"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "79"
+              "version_added": false
             },
             "edge": {
-              "version_added": "79"
+              "version_added": false
             },
             "firefox": [
               {
@@ -32,7 +32,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "72"
             },
             "ie": {
               "version_added": false
@@ -50,10 +50,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "12.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "79"
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Chromium browsers don't support offset-anchor, while mobile firefox does.
<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
I tested it on desktor Chrome, mobile Chrome, desktop Edge, desktor Firefox, mobile Firefox, mobile Samsung Browser.
On desktop browsers I checked @support(offset-anchor: auto) and examples in [offset-anchor](https://developer.mozilla.org/en-US/docs/Web/CSS/offset-anchor). On mobile browsers I checked just the examples.
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

I verified that mobile Firefox works, but I am not sure since which version. I think it's 72, because of [release notes](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/72#css).

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Issue [#1826](https://github.com/mdn/interactive-examples/issues/1826)

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
