### PR TITLE
Remove irrelevant Firefox Android flag data for -moz-context-properties CSS property

### DIFF
--- a/css/properties/-moz-context-properties.json
+++ b/css/properties/-moz-context-properties.json
@@ -27,14 +27,8 @@
             },
             "firefox_android": {
               "version_added": "55",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "svg.context-properties.content.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "With the preference set to <code>false</code>, the property still works with SVGs via <code>chrome://</code> or <code>resource://</code> URLs"
+              "partial_implementation": true,
+              "notes": "The property only works with SVGs via <code>chrome://</code> or <code>resource://</code> URLs."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox Android for the `-moz-context-properties` CSS property as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/queengooborg/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
