### PR TITLE
Mark lazy loading as non-experimental

### DIFF
--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -668,7 +668,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
Lazy loading is supported in all three major browser engines now, so this is feature is no longer experimental.  Fixes #5751.
