### PR TITLE
App badging not supported on WebView.

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -768,7 +768,7 @@
               "version_added": "13.0"
             },
             "webview_android": {
-              "version_added": "81"
+              "version_added": false
             }
           },
           "status": {
@@ -5273,7 +5273,7 @@
               "version_added": "13.0"
             },
             "webview_android": {
-              "version_added": "81"
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
The badging APIs are NOT supported on WebView. 

#### Test results and supporting details

They require an installation method that is not available on that platform. Also, here's the [Chrome Status entry](https://chromestatus.com/feature/6068482055602176). Please note that [not-webview-exposed.txt](https://source.chromium.org/chromium/chromium/src/+/main:android_webview/tools/system_webview_shell/test/data/webexposed/not-webview-exposed.txt) is not correct in this case.

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
