### PR TITLE
Collapse `window.inner{Width,Height}` notes into one support statement

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3155,7 +3155,7 @@
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "From version 4 to 24, this property could give a wrong value before page load in certain circumstances (see <a href='https://bugzil.la/641188'>bug 641188</a>)."
+              "notes": "Before version 24, this property could give a wrong value before page load in certain circumstances (see <a href='https://bugzil.la/641188'>bug 641188</a>)."
             },
             "ie": {
               "version_added": "9"
@@ -3207,7 +3207,7 @@
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "From version 4 to 24, this property could give a wrong value before page load in certain circumstances (see <a href='https://bugzil.la/641188'>bug 641188</a>)."
+              "notes": "Before version 24, this property could give a wrong value before page load in certain circumstances (see <a href='https://bugzil.la/641188'>bug 641188</a>)."
             },
             "ie": {
               "version_added": "9"

--- a/api/Window.json
+++ b/api/Window.json
@@ -3149,26 +3149,14 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "1"
-              },
-              {
-                "version_added": "4",
-                "version_removed": "24",
-                "notes": "This property was buggy and could give a wrong value before page load in certain circumstances, see <a href='https://bugzil.la/641188'>bug 641188</a>."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "4"
-              },
-              {
-                "version_added": "4",
-                "version_removed": "24",
-                "notes": "This property was buggy and could give a wrong value before page load in certain circumstances, see <a href='https://bugzil.la/641188'>bug 641188</a>."
-              }
-            ],
+            "firefox": {
+              "version_added": "1",
+              "notes": "From version 4 to 24, this property could give a wrong value before page load in certain circumstances (see <a href='https://bugzil.la/641188'>bug 641188</a>)."
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "notes": "From version 4 to 24, this property could give a wrong value before page load in certain circumstances (see <a href='https://bugzil.la/641188'>bug 641188</a>)."
+            },
             "ie": {
               "version_added": "9"
             },
@@ -3213,26 +3201,14 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "1"
-              },
-              {
-                "version_added": "4",
-                "version_removed": "24",
-                "notes": "This property was buggy and could give a wrong value before page load in certain circumstances, see <a href='https://bugzil.la/641188'>bug 641188</a>."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "4"
-              },
-              {
-                "version_added": "4",
-                "version_removed": "24",
-                "notes": "This property was buggy and could give a wrong value before page load in certain circumstances, see <a href='https://bugzil.la/641188'>bug 641188</a>."
-              }
-            ],
+            "firefox": {
+              "version_added": "1",
+              "notes": "From version 4 to 24, this property could give a wrong value before page load in certain circumstances (see <a href='https://bugzil.la/641188'>bug 641188</a>)."
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "notes": "From version 4 to 24, this property could give a wrong value before page load in certain circumstances (see <a href='https://bugzil.la/641188'>bug 641188</a>)."
+            },
             "ie": {
               "version_added": "9"
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

The Firefox notes for `window.innerWidth` and `window.innerHeight` don't really need their own statements. This collapses things into something a little less complicated. 

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

It also partially addresses an issue raised in https://github.com/mdn/yari/issues/5945

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
