### PR TITLE
Remove irrelevant Firefox flag data for HTMLStyleElement API

### DIFF
--- a/api/HTMLStyleElement.json
+++ b/api/HTMLStyleElement.json
@@ -166,42 +166,14 @@
             "edge": {
               "version_added": false
             },
-            "firefox": [
-              {
-                "version_added": "55",
-                "version_removed": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.scoped-style.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "This property was hidden behind a pref because no other browsers support it (See <a href='https://bugzil.la/1291515'>bug 1291515</a>)."
-              },
-              {
-                "version_added": "21",
-                "version_removed": "55"
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "55",
-                "version_removed": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.scoped-style.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "This property was hidden behind a pref because no other browsers support it (See <a href='https://bugzil.la/1291515'>bug 1291515</a>)."
-              },
-              {
-                "version_added": "21",
-                "version_removed": "55"
-              }
-            ],
+            "firefox": {
+              "version_added": "21",
+              "version_removed": "55"
+            },
+            "firefox_android": {
+              "version_added": "21",
+              "version_removed": "55"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `HTMLStyleElement` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/queengooborg/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
