### PR TITLE
Update text-emphasis properties information

### DIFF
--- a/css/properties/text-emphasis-color.json
+++ b/css/properties/text-emphasis-color.json
@@ -6,18 +6,33 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis-color",
           "spec_url": "https://drafts.csswg.org/css-text-decor/#text-emphasis-color-property",
           "support": {
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": "25"
-            },
-            "chrome_android": {
-              "prefix": "-webkit-",
-              "version_added": "25"
-            },
-            "edge": {
-              "prefix": "-webkit-",
-              "version_added": "79"
-            },
+            "chrome": [
+              {
+                "version_added": "99"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "25"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "99"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "25"
+              }
+            ],
+            "edge": [
+              {
+                "version_added": "99"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "79"
+              }
+            ],
             "firefox": {
               "version_added": "46"
             },

--- a/css/properties/text-emphasis-position.json
+++ b/css/properties/text-emphasis-position.json
@@ -6,18 +6,33 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis-position",
           "spec_url": "https://drafts.csswg.org/css-text-decor/#text-emphasis-position-property",
           "support": {
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": "25"
-            },
-            "chrome_android": {
-              "prefix": "-webkit-",
-              "version_added": "25"
-            },
-            "edge": {
-              "prefix": "-webkit-",
-              "version_added": "79"
-            },
+            "chrome": [
+              {
+                "version_added": "99"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "25"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "99"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "25"
+              }
+            ],
+            "edge": [
+              {
+                "version_added": "99"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "79"
+              }
+            ],
             "firefox": {
               "version_added": "46"
             },

--- a/css/properties/text-emphasis-style.json
+++ b/css/properties/text-emphasis-style.json
@@ -6,18 +6,33 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis-style",
           "spec_url": "https://drafts.csswg.org/css-text-decor/#text-emphasis-style-property",
           "support": {
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": "25"
-            },
-            "chrome_android": {
-              "prefix": "-webkit-",
-              "version_added": "25"
-            },
-            "edge": {
-              "prefix": "-webkit-",
-              "version_added": "79"
-            },
+            "chrome": [
+              {
+                "version_added": "99"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "25"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "99"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "25"
+              }
+            ],
+            "edge": [
+              {
+                "version_added": "99"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "79"
+              }
+            ],
             "firefox": {
               "version_added": "46"
             },

--- a/css/properties/text-emphasis.json
+++ b/css/properties/text-emphasis.json
@@ -6,18 +6,33 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis",
           "spec_url": "https://drafts.csswg.org/css-text-decor/#text-emphasis-property",
           "support": {
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": "25"
-            },
-            "chrome_android": {
-              "prefix": "-webkit-",
-              "version_added": "25"
-            },
-            "edge": {
-              "prefix": "-webkit-",
-              "version_added": "79"
-            },
+            "chrome": [
+              {
+                "version_added": "99"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "25"
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "99"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "25"
+              }
+            ],
+            "edge": [
+              {
+                "version_added": "99"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "79"
+              }
+            ],
             "firefox": {
               "version_added": "46"
             },


### PR DESCRIPTION

#### Summary

Update information about text-emphasis properties which are no longer prefixed in Chromium and Edge.

#### Test results and supporting details

I've tested things in Chrome 99 and Edge 101.

This is the commit that unprefixed them: https://chromiumdash.appspot.com/commit/a0d4ce22e17b2cdc22311d731c8fe9cca9ae3a8e

#### Related issues

See https://github.com/mdn/content/pull/14542
