### PR TITLE
Add Opera versions for javascript.builtins.intl/Intl.@@toStringTag

### DIFF
--- a/javascript/builtins/intl/Intl.json
+++ b/javascript/builtins/intl/Intl.json
@@ -198,7 +198,7 @@
                 "version_added": "72"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "61"
               },
               "safari": {
                 "version_added": "14"


### PR DESCRIPTION
This PR adds real values for Opera Android for the `@@toStringTag` member of the `intl/Intl` JavaScript builtin by mirroring the data.

Fixes #7294.
