### PR TITLE
Fix statuses for NodeJS releases

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -335,14 +335,14 @@
         "16.9.0": {
           "release_date": "2021-09-07",
           "release_notes": "https://nodejs.org/en/blog/release/v16.9.0/",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "9.3"
         },
         "16.11.0": {
           "release_date": "2021-10-08",
           "release_notes": "https://nodejs.org/en/blog/release/v16.11.0/",
-          "status": "current",
+          "status": "esr",
           "engine": "V8",
           "engine_version": "9.4"
         },


### PR DESCRIPTION
This PR fixes the status data for the NodeJS releases.  Currently, we have three versions marked as "current", which can't be the case.  Caught by the linter introduced in #6160.
