### PR TITLE
Add specific engine versions for Safari 15.4

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -201,7 +201,7 @@
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes",
           "status": "current",
           "engine": "WebKit",
-          "engine_version": "613"
+          "engine_version": "613.1.17"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -172,7 +172,7 @@
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes",
           "status": "current",
           "engine": "WebKit",
-          "engine_version": "613"
+          "engine_version": "613.1.17"
         }
       }
     }


### PR DESCRIPTION
This PR adds the minor and patch semver parts to the engine version for Safari 15.4.  The data comes from Safari itself.
