### PR TITLE
Remove irrelevant "dom.storage_access.enabled" flag in Firefox Android

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -6177,13 +6177,7 @@
               "version_added": "65"
             },
             "firefox_android": {
-              "version_added": "65",
-              "flags": [
-                {
-                  "type": "preference",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/Document.json
+++ b/api/Document.json
@@ -6181,7 +6181,6 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "dom.storage_access.enabled",
                   "value_to_set": "true"
                 }
               ]
@@ -9391,14 +9390,7 @@
               "version_added": "65"
             },
             "firefox_android": {
-              "version_added": "65",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.storage_access.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -1221,14 +1221,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.storage_access.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for the `dom.storage_access.enabled` flag of Firefox Android as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).
