### PR TITLE
WebExtensions > menus > overrideContext in FF64

### DIFF
--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -702,6 +702,34 @@
             }
           }
         },
+        "overrideContext": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/overrideContext",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "64"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            }
+          }
+        },
         "getTargetElement": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/getTargetElement",


### PR DESCRIPTION
FF64 added support for Web Extensions > [menus.overrideContext()](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus/overrideContext) - see https://blog.mozilla.org/addons/2018/11/08/extensions-in-firefox-64/#cm

I can't find evidence this is supported on other browsers. This follows the pattern of the other functions which were added in FF63

This is part of fixing #14562