### PR TITLE
Remove deprecated param `expandEntityReferences` from Document.createTreeWalker()

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -2912,61 +2912,6 @@
             "deprecated": false
           }
         },
-        "expandEntityReferences_parameter": {
-          "__compat": {
-            "description": "<code>expandEntityReferences</code> parameter",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": "12",
-                "version_removed": "79"
-              },
-              "firefox": {
-                "version_added": "2",
-                "version_removed": "12"
-              },
-              "firefox_android": {
-                "version_added": "4",
-                "version_removed": "14"
-              },
-              "ie": {
-                "version_added": "9"
-              },
-              "opera": {
-                "version_added": "9",
-                "version_removed": "15"
-              },
-              "opera_android": {
-                "version_added": "10.1",
-                "version_removed": "14"
-              },
-              "safari": {
-                "version_added": "3",
-                "version_removed": "10.1"
-              },
-              "safari_ios": {
-                "version_added": "3",
-                "version_removed": "10.3"
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": true
-            }
-          }
-        },
         "whatToShow_filter_parameters_optional": {
           "__compat": {
             "description": "<code>whatToShow</code> and <code>filter</code> parameters are optional",


### PR DESCRIPTION
Completes the fix for #15771

#### Summary
The expandEntityReferences parameter has been dropped from the specification long time ago. And is deprecated.

### Can you link to any release notes, bugs, pull requests, or MDN pages related to this?
The mdn/content page doesn't use the parameter. It's been lingering in BCD table.
https://developer.mozilla.org/en-US/docs/Web/API/Document/createTreeWalker

In Firefox release 21 it got removed:
https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/21#dom

It has been instructed here: https://github.com/mdn/content/pull/14856#issuecomment-1095663979