### PR TITLE
Updates firefox to version 98

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -701,23 +701,30 @@
         "97": {
           "release_date": "2022-02-08",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/97",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "97"
         },
         "98": {
           "release_date": "2022-03-08",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/98",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "98"
         },
         "99": {
           "release_date": "2022-04-05",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/99",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "99"
+        },
+        "100": {
+          "release_date": "2022-05-03",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/100",
+          "status": "nightly",
+          "engine": "Gecko",
+          "engine_version": "100"
         }
       }
     }

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -567,23 +567,30 @@
         "97": {
           "release_date": "2022-02-08",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/97",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "97"
         },
         "98": {
           "release_date": "2022-03-08",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/98",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "98"
         },
         "99": {
           "release_date": "2022-04-05",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/99",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "99"
+        },
+        "100": {
+          "release_date": "2022-05-03",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/100",
+          "status": "nightly",
+          "engine": "Gecko",
+          "engine_version": "100"
         }
       }
     }


### PR DESCRIPTION
Hello everyone!

I updated Firefox browser to version 98, according to [this release note](https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/98).

Fixes #15306.

 😉