### PR TITLE
Update Contact Picker API data

### DIFF
--- a/api/ContactsManager.json
+++ b/api/ContactsManager.json
@@ -24,7 +24,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "57"
+            "version_added": false
           },
           "opera_android": {
             "version_added": "57"
@@ -33,7 +33,13 @@
             "version_added": false
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "14.5",
+            "flags": [
+              {
+                "name": "Contact Picker API",
+                "type": "preference"
+              }
+            ]
           },
           "samsunginternet_android": {
             "version_added": "13.0"
@@ -44,7 +50,7 @@
         },
         "status": {
           "experimental": true,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },
@@ -81,7 +87,13 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5",
+              "flags": [
+                {
+                  "name": "Contact Picker API",
+                  "type": "preference"
+                }
+              ]
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -92,7 +104,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -130,7 +142,13 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5",
+              "flags": [
+                {
+                  "name": "Contact Picker API",
+                  "type": "preference"
+                }
+              ]
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -141,7 +159,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -938,7 +938,13 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "14.5",
+              "flags": [
+                {
+                  "name": "Contact Picker API",
+                  "type": "preference"
+                }
+              ]
             },
             "samsunginternet_android": {
               "version_added": "13.0"
@@ -949,7 +955,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Marked as standard track

Removed incorrect opera support data

Add Safari iOS flag data

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

The opera data is clearly an error when looking at all the data as a whole and I did double check that it wasn't exposed.

Safari I've tested on latest version.

https://firt.dev/ios-14.5#contact-picker-api and this article suggests 14.5 (which fits with what I remember)

While the flag is available on desktop and is exposed the API always throws errors for me so I've left that as false.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
