### PR TITLE
Update some WebUSB spec URLs

### DIFF
--- a/api/USBConfiguration.json
+++ b/api/USBConfiguration.json
@@ -3,7 +3,7 @@
     "USBConfiguration": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBConfiguration",
-        "spec_url": "https://wicg.github.io/webusb/#configurations",
+        "spec_url": "https://wicg.github.io/webusb/#usbconfiguration-interface",
         "support": {
           "chrome": {
             "version_added": "61"

--- a/api/USBDevice.json
+++ b/api/USBDevice.json
@@ -1228,7 +1228,7 @@
       "selectConfiguration": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBDevice/selectConfiguration",
-          "spec_url": "https://wicg.github.io/webusb/#ref-for-dom-usbdevice-selectconfiguration②",
+          "spec_url": "https://wicg.github.io/webusb/#dom-usbdevice-selectconfiguration",
           "support": {
             "chrome": {
               "version_added": "61"

--- a/api/USBEndpoint.json
+++ b/api/USBEndpoint.json
@@ -3,7 +3,7 @@
     "USBEndpoint": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBEndpoint",
-        "spec_url": "https://wicg.github.io/webusb/#endpoints",
+        "spec_url": "https://wicg.github.io/webusb/#usbendpoint-interface",
         "support": {
           "chrome": {
             "version_added": "61"


### PR DESCRIPTION
Some recent spec updates broke a few of the existing anchors in the Web USB spec.