### PR TITLE
Bumping firefox versions - current is 99

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -708,23 +708,30 @@
         "98": {
           "release_date": "2022-03-08",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/98",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "98"
         },
         "99": {
           "release_date": "2022-04-05",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/99",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "99"
         },
         "100": {
           "release_date": "2022-05-03",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/100",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "100"
+        },
+        "101": {
+          "release_date": "2022-05-31",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/101",
+          "status": "nightly",
+          "engine": "Gecko",
+          "engine_version": "101"
         }
       }
     }

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -574,23 +574,30 @@
         "98": {
           "release_date": "2022-03-08",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/98",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "98"
         },
         "99": {
           "release_date": "2022-04-05",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/99",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "99"
         },
         "100": {
           "release_date": "2022-05-03",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/100",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "100"
+        },
+        "101": {
+          "release_date": "2022-05-31",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/101",
+          "status": "nightly",
+          "engine": "Gecko",
+          "engine_version": "101"
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Firefox 99 is released tonight - so bumping versions.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

Tests pass

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
