### PR TITLE
FF100 AbortSignal.timeout() supported

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -387,6 +387,61 @@
             "deprecated": false
           }
         }
+      },
+      "timeout": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortSignal/timeout",
+          "spec_url": "https://dom.spec.whatwg.org/#dom-abortsignal-timeout",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "deno": {
+              "version_added": "1.20"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "100"
+            },
+            "firefox_android": {
+              "version_added": "100"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "98"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -391,7 +391,7 @@
       "timeout": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortSignal/timeout",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-abortsignal-timeout",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-abortsignal-timeout①",
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
`AbortSignal.timeout` was recently added to the spec. 
- FF100 added it in https://bugzilla.mozilla.org/show_bug.cgi?id=1753309
- Deno reports it in release notes for 1.20: https://deno.com/blog/v1.20#support-for-abortsignaltimeoutms
- Chrome shows not yet implemented here: https://chromestatus.com/feature/5768400507764736 (also tested using https://wpt.live/dom/abort/abort-signal-timeout.html on browserstack)
- No signal for Safari
- Not sure about Node. The intent is there, but no clear signal - e.g. this one is closed: https://github.com/nodejs/node/pull/40899
I've marked as not experimental since their are two implementations, and intent from Chromium.

Other docs work for this can be followed in https://github.com/mdn/content/issues/14641