### PR TITLE
Revert "Package data for NPM as ESM and CJS"

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,8 @@ npm install @mdn/browser-compat-data
 ## Usage
 
 ```js
-// Import BCD into your project
-import bcd from '@mdn/browser-compat-data';
-// ...or...
 const bcd = require('@mdn/browser-compat-data');
-
-// Grab the desired support statement
-const support = bcd.css.properties.background;
+bcd.css.properties.background;
 // returns a compat data object (see schema)
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,9 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
-
+/// <reference path="./types.d.ts"/>
 import { CompatData } from './types';
 
-export default CompatData;
+// This is necessary to have intellisense in projects which
+// import data from this package.
+declare const compatData: CompatData;
+export = compatData;

--- a/scripts/release-build.js
+++ b/scripts/release-build.js
@@ -15,14 +15,15 @@ function createDataBundle() {
 }
 
 // Returns a promise for writing the data to JSON file
-async function writeData(data) {
+async function writeData() {
   const dest = path.resolve(directory, 'data.json');
+  const data = createDataBundle();
   await fs.writeFile(dest, data);
 }
 
-async function writeIndexESM(data) {
+async function writeIndex() {
   const dest = path.resolve(directory, 'index.js');
-  const content = `export default ${data};\n`;
+  const content = `module.exports = require("./data.json");\n`;
   await fs.writeFile(dest, content);
 }
 
@@ -37,11 +38,7 @@ async function copyFiles() {
 
 function createManifest() {
   const full = require('../package.json');
-  const minimal = {
-    main: 'data.json',
-    exports: { import: './index.js', require: './data.json' },
-    type: 'module',
-  };
+  const minimal = { main: 'index.js' };
 
   const minimalKeys = [
     'name',
@@ -87,11 +84,9 @@ async function main() {
   // Crate a new directory
   await fs.mkdir(directory);
 
-  const data = createDataBundle();
-
   await writeManifest();
-  await writeData(data);
-  await writeIndexESM(data);
+  await writeData();
+  await writeIndex();
   await copyFiles();
 
   console.log('Data bundle is ready');

--- a/scripts/release-build.test.js
+++ b/scripts/release-build.test.js
@@ -2,23 +2,13 @@
 const assert = require('assert');
 const { execSync } = require('child_process');
 
-const prebuiltCjsPath = '../build';
-const prebuiltJsPath = '../build/index.js';
-
-const regular = require('..');
+const prebuiltPath = '../build';
 
 describe('release-build', () => {
-  before(() => {
+  it('pre-built bundles are identical to the source', () => {
     execSync('npm run release-build');
-  });
-
-  it('pre-built cjs bundles are identical to the source', () => {
-    const bundled = require(prebuiltCjsPath);
+    const regular = require('..');
+    const bundled = require(prebuiltPath);
     assert.deepEqual(regular, bundled);
-  }).timeout(5000); // Timeout must be long enough for all the file I/O;
-
-  it('pre-built esm bundles are identical to the source', async () => {
-    const { default: bundled } = await import(prebuiltJsPath);
-    assert.deepEqual(regular, bundled);
-  }).timeout(5000); // Timeout must be long enough for all the file I/O;
+  }).timeout(5000); // Timeout must be long enough for all the file I/O
 });


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

This reverts #12169 (b740c60fcd7f56138344b441a3a8cdd550294f23), which adds ESM support to the published package.

The change was [characterized in the PR as semver major](https://github.com/mdn/browser-compat-data/pull/12169#discussion_r695798800), which landed without owner consensus (clarified in https://github.com/mdn/browser-compat-data/pull/15738), so it's not ready to ship just yet.

After this lands, I'll open a PR to revert the revert, so this work isn't lost.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

- #12169
- https://github.com/mdn/browser-compat-data/pull/15738
- https://github.com/mdn/browser-compat-data/pull/12161

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
