### PR TITLE
Navigator.requestMIDIAccess - chrome secure context info

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4870,13 +4870,13 @@
             "description": "Secure context required",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "43"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "43"
               },
               "edge": {
-                "version_added": false
+                "version_added": "79"
               },
               "firefox": {
                 "version_added": "99"
@@ -4888,10 +4888,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "30"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "30"
               },
               "safari": {
                 "version_added": false
@@ -4900,10 +4900,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "43"
               }
             },
             "status": {


### PR DESCRIPTION
Chromium based browsers also require secure context for `Navigator.requestMIDIAccess`. From https://www.chromium.org/developers/design-documents/web-midi/ it looks like the sysex permission was required from M43 (first release). 
Note that for chrome there was some "non gated" use allowed prior to version 82 as well, but I don't think we need to draw this distinction (see https://chromestatus.com/feature/5138066234671104).

This follows on from #15256