### PR TITLE
Update background-attachment: fixed support in Firefox

### DIFF
--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -63,10 +63,10 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "25"
+                "version_added": "2"
               },
               "firefox_android": {
-                "version_added": "25"
+                "version_added": "4"
               },
               "ie": {
                 "version_added": "9"


### PR DESCRIPTION
I've tried it on Firefox 2 on macOS, the 'fixed' value is working so it's already being supported in the very early versions. It's also proved here: https://github.com/Fyrd/caniuse/blob/main/features-json/background-attachment.json

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
