### PR TITLE
Remove irrelevant "layout.css.getBoxQuads.enabled" flag in Firefox Android

### DIFF
--- a/api/_mixins/GeometryUtils__Document.json
+++ b/api/_mixins/GeometryUtils__Document.json
@@ -25,14 +25,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "31",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.getBoxQuads.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/_mixins/GeometryUtils__Element.json
+++ b/api/_mixins/GeometryUtils__Element.json
@@ -25,14 +25,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "31",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.getBoxQuads.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false

--- a/api/_mixins/GeometryUtils__Text.json
+++ b/api/_mixins/GeometryUtils__Text.json
@@ -25,14 +25,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "31",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.getBoxQuads.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for the `layout.css.getBoxQuads.enabled` flag of Firefox Android as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).
