### PR TITLE
Update Safari with support for smooth scroll behavior

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -6951,7 +6951,10 @@
             },
             "safari_ios": {
               "version_added": "1",
-              "notes": "No support for <code>center</code> options."
+              "notes": [
+                "No support for <code>center</code> option.",
+                "Before iOS 15.4, there was no support for the <code>smooth</code> behavior."
+              ]
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -7008,12 +7011,10 @@
                 "notes": "The <code>block</code> and <code>inline</code> options support the values <code>start</code>, <code>center</code>, <code>end</code>, <code>nearest</code>."
               },
               "safari": {
-                "version_added": "15.4",
-                "notes": "Support the <code>behavior: smooth</code>"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "15.4",
-                "notes": "Support the <code>behavior: smooth</code>"
+                "version_added": false
               },
               "samsunginternet_android": {
                 "version_added": "8.0",

--- a/api/Element.json
+++ b/api/Element.json
@@ -6944,7 +6944,10 @@
             },
             "safari": {
               "version_added": "3",
-              "notes": "No support for <code>center</code> options."
+              "notes": [
+                "No support for <code>center</code> option.",
+                "Before Safari 15.4, there was no support for the <code>smooth</code> behavior."
+              ]
             },
             "safari_ios": {
               "version_added": "1",

--- a/api/Element.json
+++ b/api/Element.json
@@ -6944,11 +6944,11 @@
             },
             "safari": {
               "version_added": "3",
-              "notes": "No support for <code>smooth</code> behavior or <code>center</code> options."
+              "notes": "No support for <code>center</code> options."
             },
             "safari_ios": {
               "version_added": "1",
-              "notes": "No support for <code>smooth</code> behavior or <code>center</code> options."
+              "notes": "No support for <code>center</code> options."
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -7005,10 +7005,12 @@
                 "notes": "The <code>block</code> and <code>inline</code> options support the values <code>start</code>, <code>center</code>, <code>end</code>, <code>nearest</code>."
               },
               "safari": {
-                "version_added": false
+                "version_added": "15.4",
+                "notes": "Support the <code>behavior: smooth</code>"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.4",
+                "notes": "Support the <code>behavior: smooth</code>"
               },
               "samsunginternet_android": {
                 "version_added": "8.0",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
As mentioned in: https://webkit.org/blog/12445/new-webkit-features-in-safari-15-4/

> Developers can also control scroll behavior for an element with either the CSS scroll-behavior property or the behavior option in window.scroll(), window.scrollTo(), and window.scrollBy() methods in JavaScript. This new support gives developers the ability to choose between instantly jumping to a position in the viewport or smoothly animating the scroll operation.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://webkit.org/blog/12445/new-webkit-features-in-safari-15-4/

Can be tested/seen on iOS 15.4: 
Go to https://stengttunnel.no and add two roads/tunnels in the search and click on the red arrow. This will trigger smooth scroll between the roads.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
