### PR TITLE
Add spec_url for HTMLMediaElement.preservesPitch

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2664,6 +2664,7 @@
       "preservesPitch": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/preservesPitch",
+          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-media-preservespitch-dev",
           "support": {
             "chrome": {
               "version_added": "86"


### PR DESCRIPTION
In https://github.com/mdn/content/pull/14183 I wanted to add a page for `HTMLMediaElement.preservesPitch`, and saw that although it has BCD, the BCD doesn't include a link to the spec.