### PR TITLE
Add Safari support for focus visible

### DIFF
--- a/css/selectors/focus-visible.json
+++ b/css/selectors/focus-visible.json
@@ -104,12 +104,10 @@
               }
             ],
             "safari": {
-              "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/185859'>bug 185859</a>."
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/185859'>bug 185859</a>."
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "14.0"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Adds Safari 15.4 support for focus visible

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://webkit.org/blog/12445/new-webkit-features-in-safari-15-4/#:~:text=WebKit%20added%20support%20for%20the%20%3Afocus%2Dvisible%20pseudo%2Dclass

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Fixes https://github.com/mdn/browser-compat-data/issues/13986

Fixes https://github.com/mdn/browser-compat-data/issues/14476

Fixes https://github.com/mdn/browser-compat-data/issues/11962