### PR TITLE
FF100 Supports WriteableStream and ReadableStream.pipeTo()

### DIFF
--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -351,11 +351,24 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "100"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "100",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.pipeTo.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "100"
             },
             "ie": {
               "version_added": false

--- a/api/WritableStream.json
+++ b/api/WritableStream.json
@@ -17,18 +17,24 @@
           "edge": {
             "version_added": "16"
           },
-          "firefox": {
-            "version_added": "99",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.streams.writable_streams.enabled",
-                "value_to_set": "true"
-              }
-            ]
-          },
+          "firefox": [
+            {
+              "version_added": "100"
+            },
+            {
+              "version_added": "99",
+              "version_removed": "100",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.writable_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
-            "version_added": false
+            "version_added": "100"
           },
           "ie": {
             "version_added": false
@@ -83,18 +89,24 @@
             "edge": {
               "version_added": "16"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.writable_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "100"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "100",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.writable_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "100"
             },
             "ie": {
               "version_added": false
@@ -145,18 +157,24 @@
             "edge": {
               "version_added": "16"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.writable_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "100"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "100",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.writable_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "100"
             },
             "ie": {
               "version_added": false
@@ -205,18 +223,24 @@
             "edge": {
               "version_added": "81"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.writable_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "100"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "100",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.writable_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "100"
             },
             "ie": {
               "version_added": false
@@ -267,18 +291,24 @@
             "edge": {
               "version_added": "16"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.writable_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "100"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "100",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.writable_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "100"
             },
             "ie": {
               "version_added": false
@@ -329,18 +359,24 @@
             "edge": {
               "version_added": "16"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.writable_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "100"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "100",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.writable_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "100"
             },
             "ie": {
               "version_added": false

--- a/api/WritableStreamDefaultController.json
+++ b/api/WritableStreamDefaultController.json
@@ -17,18 +17,24 @@
           "edge": {
             "version_added": "16"
           },
-          "firefox": {
-            "version_added": "99",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.streams.writable_streams.enabled",
-                "value_to_set": "true"
-              }
-            ]
-          },
+          "firefox": [
+            {
+              "version_added": "100"
+            },
+            {
+              "version_added": "99",
+              "version_removed": "100",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.writable_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
-            "version_added": false
+            "version_added": "100"
           },
           "ie": {
             "version_added": false
@@ -82,18 +88,24 @@
             "edge": {
               "version_added": "16"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.writable_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "100"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "100",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.writable_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "100"
             },
             "ie": {
               "version_added": false
@@ -144,18 +156,24 @@
             "edge": {
               "version_added": false
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.writable_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "100"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "100",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.writable_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "100"
             },
             "ie": {
               "version_added": false

--- a/api/WritableStreamDefaultWriter.json
+++ b/api/WritableStreamDefaultWriter.json
@@ -17,18 +17,24 @@
           "edge": {
             "version_added": "16"
           },
-          "firefox": {
-            "version_added": "99",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.streams.writable_streams.enabled",
-                "value_to_set": "true"
-              }
-            ]
-          },
+          "firefox": [
+            {
+              "version_added": "100"
+            },
+            {
+              "version_added": "99",
+              "version_removed": "100",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.writable_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
-            "version_added": false
+            "version_added": "100"
           },
           "ie": {
             "version_added": false
@@ -83,18 +89,24 @@
             "edge": {
               "version_added": "16"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.writable_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "100"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "100",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.writable_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "100"
             },
             "ie": {
               "version_added": false
@@ -145,18 +157,24 @@
             "edge": {
               "version_added": "16"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.writable_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "100"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "100",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.writable_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "100"
             },
             "ie": {
               "version_added": false
@@ -207,18 +225,24 @@
             "edge": {
               "version_added": "16"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.writable_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "100"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "100",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.writable_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "100"
             },
             "ie": {
               "version_added": false
@@ -269,18 +293,24 @@
             "edge": {
               "version_added": "16"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.writable_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "100"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "100",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.writable_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "100"
             },
             "ie": {
               "version_added": false
@@ -331,18 +361,24 @@
             "edge": {
               "version_added": "16"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.writable_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "100"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "100",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.writable_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "100"
             },
             "ie": {
               "version_added": false
@@ -393,18 +429,24 @@
             "edge": {
               "version_added": "16"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.writable_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "100"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "100",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.writable_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "100"
             },
             "ie": {
               "version_added": false
@@ -455,18 +497,24 @@
             "edge": {
               "version_added": "16"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.writable_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "100"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "100",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.writable_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "100"
             },
             "ie": {
               "version_added": false
@@ -517,18 +565,24 @@
             "edge": {
               "version_added": "16"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.writable_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "100"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "100",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.writable_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "100"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
FF100 Supports `WriteableStream` and `ReadableStream.pipeTo()` in https://bugzilla.mozilla.org/show_bug.cgi?id=1759597

This adds
- the new version for `WriteableStream` (pref was added for FF99 in  #14948).
-  pref version and new version for  `ReadableStream.pipeTo()` (pref added in FF99 by https://bugzilla.mozilla.org/show_bug.cgi?id=1734241)

Other docs work for this tracked in https://github.com/mdn/content/issues/14408