### PR TITLE
Remove irrelevant Firefox Android flag data for WorkerGlobalScope API

### DIFF
--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -84,23 +84,11 @@
                 ]
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "4",
-                "partial_implementation": true,
-                "notes": "By default, this method exists and can be called, but does nothing unless enabled in the browser's preferences."
-              },
-              {
-                "version_added": "4",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "browser.dom.window.dump.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox_android": {
+              "version_added": "4",
+              "partial_implementation": true,
+              "notes": "This method exists but has no effect."
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox Android for the `WorkerGlobalScope` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/queengooborg/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
