### PR TITLE
Navigator.pdfViewerEnabled and return_ values fix typos

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2462,7 +2462,7 @@
         },
         "returns_plugin_type": {
           "__compat": {
-            "description": "Returns mime types from plugins rather than hard coded PDF values",
+            "description": "Returns MIME types from plugins rather than hard-coded PDF values",
             "support": {
               "chrome": {
                 "version_removed": "94",
@@ -2510,9 +2510,9 @@
               }
             },
             "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
           }
         }
@@ -2876,7 +2876,7 @@
         },
         "returns_plugins": {
           "__compat": {
-            "description": "Returns plugins rather than hard coded PDF-plugin values",
+            "description": "Returns plugins rather than hard-coded PDF plugin values",
             "support": {
               "chrome": {
                 "version_removed": "94",
@@ -2924,9 +2924,9 @@
               }
             },
             "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
           }
         }


### PR DESCRIPTION
This fixes a few typos/errors as recommended by @ddbeck  in #15292

