### PR TITLE
Remove support for content-visibility for Safari 15.4

### DIFF
--- a/css/properties/content-visibility.json
+++ b/css/properties/content-visibility.json
@@ -31,10 +31,10 @@
               "version_added": "60"
             },
             "safari": {
-              "version_added": "15.4"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "15.4"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "14.0"


### PR DESCRIPTION
Safari 15.4 does not support content-visibility. This was an error. Thanks.

You can see that it's _not_ listed in the official release notes:
https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes

I'm opening this PR after talking to WebKit engineers familiar with the matter. 