### PR TITLE
Support linking tracking bugs in BCD

### DIFF
--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -394,6 +394,19 @@ It defaults to `false` (no interoperability problems expected). If set to `true`
 recommended that you add a note explaining how it diverges from the standard (such as
 that it implements an old version of the standard, for example).
 
+#### `tracking_bug`
+
+A string containing a link to a tracking bug for the implementation of the feature in the browser. This may help for verifying compatibility data.
+
+Example:
+
+```json
+{
+  "version_added": "60",
+  "tracking_bug": "https://webkit.org/b/194095"
+}
+```
+
 #### `notes`
 
 A string or `array` of strings containing additional information. If there is only one

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -57,6 +57,10 @@
             { "not": { "enum": ["true", false] } }
           ]
         },
+        "tracking_bug": {
+          "type": "string",
+          "description": "A string containing a link to a tracking bug for the implementation of the feature in the browser."
+        },
         "notes": {
           "description": "A string or array of strings containing additional information.",
           "anyOf": [


### PR DESCRIPTION
This PR adds the ability to link tracking bugs to the schema, which fixes #126.  There's no linter changes applied to ensure the value is 
actually a tracking a bug; that will be applied if this draft is approved.
