### PR TITLE
Remove incorrect version for `font-variation-settings`

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -613,13 +613,13 @@
             "spec_url": "https://drafts.csswg.org/css-fonts/#font-rend-desc",
             "support": {
               "chrome": {
-                "version_added": "62"
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": "62"
+                "version_added": false
               },
               "edge": {
-                "version_added": "79"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "62"
@@ -643,10 +643,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": "8.0"
+                "version_added": false
               },
               "webview_android": {
-                "version_added": "62"
+                "version_added": false
               }
             },
             "status": {

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -631,10 +631,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "49"
+                "version_added": "false"
               },
               "opera_android": {
-                "version_added": "46"
+                "version_added": "false"
               },
               "safari": {
                 "version_added": false

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -631,10 +631,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "false"
+                "version_added": false
               },
               "opera_android": {
-                "version_added": "false"
+                "version_added": false
               },
               "safari": {
                 "version_added": false


### PR DESCRIPTION
#### Summary
Removes reported support for font-variation-settings in Chromium-based browsers.

#### Test results and supporting details
In Chromium browsers, `font-variation-settings` is supported as a normal CSS property, but not within `@font-face` at the moment

See https://bugs.chromium.org/p/chromium/issues/detail?id=443467.

