### PR TITLE
Remove revert row from BCD table for all property

### DIFF
--- a/css/properties/all.json
+++ b/css/properties/all.json
@@ -48,54 +48,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "revert": {
-          "__compat": {
-            "description": "<code>revert</code>",
-            "support": {
-              "chrome": {
-                "version_added": "84"
-              },
-              "chrome_android": {
-                "version_added": "84"
-              },
-              "edge": {
-                "version_added": "84"
-              },
-              "firefox": {
-                "version_added": "67"
-              },
-              "firefox_android": {
-                "version_added": "67"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "70"
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": "9.1"
-              },
-              "safari_ios": {
-                "version_added": "9.3"
-              },
-              "samsunginternet_android": {
-                "version_added": "14.0"
-              },
-              "webview_android": {
-                "version_added": "84"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

The [BCD table on `all` property page](https://developer.mozilla.org/en-US/docs/Web/CSS/all#browser_compatibility) also contains a row for `revert` value.

The [BCD table for the global revert value](https://developer.mozilla.org/en-US/docs/Web/CSS/revert#browser_compatibility) is already maintained separately in this file: https://github.com/mdn/browser-compat-data/blob/main/css/types/global_keywords.json

This PR removes the `revert` row from `all` property's BCD table to avoid maintaining the same information in two places.


