### PR TITLE
content-visibility update - No support in Safari

### DIFF
--- a/css/properties/content-visibility.json
+++ b/css/properties/content-visibility.json
@@ -31,10 +31,10 @@
               "version_added": "60"
             },
             "safari": {
-              "version_added": "15.4"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "15.4"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "14.0"


### PR DESCRIPTION
#### Summary
Removing the suggested support of the content-visibility CSS property for Safari and Safari iOS as it is not yet supported.

#### Test results and supporting details
Tested manually on Safari 15.4 on Mac and iOS Safari 15.4 on real device and XCode simulator using the Safari WebInspector ("devtools").

**Supporting information**: See also in caniuse: https://caniuse.com/css-content-visibility