### PR TITLE
Remove irrelevant "dom.payments.request" flag in Firefox Android

### DIFF
--- a/api/MerchantValidationEvent.json
+++ b/api/MerchantValidationEvent.json
@@ -25,15 +25,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "64",
-            "notes": "Available only in Nightly builds.",
-            "flags": [
-              {
-                "name": "dom.payments.request.supportedRegions",
-                "type": "preference",
-                "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -82,8 +74,7 @@
               "notes": "Available only in Nightly builds."
             },
             "firefox_android": {
-              "version_added": "64",
-              "notes": "Available only in Nightly builds."
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -133,8 +124,7 @@
               "notes": "Available only in Nightly builds."
             },
             "firefox_android": {
-              "version_added": "64",
-              "notes": "Available only in Nightly builds."
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -183,8 +173,7 @@
               "notes": "Available only in Nightly builds."
             },
             "firefox_android": {
-              "version_added": "64",
-              "notes": "Available only in Nightly builds."
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -233,8 +222,7 @@
               "notes": "Available only in Nightly builds."
             },
             "firefox_android": {
-              "version_added": "64",
-              "notes": "Available only in Nightly builds."
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/PaymentMethodChangeEvent.json
+++ b/api/PaymentMethodChangeEvent.json
@@ -30,20 +30,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "55",
-            "version_removed": "79",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.payments.request.enabled",
-                "value_to_set": "true"
-              },
-              {
-                "name": "dom.payments.request.supportedRegions",
-                "type": "preference",
-                "value_to_set": "A comma-delimited list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -104,20 +91,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "name": "dom.payments.request.supportedRegions",
-                  "type": "preference",
-                  "value_to_set": "A comma-delimited list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -178,20 +152,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "name": "dom.payments.request.supportedRegions",
-                  "type": "preference",
-                  "value_to_set": "A comma-delimited list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -252,20 +213,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "name": "dom.payments.request.supportedRegions",
-                  "type": "preference",
-                  "value_to_set": "A comma-delimited list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -30,20 +30,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "55",
-            "version_removed": "79",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.payments.request.enabled",
-                "value_to_set": "true"
-              },
-              {
-                "name": "dom.payments.request.supportedRegions",
-                "type": "preference",
-                "value_to_set": "A comma-delimited list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -99,15 +86,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -164,15 +143,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -229,15 +200,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -293,15 +256,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -357,15 +312,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -425,15 +372,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -488,15 +427,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -552,15 +483,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -615,15 +538,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -679,15 +594,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -742,15 +649,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -806,15 +705,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/PaymentRequestUpdateEvent.json
+++ b/api/PaymentRequestUpdateEvent.json
@@ -30,20 +30,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "55",
-            "version_removed": "79",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.payments.request.enabled",
-                "value_to_set": "true"
-              },
-              {
-                "name": "dom.payments.request.supportedRegions",
-                "type": "preference",
-                "value_to_set": "A comma-delimited list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -99,15 +86,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -164,15 +143,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -30,20 +30,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "55",
-            "version_removed": "79",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.payments.request.enabled",
-                "value_to_set": "true"
-              },
-              {
-                "name": "dom.payments.request.supportedRegions",
-                "type": "preference",
-                "value_to_set": "A comma-delimited list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -104,20 +91,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "name": "dom.payments.request.supportedRegions",
-                  "type": "preference",
-                  "value_to_set": "A comma-delimited list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -178,20 +152,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "name": "dom.payments.request.supportedRegions",
-                  "type": "preference",
-                  "value_to_set": "A comma-delimited list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -252,20 +213,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "name": "dom.payments.request.supportedRegions",
-                  "type": "preference",
-                  "value_to_set": "A comma-delimited list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -326,20 +274,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "name": "dom.payments.request.supportedRegions",
-                  "type": "preference",
-                  "value_to_set": "A comma-delimited list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -399,20 +334,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "name": "dom.payments.request.supportedRegions",
-                  "type": "preference",
-                  "value_to_set": "A comma-delimited list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -472,20 +394,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "name": "dom.payments.request.supportedRegions",
-                  "type": "preference",
-                  "value_to_set": "A comma-delimited list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -545,20 +454,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "name": "dom.payments.request.supportedRegions",
-                  "type": "preference",
-                  "value_to_set": "A comma-delimited list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -619,20 +515,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "name": "dom.payments.request.supportedRegions",
-                  "type": "preference",
-                  "value_to_set": "A comma-delimited list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -693,20 +576,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "name": "dom.payments.request.supportedRegions",
-                  "type": "preference",
-                  "value_to_set": "A comma-delimited list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -766,20 +636,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "name": "dom.payments.request.supportedRegions",
-                  "type": "preference",
-                  "value_to_set": "A comma-delimited list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -839,20 +696,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "name": "dom.payments.request.supportedRegions",
-                  "type": "preference",
-                  "value_to_set": "A comma-delimited list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -913,20 +757,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.payments.request.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "name": "dom.payments.request.supportedRegions",
-                  "type": "preference",
-                  "value_to_set": "A comma-delimited list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>)."
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for the `dom.payments.request` flag of Firefox Android as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).
