### PR TITLE
Update spec urls for some FileSystemAccess APIs and mark as standard

### DIFF
--- a/api/FileSystemDirectoryHandle.json
+++ b/api/FileSystemDirectoryHandle.json
@@ -3,7 +3,7 @@
     "FileSystemDirectoryHandle": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle",
-        "spec_url": "https://wicg.github.io/file-system-access/#api-filesystemdirectoryhandle",
+        "spec_url": "https://fs.spec.whatwg.org/#api-filesystemdirectoryhandle",
         "support": {
           "chrome": {
             "version_added": "86"
@@ -44,13 +44,14 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },
       "entries": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/entries",
+          "spec_url": "https://fs.spec.whatwg.org/#api-filesystemdirectoryhandle-asynciterable",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -91,7 +92,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -99,7 +100,7 @@
       "getDirectoryHandle": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/getDirectoryHandle",
-          "spec_url": "https://wicg.github.io/file-system-access/#api-filesystemdirectoryhandle-getdirectoryhandle",
+          "spec_url": "https://fs.spec.whatwg.org/#api-filesystemdirectoryhandle-getdirectoryhandle",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -140,7 +141,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -148,7 +149,7 @@
       "getFileHandle": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/getFileHandle",
-          "spec_url": "https://wicg.github.io/file-system-access/#api-filesystemdirectoryhandle-getfilehandle",
+          "spec_url": "https://fs.spec.whatwg.org/#api-filesystemdirectoryhandle-getfilehandle",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -189,7 +190,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -197,6 +198,7 @@
       "keys": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/keys",
+          "spec_url": "https://fs.spec.whatwg.org/#api-filesystemdirectoryhandle-asynciterable",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -237,7 +239,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -245,7 +247,7 @@
       "removeEntry": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/removeEntry",
-          "spec_url": "https://wicg.github.io/file-system-access/#api-filesystemdirectoryhandle-removeentry",
+          "spec_url": "https://fs.spec.whatwg.org/#api-filesystemdirectoryhandle-removeentry",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -286,7 +288,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -294,7 +296,7 @@
       "resolve": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/resolve",
-          "spec_url": "https://wicg.github.io/file-system-access/#api-filesystemdirectoryhandle-resolve",
+          "spec_url": "https://fs.spec.whatwg.org/#api-filesystemdirectoryhandle-resolve",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -335,7 +337,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -343,6 +345,7 @@
       "values": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemDirectoryHandle/values",
+          "spec_url": "https://fs.spec.whatwg.org/#api-filesystemdirectoryhandle-asynciterable",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -383,7 +386,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/FileSystemFileHandle.json
+++ b/api/FileSystemFileHandle.json
@@ -3,7 +3,7 @@
     "FileSystemFileHandle": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemFileHandle",
-        "spec_url": "https://wicg.github.io/file-system-access/#api-filesystemfilehandle",
+        "spec_url": "https://fs.spec.whatwg.org/#api-filesystemfilehandle",
         "support": {
           "chrome": {
             "version_added": "86"
@@ -44,14 +44,14 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },
       "createWritable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemFileHandle/createWritable",
-          "spec_url": "https://wicg.github.io/file-system-access/#api-filesystemfilehandle-createwritable",
+          "spec_url": "https://fs.spec.whatwg.org/#api-filesystemfilehandle-createwritable",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -92,7 +92,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -100,7 +100,7 @@
       "getFile": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemFileHandle/getFile",
-          "spec_url": "https://wicg.github.io/file-system-access/#api-filesystemfilehandle-getfile",
+          "spec_url": "https://fs.spec.whatwg.org/#api-filesystemfilehandle-getfile",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -141,7 +141,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/FileSystemHandle.json
+++ b/api/FileSystemHandle.json
@@ -3,7 +3,7 @@
     "FileSystemHandle": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemHandle",
-        "spec_url": "https://wicg.github.io/file-system-access/#api-filesystemhandle",
+        "spec_url": "https://fs.spec.whatwg.org/#api-filesystemhandle",
         "support": {
           "chrome": {
             "version_added": "86"
@@ -44,14 +44,14 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },
       "isSameEntry": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemHandle/isSameEntry",
-          "spec_url": "https://wicg.github.io/file-system-access/#api-filesystemhandle-issameentry",
+          "spec_url": "https://fs.spec.whatwg.org/#api-filesystemhandle-issameentry",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -92,7 +92,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -100,7 +100,7 @@
       "kind": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemHandle/kind",
-          "spec_url": "https://wicg.github.io/file-system-access/#ref-for-dom-filesystemhandle-kind①",
+          "spec_url": "https://fs.spec.whatwg.org/#ref-for-dom-filesystemhandle-kind①",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -141,7 +141,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -149,7 +149,7 @@
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemHandle/name",
-          "spec_url": "https://wicg.github.io/file-system-access/#ref-for-dom-filesystemhandle-name①",
+          "spec_url": "https://fs.spec.whatwg.org/#ref-for-dom-filesystemhandle-name①",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -190,7 +190,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/FileSystemWritableFileStream.json
+++ b/api/FileSystemWritableFileStream.json
@@ -3,7 +3,7 @@
     "FileSystemWritableFileStream": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemWritableFileStream",
-        "spec_url": "https://wicg.github.io/file-system-access/#api-filesystemwritablefilestream",
+        "spec_url": "https://fs.spec.whatwg.org/#api-filesystemwritablefilestream",
         "support": {
           "chrome": {
             "version_added": "86"
@@ -44,14 +44,14 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },
       "seek": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemWritableFileStream/seek",
-          "spec_url": "https://wicg.github.io/file-system-access/#dom-filesystemwritablefilestream-seek",
+          "spec_url": "https://fs.spec.whatwg.org/#api-filesystemwritablefilestream-seek",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -92,7 +92,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -100,7 +100,7 @@
       "truncate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemWritableFileStream/truncate",
-          "spec_url": "https://wicg.github.io/file-system-access/#dom-filesystemwritablefilestream-truncate",
+          "spec_url": "https://fs.spec.whatwg.org/#api-filesystemwritablefilestream-truncate",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -141,7 +141,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -149,7 +149,7 @@
       "write": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemWritableFileStream/write",
-          "spec_url": "https://wicg.github.io/file-system-access/#dom-filesystemwritablefilestream-write",
+          "spec_url": "https://fs.spec.whatwg.org/#api-filesystemwritablefilestream-write",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -190,7 +190,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/StorageManager.json
+++ b/api/StorageManager.json
@@ -146,6 +146,7 @@
       },
       "getDirectory": {
         "__compat": {
+          "spec_url": "https://fs.spec.whatwg.org/#dom-storagemanager-getdirectory",
           "support": {
             "chrome": {
               "version_added": "86"
@@ -186,7 +187,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Large portions of the `File System Access API` now live under WhatWG's [File System API](https://fs.spec.whatwg.org/)

#### Test results and supporting details
This purely updates spec links of existing data.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/13149
