### PR TITLE
FF82 CSS counter-reset spec fix

### DIFF
--- a/css/properties/counter-reset.json
+++ b/css/properties/counter-reset.json
@@ -44,6 +44,38 @@
             "deprecated": false
           }
         },
+        "reset_does_not_affect_siblings": {
+          "__compat": {
+            "description": "Resets counter on current element (not sibling elements).",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "82"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "reversed": {
           "__compat": {
             "description": "<code>reversed()</code>",
@@ -75,56 +107,6 @@
               "experimental": true,
               "standard_track": true,
               "deprecated": false
-            }
-          }
-        },
-        "use_reset_for_siblings": {
-          "__compat": {
-            "description": "Reset counter used instead of ancestor for subsequent sibling elements.",
-            "support": {
-              "chrome": {
-                "version_added": "2"
-              },
-              "chrome_android": {
-                "version_added": "18"
-              },
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1",
-                "version_removed": "82"
-              },
-              "firefox_android": {
-                "version_added": "25",
-                "version_removed": "82"
-              },
-              "ie": {
-                "version_added": "8"
-              },
-              "opera": {
-                "version_added": "9.2"
-              },
-              "opera_android": {
-                "version_added": "10.1"
-              },
-              "safari": {
-                "version_added": "3"
-              },
-              "safari_ios": {
-                "version_added": "1"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0"
-              },
-              "webview_android": {
-                "version_added": "1"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         }

--- a/css/properties/counter-reset.json
+++ b/css/properties/counter-reset.json
@@ -77,6 +77,56 @@
               "deprecated": false
             }
           }
+        },
+        "use_reset_for_siblings": {
+          "__compat": {
+            "description": "Reset counter used instead of ancestor for subsequent sibling elements.",
+            "support": {
+              "chrome": {
+                "version_added": "2"
+              },
+              "chrome_android": {
+                "version_added": "18"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1",
+                "version_removed": "82"
+              },
+              "firefox_android": {
+                "version_added": "25",
+                "version_removed": "82"
+              },
+              "ie": {
+                "version_added": "8"
+              },
+              "opera": {
+                "version_added": "9.2"
+              },
+              "opera_android": {
+                "version_added": "10.1"
+              },
+              "safari": {
+                "version_added": "3"
+              },
+              "safari_ios": {
+                "version_added": "1"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.0"
+              },
+              "webview_android": {
+                "version_added": "1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
[`counter-reset`](https://developer.mozilla.org/en-US/docs/Web/CSS/counter-reset) has this example on the top. The results from Chrome, Firebox 81 and earlier, and everything else are on the left, the results from Firefox 82 are on the right.

![image](https://user-images.githubusercontent.com/5368500/161662266-e769b887-bfea-47d8-962d-f021969450b4.png)

All of those chapters are h2 headings, and the `counter-reset` is applied to the second chapter "The pool of tears". In the context of just this example you'd think that the Chrome was correct and that the subsequent items should follow the siblings, but in fact it is in violation of spec.

The reason is that each element gets a copy of the counter(s) of it's ancestors "first" if a counter is not explicitly applied. When you call `counter-reset` on an element you reset the counter on that specific element (create a new counter), not on every other (subsequent) elements ([from comment in bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1718070#c7)).
So while the selected counter should change, the other siblings keep their original counter.

This might seem odd, but normally you'd call `counter-reset` on the parent, not on some arbitrary element mid way through. 

To get the more intuitive behaviour we're seeing in chrome you could call `counter-set`. My understanding is that this would set the counter on the element and on all subsequent elements in the same scope, though I could be wrong [ @MatsPalmgren could you confirm all that? i.e. both counter-reset and set statements ]

Anyway, as this is a spec fix I have done this as a "negative subfeature", meaning that `use_reset_for_siblings` has been added as a deprecated subfeature that reflects the non-spec behaviour from the first version. This is still supported by Chrome et al, but Firefox has version_removed from FF82. Eventually all things should match the spec, and this would eventually be removed. 
I called this `use_reset_for_siblings` which I hope is a reasonable name for the bad behaviour, with description "Reset counter used instead of ancestor for subsequent sibling elements."`, Maybe better name would be "counter_reset_affects_siblings"?

FYI
1. This follows on from https://github.com/mdn/content/pull/13513 - I want to confirm that I have the problem well understood before I review and update that.
2. The example used in image above is also problematic and a fix has been proposed by Mats in https://github.com/mdn/content/issues/6277. I'll get to that eventually. 

@ddbeck Thoughts? I really want @MatsPalmgren advice too. This is an ongoing source of confusion.
