### PR TITLE
Updates edge to version 100

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -189,19 +189,26 @@
         "99": {
           "release_date": "2022-03-03",
           "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-990115030-march-3",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "99"
         },
         "100": {
-          "status": "beta",
+          "release_date": "2022-04-01",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1000118529-april-1",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "100"
         },
         "101": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "101"
+        },
+        "102": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "102"
         }
       }
     }


### PR DESCRIPTION
Hello everyone!

I updated Edge browser to version 100, according to this [release note](https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1000118529-april-1).

Fixes #15634.

😉