### PR TITLE
Add opera 71 support

### DIFF
--- a/javascript/builtins/AggregateError.json
+++ b/javascript/builtins/AggregateError.json
@@ -34,7 +34,7 @@
               "version_added": "71"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "60"
             },
             "safari": {
               "version_added": "14"
@@ -86,10 +86,10 @@
                 "version_added": "15.0.0"
               },
               "opera": {
-                "version_added": false
+                "version_added": "71"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "60"
               },
               "safari": {
                 "version_added": "14"

--- a/javascript/builtins/AggregateError.json
+++ b/javascript/builtins/AggregateError.json
@@ -31,7 +31,7 @@
               "version_added": "15.0.0"
             },
             "opera": {
-              "version_added": false
+              "version_added": "71"
             },
             "opera_android": {
               "version_added": false

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -261,7 +261,7 @@
                 "version_added": "71"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "60"
               },
               "safari": {
                 "version_added": "14"

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -258,7 +258,7 @@
                 "version_added": "15.0.0"
               },
               "opera": {
-                "version_added": false
+                "version_added": "71"
               },
               "opera_android": {
                 "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
I've tested Opera 71 against https://github.github.com/browser-support/ which uses MDN compat data to generate feature tables, but also has live tests for the currently running browser.

I've noticed that Opera 71 supports both `Promise.any` and `AggregateError`.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
 The two tests that pass are:

```js
'any' in Promise && typeof Promise.any === 'function'
```

```js
typeof globalThis.AggregateError === 'function'
```

You can verify this by visiting https://github.github.com/browser-support/ which runs these tests next to their respective table headings. The result of visiting that site in Opera 71 should be:

![a screenshot showing Opera visiting the browser-support page](https://user-images.githubusercontent.com/118266/162729843-532696e2-176b-4bb2-876c-72ae023e134a.png)

As you can see the `AggregateError` and `Promise.any` pips are green, denoting that these tests returned a true on this browser.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

https://github.com/github/browser-support/pull/16 might also be relevant. 

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
