### PR TITLE
Remove irrelevant "device.sensors" flag in Firefox Android

### DIFF
--- a/api/DeviceLightEvent.json
+++ b/api/DeviceLightEvent.json
@@ -32,23 +32,10 @@
               "notes": "Not supported for MacBook with Touch Bar and Windows 7 (see <a href='https://bugzil.la/754199'>bug 754199</a>)."
             }
           ],
-          "firefox_android": [
-            {
-              "version_added": "62",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "device.sensors.ambientLight.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            {
-              "version_added": "15",
-              "version_removed": "61"
-            }
-          ],
+          "firefox_android": {
+            "version_added": "15",
+            "version_removed": "61"
+          },
           "ie": {
             "version_added": false
           },
@@ -108,23 +95,10 @@
                 "notes": "Not supported for MacBook with Touch Bar and Windows 7 (see <a href='https://bugzil.la/754199'>bug 754199</a>)."
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "62",
-                "version_removed": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "device.sensors.ambientLight.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "15",
-                "version_removed": "61"
-              }
-            ],
+            "firefox_android": {
+              "version_added": "15",
+              "version_removed": "61"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/DeviceProximityEvent.json
+++ b/api/DeviceProximityEvent.json
@@ -30,23 +30,10 @@
               "version_removed": "61"
             }
           ],
-          "firefox_android": [
-            {
-              "version_added": "62",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "device.sensors.proximity.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            {
-              "version_added": "15",
-              "version_removed": "61"
-            }
-          ],
+          "firefox_android": {
+            "version_added": "15",
+            "version_removed": "61"
+          },
           "ie": {
             "version_added": false
           },
@@ -104,23 +91,10 @@
                 "version_removed": "61"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "62",
-                "version_removed": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "device.sensors.proximity.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "15",
-                "version_removed": "61"
-              }
-            ],
+            "firefox_android": {
+              "version_added": "15",
+              "version_removed": "61"
+            },
             "ie": {
               "version_added": false
             },
@@ -179,23 +153,10 @@
                 "version_removed": "61"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "62",
-                "version_removed": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "device.sensors.proximity.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "15",
-                "version_removed": "61"
-              }
-            ],
+            "firefox_android": {
+              "version_added": "15",
+              "version_removed": "61"
+            },
             "ie": {
               "version_added": false
             },
@@ -254,23 +215,10 @@
                 "version_removed": "61"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "62",
-                "version_removed": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "device.sensors.proximity.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "15",
-                "version_removed": "61"
-              }
-            ],
+            "firefox_android": {
+              "version_added": "15",
+              "version_removed": "61"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/UserProximityEvent.json
+++ b/api/UserProximityEvent.json
@@ -30,23 +30,10 @@
               "version_removed": "61"
             }
           ],
-          "firefox_android": [
-            {
-              "version_added": "62",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "device.sensors.proximity.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            {
-              "version_added": "15",
-              "version_removed": "61"
-            }
-          ],
+          "firefox_android": {
+            "version_added": "15",
+            "version_removed": "61"
+          },
           "ie": {
             "version_added": false
           },
@@ -104,23 +91,10 @@
                 "version_removed": "61"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "62",
-                "version_removed": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "device.sensors.proximity.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "15",
-                "version_removed": "61"
-              }
-            ],
+            "firefox_android": {
+              "version_added": "15",
+              "version_removed": "61"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/Window.json
+++ b/api/Window.json
@@ -1687,23 +1687,10 @@
                 "notes": "Not supported for MacBook with Touch Bar and Windows 7 (see <a href='https://bugzil.la/754199'>bug 754199</a>)."
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "62",
-                "version_removed": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "device.sensors.ambientLight.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "15",
-                "version_removed": "61"
-              }
-            ],
+            "firefox_android": {
+              "version_added": "15",
+              "version_removed": "61"
+            },
             "ie": {
               "version_added": false
             },
@@ -1983,23 +1970,10 @@
                 "version_removed": "61"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "62",
-                "version_removed": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "device.sensors.proximity.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "15",
-                "version_removed": "61"
-              }
-            ],
+            "firefox_android": {
+              "version_added": "15",
+              "version_removed": "61"
+            },
             "ie": {
               "version_added": false
             },
@@ -8802,23 +8776,10 @@
                 "version_removed": "61"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "62",
-                "version_removed": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "device.sensors.proximity.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "15",
-                "version_removed": "61"
-              }
-            ],
+            "firefox_android": {
+              "version_added": "15",
+              "version_removed": "61"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for the `device.sensors` flag of Firefox Android as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).
