### PR TITLE
Updates chrome to version 100

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -687,21 +687,28 @@
         "99": {
           "release_date": "2022-03-01",
           "release_notes": "https://chromereleases.googleblog.com/2022/03/stable-channel-update-for-desktop.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "99"
         },
         "100": {
           "release_date": "2022-03-29",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2022/03/stable-channel-update-for-desktop_29.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "100"
         },
         "101": {
           "release_date": "2022-04-26",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "101"
+        },
+        "102": {
+          "release_date": "2022-05-24",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "102"
         }
       }
     }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -523,21 +523,28 @@
         "99": {
           "release_date": "2022-03-01",
           "release_notes": "https://chromereleases.googleblog.com/2022/03/chrome-for-android-update.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "99"
         },
         "100": {
           "release_date": "2022-03-29",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2022/03/chrome-for-android-update_0283137014.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "100"
         },
         "101": {
           "release_date": "2022-04-26",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "101"
+        },
+        "102": {
+          "release_date": "2022-05-24",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "102"
         }
       }
     }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -488,21 +488,28 @@
         "99": {
           "release_date": "2022-03-01",
           "release_notes": "https://chromereleases.googleblog.com/2022/03/chrome-for-android-update.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "99"
         },
         "100": {
           "release_date": "2022-03-29",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2022/03/chrome-for-android-update_0283137014.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "100"
         },
         "101": {
           "release_date": "2022-04-26",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "101"
+        },
+        "102": {
+          "release_date": "2022-05-24",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "102"
         }
       }
     }


### PR DESCRIPTION
Chrome has updated to version 100.

According to https://chromiumdash.appspot.com/schedule, the release date of Chrome 102 is 24/05/2022.

Fixes #15579.