### PR TITLE
runtime.getFrameId for Safari tech preview note

### DIFF
--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -533,7 +533,8 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "notes": "Available in Safari Technology Preview 142."
               },
               "safari_ios": {
                 "version_added": false


### PR DESCRIPTION
Add to note about the availability in the Safari technology preview, as per [feedback on the MDN page changes](https://github.com/mdn/content/pull/13219#discussion_r826031603).