### PR TITLE
HTMLMediaElement.controller is deprecated

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -1827,8 +1827,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -622,8 +622,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
`HTMLMediaElement.controller` and `.mediaGroup` are deprecated and non-standard.

From the controller docs: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controller

> In 2016, the whole Media Controller feature was [removed from the HTML specification](https://github.com/w3c/html/issues/246). It is no longer on track to become a standard.

This originates in https://github.com/mdn/content/issues/14892