### PR TITLE
Fix statuses for Safari iOS/iPadOS releases

### DIFF
--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -157,7 +157,7 @@
         "15.2": {
           "release_date": "2021-12-13",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15_2-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "612.3.6"
         },


### PR DESCRIPTION
This PR fixes the status info for Safari for iOS/iPadOS.  Currently, mutliple releases are marked as "current", which doesn't make sense.  Caught by the linter introduced in #6167.
