### PR TITLE
Add Chrome/Safari versions for text-size-adjust CSS property

### DIFF
--- a/css/properties/text-size-adjust.json
+++ b/css/properties/text-size-adjust.json
@@ -6,16 +6,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-size-adjust",
           "spec_url": "https://drafts.csswg.org/css-size-adjust/#adjustment-control",
           "support": {
-            "chrome": [
-              {
-                "version_added": "54"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": false,
-                "notes": "Instead of ignoring the <code>-webkit-text-size-adjust</code> property, a bug prevents desktop Chrome users from zooming in or out. The bug was fixed after Chrome 26."
-              }
-            ],
+            "chrome": {
+              "version_added": "54"
+            },
             "chrome_android": {
               "version_added": "54"
             },
@@ -62,16 +55,9 @@
             "opera_android": {
               "version_added": "41"
             },
-            "safari": [
-              {
-                "version_added": false
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": false,
-                "notes": "Instead of ignoring the <code>-webkit-text-size-adjust</code> property, a bug prevents desktop Safari users from zooming in or out. The bug was fixed after Safari 5."
-              }
-            ],
+            "safari": {
+              "version_added": false
+            },
             "safari_ios": {
               "prefix": "-webkit-",
               "version_added": "1"


### PR DESCRIPTION
This PR adds real values for Chrome and Safari for the `text-size-adjust` CSS property.  There are `version_added: false` statements referring to a bug when the prefix is applied, however the bug was fixed a long time ago and can now be considered irrelevant.
