### PR TITLE
Remove irrelevant Firefox Android flag data for api.HTMLInputElement.webkitdirectory

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2799,14 +2799,7 @@
               "version_added": "50"
             },
             "firefox_android": {
-              "version_added": "50",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webkitBlink.dirPicker.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox Android for the `webkitdirectory` member of the `HTMLInputElement` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/queengooborg/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
