### PR TITLE
FF98 Navigator.pdfViewerEnabled - supported

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2817,6 +2817,54 @@
             "standard_track": true,
             "deprecated": true
           }
+        },
+        "fixed_return_value": {
+          "__compat": {
+            "description": "Returns hard coded list of plugins or none",
+            "support": {
+              "chrome": {
+                "version_added": "94"
+              },
+              "chrome_android": {
+                "version_added": "94"
+              },
+              "edge": {
+                "version_added": "94"
+              },
+              "firefox": {
+                "version_added": "99"
+              },
+              "firefox_android": {
+                "version_added": "99"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "80"
+              },
+              "opera_android": {
+                "version_added": "66"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "94"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "presentation": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2459,6 +2459,62 @@
             "standard_track": true,
             "deprecated": true
           }
+        },
+        "returns_plugin_type": {
+          "__compat": {
+            "description": "Returns mime types from plugins rather than hard coded PDF values",
+            "support": {
+              "chrome": {
+                "version_removed": "94",
+                "version_added": "1"
+              },
+              "chrome_android": {
+                "version_removed": "94",
+                "version_added": "18"
+              },
+              "edge": {
+                "version_removed": "94",
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_removed": "99",
+                "version_added": "1"
+              },
+              "firefox_android": {
+                "version_removed": "99",
+                "version_added": "4"
+              },
+              "ie": {
+                "version_added": "4"
+              },
+              "opera": {
+                "version_removed": "80",
+                "version_added": "≤12.1"
+              },
+              "opera_android": {
+                "version_removed": "66",
+                "version_added": "≤12.1"
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": {
+                "version_added": "1"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_removed": "94",
+                "version_added": "1"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "mozIsLocallyAvailable": {
@@ -2818,45 +2874,53 @@
             "deprecated": true
           }
         },
-        "fixed_return_value": {
+        "returns_plugins": {
           "__compat": {
-            "description": "Returns hard coded list of plugins or none",
+            "description": "Returns plugins rather than hard coded PDF-plugin values",
             "support": {
               "chrome": {
-                "version_added": "94"
+                "version_removed": "94",
+                "version_added": "1"
               },
               "chrome_android": {
-                "version_added": "94"
+                "version_removed": "94",
+                "version_added": "18"
               },
               "edge": {
-                "version_added": "94"
+                "version_removed": "94",
+                "version_added": "12"
               },
               "firefox": {
-                "version_added": "99"
+                "version_removed": "99",
+                "version_added": "1"
               },
               "firefox_android": {
-                "version_added": "99"
+                "version_removed": "99",
+                "version_added": "4"
               },
               "ie": {
-                "version_added": false
+                "version_added": "4"
               },
               "opera": {
-                "version_added": "80"
+                "version_removed": "80",
+                "version_added": "≤12.1"
               },
               "opera_android": {
-                "version_added": "66"
+                "version_removed": "66",
+                "version_added": "≤12.1"
               },
               "safari": {
-                "version_added": false
+                "version_added": "1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "1"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "1.0"
               },
               "webview_android": {
-                "version_added": "94"
+                "version_removed": "94",
+                "version_added": "1"
               }
             },
             "status": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2620,6 +2620,7 @@
       },
       "pdfViewerEnabled": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/pdfViewerEnabled",
           "spec_url": "https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-pdfviewerenabled",
           "support": {
             "chrome": {
@@ -2632,10 +2633,10 @@
               "version_added": "94"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "99"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
FF98 adds support for `Navigator.pdfViewerEnabled` in https://bugzilla.mozilla.org/show_bug.cgi?id=1720353
Other docs work for this tracked in https://github.com/mdn/content/issues/13370

Also adds subfeature for `Navigator.plugins` - see comment inline "for discussion". When that resolves I will copy the pattern for `Navigator.mimeTypes`. 

