### PR TITLE
Remove irrelevant Firefox flag data for link HTML element

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -1142,19 +1142,23 @@
                     "version_added": "85"
                   },
                   {
-                    "version_added": "78",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "network.preload",
-                        "value_to_set": "true"
-                      }
-                    ]
+                    "partial_implementation": true,
+                    "version_added": "56",
+                    "version_removed": "57",
+                    "notes": "Disabled due to various web compatibility issues (e.g. <a href='https://bugzil.la/1405761'>bug 1405761</a>)."
                   }
                 ],
-                "firefox_android": {
-                  "version_added": "85"
-                },
+                "firefox_android": [
+                  {
+                    "version_added": "85"
+                  },
+                  {
+                    "partial_implementation": true,
+                    "version_added": "56",
+                    "version_removed": "57",
+                    "notes": "Disabled due to various web compatibility issues (e.g. <a href='https://bugzil.la/1405761'>bug 1405761</a>)."
+                  }
+                ],
                 "ie": {
                   "version_added": null
                 },

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -1150,35 +1150,11 @@
                         "value_to_set": "true"
                       }
                     ]
-                  },
-                  {
-                    "partial_implementation": true,
-                    "version_added": "56",
-                    "version_removed": "57",
-                    "notes": "Disabled due to various web compatibility issues (e.g. <a href='https://bugzil.la/1405761'>bug 1405761</a>)."
                   }
                 ],
-                "firefox_android": [
-                  {
-                    "version_added": "85"
-                  },
-                  {
-                    "version_added": "79",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "network.preload",
-                        "value_to_set": "true"
-                      }
-                    ]
-                  },
-                  {
-                    "partial_implementation": true,
-                    "version_added": "56",
-                    "version_removed": "57",
-                    "notes": "Disabled due to various web compatibility issues (e.g. <a href='https://bugzil.la/1405761'>bug 1405761</a>)."
-                  }
-                ],
+                "firefox_android": {
+                  "version_added": "85"
+                },
                 "ie": {
                   "version_added": null
                 },


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `link` HTML element as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data).

This PR was created from results of a [script](https://github.com/queengooborg/browser-compat-data/blob/scripts/remove-redundant-flags/scripts/remove-redundant-flags.js) designed to remove irrelevant flags.
