### PR TITLE
HTTP Referer header length limit in Safari

### DIFF
--- a/http/headers/referer.json
+++ b/http/headers/referer.json
@@ -78,10 +78,10 @@
                 "version_added": "55"
               },
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "14"
               },
               "samsunginternet_android": {
                 "version_added": "12.0"


### PR DESCRIPTION
This is a follow-up to commit 1e966e53ce67eb46f5e633ccd949d9a0105a981c and issue #6130.


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Safari 14 limits Referer header to 4096 bytes.
<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details
This change landed in WebKit commit
https://github.com/WebKit/WebKit/commit/12b8dc73bed78248eb6697cc3c9088d1bd880dbe
which was first released in Safari 14, according to [browsers/safari.json](https://github.com/mdn/browser-compat-data/blob/main/browsers/safari.json), [browsers/safari_ios.json](https://github.com/mdn/browser-compat-data/blob/main/browsers/safari_ios.json).
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
#6125
#6130
<!-- ✅ After submitting, review the results of the "Checks" tab! -->
