### PR TITLE
WebAssembly Tag and Exception are not experimental

### DIFF
--- a/javascript/builtins/webassembly/Exception.json
+++ b/javascript/builtins/webassembly/Exception.json
@@ -77,7 +77,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -158,7 +158,7 @@
                 }
               },
               "status": {
-                "experimental": true,
+                 "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -320,7 +320,7 @@
                 }
               },
               "status": {
-                "experimental": true,
+                 "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }

--- a/javascript/builtins/webassembly/Exception.json
+++ b/javascript/builtins/webassembly/Exception.json
@@ -158,7 +158,7 @@
                 }
               },
               "status": {
-                 "experimental": false,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -320,7 +320,7 @@
                 }
               },
               "status": {
-                 "experimental": false,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }

--- a/javascript/builtins/webassembly/Tag.json
+++ b/javascript/builtins/webassembly/Tag.json
@@ -77,7 +77,7 @@
               }
             },
             "status": {
-              "experimental": true,
+               "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -158,7 +158,7 @@
                 }
               },
               "status": {
-                "experimental": true,
+                 "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -239,7 +239,7 @@
                 }
               },
               "status": {
-                "experimental": true,
+                 "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }

--- a/javascript/builtins/webassembly/Tag.json
+++ b/javascript/builtins/webassembly/Tag.json
@@ -77,7 +77,7 @@
               }
             },
             "status": {
-               "experimental": false,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -158,7 +158,7 @@
                 }
               },
               "status": {
-                 "experimental": false,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -239,7 +239,7 @@
                 }
               },
               "status": {
-                 "experimental": false,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }


### PR DESCRIPTION
Following on from #15668

Since already supported by Safari, the addition of support for these in FF100 means that these are no longer considered experimental. This removes the experimental tagging.