### PR TITLE
FF99 NavigationPreloadManager - behind pref and in nightly

### DIFF
--- a/api/NavigationPreloadManager.json
+++ b/api/NavigationPreloadManager.json
@@ -14,13 +14,23 @@
           "edge": {
             "version_added": "18"
           },
-          "firefox": {
-            "version_added": false,
-            "notes": "Implementation tracked in <a href='https://bugzil.la/1290958'>bug 1290958</a>."
-          },
+          "firefox": [
+            {
+              "version_added": "preview"
+            },
+            {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.serviceWorkers.navigationPreload.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
-            "version_added": false,
-            "notes": "Implementation tracked in <a href='https://bugzil.la/1290958'>bug 1290958</a>."
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -63,13 +73,23 @@
             "edge": {
               "version_added": "18"
             },
-            "firefox": {
-              "version_added": false,
-              "notes": "Implementation tracked in <a href='https://bugzil.la/1290958'>bug 1290958</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "97",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.serviceWorkers.navigationPreload.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false,
-              "notes": "Implementation tracked in <a href='https://bugzil.la/1290958'>bug 1290958</a>."
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -113,13 +133,23 @@
             "edge": {
               "version_added": "18"
             },
-            "firefox": {
-              "version_added": false,
-              "notes": "Implementation tracked in <a href='https://bugzil.la/1290958'>bug 1290958</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "97",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.serviceWorkers.navigationPreload.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false,
-              "notes": "Implementation tracked in <a href='https://bugzil.la/1290958'>bug 1290958</a>."
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -163,13 +193,23 @@
             "edge": {
               "version_added": "18"
             },
-            "firefox": {
-              "version_added": false,
-              "notes": "Implementation tracked in <a href='https://bugzil.la/1290958'>bug 1290958</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "97",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.serviceWorkers.navigationPreload.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false,
-              "notes": "Implementation tracked in <a href='https://bugzil.la/1290958'>bug 1290958</a>."
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -213,13 +253,23 @@
             "edge": {
               "version_added": "18"
             },
-            "firefox": {
-              "version_added": false,
-              "notes": "Implementation tracked in <a href='https://bugzil.la/1290958'>bug 1290958</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "97",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.serviceWorkers.navigationPreload.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false,
-              "notes": "Implementation tracked in <a href='https://bugzil.la/1290958'>bug 1290958</a>."
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/NavigationPreloadManager.json
+++ b/api/NavigationPreloadManager.json
@@ -63,6 +63,7 @@
       "disable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationPreloadManager/disable",
+          "spec_url": "https://w3c.github.io/ServiceWorker/#dom-navigationpreloadmanager-disable",
           "support": {
             "chrome": {
               "version_added": "59"
@@ -123,6 +124,7 @@
       "enable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationPreloadManager/enable",
+          "spec_url": "https://w3c.github.io/ServiceWorker/#dom-navigationpreloadmanager-enable",
           "support": {
             "chrome": {
               "version_added": "59"
@@ -183,6 +185,7 @@
       "getState": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationPreloadManager/getState",
+          "spec_url": "https://w3c.github.io/ServiceWorker/#dom-navigationpreloadmanager-getstate",
           "support": {
             "chrome": {
               "version_added": "59"
@@ -243,6 +246,7 @@
       "setHeaderValue": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationPreloadManager/setHeaderValue",
+          "spec_url": "https://w3c.github.io/ServiceWorker/#dom-navigationpreloadmanager-setheadervalue",
           "support": {
             "chrome": {
               "version_added": "59"


### PR DESCRIPTION
FF99 now supports [NavigationPreloadManager](https://developer.mozilla.org/en-US/docs/Web/API/NavigationPreloadManager) in nightly - see https://bugzilla.mozilla.org/show_bug.cgi?id=1750515

FF also has this behind a preference. The interface and preference were [added in FF91](https://bugzilla.mozilla.org/show_bug.cgi?id=1564235) but it looks like it only became useful in FF97 with fetch integration: https://bugzilla.mozilla.org/show_bug.cgi?id=1577346

I have therefore added for desktop a preference introduced in 97 and a preview release. Nothing appears in android, so I set that to false (i.e no pref settable, and there is no nightly build of android).

Related docs work can be tracked in https://github.com/mdn/content/issues/13367