### PR TITLE
Add Chromium versions for api.HTMLIFrameElement.allowPaymentRequest

### DIFF
--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -211,24 +211,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/allowPaymentRequest",
           "support": {
             "chrome": {
-              "version_added": "60",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "61",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#web-payments",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "57"
             },
             "edge": {
               "version_added": "15"

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -231,10 +231,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "43"
             },
             "safari": {
               "version_added": false
@@ -243,7 +243,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "7.0"
             },
             "webview_android": {
               "version_added": false

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -211,7 +211,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/allowPaymentRequest",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "57"
@@ -231,7 +231,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "48"
+              "version_added": "47"
             },
             "opera_android": {
               "version_added": "43"


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `allowPaymentRequest` member of the `HTMLIFrameElement` API.  The version numbers come from ChromeStatus: https://chromestatus.com/feature/5511036157296640

Fixes #6724.
