### PR TITLE
Update the javascript/operators/await spec URL

### DIFF
--- a/javascript/operators/await.json
+++ b/javascript/operators/await.json
@@ -70,7 +70,7 @@
           "__compat": {
             "description": "Use at module top level",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/await#top_level_await",
-            "spec_url": "https://tc39.es/ecma262/multipage/#sec-async-function-definitions",
+            "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-async-function-definitions",
             "support": {
               "chrome": {
                 "version_added": "89"


### PR DESCRIPTION
The spec URLs for the ES spec should have not just an anchor but also a filename for the multipage HTML filename the anchor is in. (Browsers do a client-side redirect of the links, so that the user ends up in the right file anyway. But having the filename avoids that unnecessary redirect.