### PR TITLE
FF99 HTTP header Service-Worker-Navigation-Preload

### DIFF
--- a/http/headers/service-worker-navigation-preload.json
+++ b/http/headers/service-worker-navigation-preload.json
@@ -1,0 +1,56 @@
+{
+  "http": {
+    "headers": {
+      "Service-Worker-Navigation-Preload": {
+        "__compat": {
+          "description": "<code>Service-Worker-Navigation-Preload</code> request header",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Service-Worker-Navigation-Preload",
+          "spec_url": "https://w3c.github.io/ServiceWorker/#handle-fetch",
+          "support": {
+            "chrome": {
+              "version_added": "59"
+            },
+            "chrome_android": {
+              "version_added": "59"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "preview"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "46"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
+            "safari": {
+              "version_added": "15.4"
+            },
+            "safari_ios": {
+              "version_added": "15.4"
+            },
+            "samsunginternet_android": {
+              "version_added": "7.0"
+            },
+            "webview_android": {
+              "version_added": "59"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/service-worker-navigation-preload.json
+++ b/http/headers/service-worker-navigation-preload.json
@@ -16,9 +16,21 @@
             "edge": {
               "version_added": "18"
             },
-            "firefox": {
-              "version_added": "preview"
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "97",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.serviceWorkers.navigationPreload.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },

--- a/http/headers/service-worker-navigation-preload.json
+++ b/http/headers/service-worker-navigation-preload.json
@@ -57,7 +57,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
The [NavigationPreloadManager](https://w3c.github.io/ServiceWorker/#navigationpreloadmanager) sets an HTTP header `Service-Worker-Navigation-Preload: true` in preload fetch requests. The value is `true` by default, but can be set to any value you like using `NavigationPreloadManager.setHeaderValue()`. The idea is that you might want to return something different in a preload request than a normal fetch.

This creates data for this header, identical to [`NavigationPreloadManager.setHeaderValue()`](https://github.com/mdn/browser-compat-data/blob/main/api/NavigationPreloadManager.json#L246). It will always have matching data to that API.

