### PR TITLE
Update governance peers and owners lists

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -61,7 +61,6 @@ It is important to recognize that being a Peer is a privilege, not a right. That
 - Michael Smith (@sideshowbarker), W3C
 - Philip Jägenstedt (@foolip), Google
 - Richard Bloor (@rebloor)
-- Vinyl Da.i'gyu (@queengooborg)
 - Will Bamberg (@wbamberg), Open Web Docs
 
 A Peer who shows an above-average level of contribution to the project, particularly with respect to its strategic direction and long-term health, may be nominated to become an Owner, described below.
@@ -105,6 +104,7 @@ An individual is invited to become an Owner by existing Owners. A nomination wil
 - Daniel Beck (@ddbeck)
 - Florian Scholz (@Elchi3), Open Web Docs
 - Ruth John (@Rumyra), Mozilla
+- Vinyl Da.i'gyu (@queengooborg)
 
 ## Additional paths to becoming a Peer or Owner
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -61,6 +61,7 @@ It is important to recognize that being a Peer is a privilege, not a right. That
 - Michael Smith (@sideshowbarker), W3C
 - Philip Jägenstedt (@foolip), Google
 - Vinyl Da.i'gyu (@queengooborg)
+- Will Bamberg (@wbamberg), Open Web Docs
 
 A Peer who shows an above-average level of contribution to the project, particularly with respect to its strategic direction and long-term health, may be nominated to become an Owner, described below.
 
@@ -102,7 +103,6 @@ An individual is invited to become an Owner by existing Owners. A nomination wil
 
 - Florian Scholz (@Elchi3), Open Web Docs
 - Daniel Beck (@ddbeck)
-- Will Bamberg (@wbamberg), Open Web Docs
 
 ## Additional paths to becoming a Peer or Owner
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -59,7 +59,6 @@ It is important to recognize that being a Peer is a privilege, not a right. That
 - Joe Medley (@jpmedley), Google
 - Luca Casonato (@lucacasonato), Deno
 - Michael Smith (@sideshowbarker), W3C
-- Philip Jägenstedt (@foolip), Google
 - Richard Bloor (@rebloor)
 - Will Bamberg (@wbamberg), Open Web Docs
 
@@ -103,6 +102,7 @@ An individual is invited to become an Owner by existing Owners. A nomination wil
 
 - Daniel Beck (@ddbeck)
 - Florian Scholz (@Elchi3), Open Web Docs
+- Philip Jägenstedt (@foolip), Google
 - Ruth John (@Rumyra), Mozilla
 - Vinyl Da.i'gyu (@queengooborg)
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -60,6 +60,7 @@ It is important to recognize that being a Peer is a privilege, not a right. That
 - Luca Casonato (@lucacasonato), Deno
 - Michael Smith (@sideshowbarker), W3C
 - Philip Jägenstedt (@foolip), Google
+- Richard Bloor (@rebloor)
 - Vinyl Da.i'gyu (@queengooborg)
 - Will Bamberg (@wbamberg), Open Web Docs
 
@@ -169,7 +170,6 @@ The `@mdn/browser-compat-data` project would like to thank the following former 
 - John Whitlock (@jwhitlock) (Technical design of the former compat data project)
 - Kadir Topal (@atopal) (BCD co-owner until September 2020)
 - Rachel Andrew (@rachelandrew) (Peer)
-- Richard Bloor (@rebloor) (Peer for WebExtensions compat data)
 - Ryan Johnson (@escattone) (Peer)
 
 ## Credits

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -102,8 +102,9 @@ An individual is invited to become an Owner by existing Owners. A nomination wil
 
 #### List of current Owners
 
-- Florian Scholz (@Elchi3), Open Web Docs
 - Daniel Beck (@ddbeck)
+- Florian Scholz (@Elchi3), Open Web Docs
+- Ruth John (@Rumyra), Mozilla
 
 ## Additional paths to becoming a Peer or Owner
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -60,8 +60,6 @@ It is important to recognize that being a Peer is a privilege, not a right. That
 - Luca Casonato (@lucacasonato), Deno
 - Michael Smith (@sideshowbarker), W3C
 - Philip Jägenstedt (@foolip), Google
-- Rachel Andrew (@rachelandrew)
-- Ryan Johnson (@escattone), Mozilla
 - Vinyl Da.i'gyu (@queengooborg)
 
 A Peer who shows an above-average level of contribution to the project, particularly with respect to its strategic direction and long-term health, may be nominated to become an Owner, described below.
@@ -105,7 +103,6 @@ An individual is invited to become an Owner by existing Owners. A nomination wil
 - Florian Scholz (@Elchi3), Open Web Docs
 - Daniel Beck (@ddbeck)
 - Will Bamberg (@wbamberg), Open Web Docs
-- Chris David Mills (@chrisdavidmills), Mozilla
 
 ## Additional paths to becoming a Peer or Owner
 
@@ -166,11 +163,14 @@ The moderator is responsible for summarizing the discussion of each agenda item 
 
 The `@mdn/browser-compat-data` project would like to thank the following former Owners and Peers for their contributions and the countless hours invested.
 
+- Chris David Mills (@chrisdavidmills), Mozilla
 - Eric Shepherd (@a2sheppy) (BCD peer until August 2020)
 - Estelle Weyl (@estelle) (Peer for CSS compat data)
 - John Whitlock (@jwhitlock) (Technical design of the former compat data project)
 - Kadir Topal (@atopal) (BCD co-owner until September 2020)
+- Rachel Andrew (@rachelandrew) (Peer)
 - Richard Bloor (@rebloor) (Peer for WebExtensions compat data)
+- Ryan Johnson (@escattone) (Peer)
 
 ## Credits
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Tidy up the peer and owners lists to reflect recent changes in participation.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

- Inactive owners and peers have been moved to the emeriti list (with the expectation they can be reinstated, if desired)
- @wbamberg has moved to peer, at his request
- @rebloor has been moved back to peer, based on recent work reviewing webextensions data
- @Rumyra has been invited (and accepted the invite) as owner, to represent Mozilla going forward
- @queengooborg has been invited (and accepted the invite) as owner, reflecting a long history of contributions to the project
- @foolip has been invited (and accepted the invite) as owner, reflecting a long history of contributions to the project

After this PR lands, I'll confirm that the repo permissions have been updated to reflect the current state of the peers and owners lists.