### PR TITLE
Remove irrelevant Firefox Android flag data for supports CSS @rule

### DIFF
--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -82,22 +82,9 @@
                   ]
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "79"
-                },
-                {
-                  "version_added": "64",
-                  "version_removed": "79",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.supports-selector.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox_android": {
+                "version_added": "79"
+              },
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox Android for the `supports` CSS @rule as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/queengooborg/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
