### PR TITLE
Safari 15.4 is released

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -191,13 +191,15 @@
           "engine_version": "612.3.6"
         },
         "15.3": {
-          "release_date": "2021-01-26",
-          "status": "current",
+          "release_date": "2022-01-26",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "612.4.9"
         },
         "15.4": {
-          "status": "beta",
+          "release_date": "2022-03-15",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes",
+          "status": "current",
           "engine": "WebKit",
           "engine_version": "613"
         }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -162,13 +162,15 @@
           "engine_version": "612.3.6"
         },
         "15.3": {
-          "release_date": "2021-01-26",
-          "status": "current",
+          "release_date": "2022-01-26",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "612.4.9"
         },
         "15.4": {
-          "status": "beta",
+          "release_date": "2022-03-15",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes",
+          "status": "current",
           "engine": "WebKit",
           "engine_version": "613"
         }


### PR DESCRIPTION
This PR updates the Safari data to reflect that Safari 15.4 has been released.  Additionally, this fixes a typo on the Safari 15.3 release date, where it was accidentally marked as "2021" rather than "2022".

Release date comes from https://support.apple.com/en-us/HT201222.
