### PR TITLE
Remove irrelevant Firefox Android flag data for CanvasCaptureMediaStreamTrack API

### DIFF
--- a/api/CanvasCaptureMediaStreamTrack.json
+++ b/api/CanvasCaptureMediaStreamTrack.json
@@ -25,15 +25,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "41",
-            "version_removed": "79",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "canvas.capturestream.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -88,15 +80,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "41",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "canvas.capturestream.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -152,15 +136,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "41",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "canvas.capturestream.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox Android for the `CanvasCaptureMediaStreamTrack` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/queengooborg/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
