### PR TITLE
usageDetails is non-standard and chromium specific

### DIFF
--- a/api/StorageManager.json
+++ b/api/StorageManager.json
@@ -95,6 +95,53 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "usageDetails": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "61"
+              },
+              "chrome_android": {
+                "version_added": "61"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "48"
+              },
+              "opera_android": {
+                "version_added": "45"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "8.0"
+              },
+              "webview_android": {
+                "version_added": "61"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
         }
       },
       "getDirectory": {


### PR DESCRIPTION
BCD part of mdn/content#14236

The returned object have this `usageDetails` property only on Chromium. And it is not in the spec.