### PR TITLE
Release 99 Intl.Locale Chromium adds support for some new properties

### DIFF
--- a/javascript/builtins/intl/Locale.json
+++ b/javascript/builtins/intl/Locale.json
@@ -227,32 +227,57 @@
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/calendars",
               "spec_url": "https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.calendars",
               "support": {
-                "chrome": {
-                  "version_added": "92",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-javascript-harmony",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
-                },
-                "chrome_android": {
-                  "version_added": "92",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-javascript-harmony",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
-                },
+                "chrome": [
+                  {
+                    "version_added": "99"
+                  },
+                  {
+                    "version_added": "92",
+                    "version_removed": "99",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
+                "chrome_android": [
+                  {
+                    "version_added": "99"
+                  },
+                  {
+                    "version_added": "92",
+                    "version_removed": "99",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "deno": {
                   "version_added": false
                 },
-                "edge": {
-                  "version_added": false
-                },
+                "edge": [
+                  {
+                    "version_added": "99"
+                  },
+                  {
+                    "version_added": "92",
+                    "version_removed": "99",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "firefox": {
                   "version_added": false
                 },
@@ -265,11 +290,31 @@
                 "nodejs": {
                   "version_added": false
                 },
-                "opera": {
-                  "version_added": false
-                },
+                "opera": [
+                  {
+                    "version_added": "85"
+                  },
+                  {
+                    "version_added": "78",
+                    "version_removed": "85",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "65",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-javascript-harmony",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
                 },
                 "safari": {
                   "version_added": "15.4"
@@ -429,9 +474,22 @@
                 "deno": {
                   "version_added": false
                 },
-                "edge": {
-                  "version_added": false
-                },
+                "edge": [
+                  {
+                    "version_added": "99"
+                  },
+                  {
+                    "version_added": "92",
+                    "version_removed": "99",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "firefox": {
                   "version_added": false
                 },
@@ -444,11 +502,31 @@
                 "nodejs": {
                   "version_added": false
                 },
-                "opera": {
-                  "version_added": false
-                },
+                "opera": [
+                  {
+                    "version_added": "85"
+                  },
+                  {
+                    "version_added": "78",
+                    "version_removed": "85",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "65",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-javascript-harmony",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
                 },
                 "safari": {
                   "version_added": "15.4"
@@ -530,32 +608,57 @@
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/hourCycles",
               "spec_url": "https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.hourCycles",
               "support": {
-                "chrome": {
-                  "version_added": "92",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-javascript-harmony",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
-                },
-                "chrome_android": {
-                  "version_added": "92",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-javascript-harmony",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
-                },
+                "chrome": [
+                  {
+                    "version_added": "99"
+                  },
+                  {
+                    "version_added": "92",
+                    "version_removed": "99",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
+                "chrome_android": [
+                  {
+                    "version_added": "99"
+                  },
+                  {
+                    "version_added": "92",
+                    "version_removed": "99",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "deno": {
                   "version_added": false
                 },
-                "edge": {
-                  "version_added": false
-                },
+                "edge": [
+                  {
+                    "version_added": "99"
+                  },
+                  {
+                    "version_added": "92",
+                    "version_removed": "99",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "firefox": {
                   "version_added": false
                 },
@@ -568,11 +671,31 @@
                 "nodejs": {
                   "version_added": false
                 },
-                "opera": {
-                  "version_added": false
-                },
+                "opera": [
+                  {
+                    "version_added": "85"
+                  },
+                  {
+                    "version_added": "78",
+                    "version_removed": "85",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "65",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-javascript-harmony",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
                 },
                 "safari": {
                   "version_added": "15.4"
@@ -819,32 +942,57 @@
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystems",
               "spec_url": "https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.numberingSystems",
               "support": {
-                "chrome": {
-                  "version_added": "92",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-javascript-harmony",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
-                },
-                "chrome_android": {
-                  "version_added": "92",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-javascript-harmony",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
-                },
+                "chrome": [
+                  {
+                    "version_added": "99"
+                  },
+                  {
+                    "version_added": "92",
+                    "version_removed": "99",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
+                "chrome_android": [
+                  {
+                    "version_added": "99"
+                  },
+                  {
+                    "version_added": "92",
+                    "version_removed": "99",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "deno": {
                   "version_added": false
                 },
-                "edge": {
-                  "version_added": false
-                },
+                "edge": [
+                  {
+                    "version_added": "99"
+                  },
+                  {
+                    "version_added": "92",
+                    "version_removed": "99",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "firefox": {
                   "version_added": false
                 },
@@ -857,11 +1005,31 @@
                 "nodejs": {
                   "version_added": false
                 },
-                "opera": {
-                  "version_added": false
-                },
+                "opera": [
+                  {
+                    "version_added": "85"
+                  },
+                  {
+                    "version_added": "78",
+                    "version_removed": "85",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "65",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-javascript-harmony",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
                 },
                 "safari": {
                   "version_added": "15.4"
@@ -1053,32 +1221,57 @@
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/textInfo",
               "spec_url": "https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.textInfo",
               "support": {
-                "chrome": {
-                  "version_added": "92",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-javascript-harmony",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
-                },
-                "chrome_android": {
-                  "version_added": "92",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-javascript-harmony",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
-                },
+                "chrome": [
+                  {
+                    "version_added": "99"
+                  },
+                  {
+                    "version_added": "92",
+                    "version_removed": "99",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
+                "chrome_android": [
+                  {
+                    "version_added": "99"
+                  },
+                  {
+                    "version_added": "92",
+                    "version_removed": "99",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "deno": {
                   "version_added": false
                 },
-                "edge": {
-                  "version_added": false
-                },
+                "edge": [
+                  {
+                    "version_added": "99"
+                  },
+                  {
+                    "version_added": "92",
+                    "version_removed": "99",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "firefox": {
                   "version_added": false
                 },
@@ -1091,11 +1284,31 @@
                 "nodejs": {
                   "version_added": false
                 },
-                "opera": {
-                  "version_added": false
-                },
+                "opera": [
+                  {
+                    "version_added": "85"
+                  },
+                  {
+                    "version_added": "78",
+                    "version_removed": "85",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "65",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-javascript-harmony",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
                 },
                 "safari": {
                   "version_added": "15.4"
@@ -1122,32 +1335,57 @@
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/timeZones",
               "spec_url": "https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.timeZones",
               "support": {
-                "chrome": {
-                  "version_added": "92",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-javascript-harmony",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
-                },
-                "chrome_android": {
-                  "version_added": "92",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-javascript-harmony",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
-                },
+                "chrome": [
+                  {
+                    "version_added": "99"
+                  },
+                  {
+                    "version_added": "92",
+                    "version_removed": "99",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
+                "chrome_android": [
+                  {
+                    "version_added": "99"
+                  },
+                  {
+                    "version_added": "92",
+                    "version_removed": "99",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "deno": {
                   "version_added": false
                 },
-                "edge": {
-                  "version_added": false
-                },
+                "edge": [
+                  {
+                    "version_added": "99"
+                  },
+                  {
+                    "version_added": "92",
+                    "version_removed": "99",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "firefox": {
                   "version_added": false
                 },
@@ -1160,11 +1398,31 @@
                 "nodejs": {
                   "version_added": false
                 },
-                "opera": {
-                  "version_added": false
-                },
+                "opera": [
+                  {
+                    "version_added": "85"
+                  },
+                  {
+                    "version_added": "78",
+                    "version_removed": "85",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "65",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-javascript-harmony",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
                 },
                 "safari": {
                   "version_added": "15.4"
@@ -1246,32 +1504,57 @@
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/weekInfo",
               "spec_url": "https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.weekInfo",
               "support": {
-                "chrome": {
-                  "version_added": "92",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-javascript-harmony",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
-                },
-                "chrome_android": {
-                  "version_added": "92",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-javascript-harmony",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
-                },
+                "chrome": [
+                  {
+                    "version_added": "99"
+                  },
+                  {
+                    "version_added": "92",
+                    "version_removed": "99",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
+                "chrome_android": [
+                  {
+                    "version_added": "99"
+                  },
+                  {
+                    "version_added": "92",
+                    "version_removed": "99",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "deno": {
                   "version_added": false
                 },
-                "edge": {
-                  "version_added": false
-                },
+                "edge": [
+                  {
+                    "version_added": "99"
+                  },
+                  {
+                    "version_added": "92",
+                    "version_removed": "99",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "firefox": {
                   "version_added": false
                 },
@@ -1284,11 +1567,31 @@
                 "nodejs": {
                   "version_added": false
                 },
-                "opera": {
-                  "version_added": false
-                },
+                "opera": [
+                  {
+                    "version_added": "85"
+                  },
+                  {
+                    "version_added": "78",
+                    "version_removed": "85",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-javascript-harmony",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "65",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-javascript-harmony",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
                 },
                 "safari": {
                   "version_added": "15.4"

--- a/javascript/builtins/intl/Locale.json
+++ b/javascript/builtins/intl/Locale.json
@@ -307,14 +307,7 @@
                   }
                 ],
                 "opera_android": {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-javascript-harmony",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
+                  "version_added": false
                 },
                 "safari": {
                   "version_added": "15.4"
@@ -519,14 +512,7 @@
                   }
                 ],
                 "opera_android": {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-javascript-harmony",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
+                  "version_added": false
                 },
                 "safari": {
                   "version_added": "15.4"
@@ -688,14 +674,7 @@
                   }
                 ],
                 "opera_android": {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-javascript-harmony",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
+                  "version_added": false
                 },
                 "safari": {
                   "version_added": "15.4"
@@ -1022,14 +1001,7 @@
                   }
                 ],
                 "opera_android": {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-javascript-harmony",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
+                  "version_added": false
                 },
                 "safari": {
                   "version_added": "15.4"
@@ -1301,14 +1273,7 @@
                   }
                 ],
                 "opera_android": {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-javascript-harmony",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
+                  "version_added": false
                 },
                 "safari": {
                   "version_added": "15.4"
@@ -1415,14 +1380,7 @@
                   }
                 ],
                 "opera_android": {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-javascript-harmony",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
+                  "version_added": false
                 },
                 "safari": {
                   "version_added": "15.4"
@@ -1584,14 +1542,7 @@
                   }
                 ],
                 "opera_android": {
-                  "version_added": "65",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-javascript-harmony",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
+                  "version_added": false
                 },
                 "safari": {
                   "version_added": "15.4"

--- a/javascript/builtins/intl/Locale.json
+++ b/javascript/builtins/intl/Locale.json
@@ -326,7 +326,7 @@
                   "version_added": false
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "99"
                 }
               },
               "status": {
@@ -538,7 +538,7 @@
                   "version_added": false
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "99"
                 }
               },
               "status": {
@@ -707,7 +707,7 @@
                   "version_added": false
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "99"
                 }
               },
               "status": {
@@ -1041,7 +1041,7 @@
                   "version_added": false
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "99"
                 }
               },
               "status": {
@@ -1320,7 +1320,7 @@
                   "version_added": false
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "99"
                 }
               },
               "status": {
@@ -1434,7 +1434,7 @@
                   "version_added": false
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "99"
                 }
               },
               "status": {
@@ -1603,7 +1603,7 @@
                   "version_added": false
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "99"
                 }
               },
               "status": {


### PR DESCRIPTION
From https://v8.dev/blog/v8-release-99#javascript

> [Intl.Locale API](https://v8.dev/blog/v8-release-74#intl.locale). With v9.9, we added seven new properties to the Intl.Locale object: calendars, collations, hourCycles, numberingSystems, timeZones, textInfo, and weekInfo.

This adds the versions. Previously these were behind flags. Note however that the flag info hadn't been extended to Opera, so I have added that too.

Fixes #15174