### PR TITLE
Safari support public static class methods from 9

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -850,10 +850,10 @@
               }
             ],
             "safari": {
-              "version_added": "9.0"
+              "version_added": "9"
             },
             "safari_ios": {
-              "version_added": "9.0"
+              "version_added": "9"
             },
             "samsunginternet_android": [
               {

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -850,10 +850,10 @@
               }
             ],
             "safari": {
-              "version_added": "14.1"
+              "version_added": "9.0"
             },
             "safari_ios": {
-              "version_added": "14.5"
+              "version_added": "9.0"
             },
             "samsunginternet_android": [
               {


### PR DESCRIPTION
#### Summary
Changed initial support of public static class methods for Safari

#### Test results and supporting details
[Test on iOS 9](https://live.browserstack.com/dashboard#os=iOS&os_version=9.0&device_browser=safari&zoom_to_fit=true&full_screen=true&url=https%3A%2F%2Fcodepen.io%2FPonomareVlad%2Fembed%2FgOoXGRx%3Fdefault-tab%3Djs%252Cresult&speed=1&start=true)

[Test on MacOS El Capitan](https://live.browserstack.com/dashboard#os=OS+X&os_version=El+Capitan&browser=Safari&browser_version=9.0&device_browser=safari&zoom_to_fit=true&full_screen=true&resolution=responsive-mode&url=https%3A%2F%2Fcodepen.io%2FPonomareVlad%2Fembed%2FgOoXGRx%3Fdefault-tab%3Djs%252Cresult&speed=1&start=true)