### PR TITLE
Update spec URLs for WebSocket features

### DIFF
--- a/api/CloseEvent.json
+++ b/api/CloseEvent.json
@@ -3,7 +3,7 @@
     "CloseEvent": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CloseEvent",
-        "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#the-closeevent-interface",
+        "spec_url": "https://websockets.spec.whatwg.org/#the-closeevent-interface",
         "support": {
           "chrome": {
             "version_added": "13"
@@ -58,7 +58,7 @@
       "CloseEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CloseEvent/CloseEvent",
-          "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#the-closeevent-interface:dom-event-constructor",
+          "spec_url": "https://websockets.spec.whatwg.org/#dom-closeevent-closeevent",
           "description": "<code>CloseEvent()</code> constructor",
           "support": {
             "chrome": {
@@ -110,7 +110,8 @@
       },
       "code": {
         "__compat": {
-          "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-closeevent-code-dev",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CloseEvent/code",
+          "spec_url": "https://websockets.spec.whatwg.org/#ref-for-dom-closeevent-code②",
           "support": {
             "chrome": {
               "version_added": "15"
@@ -215,7 +216,8 @@
       },
       "reason": {
         "__compat": {
-          "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-closeevent-reason-dev",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CloseEvent/reason",
+          "spec_url": "https://websockets.spec.whatwg.org/#ref-for-dom-closeevent-reason②",
           "support": {
             "chrome": {
               "version_added": "15"
@@ -266,7 +268,8 @@
       },
       "wasClean": {
         "__compat": {
-          "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-closeevent-wasclean-dev",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CloseEvent/wasClean",
+          "spec_url": "https://websockets.spec.whatwg.org/#ref-for-dom-closeevent-wasclean②",
           "support": {
             "chrome": {
               "version_added": "13"

--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -3,7 +3,7 @@
     "WebSocket": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocket",
-        "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#the-websocket-interface",
+        "spec_url": "https://websockets.spec.whatwg.org/#the-websocket-interface",
         "support": {
           "chrome": {
             "version_added": "4"
@@ -70,7 +70,7 @@
       "WebSocket": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocket/WebSocket",
-          "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket-dev",
+          "spec_url": "https://websockets.spec.whatwg.org/#ref-for-dom-websocket-websocket①",
           "description": "<code>WebSocket()</code> constructor",
           "support": {
             "chrome": {
@@ -137,7 +137,7 @@
       "binaryType": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocket/binaryType",
-          "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket-binarytype-dev",
+          "spec_url": "https://websockets.spec.whatwg.org/#ref-for-dom-websocket-binarytype①",
           "support": {
             "chrome": {
               "version_added": "15"
@@ -189,7 +189,7 @@
       "bufferedAmount": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocket/bufferedAmount",
-          "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket-bufferedamount-dev",
+          "spec_url": "https://websockets.spec.whatwg.org/#ref-for-dom-websocket-bufferedamount①",
           "support": {
             "chrome": {
               "version_added": "4"
@@ -241,7 +241,7 @@
       "close": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocket/close",
-          "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket-close-dev",
+          "spec_url": "https://websockets.spec.whatwg.org/#ref-for-dom-websocket-close①",
           "support": {
             "chrome": {
               "version_added": "4"
@@ -293,10 +293,7 @@
       "close_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocket/close_event",
-          "spec_url": [
-            "https://html.spec.whatwg.org/multipage/indices.html#event-close",
-            "https://html.spec.whatwg.org/multipage/web-sockets.html#handler-websocket-onclose"
-          ],
+          "spec_url": "https://websockets.spec.whatwg.org/#dom-websocket-onclose",
           "description": "<code>close</code> event",
           "support": {
             "chrome": {
@@ -349,10 +346,7 @@
       "error_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocket/error_event",
-          "spec_url": [
-            "https://html.spec.whatwg.org/multipage/indices.html#event-error",
-            "https://html.spec.whatwg.org/multipage/web-sockets.html#handler-websocket-onerror"
-          ],
+          "spec_url": "https://websockets.spec.whatwg.org/#dom-websocket-onerror",
           "description": "<code>error</code> event",
           "support": {
             "chrome": {
@@ -405,7 +399,7 @@
       "extensions": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocket/extensions",
-          "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket-extensions-dev",
+          "spec_url": "https://websockets.spec.whatwg.org/#ref-for-dom-websocket-extensions①",
           "support": {
             "chrome": {
               "version_added": "16"
@@ -457,10 +451,7 @@
       "message_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocket/message_event",
-          "spec_url": [
-            "https://html.spec.whatwg.org/multipage/indices.html#event-message",
-            "https://html.spec.whatwg.org/multipage/web-sockets.html#handler-websocket-onmessage"
-          ],
+          "spec_url": "https://websockets.spec.whatwg.org/#dom-websocket-onmessage",
           "description": "<code>message</code> event",
           "support": {
             "chrome": {
@@ -513,10 +504,7 @@
       "open_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocket/open_event",
-          "spec_url": [
-            "https://html.spec.whatwg.org/multipage/indices.html#event-open",
-            "https://html.spec.whatwg.org/multipage/web-sockets.html#handler-websocket-onopen"
-          ],
+          "spec_url": "https://websockets.spec.whatwg.org/#dom-websocket-onopen",
           "description": "<code>open</code> event",
           "support": {
             "chrome": {
@@ -569,7 +557,7 @@
       "protocol": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocket/protocol",
-          "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket-protocol-dev",
+          "spec_url": "https://websockets.spec.whatwg.org/#ref-for-dom-websocket-protocol①",
           "support": {
             "chrome": {
               "version_added": "15"
@@ -672,7 +660,7 @@
       "readyState": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocket/readyState",
-          "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket-readystate-dev",
+          "spec_url": "https://websockets.spec.whatwg.org/#ref-for-dom-websocket-readystate①",
           "support": {
             "chrome": {
               "version_added": "4"
@@ -724,7 +712,7 @@
       "send": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocket/send",
-          "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket-send-dev",
+          "spec_url": "https://websockets.spec.whatwg.org/#ref-for-dom-websocket-send①",
           "support": {
             "chrome": {
               "version_added": "4"
@@ -812,7 +800,7 @@
       "url": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebSocket/url",
-          "spec_url": "https://html.spec.whatwg.org/multipage/web-sockets.html#dom-websocket-url-dev",
+          "spec_url": "https://websockets.spec.whatwg.org/#ref-for-dom-websocket-url①",
           "support": {
             "chrome": {
               "version_added": "18"


### PR DESCRIPTION
The WebSocket section was taken out of the HTML spec and moved to its own spec at https://websockets.spec.whatwg.org/

This change also adds the following previously-missing MDN URLs:

- https://developer.mozilla.org/docs/Web/API/CloseEvent/code
- https://developer.mozilla.org/docs/Web/API/CloseEvent/reason
- https://developer.mozilla.org/docs/Web/API/CloseEvent/wasClean