### PR TITLE
FF100 WebMIDI supported (FF99 backed out)

### DIFF
--- a/api/MIDIAccess.json
+++ b/api/MIDIAccess.json
@@ -16,11 +16,11 @@
           },
           "firefox": [
             {
-              "version_added": "99"
+              "version_added": "100"
             },
             {
               "version_added": "97",
-              "version_removed": "99",
+              "version_removed": "100",
               "flags": [
                 {
                   "type": "preference",
@@ -77,11 +77,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -139,11 +139,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -202,11 +202,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -264,11 +264,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/MIDIConnectionEvent.json
+++ b/api/MIDIConnectionEvent.json
@@ -16,11 +16,11 @@
           },
           "firefox": [
             {
-              "version_added": "99"
+              "version_added": "100"
             },
             {
               "version_added": "97",
-              "version_removed": "99",
+              "version_removed": "100",
               "flags": [
                 {
                   "type": "preference",
@@ -78,11 +78,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -140,11 +140,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/MIDIInput.json
+++ b/api/MIDIInput.json
@@ -16,11 +16,11 @@
           },
           "firefox": [
             {
-              "version_added": "99"
+              "version_added": "100"
             },
             {
               "version_added": "97",
-              "version_removed": "99",
+              "version_removed": "100",
               "flags": [
                 {
                   "type": "preference",
@@ -78,11 +78,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/MIDIInputMap.json
+++ b/api/MIDIInputMap.json
@@ -16,11 +16,11 @@
           },
           "firefox": [
             {
-              "version_added": "99"
+              "version_added": "100"
             },
             {
               "version_added": "97",
-              "version_removed": "99",
+              "version_removed": "100",
               "flags": [
                 {
                   "type": "preference",
@@ -75,11 +75,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -135,11 +135,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -195,11 +195,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -255,11 +255,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -315,11 +315,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -375,11 +375,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -435,11 +435,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/MIDIMessageEvent.json
+++ b/api/MIDIMessageEvent.json
@@ -16,11 +16,11 @@
           },
           "firefox": [
             {
-              "version_added": "99"
+              "version_added": "100"
             },
             {
               "version_added": "97",
-              "version_removed": "99",
+              "version_removed": "100",
               "flags": [
                 {
                   "type": "preference",
@@ -78,11 +78,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -140,11 +140,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/MIDIOutput.json
+++ b/api/MIDIOutput.json
@@ -16,11 +16,11 @@
           },
           "firefox": [
             {
-              "version_added": "99"
+              "version_added": "100"
             },
             {
               "version_added": "97",
-              "version_removed": "99",
+              "version_removed": "100",
               "flags": [
                 {
                   "type": "preference",
@@ -78,11 +78,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -140,11 +140,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/MIDIOutputMap.json
+++ b/api/MIDIOutputMap.json
@@ -16,11 +16,11 @@
           },
           "firefox": [
             {
-              "version_added": "99"
+              "version_added": "100"
             },
             {
               "version_added": "97",
-              "version_removed": "99",
+              "version_removed": "100",
               "flags": [
                 {
                   "type": "preference",
@@ -75,11 +75,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -135,11 +135,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -195,11 +195,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -255,11 +255,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -315,11 +315,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -375,11 +375,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -435,11 +435,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/MIDIPort.json
+++ b/api/MIDIPort.json
@@ -16,11 +16,11 @@
           },
           "firefox": [
             {
-              "version_added": "99"
+              "version_added": "100"
             },
             {
               "version_added": "97",
-              "version_removed": "99",
+              "version_removed": "100",
               "flags": [
                 {
                   "type": "preference",
@@ -77,11 +77,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -139,11 +139,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -201,11 +201,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -263,11 +263,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -325,11 +325,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -387,11 +387,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -449,11 +449,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -512,11 +512,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -574,11 +574,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -636,11 +636,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4934,11 +4934,11 @@
             },
             "firefox": [
               {
-                "version_added": "99"
+                "version_added": "100"
               },
               {
                 "version_added": "97",
-                "version_removed": "99",
+                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -4993,7 +4993,7 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": "99",
+                "version_added": "100",
                 "notes": "Permission must be granted through a <a href='https://extensionworkshop.com/documentation/publish/site-permission-add-on/'>site permission add-on</a>."
               },
               "firefox_android": {


### PR DESCRIPTION
WebMIDI was backed out of FF99 and added to FF100: https://bugzilla.mozilla.org/show_bug.cgi?id=1752906#c30

This updates all the instances.