### PR TITLE
Safari 15.4: CSS text-align supports match-parent

### DIFF
--- a/css/properties/text-align.json
+++ b/css/properties/text-align.json
@@ -248,10 +248,10 @@
                 "version_added": "14"
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "samsunginternet_android": {
                 "version_added": "1.0"


### PR DESCRIPTION
See notes https://webkit.org/blog/12445/new-webkit-features-in-safari-15-4/#retiring-webkit-prefixes under "Retiring WebKit prefixes"

This is a part fix for mdn/browser-compat-data#15374

