### PR TITLE
Remove irrelevant "gfx.offscreencanvas.enabled" flag in Firefox Android

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -1455,13 +1455,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "44",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "gfx.offscreencanvas.enabled"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -26,15 +26,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "44",
-            "partial_implementation": true,
-            "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "gfx.offscreencanvas.enabled"
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -91,15 +83,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "46",
-              "partial_implementation": true,
-              "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "gfx.offscreencanvas.enabled"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -157,16 +141,7 @@
               ]
             },
             "firefox_android": {
-              "alternative_name": "toBlob",
-              "version_added": "46",
-              "partial_implementation": true,
-              "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "gfx.offscreencanvas.enabled"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -213,7 +188,7 @@
                 "version_added": "96"
               },
               "firefox_android": {
-                "version_added": "96"
+                "version_added": false
               },
               "ie": {
                 "version_added": false
@@ -271,15 +246,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "44",
-              "partial_implementation": true,
-              "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "gfx.offscreencanvas.enabled"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -334,15 +301,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "46",
-                "partial_implementation": true,
-                "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false
@@ -398,15 +357,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "44",
-                "partial_implementation": true,
-                "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false
@@ -462,15 +413,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "44",
-                "partial_implementation": true,
-                "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false
@@ -576,15 +519,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "44",
-              "partial_implementation": true,
-              "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "gfx.offscreencanvas.enabled"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -641,15 +576,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "46",
-              "partial_implementation": true,
-              "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "gfx.offscreencanvas.enabled"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -706,15 +633,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "44",
-              "partial_implementation": true,
-              "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "gfx.offscreencanvas.enabled"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for the `gfx.offscreencanvas.enabled` flag of Firefox Android as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).
