### PR TITLE
Add Chromium versions for javascript.builtins.Atomics.notify

### DIFF
--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -1213,9 +1213,7 @@
                 }
               ],
               "samsunginternet_android": {
-                "version_added": false,
-                "alternative_name": "wake",
-                "notes": "Chrome disabled <code>SharedArrayBuffer</code> on January 5, 2018 to help reduce the efficacy of <a href='https://www.chromium.org/Home/chromium-security/ssca'>speculative side-channel attacks</a>. This is intended as a temporary measure until other mitigations are in place."
+                "version_added": false
               },
               "webview_android": {
                 "version_added": "60",


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `notify` member of the `Atomics` JavaScript builtin.  The data for Samsung Internet was mirrored from Chrome, but it's set to `false` because it was added and removed from Chrome before a Samsung Internet release came out.
