### PR TITLE
Package data for npm as ESM and CJS (do-over)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,13 @@ npm install @mdn/browser-compat-data
 ## Usage
 
 ```js
+// Import BCD into your project
+import bcd from '@mdn/browser-compat-data';
+// ...or...
 const bcd = require('@mdn/browser-compat-data');
-bcd.css.properties.background;
+
+// Grab the desired support statement
+const support = bcd.css.properties.background;
 // returns a compat data object (see schema)
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,6 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
-/// <reference path="./types.d.ts"/>
+
 import { CompatData } from './types';
 
-// This is necessary to have intellisense in projects which
-// import data from this package.
-declare const compatData: CompatData;
-export = compatData;
+export default CompatData;

--- a/scripts/release-build.test.js
+++ b/scripts/release-build.test.js
@@ -2,13 +2,23 @@
 const assert = require('assert');
 const { execSync } = require('child_process');
 
-const prebuiltPath = '../build';
+const prebuiltCjsPath = '../build';
+const prebuiltJsPath = '../build/index.js';
+
+const regular = require('..');
 
 describe('release-build', () => {
-  it('pre-built bundles are identical to the source', () => {
+  before(() => {
     execSync('npm run release-build');
-    const regular = require('..');
-    const bundled = require(prebuiltPath);
+  });
+
+  it('pre-built cjs bundles are identical to the source', () => {
+    const bundled = require(prebuiltCjsPath);
     assert.deepEqual(regular, bundled);
-  }).timeout(5000); // Timeout must be long enough for all the file I/O
+  }).timeout(5000); // Timeout must be long enough for all the file I/O;
+
+  it('pre-built esm bundles are identical to the source', async () => {
+    const { default: bundled } = await import(prebuiltJsPath);
+    assert.deepEqual(regular, bundled);
+  }).timeout(5000); // Timeout must be long enough for all the file I/O;
 });


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

This reinstates the work of #12169, which was merged then reverted. Which is to say, it reverts the revert.

ESM releases of BCD are still a goal, but they're not ready for immediate release (see related issues).

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

- https://github.com/mdn/browser-compat-data/pull/15774
- #12169
- https://github.com/mdn/browser-compat-data/pull/15738
- https://github.com/mdn/browser-compat-data/pull/12161


<!-- ✅ After submitting, review the results of the "Checks" tab! -->
