### PR TITLE
Remove irrelevant Firefox Android flag data for document CSS @rule

### DIFF
--- a/css/at-rules/document.json
+++ b/css/at-rules/document.json
@@ -82,22 +82,10 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": [
-                {
-                  "version_added": "61",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.moz-document.content.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                {
-                  "version_added": "6",
-                  "version_removed": "61"
-                }
-              ],
+              "firefox": {
+                "version_added": "6",
+                "version_removed": "61"
+              },
               "firefox_android": {
                 "version_added": "6",
                 "version_removed": "61"

--- a/css/at-rules/document.json
+++ b/css/at-rules/document.json
@@ -24,18 +24,6 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.moz-document.content.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "To use values other than an empty <code>url-prefix()</code>, set this browser flag to true."
-              },
-              {
-                "prefix": "-moz-",
                 "version_added": "1.5",
                 "version_removed": "61"
               }

--- a/css/at-rules/document.json
+++ b/css/at-rules/document.json
@@ -34,25 +34,11 @@
                 "version_removed": "61"
               }
             ],
-            "firefox_android": [
-              {
-                "prefix": "-moz-",
-                "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.moz-document.content.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Disabled by default in web pages, except for an empty <code>url-prefix()</code> value, which is supported due to its <a href='https://css-tricks.com/snippets/css/css-hacks-targeting-firefox/'>use in Firefox browser detection</a>. Still supported in user stylesheets."
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "4",
-                "version_removed": "61"
-              }
-            ],
+            "firefox_android": {
+              "prefix": "-moz-",
+              "version_added": "4",
+              "version_removed": "61"
+            },
             "ie": {
               "version_added": false
             },
@@ -98,7 +84,8 @@
                 "version_added": "6"
               },
               "firefox_android": {
-                "version_added": "6"
+                "version_added": "6",
+                "version_removed": "61"
               },
               "ie": {
                 "version_added": false

--- a/css/at-rules/document.json
+++ b/css/at-rules/document.json
@@ -34,11 +34,19 @@
                 "version_removed": "61"
               }
             ],
-            "firefox_android": {
-              "prefix": "-moz-",
-              "version_added": "4",
-              "version_removed": "61"
-            },
+            "firefox_android": [
+              {
+                "prefix": "-moz-",
+                "version_added": "61",
+                "partial_implementation": true,
+                "notes": "Only supports an empty <code>url-prefix()</code> value, which is supported due to its <a href='https://css-tricks.com/snippets/css/css-hacks-targeting-firefox/'>use in Firefox browser detection</a>. Still supported in user stylesheets."
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "4",
+                "version_removed": "61"
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/css/at-rules/document.json
+++ b/css/at-rules/document.json
@@ -19,6 +19,12 @@
               {
                 "prefix": "-moz-",
                 "version_added": "61",
+                "partial_implementation": true,
+                "notes": "Only supports an empty <code>url-prefix()</code> value, which is supported due to its <a href='https://css-tricks.com/snippets/css/css-hacks-targeting-firefox/'>use in Firefox browser detection</a>. Still supported in user stylesheets."
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "61",
                 "flags": [
                   {
                     "type": "preference",
@@ -26,7 +32,7 @@
                     "value_to_set": "true"
                   }
                 ],
-                "notes": "Disabled by default in web pages, except for an empty <code>url-prefix()</code> value, which is supported due to its <a href='https://css-tricks.com/snippets/css/css-hacks-targeting-firefox/'>use in Firefox browser detection</a>. Still supported in user stylesheets."
+                "notes": "To use values other than an empty <code>url-prefix()</code>, set this browser flag to true."
               },
               {
                 "prefix": "-moz-",
@@ -88,9 +94,22 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "6"
-              },
+              "firefox": [
+                {
+                  "version_added": "61",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.moz-document.content.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "61"
+                }
+              ],
               "firefox_android": {
                 "version_added": "6",
                 "version_removed": "61"


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox Android for the `document` CSS @rule as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/queengooborg/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
