### PR TITLE
Update SensorErrorEvent»error spec URL

### DIFF
--- a/api/SensorErrorEvent.json
+++ b/api/SensorErrorEvent.json
@@ -101,7 +101,7 @@
       "error": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SensorErrorEvent/error",
-          "spec_url": "https://w3c.github.io/sensors/#sensor-error-event-error",
+          "spec_url": "https://w3c.github.io/sensors/#dom-sensorerrorevent-error",
           "support": {
             "chrome": {
               "version_added": "67"


### PR DESCRIPTION
https://github.com/w3c/sensors/pull/430 caused the generated ID for `SensorErrorEvent»error` to change.