### PR TITLE
cascade layers shipped in Chrome 99

### DIFF
--- a/css/at-rules/layer.json
+++ b/css/at-rules/layer.json
@@ -8,12 +8,10 @@
           "spec_url": "https://drafts.csswg.org/css-cascade-5/#layering",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See Chromium <a href='https://crbug.com/1164367'>bug 1164367</a>."
+              "version_added": "99"
             },
             "chrome_android": {
-              "version_added": false,
-              "notes": "See Chromium <a href='https://crbug.com/1164367'>bug 1164367</a>."
+              "version_added": "99"
             },
             "edge": {
               "version_added": false
@@ -57,12 +55,11 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "See Chromium <a href='https://crbug.com/1164367'>bug 1164367</a>."
+              "version_added": "99"
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
Cascade layers `@layer` shipped in Chrome 99, I also marked this as experimental: false now it has landed in three browsers.

https://chromestatus.com/feature/5663362835808256
