### PR TITLE
screen.lockOrientation/unlockOrientation don't support all version Blink-based browsers

### DIFF
--- a/api/Screen.json
+++ b/api/Screen.json
@@ -399,13 +399,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Screen/lockOrientation",
           "support": {
             "chrome": {
-              "version_added": "38"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "38"
+              "version_added": false
             },
             "edge": {
               "version_added": "12",
+              "version_removed": "79",
               "prefix": "ms"
             },
             "firefox": {
@@ -421,10 +422,10 @@
               "prefix": "ms"
             },
             "opera": {
-              "version_added": "25"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "25"
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -433,10 +434,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "3.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "38"
+              "version_added": false
             }
           },
           "status": {
@@ -798,13 +799,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Screen/unlockOrientation",
           "support": {
             "chrome": {
-              "version_added": "38"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "38"
+              "version_added": false
             },
             "edge": {
               "version_added": "12",
+              "version_removed": "79",
               "prefix": "ms"
             },
             "firefox": {
@@ -820,10 +822,10 @@
               "prefix": "ms"
             },
             "opera": {
-              "version_added": "25"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "25"
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -832,10 +834,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "3.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "38"
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
#### Summary
`screen.lockOrientation` and `screen.unlockOrientation` was prefixed API and both become `screen.orientation.lock` and `screen.orientation.unlock` as standard. IE, old Edge (EdgeHTML) and Gecko support it with prefixed, but other don't.

As long as I check Blink's code, although it isn't implemented, BCD says "supported".

This data is added by https://github.com/mdn/browser-compat-data/pull/2103, but this change is incorrect for these APIs. So we should update it.

(I guess that Chrome added `screen.orientation` by 38, so anyone copies the version by mistake)

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Test results and supporting details
Using https://mdn-bcd-collector.appspot.com/tests/api/Screen with https://browserstack.com