### PR TITLE
Throw a better-worded error when duplicate features found

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function isPlainObject(v) {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
 }
 
-function extend(target, source) {
+function extend(target, source, feature = '') {
   if (!isPlainObject(target) || !isPlainObject(source)) {
     throw new Error('Both target and source must be plain objects');
   }
@@ -52,7 +52,13 @@ function extend(target, source) {
   for (const [key, value] of Object.entries(source)) {
     // recursively extend if target has the same key, otherwise just assign
     if (Object.prototype.hasOwnProperty.call(target, key)) {
-      extend(target[key], value);
+      if (key == '__compat') {
+        // If attempting to merge __compat, we have a double-entry
+        throw new Error(
+          `${feature} was found twice! Please remove duplicate entries.`,
+        );
+      }
+      extend(target[key], value, feature + `${feature ? '.' : ''}${key}`);
     } else {
       target[key] = value;
     }

--- a/index.js
+++ b/index.js
@@ -2,6 +2,13 @@
 const fs = require('fs');
 const path = require('path');
 
+class DuplicateCompatError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'DuplicateCompatError';
+  }
+}
+
 function load() {
   // Recursively load one or more directories passed as arguments.
   let dir,
@@ -54,7 +61,7 @@ function extend(target, source, feature = '') {
     if (Object.prototype.hasOwnProperty.call(target, key)) {
       if (key == '__compat') {
         // If attempting to merge __compat, we have a double-entry
-        throw new Error(
+        throw new DuplicateCompatError(
           `${feature} was found twice! Please remove duplicate entries.`,
         );
       }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 class DuplicateCompatError extends Error {
   constructor(message) {
-    super(message);
+    super(`${feature} already exists! Remove duplicate entries.`);
     this.name = 'DuplicateCompatError';
   }
 }
@@ -61,9 +61,7 @@ function extend(target, source, feature = '') {
     if (Object.prototype.hasOwnProperty.call(target, key)) {
       if (key == '__compat') {
         // If attempting to merge __compat, we have a double-entry
-        throw new DuplicateCompatError(
-          `${feature} was found twice! Please remove duplicate entries.`,
-        );
+        throw new DuplicateCompatError(feature);
       }
       extend(target[key], value, feature + `${feature ? '.' : ''}${key}`);
     } else {


### PR DESCRIPTION
In `index.js`, an error is thrown when attempting to run the `extend()` function on non-objects.  This error also unintentionally catches duplicate entries found in BCD, when attempting to merge their `mdn_url` properties.

However, in the context of duplicate entries, the error message is unhelpful at best.  It is not clear to the contributor that this means a feature's compat data was found twice in BCD.  This PR attempts to resolve that by throwing a more helpful error, stating that a duplicate entry was found.

Fixes #10734.

## Steps to replicate issue

1. Copy the JSON for `api.Document.copy_event` (the entire section) in `api/Document.json`
2. Paste it into a mixins file pertaining to Document, say `api/_mixins/DocumentOrShadowRoot__Document.json`, within `api.Document` (ex. right after line 3).  (Do not paste it into the same file.)

Before this PR, an error reading "Both target and source must be plain objects" will throw.  This PR will instead throw an error that reads "api.Document.copy_event was found twice! Please remove duplicate entries."

Before:
```
> @mdn/browser-compat-data@4.1.13 lint /Users/queengooborg/Developer/Gooborg/browser-compat-data
> node test/lint

/Users/queengooborg/Developer/Gooborg/browser-compat-data/index.js:48
    throw new Error('Both target and source must be plain objects');
    ^

Error: Both target and source must be plain objects
    at extend (/Users/queengooborg/Developer/Gooborg/browser-compat-data/index.js:48:11)
    at extend (/Users/queengooborg/Developer/Gooborg/browser-compat-data/index.js:55:7)
    at extend (/Users/queengooborg/Developer/Gooborg/browser-compat-data/index.js:55:7)
    at extend (/Users/queengooborg/Developer/Gooborg/browser-compat-data/index.js:55:7)
    at extend (/Users/queengooborg/Developer/Gooborg/browser-compat-data/index.js:55:7)
    at extend (/Users/queengooborg/Developer/Gooborg/browser-compat-data/index.js:55:7)
    at processFilename (/Users/queengooborg/Developer/Gooborg/browser-compat-data/index.js:31:5)
    at Array.forEach (<anonymous>)
    at load (/Users/queengooborg/Developer/Gooborg/browser-compat-data/index.js:36:25)
    at Object.<anonymous> (/Users/queengooborg/Developer/Gooborg/browser-compat-data/index.js:62:18)
```

After:
```
> @mdn/browser-compat-data@4.1.13 lint /Users/queengooborg/Developer/Gooborg/browser-compat-data
> node test/lint

/Users/queengooborg/Developer/Gooborg/browser-compat-data/index.js:57
        throw new Error(
        ^

Error: api.Document.copy_event was found twice! Please remove duplicate entries.
    at extend (/Users/queengooborg/Developer/Gooborg/browser-compat-data/index.js:57:15)
    at extend (/Users/queengooborg/Developer/Gooborg/browser-compat-data/index.js:61:7)
    at extend (/Users/queengooborg/Developer/Gooborg/browser-compat-data/index.js:61:7)
    at extend (/Users/queengooborg/Developer/Gooborg/browser-compat-data/index.js:61:7)
    at processFilename (/Users/queengooborg/Developer/Gooborg/browser-compat-data/index.js:31:5)
    at Array.forEach (<anonymous>)
    at load (/Users/queengooborg/Developer/Gooborg/browser-compat-data/index.js:36:25)
    at Object.<anonymous> (/Users/queengooborg/Developer/Gooborg/browser-compat-data/index.js:68:18)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
```