### PR TITLE
Update Edge versions for -webkit-mask-repeat CSS property

### DIFF
--- a/css/properties/-webkit-mask-repeat-x.json
+++ b/css/properties/-webkit-mask-repeat-x.json
@@ -12,7 +12,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false

--- a/css/properties/-webkit-mask-repeat-y.json
+++ b/css/properties/-webkit-mask-repeat-y.json
@@ -12,7 +12,7 @@
               "version_added": "18"
             },
             "edge": {
-              "version_added": "18"
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `-webkit-mask-repeat` CSS property, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v5.0.0).

Tests Used:
https://mdn-bcd-collector.appspot.com/tests/css/properties/-webkit-mask-repeat-x
https://mdn-bcd-collector.appspot.com/tests/css/properties/-webkit-mask-repeat-y

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._

Fixes #6669.