### PR TITLE
Remove irrelevant Firefox Android flag data for Screen API

### DIFF
--- a/api/Screen.json
+++ b/api/Screen.json
@@ -471,14 +471,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "14",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.screenBrightnessProperty.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -533,14 +526,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "14",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.screenEnabledProperty.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox Android for the `Screen` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/queengooborg/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
