### PR TITLE
fix: Remove `NodeIterator.expandEntityReferences` and `TreeWalker.expandEntityReferences`

### DIFF
--- a/api/TreeWalker.json
+++ b/api/TreeWalker.json
@@ -97,65 +97,6 @@
           }
         }
       },
-      "expandEntityReferences": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TreeWalker/expandEntityReferences",
-          "support": {
-            "chrome": {
-              "version_added": "1",
-              "version_removed": "41"
-            },
-            "chrome_android": {
-              "version_added": "18",
-              "version_removed": "41"
-            },
-            "edge": {
-              "version_added": "12",
-              "version_removed": "79"
-            },
-            "firefox": {
-              "version_added": "4",
-              "version_removed": "21"
-            },
-            "firefox_android": {
-              "version_added": "4",
-              "version_removed": "21"
-            },
-            "ie": {
-              "version_added": "9"
-            },
-            "opera": {
-              "version_added": "9",
-              "version_removed": "28"
-            },
-            "opera_android": {
-              "version_added": "10.1",
-              "version_removed": "28"
-            },
-            "safari": {
-              "version_added": "3",
-              "version_removed": "10.1"
-            },
-            "safari_ios": {
-              "version_added": "3",
-              "version_removed": "10.3"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.0",
-              "version_removed": "4.0"
-            },
-            "webview_android": {
-              "version_added": "3",
-              "version_removed": "41"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "filter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TreeWalker/filter",


### PR DESCRIPTION
Fixes #15771 

#### Summary
The PR https://github.com/mdn/content/pull/14922 removed following WebAPI property pages from `mdn/content`:
- NodeIterator.expandEntityReferences
- TreeWalker.expandEntityReferences

These expandEntityReferences properties have been dropped from the specification long time ago. And are deprecated.
So they are no longer needed in BCD and need to be removed.

### Can you link to any release notes, bugs, pull requests, or MDN pages related to this?
In Firefox release 21 they got removed:
https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/21#dom

It has been instructed here: https://github.com/mdn/content/pull/14856#issuecomment-1095663979
