### PR TITLE
Fix tabs.removeCSS compat data for Chromium-based browsers

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -4118,10 +4118,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/removeCSS",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87"
               },
               "edge": {
-                "version_added": false
+                "version_added": "87"
               },
               "firefox": {
                 "version_added": "49"
@@ -4130,7 +4130,7 @@
                 "version_added": "54"
               },
               "opera": {
-                "version_added": false
+                "version_added": "73"
               },
               "safari": {
                 "version_added": "14"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Fix compat data for the `tabs.removeCSS` method of the extension API for Chromium-based browsers.

#### Test results and supporting details

This was implemented in Chromium 87 in https://crbug.com/608854 ([link to chrome/VERSION of commit](https://chromium.googlesource.com/chromium/src.git/+/a4e391a463b57c39423c3555275d209525e2cb90/chrome/VERSION).
MS Edge uses the same major version number as Chromium (https://en.wikipedia.org/wiki/Microsoft_Edge#New_Edge_release_history).
Opera's version is based on the table at https://en.wikipedia.org/wiki/History_of_the_Opera_web_browser#Opera_2020

#### Related issues
N/A
