### PR TITLE
Remove irrelevant Firefox Android flag data for contain CSS property

### DIFF
--- a/css/properties/contain.json
+++ b/css/properties/contain.json
@@ -32,14 +32,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": "41",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.contain.enabled",
-                  "value_to_set": "true"
-                }
-              ],
+              "version_added": "79",
               "notes": "Firefox does not support the <code>style</code> value."
             },
             "ie": {


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox Android for the `contain` CSS property as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/queengooborg/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
