### PR TITLE
Adds HIDDevice.forget()

### DIFF
--- a/api/HIDDevice.json
+++ b/api/HIDDevice.json
@@ -146,6 +146,55 @@
           }
         }
       },
+      "forget": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HIDDevice/forget",
+          "spec_url": "https://wicg.github.io/webhid/#dom-hiddevice-forget",
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "inputreport_event": {
         "__compat": {
           "description": "<code>inputreport</code> event",


### PR DESCRIPTION
There is a new `forget()` method for HIDDevice, shipped in Chrome 100 desktop.

https://chromestatus.com/feature/5723581527883776
