### PR TITLE
FF100 supports WebAssembly.Tag and .Exception

### DIFF
--- a/javascript/builtins/webassembly/Exception.json
+++ b/javascript/builtins/webassembly/Exception.json
@@ -19,12 +19,38 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox": [
+                {
+                  "version_added": "100"
+                },
+                {
+                  "version_added": "98",
+                  "version_removed": "100",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.wasm_exceptions",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "100"
+                },
+                {
+                  "version_added": "98",
+                  "version_removed": "100",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.wasm_exceptions",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -74,12 +100,38 @@
                 "edge": {
                   "version_added": false
                 },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
+                "firefox": [
+                  {
+                    "version_added": "100"
+                  },
+                  {
+                    "version_added": "98",
+                    "version_removed": "100",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "javascript.options.wasm_exceptions",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
+                "firefox_android": [
+                  {
+                    "version_added": "100"
+                  },
+                  {
+                    "version_added": "98",
+                    "version_removed": "100",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "javascript.options.wasm_exceptions",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
                 "ie": {
                   "version_added": false
                 },
@@ -129,12 +181,38 @@
                 "edge": {
                   "version_added": false
                 },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
+                "firefox": [
+                  {
+                    "version_added": "100"
+                  },
+                  {
+                    "version_added": "98",
+                    "version_removed": "100",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "javascript.options.wasm_exceptions",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
+                "firefox_android": [
+                  {
+                    "version_added": "100"
+                  },
+                  {
+                    "version_added": "98",
+                    "version_removed": "100",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "javascript.options.wasm_exceptions",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
                 "ie": {
                   "version_added": false
                 },
@@ -184,12 +262,38 @@
                 "edge": {
                   "version_added": false
                 },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
+                "firefox": [
+                  {
+                    "version_added": "100"
+                  },
+                  {
+                    "version_added": "98",
+                    "version_removed": "100",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "javascript.options.wasm_exceptions",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
+                "firefox_android": [
+                  {
+                    "version_added": "100"
+                  },
+                  {
+                    "version_added": "98",
+                    "version_removed": "100",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "javascript.options.wasm_exceptions",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
                 "ie": {
                   "version_added": false
                 },

--- a/javascript/builtins/webassembly/Tag.json
+++ b/javascript/builtins/webassembly/Tag.json
@@ -19,12 +19,38 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox": [
+                {
+                  "version_added": "100"
+                },
+                {
+                  "version_added": "98",
+                  "version_removed": "100",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.wasm_exceptions",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "100"
+                },
+                {
+                  "version_added": "98",
+                  "version_removed": "100",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.wasm_exceptions",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -74,12 +100,38 @@
                 "edge": {
                   "version_added": false
                 },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
+                "firefox": [
+                  {
+                    "version_added": "100"
+                  },
+                  {
+                    "version_added": "98",
+                    "version_removed": "100",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "javascript.options.wasm_exceptions",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
+                "firefox_android": [
+                  {
+                    "version_added": "100"
+                  },
+                  {
+                    "version_added": "98",
+                    "version_removed": "100",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "javascript.options.wasm_exceptions",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
                 "ie": {
                   "version_added": false
                 },
@@ -129,12 +181,38 @@
                 "edge": {
                   "version_added": false
                 },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
+                "firefox": [
+                  {
+                    "version_added": "100"
+                  },
+                  {
+                    "version_added": "98",
+                    "version_removed": "100",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "javascript.options.wasm_exceptions",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
+                "firefox_android": [
+                  {
+                    "version_added": "100"
+                  },
+                  {
+                    "version_added": "98",
+                    "version_removed": "100",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "javascript.options.wasm_exceptions",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
                 "ie": {
                   "version_added": false
                 },


### PR DESCRIPTION
FF100 supports `WebAssembly.Tag` and `WebAssembly.Exception` 
- went to nightly in FF98 behind pref https://bugzilla.mozilla.org/show_bug.cgi?id=1750040
- shipped FF100 https://bugzilla.mozilla.org/show_bug.cgi?id=1759217
- meta bug on feature https://bugzilla.mozilla.org/show_bug.cgi?id=1695715

Very pleased Safari got in first :-) https://github.com/mdn/browser-compat-data/pull/14910

Docs work associated with this can be tracked in https://github.com/mdn/content/issues/14392