### PR TITLE
Add revert-layer to bcd table and add spec url

### DIFF
--- a/css/types/global_keywords.json
+++ b/css/types/global_keywords.json
@@ -209,6 +209,55 @@
             }
           }
         },
+        "revert_layer": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/revert-layer",
+            "spec_url": "https://drafts.csswg.org/css-cascade-5/#revert-layer",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "97"
+              },
+              "firefox_android": {
+                "version_added": "97"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "unset": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/unset",

--- a/css/types/global_keywords.json
+++ b/css/types/global_keywords.json
@@ -209,7 +209,7 @@
             }
           }
         },
-        "revert_layer": {
+        "revert-layer": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/revert-layer",
             "spec_url": "https://drafts.csswg.org/css-cascade-5/#revert-layer",
@@ -252,8 +252,8 @@
               }
             },
             "status": {
-              "experimental": false,
-              "standard_track": true,
+              "experimental": true,
+              "standard_track": false,
               "deprecated": false
             }
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

A new global keyword was introduced in FF97, the `revert-layer` keyword.

- Added the spec url
- Added BCD table for `revert-layer`.
    - Currently, the table only contains information about support in Firefox.
    - Information about support in other browsers and the specific versions is not known at this point, so leaving them as `false` for now.
    - Also, `standard_track` has been kept as `true` for now - hopefully information about support in other browsers will be available soon.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://bugzilla.mozilla.org/show_bug.cgi?id=1699220
https://drafts.csswg.org/css-cascade-5/#revert-layer

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Content issue tracking this work: https://github.com/mdn/content/issues/13373
PR for the new `revert-layer` page: https://github.com/mdn/content/pull/14287
