### PR TITLE
Remove irrelevant "layout.css.individual-transform.enabled" flag in Firefox Android

### DIFF
--- a/css/properties/rotate.json
+++ b/css/properties/rotate.json
@@ -34,22 +34,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "79"
-              },
-              {
-                "version_added": "60",
-                "version_removed": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.individual-transform.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "79"
+            },
             "ie": {
               "version_added": false
             },
@@ -112,14 +99,7 @@
                 }
               ],
               "firefox_android": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.individual-transform.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "79"
               },
               "ie": {
                 "version_added": false

--- a/css/properties/scale.json
+++ b/css/properties/scale.json
@@ -34,22 +34,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "79"
-              },
-              {
-                "version_added": "60",
-                "version_removed": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.individual-transform.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "79"
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/translate.json
+++ b/css/properties/translate.json
@@ -34,22 +34,9 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "79"
-              },
-              {
-                "version_added": "60",
-                "version_removed": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.individual-transform.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "79"
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for the `layout.css.individual-transform.enabled` flag of Firefox Android as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).
