### PR TITLE
Add Chromium versions for api.RTCPeerConnection.canTrickleIceCandidate

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -664,10 +664,10 @@
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-cantrickleicecandidates",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "83"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "83"
             },
             "edge": {
               "version_added": "15",
@@ -683,10 +683,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "69"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "59"
             },
             "safari": {
               "version_added": "15.4"
@@ -698,7 +698,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "83"
             }
           },
           "status": {

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -669,10 +669,15 @@
             "chrome_android": {
               "version_added": "83"
             },
-            "edge": {
-              "version_added": "15",
-              "version_removed": "79"
-            },
+            "edge": [
+              {
+                "version_added": "83"
+              },
+              {
+                "version_added": "15",
+                "version_removed": "79"
+              }
+            ],
             "firefox": {
               "version_added": "47"
             },


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `canTrickleIceCandidate` member of the `RTCPeerConnection` API, based upon commit history and date.

Commit: https://storage.googleapis.com/chromium-find-releases-static/47b.html#47bfc2a8519a67075c592a34d4496d174bce43d7 (says "82" but M82 was skipped)

Fixes #6732.