### PR TITLE
Added browser compat data for priority-hints

### DIFF
--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -494,6 +494,54 @@
           }
         }
       },
+      "fetchpriority": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/priority-hints/#iframe",
+          "support": {
+            "chrome": {
+              "version_added": "101"
+            },
+            "chrome_android": {
+              "version_added": "101"
+            },
+            "edge": {
+              "version_added": "101"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "101"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "frameBorder": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/frameBorder",

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -492,6 +492,54 @@
           }
         }
       },
+      "fetchpriority": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/priority-hints/#img",
+          "support": {
+            "chrome": {
+              "version_added": "101"
+            },
+            "chrome_android": {
+              "version_added": "101"
+            },
+            "edge": {
+              "version_added": "101"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "101"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "height": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLImageElement/height",

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -246,6 +246,54 @@
           }
         }
       },
+      "fetchpriority": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/priority-hints/#link",
+          "support": {
+            "chrome": {
+              "version_added": "101"
+            },
+            "chrome_android": {
+              "version_added": "101"
+            },
+            "edge": {
+              "version_added": "101"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "101"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "href": {
         "__compat": {
           "support": {

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -284,6 +284,54 @@
           }
         }
       },
+      "fetchpriority": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/priority-hints/#script",
+          "support": {
+            "chrome": {
+              "version_added": "101"
+            },
+            "chrome_android": {
+              "version_added": "101"
+            },
+            "edge": {
+              "version_added": "101"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "101"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "htmlFor": {
         "__compat": {
           "support": {

--- a/api/Request.json
+++ b/api/Request.json
@@ -1081,6 +1081,54 @@
           }
         }
       },
+      "priority": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/priority-hints/#fetch-integration",
+          "support": {
+            "chrome": {
+              "version_added": "101"
+            },
+            "chrome_android": {
+              "version_added": "101"
+            },
+            "edge": {
+              "version_added": "101"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "101"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "redirect": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Request/redirect",

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -428,6 +428,54 @@
             }
           }
         },
+        "fetchpriority": {
+          "__compat": {
+            "spec_url": "https://wicg.github.io/priority-hints/#iframe",
+            "support": {
+              "chrome": {
+                "version_added": "101"
+              },
+              "chrome_android": {
+                "version_added": "101"
+              },
+              "edge": {
+                "version_added": "101"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "101"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "frameborder": {
           "__compat": {
             "support": {

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -361,6 +361,54 @@
             }
           }
         },
+        "fetchpriority": {
+          "__compat": {
+            "spec_url": "https://wicg.github.io/priority-hints/#img",
+            "support": {
+              "chrome": {
+                "version_added": "101"
+              },
+              "chrome_android": {
+                "version_added": "101"
+              },
+              "edge": {
+                "version_added": "101"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "101"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "height": {
           "__compat": {
             "support": {

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -198,6 +198,54 @@
             }
           }
         },
+        "fetchpriority": {
+          "__compat": {
+            "spec_url": "https://wicg.github.io/priority-hints/#link",
+            "support": {
+              "chrome": {
+                "version_added": "101"
+              },
+              "chrome_android": {
+                "version_added": "101"
+              },
+              "edge": {
+                "version_added": "101"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "101"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "href": {
           "__compat": {
             "support": {

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -200,6 +200,54 @@
             }
           }
         },
+        "fetchpriority": {
+          "__compat": {
+            "spec_url": "https://wicg.github.io/priority-hints/#script",
+            "support": {
+              "chrome": {
+                "version_added": "101"
+              },
+              "chrome_android": {
+                "version_added": "101"
+              },
+              "edge": {
+                "version_added": "101"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "101"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "integrity": {
           "__compat": {
             "support": {


### PR DESCRIPTION
#### Summary
Added browser compatibility data for the [priority hints](https://wicg.github.io/priority-hints/) attributes and properties.

#### Test results and supporting details
[Chromium status for priority hints](https://chromestatus.com/feature/5273474901737472) - enabled by default in 101.

#### Related issues
Part of the documentation addition for https://github.com/mdn/content/issues/14208

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
