### PR TITLE
Remove irrelevant Firefox Android flag data for area HTML element

### DIFF
--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -543,15 +543,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": true,
-                "version_removed": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "browser.send_pings",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": false
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox Android for the `area` HTML element as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/queengooborg/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
