### PR TITLE
Remove irrelevant "media.track.enabled" flag in Firefox Android

### DIFF
--- a/api/AudioTrack.json
+++ b/api/AudioTrack.json
@@ -52,14 +52,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "33",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "media.track.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": "10"
@@ -155,14 +148,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "33",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.track.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": "10"
@@ -259,14 +245,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "33",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.track.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": "10"
@@ -363,14 +342,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "33",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.track.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": "10"
@@ -467,14 +439,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "33",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.track.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": "10"
@@ -571,14 +536,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "33",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.track.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": "10"

--- a/api/AudioTrackList.json
+++ b/api/AudioTrackList.json
@@ -52,14 +52,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "33",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "media.track.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": "10"
@@ -159,14 +152,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "33",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.track.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": "10"
@@ -267,14 +253,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "33",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.track.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": "10"
@@ -371,14 +350,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "33",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.track.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": "10"
@@ -475,14 +447,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "33",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.track.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": "10"
@@ -583,14 +548,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "33",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.track.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": "10"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -222,14 +222,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "33",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.track.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": "10"
@@ -3708,14 +3701,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "33",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.track.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/VideoTrack.json
+++ b/api/VideoTrack.json
@@ -52,14 +52,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "33",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "media.track.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": "10"
@@ -155,14 +148,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "33",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.track.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": "10"
@@ -259,14 +245,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "33",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.track.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": "10"
@@ -363,14 +342,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "33",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.track.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": "10"
@@ -467,14 +439,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "33",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.track.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": "10"
@@ -571,14 +536,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "33",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.track.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": "10"

--- a/api/VideoTrackList.json
+++ b/api/VideoTrackList.json
@@ -52,14 +52,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "33",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "media.track.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": "10"
@@ -159,14 +152,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "33",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.track.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": "10"
@@ -267,14 +253,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "33",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.track.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": "10"
@@ -371,14 +350,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "33",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.track.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": "10"
@@ -475,14 +447,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "33",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.track.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": "10"
@@ -583,14 +548,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "33",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.track.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": "10"
@@ -687,14 +645,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "33",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.track.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": "10"


### PR DESCRIPTION
This PR removes irrelevant flag data for the `media.track.enabled` flag of Firefox Android as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).
