### PR TITLE
Remove irrelevant Chromium flag data for JavaScript classes

### DIFF
--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -13,17 +13,6 @@
               "version_removed": "49",
               "version_added": "42",
               "notes": "Strict mode is required."
-            },
-            {
-              "version_removed": "49",
-              "version_added": "42",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental JavaScript",
-                  "value_to_set": "Enabled"
-                }
-              ]
             }
           ],
           "chrome_android": [
@@ -34,17 +23,6 @@
               "version_removed": "49",
               "version_added": "42",
               "notes": "Strict mode is required."
-            },
-            {
-              "version_removed": "49",
-              "version_added": "42",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental JavaScript",
-                  "value_to_set": "Enabled"
-                }
-              ]
             }
           ],
           "deno": {
@@ -93,17 +71,6 @@
               "version_removed": "36",
               "version_added": "29",
               "notes": "Strict mode is required."
-            },
-            {
-              "version_removed": "36",
-              "version_added": "29",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental JavaScript",
-                  "value_to_set": "Enabled"
-                }
-              ]
             }
           ],
           "opera_android": [
@@ -114,17 +81,6 @@
               "version_removed": "36",
               "version_added": "29",
               "notes": "Strict mode is required."
-            },
-            {
-              "version_removed": "36",
-              "version_added": "29",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "Experimental JavaScript",
-                  "value_to_set": "Enabled"
-                }
-              ]
             }
           ],
           "safari": {
@@ -173,17 +129,6 @@
                 "version_removed": "49",
                 "version_added": "42",
                 "notes": "Strict mode is required."
-              },
-              {
-                "version_removed": "49",
-                "version_added": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental JavaScript",
-                    "value_to_set": "Enabled"
-                  }
-                ]
               }
             ],
             "chrome_android": [
@@ -194,17 +139,6 @@
                 "version_removed": "49",
                 "version_added": "42",
                 "notes": "Strict mode is required."
-              },
-              {
-                "version_removed": "49",
-                "version_added": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental JavaScript",
-                    "value_to_set": "Enabled"
-                  }
-                ]
               }
             ],
             "deno": {
@@ -253,17 +187,6 @@
                 "version_removed": "36",
                 "version_added": "29",
                 "notes": "Strict mode is required."
-              },
-              {
-                "version_removed": "36",
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental JavaScript",
-                    "value_to_set": "Enabled"
-                  }
-                ]
               }
             ],
             "opera_android": [
@@ -274,17 +197,6 @@
                 "version_removed": "36",
                 "version_added": "29",
                 "notes": "Strict mode is required."
-              },
-              {
-                "version_removed": "36",
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental JavaScript",
-                    "value_to_set": "Enabled"
-                  }
-                ]
               }
             ],
             "safari": {
@@ -334,17 +246,6 @@
                 "version_removed": "49",
                 "version_added": "42",
                 "notes": "Strict mode is required."
-              },
-              {
-                "version_removed": "49",
-                "version_added": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental JavaScript",
-                    "value_to_set": "Enabled"
-                  }
-                ]
               }
             ],
             "chrome_android": [
@@ -355,17 +256,6 @@
                 "version_removed": "49",
                 "version_added": "42",
                 "notes": "Strict mode is required."
-              },
-              {
-                "version_removed": "49",
-                "version_added": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental JavaScript",
-                    "value_to_set": "Enabled"
-                  }
-                ]
               }
             ],
             "deno": {
@@ -414,17 +304,6 @@
                 "version_removed": "36",
                 "version_added": "29",
                 "notes": "Strict mode is required."
-              },
-              {
-                "version_removed": "36",
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental JavaScript",
-                    "value_to_set": "Enabled"
-                  }
-                ]
               }
             ],
             "opera_android": [
@@ -435,17 +314,6 @@
                 "version_removed": "36",
                 "version_added": "29",
                 "notes": "Strict mode is required."
-              },
-              {
-                "version_removed": "36",
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental JavaScript",
-                    "value_to_set": "Enabled"
-                  }
-                ]
               }
             ],
             "safari": {
@@ -735,17 +603,6 @@
                 "version_removed": "49",
                 "version_added": "42",
                 "notes": "Strict mode is required."
-              },
-              {
-                "version_removed": "49",
-                "version_added": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental JavaScript",
-                    "value_to_set": "Enabled"
-                  }
-                ]
               }
             ],
             "chrome_android": [
@@ -756,17 +613,6 @@
                 "version_removed": "49",
                 "version_added": "42",
                 "notes": "Strict mode is required."
-              },
-              {
-                "version_removed": "49",
-                "version_added": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental JavaScript",
-                    "value_to_set": "Enabled"
-                  }
-                ]
               }
             ],
             "deno": {
@@ -815,17 +661,6 @@
                 "version_removed": "36",
                 "version_added": "29",
                 "notes": "Strict mode is required."
-              },
-              {
-                "version_removed": "36",
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental JavaScript",
-                    "value_to_set": "Enabled"
-                  }
-                ]
               }
             ],
             "opera_android": [
@@ -836,17 +671,6 @@
                 "version_removed": "36",
                 "version_added": "29",
                 "notes": "Strict mode is required."
-              },
-              {
-                "version_removed": "36",
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental JavaScript",
-                    "value_to_set": "Enabled"
-                  }
-                ]
               }
             ],
             "safari": {

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -258,17 +258,6 @@
                 "version_removed": "49",
                 "version_added": "42",
                 "notes": "Strict mode is required."
-              },
-              {
-                "version_removed": "49",
-                "version_added": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental JavaScript",
-                    "value_to_set": "Enabled"
-                  }
-                ]
               }
             ],
             "chrome_android": [
@@ -279,17 +268,6 @@
                 "version_removed": "49",
                 "version_added": "42",
                 "notes": "Strict mode is required."
-              },
-              {
-                "version_removed": "49",
-                "version_added": "42",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental JavaScript",
-                    "value_to_set": "Enabled"
-                  }
-                ]
               }
             ],
             "deno": {
@@ -318,17 +296,6 @@
                 "version_removed": "36",
                 "version_added": "29",
                 "notes": "Strict mode is required."
-              },
-              {
-                "version_removed": "36",
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental JavaScript",
-                    "value_to_set": "Enabled"
-                  }
-                ]
               }
             ],
             "opera_android": [
@@ -339,17 +306,6 @@
                 "version_removed": "36",
                 "version_added": "29",
                 "notes": "Strict mode is required."
-              },
-              {
-                "version_removed": "36",
-                "version_added": "29",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Experimental JavaScript",
-                    "value_to_set": "Enabled"
-                  }
-                ]
               }
             ],
             "safari": {


### PR DESCRIPTION
This PR removes irrelevant flag data for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for JavaScript classes as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).
