### PR TITLE
Remove irrelevant Firefox Android flag data for basic-shape CSS type

### DIFF
--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -307,30 +307,15 @@
                   "notes": "With the preference enabled, the <code>clip-path</code> and <code>offset-path</code> properties support <code>path()</code>."
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "63",
-                  "partial_implementation": true,
-                  "notes": [
-                    "From version 97, the <code>d</code> SVG presentation attribute supports <code>path()</code>.",
-                    "From version 79, the <code>clip-path</code> property supports <code>path()</code>.",
-                    "Before version 79, only the <code>offset-path</code> property supports <code>path()</code>."
-                  ]
-                },
-                {
-                  "version_added": "64",
-                  "version_removed": "79",
-                  "partial_implementation": true,
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.clip-path-path.enabled",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "notes": "With the preference enabled, the <code>clip-path</code> and <code>offset-path</code> properties support <code>path()</code>."
-                }
-              ],
+              "firefox_android": {
+                "version_added": "63",
+                "partial_implementation": true,
+                "notes": [
+                  "From version 97, the <code>d</code> SVG presentation attribute supports <code>path()</code>.",
+                  "From version 79, the <code>clip-path</code> property supports <code>path()</code>.",
+                  "Before version 79, only the <code>offset-path</code> property supports <code>path()</code>."
+                ]
+              },
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox Android for the `basic-shape` CSS type as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/queengooborg/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
