### PR TITLE
Update spec URLs for VisualViewport events

### DIFF
--- a/api/VisualViewport.json
+++ b/api/VisualViewport.json
@@ -441,10 +441,7 @@
         "__compat": {
           "description": "<code>resize</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VisualViewport/resize_event",
-          "spec_url": [
-            "https://wicg.github.io/visual-viewport/#events",
-            "https://wicg.github.io/visual-viewport/#dom-visualviewport-onresize"
-          ],
+          "spec_url": "https://wicg.github.io/visual-viewport/#dfn-run-the-resize-steps",
           "support": {
             "chrome": [
               {
@@ -626,10 +623,7 @@
         "__compat": {
           "description": "<code>scroll</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VisualViewport/scroll_event",
-          "spec_url": [
-            "https://wicg.github.io/visual-viewport/#events",
-            "https://wicg.github.io/visual-viewport/#dom-visualviewport-onscroll"
-          ],
+          "spec_url": "https://wicg.github.io/visual-viewport/#dfn-run-the-scroll-steps",
           "support": {
             "chrome": [
               {


### PR DESCRIPTION
A recent spec change removed the anchor we were using. The spec doesn’t give us ideal anchors for these events, but these updates point readers to somewhere reasonably useful.