### PR TITLE
Safari on iOS does not support ::selection

### DIFF
--- a/css/selectors/selection.json
+++ b/css/selectors/selection.json
@@ -47,7 +47,7 @@
               "version_added": "1.1"
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
#### Summary
Safari on iOS does not support ::selection

#### Test results and supporting details
Verified in iOS Simulator - iPhone 13 - iOS 15.2 using https://quirksmode.org/css/selectors/selection.html

Also corroborated by https://caniuse.com/css-selection
