### PR TITLE
FF99 supports RTCPeerConnection.setConfiguration()

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -3357,12 +3357,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1253706'>bug 1253706</a>."
+              "version_added": "99"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1253706'>bug 1253706</a>."
+              "version_added": "99"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
FF998 supports [RTCPeerConnection.setConfiguration()](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/setConfiguration) - see https://bugzilla.mozilla.org/show_bug.cgi?id=1253706

This is part of docs work for https://github.com/mdn/content/issues/13371

