### PR TITLE
Remove invalid Firefox Android flag data

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -532,21 +532,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "90"
-              },
-              {
-                "version_added": "86",
-                "version_removed": "90",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "canvas.createConicGradient.enabled"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "90"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -131,47 +131,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "90",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.events.asyncClipboard.read",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Firefox only supports reading the clipboard in browser extensions, using the <code>\"clipboardRead\"</code> extension permission."
-              },
-              {
-                "version_added": "87",
-                "version_removed": "90",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.events.asyncClipboard.clipboardItem",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Firefox only supports reading the clipboard in browser extensions, using the <code>\"clipboardRead\"</code> extension permission."
-              },
-              {
-                "version_added": "63",
-                "version_removed": "87",
-                "partial_implementation": true,
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.events.asyncClipboard.dataTransfer",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": [
-                  "This method returns a <code>DataTransfer</code> object instead of an array of <code>ClipboardItem</code> objects.",
-                  "Firefox only supports reading the clipboard in browser extensions, using the <code>\"clipboardRead\"</code> extension permission."
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -305,34 +267,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "87",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.events.asyncClipboard.clipboardItem",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Writing to the clipboard is available without permission in secure contexts and browser extensions, but only from user-initiated event callbacks. Browser extensions with the <code>\"clipboardWrite\"</code> permission can write to the clipboard at any time."
-              },
-              {
-                "version_added": "63",
-                "partial_implementation": true,
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.events.asyncClipboard.dataTransfer",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": [
-                  "This method accepts a <code>DataTransfer</code> object instead of an array of <code>ClipboardItem</code> objects.",
-                  "Writing to the clipboard is available without permission in secure contexts and browser extensions, but only from user-initiated event callbacks. Browser extensions with the <code>\"clipboardWrite\"</code> permission can write to the clipboard at any time."
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },

--- a/api/ClipboardItem.json
+++ b/api/ClipboardItem.json
@@ -25,14 +25,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "87",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.events.asyncClipboard.clipboardItem",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -94,14 +87,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "87",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.events.asyncClipboard.clipboardItem",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -165,14 +151,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "87",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.events.asyncClipboard.clipboardItem",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -228,14 +207,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "87",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.events.asyncClipboard.clipboardItem",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -291,14 +263,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "87",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.events.asyncClipboard.clipboardItem",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/Element.json
+++ b/api/Element.json
@@ -8113,22 +8113,10 @@
                 "version_removed": "85"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "85",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.menuitem.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "8",
-                "version_removed": "85"
-              }
-            ],
+            "firefox_android": {
+              "version_added": "8",
+              "version_removed": "85"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -4356,22 +4356,10 @@
                 "version_removed": "85"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "85",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.menuitem.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "8",
-                "version_removed": "85"
-              }
-            ],
+            "firefox_android": {
+              "version_added": "8",
+              "version_removed": "85"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -441,14 +441,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "83",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.forms.autocapitalize",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -634,22 +627,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "87"
-              },
-              {
-                "version_added": "79",
-                "version_removed": "87",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.input_events.beforeinput.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "87"
+            },
             "ie": {
               "version_added": false
             },
@@ -870,22 +850,10 @@
                 "version_removed": "85"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "85",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.menuitem.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "8",
-                "version_removed": "85"
-              }
-            ],
+            "firefox_android": {
+              "version_added": "8",
+              "version_removed": "85"
+            },
             "ie": {
               "version_added": false
             },
@@ -1483,14 +1451,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "81",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "html5.inert.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/HTMLMenuElement.json
+++ b/api/HTMLMenuElement.json
@@ -126,24 +126,11 @@
                 "version_removed": "85"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "85",
-                "notes": "Nested menus are not supported.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.menuitem.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "8",
-                "version_removed": "85",
-                "notes": "Nested menus are not supported."
-              }
-            ],
+            "firefox_android": {
+              "version_added": "8",
+              "version_removed": "85",
+              "notes": "Nested menus are not supported."
+            },
             "ie": {
               "version_added": false
             },
@@ -203,22 +190,10 @@
                 "version_removed": "85"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "85",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.menuitem.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "8",
-                "version_removed": "85"
-              }
-            ],
+            "firefox_android": {
+              "version_added": "8",
+              "version_removed": "85"
+            },
             "ie": {
               "version_added": "6"
             },

--- a/api/HTMLMenuItemElement.json
+++ b/api/HTMLMenuItemElement.json
@@ -29,22 +29,10 @@
               "version_removed": "85"
             }
           ],
-          "firefox_android": [
-            {
-              "version_added": "85",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.menuitem.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            {
-              "version_added": "8",
-              "version_removed": "85"
-            }
-          ],
+          "firefox_android": {
+            "version_added": "8",
+            "version_removed": "85"
+          },
           "ie": {
             "version_added": false
           },
@@ -102,22 +90,10 @@
                 "version_removed": "85"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "85",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.menuitem.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "8",
-                "version_removed": "85"
-              }
-            ],
+            "firefox_android": {
+              "version_added": "8",
+              "version_removed": "85"
+            },
             "ie": {
               "version_added": false
             },
@@ -178,24 +154,11 @@
                 "version_removed": "85"
               }
             ],
-            "firefox_android": [
-              {
-                "alternative_name": "defaultChecked",
-                "version_added": "85",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.menuitem.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "alternative_name": "defaultChecked",
-                "version_added": "8",
-                "version_removed": "85"
-              }
-            ],
+            "firefox_android": {
+              "alternative_name": "defaultChecked",
+              "version_added": "8",
+              "version_removed": "85"
+            },
             "ie": {
               "version_added": false
             },
@@ -254,22 +217,10 @@
                 "version_removed": "85"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "85",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.menuitem.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "8",
-                "version_removed": "85"
-              }
-            ],
+            "firefox_android": {
+              "version_added": "8",
+              "version_removed": "85"
+            },
             "ie": {
               "version_added": false
             },
@@ -328,22 +279,10 @@
                 "version_removed": "85"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "85",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.menuitem.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "8",
-                "version_removed": "85"
-              }
-            ],
+            "firefox_android": {
+              "version_added": "8",
+              "version_removed": "85"
+            },
             "ie": {
               "version_added": false
             },
@@ -402,22 +341,10 @@
                 "version_removed": "85"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "85",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.menuitem.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "8",
-                "version_removed": "85"
-              }
-            ],
+            "firefox_android": {
+              "version_added": "8",
+              "version_removed": "85"
+            },
             "ie": {
               "version_added": false
             },
@@ -476,22 +403,10 @@
                 "version_removed": "85"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "85",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.menuitem.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "8",
-                "version_removed": "85"
-              }
-            ],
+            "firefox_android": {
+              "version_added": "8",
+              "version_removed": "85"
+            },
             "ie": {
               "version_added": false
             },
@@ -550,22 +465,10 @@
                 "version_removed": "85"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "85",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.menuitem.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "8",
-                "version_removed": "85"
-              }
-            ],
+            "firefox_android": {
+              "version_added": "8",
+              "version_removed": "85"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -233,22 +233,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "87"
-              },
-              {
-                "version_added": "79",
-                "version_removed": "87",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.input_events.beforeinput.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "87"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/block-size.json
+++ b/css/properties/block-size.json
@@ -123,13 +123,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "91",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.fit-content-function.enabled"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -168,13 +168,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "91",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.element-content-none.enabled"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -124,21 +124,9 @@
                   ]
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "92"
-                },
-                {
-                  "version_added": "91",
-                  "version_removed": "92",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.font-size-adjust.basis.enabled"
-                    }
-                  ]
-                }
-              ],
+              "firefox_android": {
+                "version_added": "92"
+              },
               "ie": {
                 "version_added": false
               },

--- a/css/properties/height.json
+++ b/css/properties/height.json
@@ -132,13 +132,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "91",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.fit-content-function.enabled"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/css/properties/inline-size.json
+++ b/css/properties/inline-size.json
@@ -123,13 +123,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "91",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.fit-content-function.enabled"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/css/properties/math-style.json
+++ b/css/properties/math-style.json
@@ -38,14 +38,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "83",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.math-style.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/css/properties/max-block-size.json
+++ b/css/properties/max-block-size.json
@@ -121,13 +121,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "91",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.fit-content-function.enabled"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -178,13 +178,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "91",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.fit-content-function.enabled"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/css/properties/max-inline-size.json
+++ b/css/properties/max-inline-size.json
@@ -135,13 +135,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "91",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.fit-content-function.enabled"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -167,13 +167,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "91",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.fit-content-function.enabled"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/css/properties/min-block-size.json
+++ b/css/properties/min-block-size.json
@@ -121,13 +121,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "91",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.fit-content-function.enabled"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -218,13 +218,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "91",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.fit-content-function.enabled"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/css/properties/min-inline-size.json
+++ b/css/properties/min-inline-size.json
@@ -123,13 +123,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "91",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.fit-content-function.enabled"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -233,13 +233,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "91",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.fit-content-function.enabled"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -311,13 +311,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "91",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.fit-content-function.enabled"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -305,14 +305,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "88",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.color-mix.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -354,20 +354,9 @@
                     ]
                   }
                 ],
-                "firefox_android": [
-                  {
-                    "version_added": "83"
-                  },
-                  {
-                    "version_added": "79",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.conic-gradient.enabled"
-                      }
-                    ]
-                  }
-                ],
+                "firefox_android": {
+                  "version_added": "83"
+                },
                 "ie": {
                   "version_added": false
                 },
@@ -1142,20 +1131,9 @@
                     ]
                   }
                 ],
-                "firefox_android": [
-                  {
-                    "version_added": "83"
-                  },
-                  {
-                    "version_added": "79",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "layout.css.conic-gradient.enabled"
-                      }
-                    ]
-                  }
-                ],
+                "firefox_android": {
+                  "version_added": "83"
+                },
                 "ie": {
                   "version_added": false
                 },

--- a/html/elements/menu.json
+++ b/html/elements/menu.json
@@ -126,22 +126,10 @@
                   "version_removed": "85"
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "85",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.menuitem.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                {
-                  "version_added": "51",
-                  "version_removed": "85"
-                }
-              ],
+              "firefox_android": {
+                "version_added": "51",
+                "version_removed": "85"
+              },
               "ie": {
                 "version_added": false
               },
@@ -199,24 +187,11 @@
                   "version_removed": "85"
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "85",
-                  "notes": "Nested menus are not supported.",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.menuitem.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                {
-                  "version_added": "8",
-                  "version_removed": "85",
-                  "notes": "Nested menus are not supported."
-                }
-              ],
+              "firefox_android": {
+                "version_added": "8",
+                "version_removed": "85",
+                "notes": "Nested menus are not supported."
+              },
               "ie": {
                 "version_added": false
               },
@@ -277,24 +252,11 @@
                     "version_removed": "85"
                   }
                 ],
-                "firefox_android": [
-                  {
-                    "version_added": "85",
-                    "notes": "Nested menus are not supported.",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "dom.menuitem.enabled",
-                        "value_to_set": "true"
-                      }
-                    ]
-                  },
-                  {
-                    "version_added": "8",
-                    "version_removed": "85",
-                    "notes": "Nested menus are not supported."
-                  }
-                ],
+                "firefox_android": {
+                  "version_added": "8",
+                  "version_removed": "85",
+                  "notes": "Nested menus are not supported."
+                },
                 "ie": {
                   "version_added": false
                 },

--- a/html/elements/menuitem.json
+++ b/html/elements/menuitem.json
@@ -102,22 +102,10 @@
                   "version_removed": "85"
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "85",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.menuitem.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                {
-                  "version_added": "8",
-                  "version_removed": "85"
-                }
-              ],
+              "firefox_android": {
+                "version_added": "8",
+                "version_removed": "85"
+              },
               "ie": {
                 "version_added": false
               },
@@ -175,22 +163,10 @@
                   "version_removed": "85"
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "85",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.menuitem.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                {
-                  "version_added": "8",
-                  "version_removed": "85"
-                }
-              ],
+              "firefox_android": {
+                "version_added": "8",
+                "version_removed": "85"
+              },
               "ie": {
                 "version_added": false
               },
@@ -248,22 +224,10 @@
                   "version_removed": "85"
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "85",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.menuitem.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                {
-                  "version_added": "8",
-                  "version_removed": "85"
-                }
-              ],
+              "firefox_android": {
+                "version_added": "8",
+                "version_removed": "85"
+              },
               "ie": {
                 "version_added": false
               },
@@ -321,22 +285,10 @@
                   "version_removed": "85"
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "85",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.menuitem.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                {
-                  "version_added": "8",
-                  "version_removed": "85"
-                }
-              ],
+              "firefox_android": {
+                "version_added": "8",
+                "version_removed": "85"
+              },
               "ie": {
                 "version_added": false
               },
@@ -394,22 +346,10 @@
                   "version_removed": "85"
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "85",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.menuitem.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                {
-                  "version_added": "8",
-                  "version_removed": "85"
-                }
-              ],
+              "firefox_android": {
+                "version_added": "8",
+                "version_removed": "85"
+              },
               "ie": {
                 "version_added": false
               },
@@ -467,22 +407,10 @@
                   "version_removed": "85"
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "85",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.menuitem.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                {
-                  "version_added": "8",
-                  "version_removed": "85"
-                }
-              ],
+              "firefox_android": {
+                "version_added": "8",
+                "version_removed": "85"
+              },
               "ie": {
                 "version_added": false
               },
@@ -540,22 +468,10 @@
                   "version_removed": "85"
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "85",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.menuitem.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                {
-                  "version_added": "8",
-                  "version_removed": "85"
-                }
-              ],
+              "firefox_android": {
+                "version_added": "8",
+                "version_removed": "85"
+              },
               "ie": {
                 "version_added": false
               },

--- a/html/elements/menuitem.json
+++ b/html/elements/menuitem.json
@@ -38,30 +38,14 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "85",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.menuitem.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": [
-                  "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
-                  "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
-                ]
-              },
-              {
-                "version_added": "8",
-                "version_removed": "85",
-                "notes": [
-                  "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
-                  "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "8",
+              "version_removed": "85",
+              "notes": [
+                "Only works for <code>&lt;menuitem&gt;</code> elements defined within a <code>&lt;menu&gt;</code> element assigned to an element via the <code>contextmenu</code> attribute.",
+                "The <code>&lt;menuitem&gt;</code> element requires a closing tag."
+              ]
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes invalid flag data for Firefox Android.  In the new version of Firefox Android, Fenix, which began with 79, the ability to set flags had been removed.  However, there is a lot of data that had been mirrored from Firefox desktop that refer to Firefox Android versions of 79 or greater.  This PR fixes that data and marks such features as unsupported.
