### PR TITLE
Remove irrelevant "dom.presentation" flag in Firefox Android

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2960,15 +2960,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/Presentation.json
+++ b/api/Presentation.json
@@ -26,15 +26,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "51",
-            "version_removed": "79",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.presentation.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -90,15 +82,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.controller.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -155,15 +139,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.receiver.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/PresentationAvailability.json
+++ b/api/PresentationAvailability.json
@@ -26,15 +26,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "51",
-            "version_removed": "79",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.presentation.controller.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -91,15 +83,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.controller.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -156,15 +140,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.controller.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/PresentationConnection.json
+++ b/api/PresentationConnection.json
@@ -26,15 +26,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "51",
-            "version_removed": "79",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.presentation.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -90,15 +82,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -155,15 +139,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -219,15 +195,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -283,15 +251,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -348,15 +308,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -412,15 +364,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -477,15 +421,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -542,15 +478,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -607,15 +535,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -671,15 +591,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -736,15 +648,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/PresentationConnectionAvailableEvent.json
+++ b/api/PresentationConnectionAvailableEvent.json
@@ -26,15 +26,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "51",
-            "version_removed": "79",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.presentation.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -91,15 +83,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -156,15 +140,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/PresentationConnectionCloseEvent.json
+++ b/api/PresentationConnectionCloseEvent.json
@@ -26,15 +26,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "51",
-            "version_removed": "79",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.presentation.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -90,15 +82,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -154,15 +138,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -218,15 +194,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/PresentationConnectionList.json
+++ b/api/PresentationConnectionList.json
@@ -26,15 +26,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "51",
-            "version_removed": "79",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.presentation.receiver.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -89,15 +81,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.receiver.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -153,15 +137,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.receiver.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/PresentationReceiver.json
+++ b/api/PresentationReceiver.json
@@ -26,15 +26,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "51",
-            "version_removed": "79",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.presentation.receiver.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -89,15 +81,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.receiver.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/PresentationRequest.json
+++ b/api/PresentationRequest.json
@@ -26,15 +26,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "51",
-            "version_removed": "79",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.presentation.controller.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -91,15 +83,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.controller.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -156,15 +140,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.controller.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -221,15 +197,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.controller.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -286,15 +254,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.controller.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -401,15 +361,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.controller.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -465,15 +417,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "51",
-              "version_removed": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.controller.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for the `dom.presentation` flag of Firefox Android as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).
