### PR TITLE
Add support for AbortSignal.throwIfAborted() in Chromium Based Browsers

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -339,16 +339,16 @@
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-abortsignal-throwifaborted①",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "100"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "100"
             },
             "deno": {
               "version_added": "1.17"
             },
             "edge": {
-              "version_added": false
+              "version_added": "100"
             },
             "firefox": {
               "version_added": "97"
@@ -363,7 +363,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "86"
             },
             "opera_android": {
               "version_added": false
@@ -378,7 +378,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "100"
             }
           },
           "status": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Updated AbortSignal.json since AbortSignal.throwIfAborted() is now supported by Chromium Based Browsers.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://chromestatus.com/feature/5029737100476416

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #15418 

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
