### PR TITLE
Remove irrelevant Firefox Android flag data for HTML dialog Element

### DIFF
--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -29,22 +29,9 @@
               ]
             }
           ],
-          "firefox_android": [
-            {
-              "version_added": "98"
-            },
-            {
-              "version_added": "53",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.dialog_element.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox_android": {
+            "version_added": "98"
+          },
           "ie": {
             "version_added": false
           },
@@ -164,22 +151,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "98"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.dialog_element.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "98"
+            },
             "ie": {
               "version_added": false
             },
@@ -288,22 +262,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "98"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.dialog_element.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "98"
+            },
             "ie": {
               "version_added": false
             },
@@ -362,22 +323,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "98"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.dialog_element.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "98"
+            },
             "ie": {
               "version_added": false
             },
@@ -436,22 +384,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "98"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.dialog_element.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "98"
+            },
             "ie": {
               "version_added": false
             },
@@ -510,22 +445,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "98"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.dialog_element.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "98"
+            },
             "ie": {
               "version_added": false
             },

--- a/html/elements/dialog.json
+++ b/html/elements/dialog.json
@@ -30,22 +30,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "98"
-              },
-              {
-                "version_added": "53",
-                "version_removed": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.dialog_element.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "98"
+            },
             "ie": {
               "version_added": false
             },
@@ -101,22 +88,9 @@
                   ]
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "98"
-                },
-                {
-                  "version_added": "53",
-                  "version_removed": "79",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.dialog_element.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox_android": {
+                "version_added": "98"
+              },
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox Android for the `dialog` HTML element and the `HTMLDialogElement` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/queengooborg/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
