### PR TITLE
Remove irrelevant Mediarecorder.ignoreMutedMedia property

### DIFF
--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -359,60 +359,6 @@
           }
         }
       },
-      "ignoreMutedMedia": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorder/ignoreMutedMedia",
-          "support": {
-            "chrome": {
-              "version_added": "49",
-              "version_removed": "57"
-            },
-            "chrome_android": {
-              "version_added": "49",
-              "version_removed": "57"
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "36",
-              "version_removed": "44"
-            },
-            "opera_android": {
-              "version_added": "36",
-              "version_removed": "44"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "5.0",
-              "version_removed": "7.0"
-            },
-            "webview_android": {
-              "version_added": "49",
-              "version_removed": "57"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "isTypeSupported": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorder/isTypeSupported",


### PR DESCRIPTION
This feature is no longer relevant
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features

I will remove the MDN page, too.