### PR TITLE
Remove irrelevant "media.peerconnection.rtpsourcesapi.enable" flag in Firefox Android

### DIFF
--- a/api/RTCRtpContributingSource.json
+++ b/api/RTCRtpContributingSource.json
@@ -25,14 +25,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "59",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "media.peerconnection.rtpsourcesapi.enable",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -87,14 +80,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.peerconnection.rtpsourcesapi.enable",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -150,14 +136,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.peerconnection.rtpsourcesapi.enable",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -214,15 +193,7 @@
               "notes": "Starting in version 60, the <code>timestamp</code> is correctly computed based on the window's <code>Performance</code> time, rather than <code>Date.getTime()</code>."
             },
             "firefox_android": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.peerconnection.rtpsourcesapi.enable",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "Starting in version 60, the <code>timestamp</code> is correctly computed based on the window's <code>Performance</code> time, rather than <code>Date.getTime()</code>."
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -162,14 +162,7 @@
               "version_added": "59"
             },
             "firefox_android": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.peerconnection.rtpsourcesapi.enable",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -216,14 +209,7 @@
                 "version_added": "59"
               },
               "firefox_android": {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.peerconnection.rtpsourcesapi.enable",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false
@@ -271,14 +257,7 @@
                 "version_added": "68"
               },
               "firefox_android": {
-                "version_added": "68",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.peerconnection.rtpsourcesapi.enable",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false
@@ -426,14 +405,7 @@
               "version_added": "59"
             },
             "firefox_android": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.peerconnection.rtpsourcesapi.enable",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -480,14 +452,7 @@
                 "version_added": "59"
               },
               "firefox_android": {
-                "version_added": "59",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.peerconnection.rtpsourcesapi.enable",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false
@@ -535,14 +500,7 @@
                 "version_added": "68"
               },
               "firefox_android": {
-                "version_added": "68",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.peerconnection.rtpsourcesapi.enable",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false

--- a/api/RTCRtpSynchronizationSource.json
+++ b/api/RTCRtpSynchronizationSource.json
@@ -25,14 +25,7 @@
             ]
           },
           "firefox_android": {
-            "version_added": "59",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "media.peerconnection.rtpsourcesapi.enable",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -86,14 +79,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.peerconnection.rtpsourcesapi.enable",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for the `media.peerconnection.rtpsourcesapi.enable` flag of Firefox Android as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).
