### PR TITLE
removing onstatechange from MIDIPort

### DIFF
--- a/api/MIDIPort.json
+++ b/api/MIDIPort.json
@@ -371,68 +371,6 @@
           }
         }
       },
-      "onstatechange": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/onstatechange",
-          "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-onstatechange",
-          "support": {
-            "chrome": {
-              "version_added": "43"
-            },
-            "chrome_android": {
-              "version_added": "43"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": [
-              {
-                "version_added": "99"
-              },
-              {
-                "version_added": "97",
-                "version_removed": "99",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "30"
-            },
-            "opera_android": {
-              "version_added": "30"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": "4.0"
-            },
-            "webview_android": {
-              "version_added": "43"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "open": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/open",
@@ -560,6 +498,7 @@
       "statechange_event": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MIDIPort/statechange_event",
+          "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiport-onstatechange",
           "description": "<code>statechange</code> event",
           "support": {
             "chrome": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Removing `MIDIPort.onstatechange` and moving spec url to `statechange_event`

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

https://github.com/mdn/browser-compat-data/issues/14578
Content pr: https://github.com/mdn/content/pull/14034

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
