### PR TITLE
Safari supports Subresource Integrity

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1169,10 +1169,10 @@
                   "version_added": "41"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "11"
                 },
                 "safari_ios": {
-                  "version_added": false
+                  "version_added": "11.3"
                 },
                 "samsunginternet_android": {
                   "version_added": "6.0"


### PR DESCRIPTION
This PR fixes #5430 by copying the data from CanIUse: https://caniuse.com/subresource-integrity
