### PR TITLE
Update CSP support in Safari 15.4

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1007,10 +1007,10 @@
                   "version_added": "43"
                 },
                 "safari": {
-                  "version_added": null
+                  "version_added": "15.4"
                 },
                 "safari_ios": {
-                  "version_added": null
+                  "version_added": "15.4"
                 },
                 "samsunginternet_android": {
                   "version_added": "7.0"
@@ -1514,10 +1514,10 @@
                   "version_added": "41"
                 },
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "15.4"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "15.4"
                 },
                 "samsunginternet_android": {
                   "version_added": "6.0"
@@ -1789,10 +1789,10 @@
                   "version_added": "48"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "15.4"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "15.4"
                 },
                 "samsunginternet_android": {
                   "version_added": "10.0"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Safari 15.4 is now publicly released on both desktop and mobile (iOS 15.4). The release brings many notable improvements to CSP support, including:
* Support for `strict-dynamic`
* Support for `report-sample`
* Support for `unsafe-hashes`

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
* Navigated to a strict-dynamic csp page, ex: https://web.dev and verified no console errors about unsupported directive 'strict-dynamic'. Also tested with an internal site that trust propagation was working correctly.
* Navigated to a report-sample csp page, ex: https://csper.io/blog/csp-report-filtering and verified no console errors about unsupported directive 'report-sample'.
* Trusting the release notes for 'unsafe-hashes'

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
See [Safari 15.4 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes) (Page title still indicates beta, but this is publicly released now)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
