### PR TITLE
Add Chromium versions for css.at-rules.font-face.font-display

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -305,10 +305,10 @@
             "spec_url": "https://drafts.csswg.org/css-fonts/#font-display-desc",
             "support": {
               "chrome": {
-                "version_added": "72"
+                "version_added": "60"
               },
               "chrome_android": {
-                "version_added": "72"
+                "version_added": "60"
               },
               "edge": {
                 "version_added": "79"
@@ -323,10 +323,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "60"
+                "version_added": "47"
               },
               "opera_android": {
-                "version_added": "51"
+                "version_added": "44"
               },
               "safari": {
                 "version_added": "11.1"
@@ -338,7 +338,7 @@
                 "version_added": "11.0"
               },
               "webview_android": {
-                "version_added": "72"
+                "version_added": "60"
               }
             },
             "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `font-display` member of the `font-face` CSS @rule.  This updates our data to match with both CanIUse and [ChromeStatus](https://chromestatus.com/feature/4799947908055040).  Fixes #5224.
