### PR TITLE
Add inert IDL attribute spec link

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1326,6 +1326,7 @@
       "inert": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/inert",
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-inert",
           "support": {
             "chrome": {
               "version_added": "60",


### PR DESCRIPTION
The inert attribute was recently added to the spec: https://html.spec.whatwg.org/multipage/interaction.html#dom-inert