### PR TITLE
Fix statuses for Deno releases

### DIFF
--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -118,28 +118,28 @@
         "1.16": {
           "release_date": "2021-11-08",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.16.0",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "9.7"
         },
         "1.17": {
           "release_date": "2021-12-16",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.17.0",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "9.7"
         },
         "1.18": {
           "release_date": "2022-01-20",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.18.0",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "9.8"
         },
         "1.19": {
           "release_date": "2022-02-17",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.19.0",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "9.9"
         },


### PR DESCRIPTION
This PR fixes the status data for Deno releases.  Multiple releases are marked as "current", which can't be true.  Caught by the linter in 
#6167.

Pinging @lucacasonato for review.
