### PR TITLE
Fix some spec URLs for SVG <mask> attributes

### DIFF
--- a/svg/elements/mask.json
+++ b/svg/elements/mask.json
@@ -99,7 +99,7 @@
         "maskContentUnits": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/maskContentUnits",
-            "spec_url": "https://drafts.fxtf.org/css-masking-1/#element-attrdef-mask-maskcontentunits",
+            "spec_url": "https://drafts.fxtf.org/css-masking/#element-attrdef-mask-maskcontentunits",
             "support": {
               "chrome": {
                 "version_added": null
@@ -148,7 +148,7 @@
         "maskUnits": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/maskUnits",
-            "spec_url": "https://drafts.fxtf.org/css-masking-1/#element-attrdef-mask-maskunits",
+            "spec_url": "https://drafts.fxtf.org/css-masking/#element-attrdef-mask-maskunits",
             "support": {
               "chrome": {
                 "version_added": null


### PR DESCRIPTION
This removes the unnecessary “-1” level number.