### PR TITLE
Adds mix-blend-mode: plus-lighter - shipped in Chrome, Firefox, and Safari

### DIFF
--- a/css/properties/mix-blend-mode.json
+++ b/css/properties/mix-blend-mode.json
@@ -49,6 +49,54 @@
             "deprecated": false
           }
         },
+        "plus-lighter": {
+          "__compat": {
+            "description": "plus-lighter",
+            "support": {
+              "chrome": {
+                "version_added": "100"
+              },
+              "chrome_android": {
+                "version_added": "100"
+              },
+              "edge": {
+                "version_added": "100"
+              },
+              "firefox": {
+                "version_added": "99"
+              },
+              "firefox_android": {
+                "version_added": "99"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "9.0"
+              },
+              "safari_ios": {
+                "version_added": "9.0"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "100"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "svg": {
           "__compat": {
             "description": "On SVG elements",

--- a/css/properties/mix-blend-mode.json
+++ b/css/properties/mix-blend-mode.json
@@ -78,10 +78,10 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "9.0"
+                "version_added": "9.1"
               },
               "safari_ios": {
-                "version_added": "9.0"
+                "version_added": "9.3"
               },
               "samsunginternet_android": {
                 "version_added": false


### PR DESCRIPTION
There is a new value for `mix-blend-mode` of `plus-lighter` which has just shipped in Chrome 100, it looks like Firefox 99, and was already in Safari.

- Chrome: https://chromestatus.com/feature/5677338286096384
- Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1746248
- Safari: https://trac.webkit.org/changeset/181191/webkit (WebKit 601.1.22 which maps to Safari 9.0)
