### PR TITLE
Add overflow:overlay property compatibility

### DIFF
--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -119,54 +119,6 @@
             }
           }
         },
-        "overlay": {
-          "__compat": {
-            "description": "<code>overlay</code> value",
-            "support": {
-              "chrome": {
-                "version_added": "15"
-              },
-              "chrome_android": {
-                "version_added": "100"
-              },
-              "edge": {
-                "version_added": "79"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "15"
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": "4"
-              },
-              "webview_android": {
-                "version_added": "2.1"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "multiple_keywords": {
           "__compat": {
             "description": "Multiple keyword syntax for <code>overflow-x</code> and <code>overflow-y</code>",
@@ -206,6 +158,54 @@
               },
               "webview_android": {
                 "version_added": "68"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "overlay": {
+          "__compat": {
+            "description": "<code>overlay</code> value",
+            "support": {
+              "chrome": {
+                "version_added": "15"
+              },
+              "chrome_android": {
+                "version_added": "100"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "4.0"
+              },
+              "webview_android": {
+                "version_added": "100"
               }
             },
             "status": {

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -119,6 +119,54 @@
             }
           }
         },
+        "overlay": {
+          "__compat": {
+            "description": "<code>overlay</code> value",
+            "support": {
+              "chrome": {
+                "version_added": "15"
+              },
+              "chrome_android": {
+                "version_added": "100"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "4"
+              },
+              "webview_android": {
+                "version_added": "2.1"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "multiple_keywords": {
           "__compat": {
             "description": "Multiple keyword syntax for <code>overflow-x</code> and <code>overflow-y</code>",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Add overflow:overlay property compatibility. This was requested in https://github.com/mdn/content/pull/14435

#### Test results and supporting details
Tested the compatibility on Safari on Mac; the behavior is exactly described here:

https://caniuse.com/?search=overlay

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
