### PR TITLE
Remove irrelevant "dom.visualviewport.enabled" flag in Firefox Android

### DIFF
--- a/api/VisualViewport.json
+++ b/api/VisualViewport.json
@@ -29,21 +29,9 @@
               ]
             }
           ],
-          "firefox_android": [
-            {
-              "version_added": "68"
-            },
-            {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.visualviewport.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox_android": {
+            "version_added": "68"
+          },
           "ie": {
             "version_added": false
           },
@@ -101,21 +89,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "68"
-              },
-              {
-                "version_added": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.visualviewport.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "68"
+            },
             "ie": {
               "version_added": false
             },
@@ -174,21 +150,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "68"
-              },
-              {
-                "version_added": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.visualviewport.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "68"
+            },
             "ie": {
               "version_added": false
             },
@@ -247,21 +211,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "68"
-              },
-              {
-                "version_added": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.visualviewport.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "68"
+            },
             "ie": {
               "version_added": false
             },
@@ -320,21 +272,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "68"
-              },
-              {
-                "version_added": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.visualviewport.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "68"
+            },
             "ie": {
               "version_added": false
             },
@@ -393,21 +333,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "68"
-              },
-              {
-                "version_added": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.visualviewport.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "68"
+            },
             "ie": {
               "version_added": false
             },
@@ -481,21 +409,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "68"
-              },
-              {
-                "version_added": "66",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.visualviewport.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "68"
+            },
             "ie": {
               "version_added": false
             },
@@ -575,21 +491,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "68"
-              },
-              {
-                "version_added": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.visualviewport.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "68"
+            },
             "ie": {
               "version_added": false
             },
@@ -663,21 +567,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "68"
-              },
-              {
-                "version_added": "66",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.visualviewport.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "68"
+            },
             "ie": {
               "version_added": false
             },
@@ -757,21 +649,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "68"
-              },
-              {
-                "version_added": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.visualviewport.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "68"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/Window.json
+++ b/api/Window.json
@@ -8877,21 +8877,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "68"
-              },
-              {
-                "version_added": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.visualviewport.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "68"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for the `dom.visualviewport.enabled` flag of Firefox Android as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).
