### PR TITLE
Remove irrelevant Firefox Android flag data for column-span CSS property

### DIFF
--- a/css/properties/column-span.json
+++ b/css/properties/column-span.json
@@ -49,14 +49,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": "65",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.column-span.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "79"
             },
             "ie": {
               "version_added": "10"


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox Android for the `column-span` CSS property as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/queengooborg/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
