### PR TITLE
fix(contextualIdentities): split firefox entries

### DIFF
--- a/webextensions/api/contextualIdentities.json
+++ b/webextensions/api/contextualIdentities.json
@@ -176,14 +176,24 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "notes": "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
-                "version_added": "53"
-              },
-              "firefox_android": {
-                "notes": "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
-                "version_added": "53"
-              },
+              "firefox": [
+                {
+                  "version_added": "57"
+                },
+                {
+                  "notes": "This method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
+                  "version_added": "53"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "57"
+                },
+                {
+                  "notes": "This method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
+                  "version_added": "53"
+                }
+              ],
               "opera": {
                 "version_added": false
               },
@@ -206,20 +216,30 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "notes": [
-                  "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
-                  "Before version 57, this method resolves its promise with <code>null</code> if the given identity was not found."
-                ],
-                "version_added": "53"
-              },
-              "firefox_android": {
-                "notes": [
-                  "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
-                  "Before version 57, this method resolves its promise with <code>null</code> if the given identity was not found."
-                ],
-                "version_added": "53"
-              },
+              "firefox": [
+                {
+                  "version_added": "57"
+                },
+                {
+                  "notes": [
+                    "This method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
+                    "This method resolves its promise with <code>null</code> if the given identity was not found."
+                  ],
+                  "version_added": "53"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "57"
+                },
+                {
+                  "notes": [
+                    "This method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
+                    "This method resolves its promise with <code>null</code> if the given identity was not found."
+                  ],
+                  "version_added": "53"
+                }
+              ],
               "opera": {
                 "version_added": false
               },
@@ -326,14 +346,24 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "notes": "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
-                "version_added": "53"
-              },
-              "firefox_android": {
-                "notes": "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
-                "version_added": "53"
-              },
+              "firefox": [
+                {
+                  "version_added": "57"
+                },
+                {
+                  "notes": "This method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
+                  "version_added": "53"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "57"
+                },
+                {
+                  "notes": "This method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
+                  "version_added": "53"
+                }
+              ],
               "opera": {
                 "version_added": false
               },
@@ -356,20 +386,30 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "notes": [
-                  "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
-                  "Before version 57, this method resolves its promise with <code>null</code> if the given identity was not found."
-                ],
-                "version_added": "53"
-              },
-              "firefox_android": {
-                "notes": [
-                  "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
-                  "Before version 57, this method resolves its promise with <code>null</code> if the given identity was not found."
-                ],
-                "version_added": "53"
-              },
+              "firefox": [
+                {
+                  "version_added": "57"
+                },
+                {
+                  "notes": [
+                    "This method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
+                    "This method resolves its promise with <code>null</code> if the given identity was not found."
+                  ],
+                  "version_added": "53"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "57"
+                },
+                {
+                  "notes": [
+                    "This method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
+                    "This method resolves its promise with <code>null</code> if the given identity was not found."
+                  ],
+                  "version_added": "53"
+                }
+              ],
               "opera": {
                 "version_added": false
               },
@@ -392,20 +432,30 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "notes": [
-                  "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
-                  "Before version 57, this method resolves its promise with <code>null</code> if the given identity was not found."
-                ],
-                "version_added": "53"
-              },
-              "firefox_android": {
-                "notes": [
-                  "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
-                  "Before version 57, this method resolves its promise with <code>null</code> if the given identity was not found."
-                ],
-                "version_added": "53"
-              },
+              "firefox": [
+                {
+                  "version_added": "57"
+                },
+                {
+                  "notes": [
+                    "This method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
+                    "This method resolves its promise with <code>null</code> if the given identity was not found."
+                  ],
+                  "version_added": "53"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "57"
+                },
+                {
+                  "notes": [
+                    "This method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
+                    "This method resolves its promise with <code>null</code> if the given identity was not found."
+                  ],
+                  "version_added": "53"
+                }
+              ],
               "opera": {
                 "version_added": false
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

contextualIdentities had behavior in Firefox 53 that was changed in Firefox 57, but this is not reflected in the data.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

_(Not tested.)_

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
