### PR TITLE
Include API WebSocket supports for IE 10

### DIFF
--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -577,7 +577,7 @@
               "version_added": "7"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12.1"
@@ -629,7 +629,7 @@
               "version_added": "7"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12.1"
@@ -681,7 +681,7 @@
               "version_added": "7"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12.1"
@@ -889,7 +889,7 @@
               "version_added": "7"
             },
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12.1"
@@ -977,7 +977,7 @@
               }
             ],
             "ie": {
-              "version_added": false
+              "version_added": "10"
             },
             "opera": {
               "version_added": "12.1"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗description: Install Ruby within a build. To be used in a Linux distro with Apt available.
parameters:
  version:
    description: Ruby version.
    type: string
steps:
  - run:
      command: >
        # Disable IPv6

        mkdir -p ~/.gnupg/

        find ~/.gnupg -type d -exec chmod 700 {} \;

        echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf


        count=0

        until gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys
        409B6B1796C275462A1703113804BB82D39DC0E3
        7D2BAF1CF37B13E2069D6956105BD0E739499BDB

        do
            count=$((count+1)); sleep 10;
            if [ $count -gt 2 ]; then
                echo "Unable to receive GPG keys, FAILING";
                exit 1;
            fi;
            echo "Network error: Unable to receive GPG keys. Will attempt again ($count/3)";
        done;

        ## Update if RVM is installed and exit

        if [ -x "$(command -v rvm -v)" ]; then
            rvm get stable
            exit 0
        fi


        curl -sSL "https://get.rvm.io" | bash -s stable


        # check for machine image specific path

        if [ -d /opt/circleci/.rvm ]; then
          echo "Setting PATH up for system install"
          # this should be what needs to be added to that $BASH_ENV since this is what's in bash_profile - i dont know when $HOME is set
          echo 'export PATH=$PATH:/opt/circleci/.rvm/bin' >> $BASH_ENV
          echo "source /opt/circleci/.rvm/scripts/rvm" >> $BASH_ENV
          # this will source if anyone logs in noninteractively, nvm setup only adds nvm to the path, to get the rubygems later you need to source this again
          echo "source /opt/circleci/.rvm/scripts/rvm" >> ~/.bashrc
        else
          echo "Setting PATH up for local install"
          # this should be what needs to be added to that $BASH_ENV since this is what's in bash_profile - i dont know when $HOME is set
          echo 'export PATH=$PATH:$HOME/.rvm/bin' >> $BASH_ENV
          echo "source $HOME/.rvm/scripts/rvm" >> $BASH_ENV
          # this will source if anyone logs in noninteractively, nvm setup only adds nvm to the path, to get the rubygems later you need to source this again
          echo "source $HOME/.rvm/scripts/rvm" >> ~/.bashrc
        fi
      name: Install/Verify Ruby Version Manager.
  - run:
      command: |
        rvm install << parameters.version >>
        rvm use << parameters.version >>
        echo . $(rvm <<parameters.version>> do rvm env --path) >> $BASH_ENV
      name: Install Ruby v<< parameters.version >> via RVM
 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
