### PR TITLE
Remove irrelevant "dom.security.featurePolicy.webidl.enabled" flag in Firefox Android

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4847,16 +4847,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "65",
-              "version_removed": "79",
-              "alternative_name": "policy",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.featurePolicy.webidl.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/FeaturePolicy.json
+++ b/api/FeaturePolicy.json
@@ -25,15 +25,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "65",
-            "alternative_name": "Policy",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.security.featurePolicy.webidl.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -87,14 +79,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "65",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.featurePolicy.webidl.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -149,14 +134,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "65",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.featurePolicy.webidl.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -266,14 +244,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "65",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.featurePolicy.webidl.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -455,15 +455,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": "65",
-              "alternative_name": "policy",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.featurePolicy.webidl.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for the `dom.security.featurePolicy.webidl.enabled` flag of Firefox Android as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).
