### PR TITLE
Fix broken HTML in notes

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -358,7 +358,7 @@
                 "version_added": "1.0",
                 "notes": [
                   "Before Deno 1.4, <code>%c</code> is not supported.",
-                  "<code>%c</code> only supports CSS properties <code>color<code/>, <code>background-color<code/>, <code>font-weight<code/>, <code>font-style<code/>, <code>text-decoration-color<code/>, and <code>text-decoration-line<code/>."
+                  "<code>%c</code> only supports CSS properties <code>color</code>, <code>background-color</code>, <code>font-weight</code>, <code>font-style</code>, <code>text-decoration-color</code>, and <code>text-decoration-line</code>."
                 ]
               },
               "edge": {
@@ -598,7 +598,7 @@
                 "version_added": "1.0",
                 "notes": [
                   "Before Deno 1.4, <code>%c</code> is not supported.",
-                  "<code>%c</code> only supports CSS properties <code>color<code/>, <code>background-color<code/>, <code>font-weight<code/>, <code>font-style<code/>, <code>text-decoration-color<code/>, and <code>text-decoration-line<code/>."
+                  "<code>%c</code> only supports CSS properties <code>color</code>, <code>background-color</code>, <code>font-weight</code>, <code>font-style</code>, <code>text-decoration-color</code>, and <code>text-decoration-line</code>."
                 ]
               },
               "edge": {
@@ -996,7 +996,7 @@
                 "version_added": "1.0",
                 "notes": [
                   "Before Deno 1.4, <code>%c</code> is not supported.",
-                  "<code>%c</code> only supports CSS properties <code>color<code/>, <code>background-color<code/>, <code>font-weight<code/>, <code>font-style<code/>, <code>text-decoration-color<code/>, and <code>text-decoration-line<code/>."
+                  "<code>%c</code> only supports CSS properties <code>color</code>, <code>background-color</code>, <code>font-weight</code>, <code>font-style</code>, <code>text-decoration-color</code>, and <code>text-decoration-line</code>."
                 ]
               },
               "edge": {
@@ -1119,7 +1119,7 @@
                 "version_added": "1.0",
                 "notes": [
                   "Before Deno 1.4, <code>%c</code> is not supported.",
-                  "<code>%c</code> only supports CSS properties <code>color<code/>, <code>background-color<code/>, <code>font-weight<code/>, <code>font-style<code/>, <code>text-decoration-color<code/>, and <code>text-decoration-line<code/>."
+                  "<code>%c</code> only supports CSS properties <code>color</code>, <code>background-color</code>, <code>font-weight</code>, <code>font-style</code>, <code>text-decoration-color</code>, and <code>text-decoration-line</code>."
                 ]
               },
               "edge": {
@@ -1698,7 +1698,7 @@
                 "version_added": "1.0",
                 "notes": [
                   "Before Deno 1.4, <code>%c</code> is not supported.",
-                  "<code>%c</code> only supports CSS properties <code>color<code/>, <code>background-color<code/>, <code>font-weight<code/>, <code>font-style<code/>, <code>text-decoration-color<code/>, and <code>text-decoration-line<code/>."
+                  "<code>%c</code> only supports CSS properties <code>color</code>, <code>background-color</code>, <code>font-weight</code>, <code>font-style</code>, <code>text-decoration-color</code>, and <code>text-decoration-line</code>."
                 ]
               },
               "edge": {

--- a/api/HTMLTrackElement.json
+++ b/api/HTMLTrackElement.json
@@ -16,11 +16,11 @@
           },
           "firefox": {
             "version_added": "31",
-            "notes": "Before Firefox 50, text tracks would only load if the <track> element is in a document."
+            "notes": "Before Firefox 50, text tracks would only load if the <code>&lt;track&gt;</code> element is in a document."
           },
           "firefox_android": {
             "version_added": "31",
-            "notes": "Before Firefox 50, text tracks would only load if the <track> element is in a document."
+            "notes": "Before Firefox 50, text tracks would only load if the <code>&lt;track&gt;</code> element is in a document."
           },
           "ie": {
             "version_added": "10"

--- a/api/Location.json
+++ b/api/Location.json
@@ -490,11 +490,11 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Before Firefox 53, the <code>pathname</code> property returned wrong parts of the URL. For example, for a URL of http://z.com/x?a=true&b=false, <code>pathname</code> would return \"/x?a=true&b=false\" rather than \"/x\"."
+              "notes": "Before Firefox 53, the <code>pathname</code> property returned wrong parts of the URL. For example, for a URL of http://z.com/x?a=true&amp;b=false, <code>pathname</code> would return \"/x?a=true&amp;b=false\" rather than \"/x\"."
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "Before Firefox 53, the <code>pathname</code> property returned wrong parts of the URL. For example, for a URL of http://z.com/x?a=true&b=false, <code>pathname</code> would return \"/x?a=true&b=false\" rather than \"/x\"."
+              "notes": "Before Firefox 53, the <code>pathname</code> property returned wrong parts of the URL. For example, for a URL of http://z.com/x?a=true&amp;b=false, <code>pathname</code> would return \"/x?a=true&amp;b=false\" rather than \"/x\"."
             },
             "ie": {
               "version_added": "3",
@@ -755,11 +755,11 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Before Firefox 53, the <code>search</code> property returned wrong parts of the URL. For example, for a URL of http://z.com/x?a=true&b=false, <code>search</code> would return \"\", rather than \"?a=true&b=false\"."
+              "notes": "Before Firefox 53, the <code>search</code> property returned wrong parts of the URL. For example, for a URL of http://z.com/x?a=true&amp;b=false, <code>search</code> would return \"\", rather than \"?a=true&amp;b=false\"."
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "Before Firefox 53, the <code>search</code> property returned wrong parts of the URL. For example, for a URL of http://z.com/x?a=true&b=false, <code>search</code> would return \"\", rather than \"?a=true&b=false\"."
+              "notes": "Before Firefox 53, the <code>search</code> property returned wrong parts of the URL. For example, for a URL of http://z.com/x?a=true&amp;b=false, <code>search</code> would return \"\", rather than \"?a=true&amp;b=false\"."
             },
             "ie": {
               "version_added": "3"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -978,7 +978,7 @@
             },
             "ie": {
               "version_added": "4",
-              "notes": "<code>navigator.cookieEnabled</code> returns <code>true</true> even if the browser is set to block cookies (for example, if the page is in the <em>Restricted sites</em> security zone)."
+              "notes": "<code>navigator.cookieEnabled</code> returns <code>true</code> even if the browser is set to block cookies (for example, if the page is in the <em>Restricted sites</em> security zone)."
             },
             "opera": {
               "version_added": "≤12.1"
@@ -4881,7 +4881,7 @@
               "version_added": "38",
               "notes": [
                 "Starting in Firefox 55, if neither <code>audioCapabilities</code> nor <code>videoCapabilities</code> is specified in <code>supportedConfigurations</code>, a warning is output to the web console.",
-                "In addition, starting in Firefox 55, if in <code>supportedConfigurations</code>, either <code>audioCapabilities</code>'s or <code>videoCapabilities</code>'s <code>contentType</code> value doesn't specify a </code>\"codecs\"</code> substring to define allowed codecs within the media wrapper, a warning is output to the web console. See note below table for example and correction.",
+                "In addition, starting in Firefox 55, if in <code>supportedConfigurations</code>, either <code>audioCapabilities</code>'s or <code>videoCapabilities</code>'s <code>contentType</code> value doesn't specify a <code>\"codecs\"</code> substring to define allowed codecs within the media wrapper, a warning is output to the web console. See note below table for example and correction.",
                 "In the future, if neither <code>audioCapabilities</code> nor <code>videoCapabilities</code> is specified in the <code>supportedConfigurations</code>, a <code>NotSupported</code> exception will be thrown."
               ]
             },
@@ -4889,7 +4889,7 @@
               "version_added": "38",
               "notes": [
                 "Starting in Firefox 55, if neither <code>audioCapabilities</code> nor <code>videoCapabilities</code> is specified in <code>supportedConfigurations</code>, a warning is output to the web console.",
-                "In addition, starting in Firefox 55, if in <code>supportedConfigurations</code>, either <code>audioCapabilities</code>'s or <code>videoCapabilities</code>'s <code>contentType</code> value doesn't specify a </code>\"codecs\"</code> substring to define allowed codecs within the media wrapper, a warning is output to the web console. See note below table for example and correction.",
+                "In addition, starting in Firefox 55, if in <code>supportedConfigurations</code>, either <code>audioCapabilities</code>'s or <code>videoCapabilities</code>'s <code>contentType</code> value doesn't specify a <code>\"codecs\"</code> substring to define allowed codecs within the media wrapper, a warning is output to the web console. See note below table for example and correction.",
                 "In the future, if neither <code>audioCapabilities</code> nor <code>videoCapabilities</code> is specified in the <code>supportedConfigurations</code>, a <code>NotSupported</code> exception will be thrown."
               ]
             },

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -157,15 +157,15 @@
           "support": {
             "chrome": {
               "version_added": "57",
-              "notes": "The default for <code>rtcpMuxPolicy<code> is <code>require<code>."
+              "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
             },
             "chrome_android": {
               "version_added": "57",
-              "notes": "The default for <code>rtcpMuxPolicy<code> is <code>require<code>."
+              "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
             },
             "edge": {
               "version_added": "79",
-              "notes": "The default for <code>rtcpMuxPolicy<code> is <code>require<code>."
+              "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
             },
             "firefox": {
               "version_added": "44"
@@ -178,11 +178,11 @@
             },
             "opera": {
               "version_added": "44",
-              "notes": "The default for <code>rtcpMuxPolicy<code> is <code>require<code>."
+              "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
             },
             "opera_android": {
               "version_added": "43",
-              "notes": "The default for <code>rtcpMuxPolicy<code> is <code>require<code>."
+              "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
             },
             "safari": {
               "version_added": "11"
@@ -192,11 +192,11 @@
             },
             "samsunginternet_android": {
               "version_added": "7.0",
-              "notes": "The default for <code>rtcpMuxPolicy<code> is <code>require<code>."
+              "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
             },
             "webview_android": {
               "version_added": "57",
-              "notes": "The default for <code>rtcpMuxPolicy<code> is <code>require<code>."
+              "notes": "The default for <code>rtcpMuxPolicy</code> is <code>require</code>."
             }
           },
           "status": {

--- a/api/URL.json
+++ b/api/URL.json
@@ -679,11 +679,11 @@
             },
             "firefox": {
               "version_added": "22",
-              "notes": "Before Firefox 53, <code>pathname</code> and <code>search</code> returned wrong values for custom protocols. Given <code>protocol:host/x?a=true&b=false</code>, <code>pathname</code> would return \"/x?a=true&b=false\" and <code>search</code> would return \"\", rather than \"/x\" and \"?a=true&b=false\" respectively. See <a href='https://bugzil.la/1310483'>bug 1310483</a>."
+              "notes": "Before Firefox 53, <code>pathname</code> and <code>search</code> returned wrong values for custom protocols. Given <code>protocol:host/x?a=true&amp;b=false</code>, <code>pathname</code> would return \"/x?a=true&amp;b=false\" and <code>search</code> would return \"\", rather than \"/x\" and \"?a=true&amp;b=false\" respectively. See <a href='https://bugzil.la/1310483'>bug 1310483</a>."
             },
             "firefox_android": {
               "version_added": "22",
-              "notes": "Before Firefox 53, <code>pathname</code> and <code>search</code> returned wrong values for custom protocols. Given <code>protocol:host/x?a=true&b=false</code>, <code>pathname</code> would return \"/x?a=true&b=false\" and <code>search</code> would return \"\", rather than \"/x\" and \"?a=true&b=false\" respectively. See <a href='https://bugzil.la/1310483'>bug 1310483</a>."
+              "notes": "Before Firefox 53, <code>pathname</code> and <code>search</code> returned wrong values for custom protocols. Given <code>protocol:host/x?a=true&amp;b=false</code>, <code>pathname</code> would return \"/x?a=true&amp;b=false\" and <code>search</code> would return \"\", rather than \"/x\" and \"?a=true&amp;b=false\" respectively. See <a href='https://bugzil.la/1310483'>bug 1310483</a>."
             },
             "ie": {
               "version_added": false
@@ -903,11 +903,11 @@
             },
             "firefox": {
               "version_added": "22",
-              "notes": "Before Firefox 53, <code>pathname</code> and <code>search</code> returned wrong values for custom protocols. Given <code>protocol:host/x?a=true&b=false</code>, <code>pathname</code> would return \"/x?a=true&b=false\" and <code>search</code> would return \"\", rather than \"/x\" and \"?a=true&b=false\" respectively. See <a href='https://bugzil.la/1310483'>bug 1310483</a>."
+              "notes": "Before Firefox 53, <code>pathname</code> and <code>search</code> returned wrong values for custom protocols. Given <code>protocol:host/x?a=true&amp;b=false</code>, <code>pathname</code> would return \"/x?a=true&amp;b=false\" and <code>search</code> would return \"\", rather than \"/x\" and \"?a=true&amp;b=false\" respectively. See <a href='https://bugzil.la/1310483'>bug 1310483</a>."
             },
             "firefox_android": {
               "version_added": "22",
-              "notes": "Before Firefox 53, <code>pathname</code> and <code>search</code> returned wrong values for custom protocols. Given <code>protocol:host/x?a=true&b=false</code>, <code>pathname</code> would return \"/x?a=true&b=false\" and <code>search</code> would return \"\", rather than \"/x\" and \"?a=true&b=false\" respectively. See <a href='https://bugzil.la/1310483'>bug 1310483</a>."
+              "notes": "Before Firefox 53, <code>pathname</code> and <code>search</code> returned wrong values for custom protocols. Given <code>protocol:host/x?a=true&amp;b=false</code>, <code>pathname</code> would return \"/x?a=true&amp;b=false\" and <code>search</code> would return \"\", rather than \"/x\" and \"?a=true&amp;b=false\" respectively. See <a href='https://bugzil.la/1310483'>bug 1310483</a>."
             },
             "ie": {
               "version_added": false

--- a/api/_mixins/HTMLHyperlinkElementUtils__HTMLAnchorElement.json
+++ b/api/_mixins/HTMLHyperlinkElementUtils__HTMLAnchorElement.json
@@ -316,11 +316,11 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."
+              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&amp;b=false</code>, <code>pathname</code> would return <code>'/x?a=true&amp;b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&amp;b=false'</code> respectively. This has now been fixed."
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."
+              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&amp;b=false</code>, <code>pathname</code> would return <code>'/x?a=true&amp;b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&amp;b=false'</code> respectively. This has now been fixed."
             },
             "ie": {
               "version_added": "5"
@@ -465,11 +465,11 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."
+              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&amp;b=false</code>, <code>pathname</code> would return <code>'/x?a=true&amp;b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&amp;b=false'</code> respectively. This has now been fixed."
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."
+              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&amp;b=false</code>, <code>pathname</code> would return <code>'/x?a=true&amp;b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&amp;b=false'</code> respectively. This has now been fixed."
             },
             "ie": {
               "version_added": "5"

--- a/api/_mixins/HTMLHyperlinkElementUtils__HTMLAreaElement.json
+++ b/api/_mixins/HTMLHyperlinkElementUtils__HTMLAreaElement.json
@@ -316,11 +316,11 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."
+              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&amp;b=false</code>, <code>pathname</code> would return <code>'/x?a=true&amp;b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&amp;b=false'</code> respectively. This has now been fixed."
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."
+              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&amp;b=false</code>, <code>pathname</code> would return <code>'/x?a=true&amp;b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&amp;b=false'</code> respectively. This has now been fixed."
             },
             "ie": {
               "version_added": "5"
@@ -465,11 +465,11 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."
+              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&amp;b=false</code>, <code>pathname</code> would return <code>'/x?a=true&amp;b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&amp;b=false'</code> respectively. This has now been fixed."
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&b=false</code>, <code>pathname</code> would return <code>'/x?a=true&b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&b=false'</code> respectively. This has now been fixed."
+              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&amp;b=false</code>, <code>pathname</code> would return <code>'/x?a=true&amp;b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&amp;b=false'</code> respectively. This has now been fixed."
             },
             "ie": {
               "version_added": "5"

--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -91,7 +91,7 @@
               "safari_ios": {
                 "version_added": "5",
                 "partial_implementation": true,
-                "notes": "<code>fixed<code> is recognized but has no effect. See <a href='https://webkit.org/b/219324'>bug 219324</a>."
+                "notes": "<code>fixed</code> is recognized but has no effect. See <a href='https://webkit.org/b/219324'>bug 219324</a>."
               },
               "samsunginternet_android": {
                 "version_added": "1.0"

--- a/css/types/transform-function.json
+++ b/css/types/transform-function.json
@@ -723,7 +723,7 @@
               },
               "firefox": {
                 "version_added": "3.5",
-                "notes": "Firefox 14 removed experimental support for <code>skew()</code></a>, but it was reintroduced in Firefox 15."
+                "notes": "Firefox 14 removed experimental support for <code>skew()</code>, but it was reintroduced in Firefox 15."
               },
               "firefox_android": {
                 "version_added": "4"

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -299,14 +299,14 @@
               "version_added": "22",
               "notes": [
                 "The initial implementation of arrow functions in Firefox made them automatically strict. This has been changed as of Firefox 24. The use of <code>'use strict';</code> is now required.",
-                "Before Firefox 39, a line terminator (<code>\\n</code>) was incorrectly allowed after arrow function arguments. This has been fixed to conform to the ES2015 specification and code like <code>() \\n => {}</code> will now throw a <code>SyntaxError</code> in this and later versions."
+                "Before Firefox 39, a line terminator (<code>\\n</code>) was incorrectly allowed after arrow function arguments. This has been fixed to conform to the ES2015 specification and code like <code>() \\n =&gt; {}</code> will now throw a <code>SyntaxError</code> in this and later versions."
               ]
             },
             "firefox_android": {
               "version_added": "22",
               "notes": [
                 "The initial implementation of arrow functions in Firefox made them automatically strict. This has been changed as of Firefox 24. The use of <code>'use strict';</code> is now required.",
-                "Before Firefox 39, a line terminator (<code>\\n</code>) was incorrectly allowed after arrow function arguments. This has been fixed to conform to the ES2015 specification and code like <code>() \\n => {}</code> will now throw a <code>SyntaxError</code> in this and later versions."
+                "Before Firefox 39, a line terminator (<code>\\n</code>) was incorrectly allowed after arrow function arguments. This has been fixed to conform to the ES2015 specification and code like <code>() \\n =&gt; {}</code> will now throw a <code>SyntaxError</code> in this and later versions."
               ]
             },
             "ie": {

--- a/webextensions/api/management.json
+++ b/webextensions/api/management.json
@@ -326,7 +326,7 @@
               },
               "firefox_android": {
                 "version_added": "55",
-                "notes": "Before version 56, only extensions whose <code>'type'</code> is <code>'theme'<code> are supported."
+                "notes": "Before version 56, only extensions whose <code>type</code> is <code>'theme'</code> are supported."
               },
               "opera": {
                 "version_added": true

--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -592,7 +592,7 @@
           },
           "accessKey": {
             "__compat": {
-              "description": "<code>&</code> in <code>title</code> sets access key",
+              "description": "<code>&amp;</code> in <code>title</code> sets access key",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -610,7 +610,7 @@
                   "version_added": true
                 },
                 "safari": {
-                  "notes": "Safari removes <code>&</code> from menu items' displayed titles, but does not support invoking menu items via access keys.",
+                  "notes": "Safari removes <code>&amp;</code> from menu items' displayed titles, but does not support invoking menu items via access keys.",
                   "partial_implementation": true,
                   "version_added": "14"
                 },

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -466,7 +466,7 @@
                 },
                 "firefox_android": {
                   "version_added": "55",
-                  "notes": "Requests have been reported as <code>object_subrequest</code>  before, but the type was missing in the <code>ResourceType</code> object before Firefox 55."
+                  "notes": "Requests have been reported as <code>object_subrequest</code> before, but the type was missing in the <code>ResourceType</code> object before Firefox 55."
                 },
                 "opera": {
                   "version_added": false


### PR DESCRIPTION
This PR fixes the broken HTML currently present in the notes.  These were all caught by the linter introduced in #5591.
