### PR TITLE
FF WebMIDI gated by permission add on

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4879,7 +4879,8 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": "99"
+                "version_added": "99",
+                "notes": "Permission must be granted through a <a href='https://extensionworkshop.com/documentation/publish/site-permission-add-on/'>site permission add-on</a>."
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
In FF99 WebMIDI is gated by a https://extensionworkshop.com/documentation/publish/site-permission-add-on/

I have added this as a note to the secure_context flag on `Navigator.requestMIDIAccess()` because it is a new, unusual and unexpected mechanism in firefox. 

Note 
- it isn't strictly speaking a spec compatibility issue because the "secure context" has such a broad definition as to be useless for working out "what do I use to get permission". However this is the only reasonable place for this information to live in docs/data, and it is certainly different than any other approach used on other platforms.
- there is now an FF bug now to provide better debug info if the API is accessed without the permission.

