### PR TITLE
hwb() color notation in Chrome 101

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -563,7 +563,7 @@
                 "version_added": "101"
               },
               "edge": {
-                "version_added": false
+                "version_added": "101"
               },
               "firefox": {
                 "version_added": "96"

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -557,10 +557,10 @@
             "spec_url": "https://drafts.csswg.org/css-color/#the-hwb-notation",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "101"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "101"
               },
               "edge": {
                 "version_added": false
@@ -590,11 +590,11 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "101"
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
hwb() color is supported in Chrome Beta (version 101): https://chromestatus.com/feature/5637256860663808

I also updated experimental to false as this has landed in all browsers now.
