### PR TITLE
Remove irrelevant "dom.promise_rejection_events.enabled" flag in Firefox Android

### DIFF
--- a/api/PromiseRejectionEvent.json
+++ b/api/PromiseRejectionEvent.json
@@ -32,21 +32,9 @@
               ]
             }
           ],
-          "firefox_android": [
-            {
-              "version_added": "79"
-            },
-            {
-              "version_added": "68",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.promise_rejection_events.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox_android": {
+            "version_added": "79"
+          },
           "ie": {
             "version_added": false
           },
@@ -108,21 +96,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "79"
-              },
-              {
-                "version_added": "68",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.promise_rejection_events.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "79"
+            },
             "ie": {
               "version_added": false
             },
@@ -184,21 +160,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "79"
-              },
-              {
-                "version_added": "68",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.promise_rejection_events.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "79"
+            },
             "ie": {
               "version_added": false
             },
@@ -260,21 +224,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "79"
-              },
-              {
-                "version_added": "68",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.promise_rejection_events.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "79"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/Window.json
+++ b/api/Window.json
@@ -5539,14 +5539,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": "68",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.promise_rejection_events.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -8633,14 +8626,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": "68",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.promise_rejection_events.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "79"
             },
             "ie": {
               "version_added": false

--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -479,30 +479,9 @@
                 "notes": "This event handler was added in Firefox 55 but was disabled since it wasn't fully implemented. It was fully implemented in Firefox 68 and enabled by default in Firefox 69."
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "68",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.promise_rejection_events.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "55",
-                "partial_implementation": true,
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.promise_rejection_events.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "This event handler was added in Firefox 55 but was disabled since it wasn't fully implemented. It was fully implemented in Firefox 68 but not enabled by default."
-              }
-            ],
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -622,30 +601,9 @@
                 "notes": "This event handler was added in Firefox 55 but was disabled since it wasn't fully implemented. It was fully implemented in Firefox 68 and enabled by default in Firefox 69."
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "68",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.promise_rejection_events.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "55",
-                "partial_implementation": true,
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.promise_rejection_events.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "This event handler was added in Firefox 55 but was disabled since it wasn't fully implemented. It was fully implemented in Firefox 68 but not enabled by default."
-              }
-            ],
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for the `dom.promise_rejection_events.enabled` flag of Firefox Android as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).
