### PR TITLE
Mirror Samsung Internet April 2022

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -96,7 +96,7 @@
               "version_added": "15"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "93"

--- a/api/AudioData.json
+++ b/api/AudioData.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "17.0"
           },
           "webview_android": {
             "version_added": "94"
@@ -85,7 +85,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -134,7 +134,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -183,7 +183,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -232,7 +232,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -281,7 +281,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -330,7 +330,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -379,7 +379,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -428,7 +428,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -477,7 +477,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -526,7 +526,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -575,7 +575,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/api/AudioDecoder.json
+++ b/api/AudioDecoder.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "17.0"
           },
           "webview_android": {
             "version_added": "94"
@@ -85,7 +85,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -134,7 +134,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -183,7 +183,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -232,7 +232,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -281,7 +281,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -330,7 +330,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -378,7 +378,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -427,7 +427,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -476,7 +476,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/api/AudioEncoder.json
+++ b/api/AudioEncoder.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "17.0"
           },
           "webview_android": {
             "version_added": "94"
@@ -85,7 +85,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -134,7 +134,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -183,7 +183,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -232,7 +232,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -281,7 +281,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -329,7 +329,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -377,7 +377,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -426,7 +426,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -475,7 +475,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/api/EncodedAudioChunk.json
+++ b/api/EncodedAudioChunk.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "17.0"
           },
           "webview_android": {
             "version_added": "94"
@@ -85,7 +85,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -134,7 +134,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -183,7 +183,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -232,7 +232,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -281,7 +281,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -330,7 +330,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/api/EncodedVideoChunk.json
+++ b/api/EncodedVideoChunk.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "17.0"
           },
           "webview_android": {
             "version_added": "94"
@@ -85,7 +85,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -134,7 +134,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -183,7 +183,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -232,7 +232,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -281,7 +281,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -330,7 +330,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/api/HTMLMetaElement.json
+++ b/api/HTMLMetaElement.json
@@ -179,7 +179,7 @@
               "version_added": "15"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "93"

--- a/api/IdleDetector.json
+++ b/api/IdleDetector.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "17.0"
           },
           "webview_android": {
             "version_added": "94"
@@ -85,7 +85,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -135,7 +135,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -184,7 +184,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -233,7 +233,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -282,7 +282,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -331,7 +331,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -133,7 +133,7 @@
               "version_added": "15.2"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "16.0"
             },
             "webview_android": {
               "version_added": "92"

--- a/api/ImageDecoder.json
+++ b/api/ImageDecoder.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "17.0"
           },
           "webview_android": {
             "version_added": "94"
@@ -85,7 +85,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -134,7 +134,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -183,7 +183,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -232,7 +232,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -280,7 +280,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -328,7 +328,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -377,7 +377,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -426,7 +426,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -473,7 +473,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/api/ImageTrack.json
+++ b/api/ImageTrack.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "17.0"
           },
           "webview_android": {
             "version_added": "94"
@@ -84,7 +84,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -133,7 +133,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -182,7 +182,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -231,7 +231,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/api/ImageTrackList.json
+++ b/api/ImageTrackList.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "17.0"
           },
           "webview_android": {
             "version_added": "94"
@@ -84,7 +84,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -133,7 +133,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -182,7 +182,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -231,7 +231,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/api/Ink.json
+++ b/api/Ink.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "17.0"
           },
           "webview_android": {
             "version_added": "94"
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -287,7 +287,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": false
@@ -335,7 +335,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/MediaStreamTrackGenerator.json
+++ b/api/MediaStreamTrackGenerator.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "17.0"
           },
           "webview_android": {
             "version_added": "94"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/api/MediaStreamTrackProcessor.json
+++ b/api/MediaStreamTrackProcessor.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "17.0"
           },
           "webview_android": {
             "version_added": "94"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1849,7 +1849,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -2713,7 +2713,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -5742,7 +5742,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "15.0"
             },
             "webview_android": {
               "version_added": false,
@@ -5789,7 +5789,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "15.0"
               },
               "webview_android": {
                 "version_added": false
@@ -6030,7 +6030,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/api/NavigatorUAData.json
+++ b/api/NavigatorUAData.json
@@ -227,7 +227,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": false
@@ -275,7 +275,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/Profiler.json
+++ b/api/Profiler.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "17.0"
           },
           "webview_android": {
             "version_added": "94"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -179,7 +179,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -227,7 +227,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/api/Scheduler.json
+++ b/api/Scheduler.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "17.0"
           },
           "webview_android": {
             "version_added": "94"
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/api/TaskController.json
+++ b/api/TaskController.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "17.0"
           },
           "webview_android": {
             "version_added": "94"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/api/TaskPriorityChangeEvent.json
+++ b/api/TaskPriorityChangeEvent.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "17.0"
           },
           "webview_android": {
             "version_added": "94"
@@ -83,7 +83,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/api/TaskSignal.json
+++ b/api/TaskSignal.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "17.0"
           },
           "webview_android": {
             "version_added": "94"
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -134,7 +134,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/api/VideoColorSpace.json
+++ b/api/VideoColorSpace.json
@@ -36,7 +36,7 @@
             "version_added": "15.4"
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "17.0"
           },
           "webview_android": {
             "version_added": "94"
@@ -85,7 +85,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -134,7 +134,7 @@
               "version_added": "15.4"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -183,7 +183,7 @@
               "version_added": "15.4"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -232,7 +232,7 @@
               "version_added": "15.4"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -281,7 +281,7 @@
               "version_added": "15.4"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -330,7 +330,7 @@
               "version_added": "15.4"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/api/VideoDecoder.json
+++ b/api/VideoDecoder.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "17.0"
           },
           "webview_android": {
             "version_added": "94"
@@ -85,7 +85,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -134,7 +134,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -183,7 +183,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -232,7 +232,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -281,7 +281,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -330,7 +330,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -378,7 +378,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -427,7 +427,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -476,7 +476,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/api/VideoEncoder.json
+++ b/api/VideoEncoder.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "17.0"
           },
           "webview_android": {
             "version_added": "94"
@@ -85,7 +85,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -134,7 +134,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -183,7 +183,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -232,7 +232,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -281,7 +281,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -329,7 +329,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -377,7 +377,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -426,7 +426,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -475,7 +475,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/api/VideoFrame.json
+++ b/api/VideoFrame.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "17.0"
           },
           "webview_android": {
             "version_added": "94"
@@ -85,7 +85,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -134,7 +134,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -183,7 +183,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -232,7 +232,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -281,7 +281,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -330,7 +330,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -379,7 +379,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -428,7 +428,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -476,7 +476,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -525,7 +525,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -574,7 +574,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -623,7 +623,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -672,7 +672,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -721,7 +721,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -770,7 +770,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/api/VirtualKeyboard.json
+++ b/api/VirtualKeyboard.json
@@ -35,7 +35,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "17.0"
           },
           "webview_android": {
             "version_added": "94"
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -131,7 +131,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -179,7 +179,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -227,7 +227,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"
@@ -275,7 +275,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -1096,7 +1096,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "15.0"
             },
             "webview_android": {
               "version_added": false,

--- a/api/XRAnchorSet.json
+++ b/api/XRAnchorSet.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "14.0"
           },
           "webview_android": {
             "version_added": false
@@ -82,7 +82,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "14.0"
             },
             "webview_android": {
               "version_added": false
@@ -129,7 +129,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "14.0"
             },
             "webview_android": {
               "version_added": false
@@ -176,7 +176,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "14.0"
             },
             "webview_android": {
               "version_added": false
@@ -223,7 +223,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "14.0"
             },
             "webview_android": {
               "version_added": false
@@ -270,7 +270,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "14.0"
             },
             "webview_android": {
               "version_added": false
@@ -317,7 +317,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "14.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/XRCPUDepthInformation.json
+++ b/api/XRCPUDepthInformation.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "15.0"
           },
           "webview_android": {
             "version_added": false
@@ -84,7 +84,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "15.0"
             },
             "webview_android": {
               "version_added": false
@@ -133,7 +133,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "15.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/XRDepthInformation.json
+++ b/api/XRDepthInformation.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "15.0"
           },
           "webview_android": {
             "version_added": false
@@ -84,7 +84,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "15.0"
             },
             "webview_android": {
               "version_added": false
@@ -133,7 +133,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "15.0"
             },
             "webview_android": {
               "version_added": false
@@ -182,7 +182,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "15.0"
             },
             "webview_android": {
               "version_added": false
@@ -231,7 +231,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "15.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/XRFrame.json
+++ b/api/XRFrame.json
@@ -84,7 +84,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "14.0"
             },
             "webview_android": {
               "version_added": false
@@ -133,7 +133,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "15.0"
             },
             "webview_android": {
               "version_added": false
@@ -280,7 +280,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "15.0"
             },
             "webview_android": {
               "version_added": false
@@ -478,7 +478,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "14.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/XRHitTestResult.json
+++ b/api/XRHitTestResult.json
@@ -84,7 +84,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "14.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/XRLayer.json
+++ b/api/XRLayer.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "14.0"
           },
           "webview_android": {
             "version_added": "84"

--- a/api/XRSession.json
+++ b/api/XRSession.json
@@ -134,7 +134,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "15.0"
             },
             "webview_android": {
               "version_added": false
@@ -183,7 +183,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "15.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/XRWebGLBinding.json
+++ b/api/XRWebGLBinding.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "15.0"
           },
           "webview_android": {
             "version_added": false
@@ -85,7 +85,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "15.0"
             },
             "webview_android": {
               "version_added": false
@@ -134,7 +134,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "15.0"
             },
             "webview_android": {
               "version_added": false
@@ -183,7 +183,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "15.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/XRWebGLDepthInformation.json
+++ b/api/XRWebGLDepthInformation.json
@@ -36,7 +36,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "15.0"
           },
           "webview_android": {
             "version_added": false
@@ -84,7 +84,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "15.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/_globals/reportError.json
+++ b/api/_globals/reportError.json
@@ -3,7 +3,7 @@
     "reportError": {
       "__compat": {
         "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#runtime-script-errors",
-        "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/reportError",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/reportError",
         "support": {
           "chrome": {
             "version_added": "95"

--- a/api/_globals/reportError.json
+++ b/api/_globals/reportError.json
@@ -3,6 +3,7 @@
     "reportError": {
       "__compat": {
         "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#runtime-script-errors",
+        "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/reportError",
         "support": {
           "chrome": {
             "version_added": "95"
@@ -41,7 +42,7 @@
             "version_added": "15.4"
           },
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "17.0"
           },
           "webview_android": {
             "version_added": "95"
@@ -94,7 +95,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "95"

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -213,6 +213,12 @@
           "status": "current",
           "engine": "Blink",
           "engine_version": "92"
+        },
+        "17.0": {
+          "release_date": "2022-03-26",
+          "status": "beta",
+          "engine": "Blink",
+          "engine_version": "96"
         }
       }
     }

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1428,7 +1428,7 @@
                 "version_added": "14.5"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "17.0"
               },
               "webview_android": {
                 "version_added": "96"

--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -90,7 +90,7 @@
               "version_added": "15.4"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "93"

--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -244,8 +244,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "17.0"
                 },
                 "webview_android": {
                   "version_added": "93"
@@ -400,8 +399,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "17.0"
                 },
                 "webview_android": {
                   "version_added": "93"

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -214,7 +214,7 @@
                   "version_added": "9"
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "17.0"
                 },
                 "webview_android": {
                   "version_added": "93"
@@ -320,8 +320,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "17.0"
                 },
                 "webview_android": {
                   "version_added": "93"

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -261,7 +261,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "17.0"
                 },
                 "webview_android": {
                   "version_added": "93"
@@ -367,8 +367,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "17.0"
                 },
                 "webview_android": {
                   "version_added": "93"

--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -374,7 +374,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "17.0"
                 },
                 "webview_android": {
                   "version_added": false
@@ -448,7 +448,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "17.0"
                 },
                 "webview_android": {
                   "version_added": false
@@ -522,7 +522,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "17.0"
                 },
                 "webview_android": {
                   "version_added": false
@@ -596,7 +596,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "17.0"
                 },
                 "webview_android": {
                   "version_added": false

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -219,7 +219,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "17.0"
               },
               "webview_android": {
                 "version_added": "94"
@@ -279,7 +279,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "17.0"
               },
               "webview_android": {
                 "version_added": "94"
@@ -338,7 +338,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "17.0"
               },
               "webview_android": {
                 "version_added": "94"
@@ -397,7 +397,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "17.0"
               },
               "webview_android": {
                 "version_added": "94"

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -167,8 +167,7 @@
                   "version_added": "9"
                 },
                 "samsunginternet_android": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "17.0"
                 },
                 "webview_android": {
                   "version_added": "93"
@@ -322,8 +321,7 @@
                   "version_added": false
                 },
                 "samsunginternet_android": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "17.0"
                 },
                 "webview_android": {
                   "version_added": "93"

--- a/css/properties/scrollbar-gutter.json
+++ b/css/properties/scrollbar-gutter.json
@@ -63,7 +63,7 @@
               "notes": "See <a href='https://webkit.org/b/167335'>bug 167335</a>."
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -83,7 +83,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "15.0"
               },
               "webview_android": {
                 "version_added": "90"

--- a/html/manifest/display_override.json
+++ b/html/manifest/display_override.json
@@ -37,7 +37,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "15.0"
             },
             "webview_android": {
               "version_added": false

--- a/html/manifest/protocol_handlers.json
+++ b/html/manifest/protocol_handlers.json
@@ -37,7 +37,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": false
@@ -85,7 +85,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "17.0"
               },
               "webview_android": {
                 "version_added": false
@@ -134,7 +134,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "17.0"
               },
               "webview_android": {
                 "version_added": false

--- a/http/headers/cross-origin-embedder-policy.json
+++ b/http/headers/cross-origin-embedder-policy.json
@@ -84,7 +84,7 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "17.0"
               },
               "webview_android": {
                 "version_added": "96"

--- a/http/headers/sec-ch-ua-bitness.json
+++ b/http/headers/sec-ch-ua-bitness.json
@@ -38,7 +38,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "93"

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -260,7 +260,7 @@
                   "version_added": "15"
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "17.0"
                 },
                 "webview_android": {
                   "version_added": "93"
@@ -315,7 +315,7 @@
                 "version_added": "15"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "17.0"
               },
               "webview_android": {
                 "version_added": "93"

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -1020,7 +1020,7 @@
                 "version_added": "15.4"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "17.0"
               },
               "webview_android": {
                 "version_added": "93"

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -982,7 +982,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
               "version_added": "94"


### PR DESCRIPTION
#### Summary
Mirroring Samsung Internet, this includes the new 17.0 beta.

#### Test results and supporting details
This was generated from the mirror script.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
