### PR TITLE
Remove redundant IE note on transform CSS property

### DIFF
--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -183,8 +183,7 @@
                 "version_added": "16"
               },
               "ie": {
-                "version_added": "10",
-                "notes": "Internet Explorer 9.0 or earlier has no support for 3D transforms. Mixing 3D and 2D transform functions, such as <code>-ms-transform:rotate(10deg) translateZ(0);</code>, will prevent the entire property from being applied."
+                "version_added": "10"
               },
               "opera": {
                 "version_added": "15"


### PR DESCRIPTION
This PR removes a redundant note on Internet Explorer for 3D support of the `transform` CSS property.  The note basically states that "IE 9 
and earlier don't support the property", which is already clearly stated by our data, with `"version_added": "10"`.
