### PR TITLE
FF100 Remove and deprecate Large-Allocation HTTP header

### DIFF
--- a/http/headers/large-allocation.json
+++ b/http/headers/large-allocation.json
@@ -15,7 +15,8 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "53",
+              "version_removed": "100"
             },
             "firefox_android": {
               "version_added": false
@@ -45,7 +46,7 @@
           "status": {
             "experimental": true,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
FF100 has removed the non-standard [Large-Allocation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Large-Allocation) HTTP header in https://bugzilla.mozilla.org/show_bug.cgi?id=1598759. 

I've recorded the removal. As this was the only browser using it, I have also marked the API as deprecated.