### PR TITLE
Edge supports @layer

### DIFF
--- a/css/at-rules/layer.json
+++ b/css/at-rules/layer.json
@@ -14,7 +14,7 @@
               "version_added": "99"
             },
             "edge": {
-              "version_added": false
+              "version_added": "99"
             },
             "firefox": [
               {


### PR DESCRIPTION
Adds Edge 99 to list of supported browsers.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Adds Edge 99 to the list of supported browsers for cascade layers.

#### Test results and supporting details
Matches release in other Chromium-based browsers. Manually tested in Edge 99 to confirm.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
