### PR TITLE
Remove irrelevant Firefox Android flag data for offset-path CSS property

### DIFF
--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -50,14 +50,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": "63",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.motion-path.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -129,7 +122,7 @@
                 "version_added": "63"
               },
               "firefox_android": {
-                "version_added": "63"
+                "version_added": "79"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox Android for the `offset-path` CSS property as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/queengooborg/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
