### PR TITLE
Remove irrelevant Firefox Android flag data for api.Permissions.revoke

### DIFF
--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -1082,22 +1082,10 @@
                 "version_removed": "51"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "51",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.permissions.revoke.enable",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "47",
-                "version_removed": "51"
-              }
-            ],
+            "firefox_android": {
+              "version_added": "47",
+              "version_removed": "51"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox Android for the `revoke` member of the `Permissions` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/queengooborg/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
