### PR TITLE
Remove irrelevant "dom.indexedDB" flag in Firefox Android

### DIFF
--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -257,13 +257,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "44",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.indexedDB.experimental"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/IDBLocaleAwareKeyRange.json
+++ b/api/IDBLocaleAwareKeyRange.json
@@ -23,13 +23,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "43",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.indexedDB.experimental"
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for the `dom.indexedDB` flag of Firefox Android as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).
