### PR TITLE
Unmark content-visibility as experimental

### DIFF
--- a/css/properties/content-visibility.json
+++ b/css/properties/content-visibility.json
@@ -44,7 +44,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Unmarks `content-visibility` as experimental as it now has at least 2 implementations.

#### Test results and supporting details

Chromium and WebKit both have support.
