### PR TITLE
Updates opera browser to version 85

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -643,19 +643,26 @@
         "84": {
           "release_date": "2022-02-16",
           "release_notes": "https://blogs.opera.com/desktop/2022/02/opera-84/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "98"
         },
         "85": {
-          "status": "beta",
+          "release_date": "2022-03-23",
+          "release_notes": "https://blogs.opera.com/desktop/2022/03/opera-85/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "99"
         },
         "86": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "100"
+        },
+        "87": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "101"
         }
       }
     }


### PR DESCRIPTION
Hello!

According to this [release note](https://blogs.opera.com/desktop/2022/03/opera-85/), opera browser has updated to version 85.

Fixes #15508.