### PR TITLE
Un-deprecate navigator.platform

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2823,7 +2823,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },


### PR DESCRIPTION
Given the spec change at https://github.com/whatwg/html/pull/7762 we no longer have justification for marking `navigator.platform` as deprecated.

Related MDN change: https://github.com/mdn/content/pull/14452