### PR TITLE
Add Firefox implementation note for api.ResizeObserverEntry.borderBoxSize

### DIFF
--- a/api/ResizeObserverEntry.json
+++ b/api/ResizeObserverEntry.json
@@ -62,12 +62,28 @@
             "edge": {
               "version_added": "84"
             },
-            "firefox": {
-              "version_added": "69"
-            },
-            "firefox_android": {
-              "version_added": "79"
-            },
+            "firefox": [
+              {
+                "version_added": "92"
+              },
+              {
+                "version_added": "69",
+                "version_removed": "92",
+                "partial_implementation": true,
+                "notes": "Implemented as a single object representing a content box size, rather than an array of content box size objects."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "92"
+              },
+              {
+                "version_added": "79",
+                "version_removed": "92",
+                "partial_implementation": true,
+                "notes": "Implemented as a single object representing a content box size, rather than an array of content box size objects."
+              }
+            ],
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR is a follow-up to #10939 that applies the same note to `borderBoxSize`.  Fixes #8730.

Test code used:
```html
<style id="test-style">
    html {
        height: 100%;
    }
    body {
        height: inherit;
        margin: 0;
        display: flex;
        justify-content: center;
        align-items: center;
    }
    #test {
        background-color: #222;
        border: 1px solid #ccc;
        padding: 20px;
        width: 50%;
        min-width: 320px;
    }
    form {
        width: 100%;
    }
    form > div {
        display: flex;
    }

    form label {
        flex: 2;
    }

    form input {
        flex: 3;
    }

    input[type="checkbox"] {
        height: 2rem;
    }
</style>

<div id="test">
    <h1>So what happened?</h1>
    <p>And remember, don't do anything that affects anything, unless it turns out you were supposed to, in which case, for the love of God, don't not do it! Ow, my spirit! I don't want to be rescued. You guys aren't Santa! You're not even robots. I've got to find a way to escape the horrible ravages of youth. Suddenly, I'm going to the bathroom like clockwork, every three hours. And those jerks at Social Security stopped sending me checks. Now 'I' have to pay 'them'!</p>
    <p id="log">[Log here...]</p>
    <form>
        <div><label>Observer enabled:</label><input type="checkbox" checked></div>
        <div><label>Adjust width:</label><input type="range" value="600" min="300" max="1300"></div>
    </form>
</div>

<script>
    const logEl = document.querySelector('#log');

    const log = (msg) => {
        logEl.innerText = msg;
        console.log(msg);
    }

    if(window.ResizeObserver) {
        const h1Elem = document.querySelector('h1');
        const pElem = document.querySelector('p');
        const divElem = document.querySelector('#test');
        const slider = document.querySelector('input[type="range"]');
        const checkbox = document.querySelector('input[type="checkbox"]');

        divElem.style.width = '600px';

        slider.addEventListener('input', () => {
            divElem.style.width = slider.value + 'px';
        });

        const resizeObserver = new ResizeObserver(entries => {
            for (let entry of entries) {
                let size;
                if(entry.contentBoxSize) {
                    // The standard makes contentBoxSize an array...
                    if (entry.contentBoxSize[0]) {
                        size = entry.contentBoxSize[0].inlineSize;
                        log('Resize using contentBoxSize[]: ' + size);
                    } else {
                        // ...but old versions of Firefox treat it as a single item
                        size = entry.contentBoxSize.inlineSize;
                        log('Resize using contentBoxSize (Firefox legacy): ' + size);
                    }
                } else {
                    size = entry.contentRect.width;
                    log('Resize using contentRect.width: ' + size);
                }

                h1Elem.style.fontSize = Math.max(1.5, size/200) + 'rem';
                pElem.style.fontSize = Math.max(1, size/600) + 'rem';
            }
        });

        log('Initialized');
        resizeObserver.observe(divElem);

        checkbox.addEventListener('change', () => {
            if(checkbox.checked) {
                log('Observer reconnected');
                resizeObserver.observe(divElem);
            } else {
                log('Observer disconnected');
                resizeObserver.unobserve(divElem);
            }
        });
    } else {
        log('Resize observer not supported!');
    }
</script>
```
