### PR TITLE
Remove irrelevant Firefox Android flag data for api.MouseEvent.region

### DIFF
--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -1071,14 +1071,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "30",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "canvas.hitregions.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox Android for the `region` member of the `MouseEvent` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/queengooborg/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
