### PR TITLE
removing MIDIAccess onstatechange

### DIFF
--- a/api/MIDIAccess.json
+++ b/api/MIDIAccess.json
@@ -123,68 +123,6 @@
           }
         }
       },
-      "onstatechange": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIAccess/onstatechange",
-          "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiaccess-onstatechange",
-          "support": {
-            "chrome": {
-              "version_added": "43"
-            },
-            "chrome_android": {
-              "version_added": "43"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": [
-              {
-                "version_added": "99"
-              },
-              {
-                "version_added": "97",
-                "version_removed": "99",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "30"
-            },
-            "opera_android": {
-              "version_added": "30"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "4.0"
-            },
-            "webview_android": {
-              "version_added": "43"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "outputs": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIAccess/outputs",
@@ -250,6 +188,7 @@
       "statechange_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIAccess/statechange_event",
+          "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiaccess-onstatechange",
           "description": "<code>statechange</code> event",
           "support": {
             "chrome": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Removes `MIDIAccess.onstatechange` and moves spec url to `statechange_event` in the same file

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

https://github.com/mdn/browser-compat-data/issues/14578
Content pr: https://github.com/mdn/content/pull/14034

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
