### PR TITLE
Update Chromium versions for Animation API

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -5,26 +5,12 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation",
         "spec_url": "https://drafts.csswg.org/web-animations-1/#the-animation-interface",
         "support": {
-          "chrome": [
-            {
-              "version_added": "44"
-            },
-            {
-              "alternative_name": "AnimationPlayer",
-              "version_added": "39",
-              "version_removed": "44"
-            }
-          ],
-          "chrome_android": [
-            {
-              "version_added": "44"
-            },
-            {
-              "alternative_name": "AnimationPlayer",
-              "version_added": "39",
-              "version_removed": "44"
-            }
-          ],
+          "chrome": {
+            "version_added": "75"
+          },
+          "chrome_android": {
+            "version_added": "75"
+          },
           "edge": {
             "version_added": "79"
           },
@@ -38,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "26"
+            "version_added": "62"
           },
           "opera_android": {
-            "version_added": "26"
+            "version_added": "54"
           },
           "safari": {
             "version_added": "13.1"
@@ -50,18 +36,11 @@
             "version_added": "13.4"
           },
           "samsunginternet_android": {
-            "version_added": "4.0"
+            "version_added": "11.0"
           },
-          "webview_android": [
-            {
-              "version_added": "44"
-            },
-            {
-              "alternative_name": "AnimationPlayer",
-              "version_added": "39",
-              "version_removed": "44"
-            }
-          ]
+          "webview_android": {
+            "version_added": "75"
+          }
         },
         "status": {
           "experimental": false,
@@ -76,10 +55,10 @@
           "description": "<code>Animation()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": "61"
+              "version_added": "75"
             },
             "edge": {
               "version_added": "79"
@@ -94,10 +73,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "48"
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": "45"
+              "version_added": "54"
             },
             "safari": {
               "version_added": "13.1"
@@ -106,10 +85,10 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": "8.0"
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": "61"
+              "version_added": "75"
             }
           },
           "status": {
@@ -125,10 +104,10 @@
           "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-cancel",
           "support": {
             "chrome": {
-              "version_added": "39"
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": "39"
+              "version_added": "75"
             },
             "edge": {
               "version_added": "79"
@@ -143,10 +122,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "26"
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": "26"
+              "version_added": "54"
             },
             "safari": {
               "version_added": "13.1"
@@ -155,10 +134,10 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": "39"
+              "version_added": "75"
             }
           },
           "status": {
@@ -178,10 +157,10 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "50"
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": "50"
+              "version_added": "75"
             },
             "edge": {
               "version_added": "79"
@@ -196,10 +175,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "37"
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": "37"
+              "version_added": "54"
             },
             "safari": {
               "version_added": "13.1"
@@ -208,10 +187,10 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": "50"
+              "version_added": "75"
             }
           },
           "status": {
@@ -276,10 +255,10 @@
           "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-currenttime",
           "support": {
             "chrome": {
-              "version_added": "39"
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": "39"
+              "version_added": "75"
             },
             "edge": {
               "version_added": "79"
@@ -294,10 +273,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "26"
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": "26"
+              "version_added": "54"
             },
             "safari": {
               "version_added": "13.1"
@@ -306,10 +285,10 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": "39"
+              "version_added": "75"
             }
           },
           "status": {
@@ -374,10 +353,10 @@
           "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-finish",
           "support": {
             "chrome": {
-              "version_added": "39"
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": "39"
+              "version_added": "75"
             },
             "edge": {
               "version_added": "79"
@@ -392,10 +371,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "26"
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": "26"
+              "version_added": "54"
             },
             "safari": {
               "version_added": "13.1"
@@ -404,10 +383,10 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": "39"
+              "version_added": "75"
             }
           },
           "status": {
@@ -427,10 +406,10 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "39"
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": "39"
+              "version_added": "75"
             },
             "edge": {
               "version_added": "79"
@@ -445,10 +424,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "26"
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": "26"
+              "version_added": "54"
             },
             "safari": {
               "version_added": "13.1"
@@ -457,10 +436,10 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": "39"
+              "version_added": "75"
             }
           },
           "status": {
@@ -525,10 +504,10 @@
           "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-id",
           "support": {
             "chrome": {
-              "version_added": "50"
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": "50"
+              "version_added": "75"
             },
             "edge": {
               "version_added": "79"
@@ -543,10 +522,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "37"
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": "37"
+              "version_added": "54"
             },
             "safari": {
               "version_added": "13.1"
@@ -555,10 +534,10 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": "50"
+              "version_added": "75"
             }
           },
           "status": {
@@ -574,10 +553,10 @@
           "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-pause",
           "support": {
             "chrome": {
-              "version_added": "39"
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": "39"
+              "version_added": "75"
             },
             "edge": {
               "version_added": "79"
@@ -592,10 +571,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "26"
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": "26"
+              "version_added": "54"
             },
             "safari": {
               "version_added": "13.1"
@@ -604,10 +583,10 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": "39"
+              "version_added": "75"
             }
           },
           "status": {
@@ -723,10 +702,10 @@
           "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-play",
           "support": {
             "chrome": {
-              "version_added": "39"
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": "39"
+              "version_added": "75"
             },
             "edge": {
               "version_added": "79"
@@ -741,10 +720,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "26"
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": "26"
+              "version_added": "54"
             },
             "safari": {
               "version_added": "13.1"
@@ -753,10 +732,10 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": "39"
+              "version_added": "75"
             }
           },
           "status": {
@@ -772,10 +751,10 @@
           "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-playbackrate",
           "support": {
             "chrome": {
-              "version_added": "39"
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": "39"
+              "version_added": "75"
             },
             "edge": {
               "version_added": "79"
@@ -790,10 +769,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "26"
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": "26"
+              "version_added": "54"
             },
             "safari": {
               "version_added": "13.1"
@@ -802,10 +781,10 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": "39"
+              "version_added": "75"
             }
           },
           "status": {
@@ -821,11 +800,11 @@
           "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-playstate",
           "support": {
             "chrome": {
-              "version_added": "39",
+              "version_added": "75",
               "notes": "Before Chrome 50/Opera 37, this property returned <code>idle</code> for an animation that had not yet started. Starting with Chrome 50/Opera 37, it shows <code>paused</code>."
             },
             "chrome_android": {
-              "version_added": "39",
+              "version_added": "75",
               "notes": "Before Chrome 50/Opera 37, this property returned <code>idle</code> for an animation that had not yet started. Starting with Chrome 50/Opera 37, it shows <code>paused</code>."
             },
             "edge": {
@@ -843,11 +822,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "26",
+              "version_added": "62",
               "notes": "Before Chrome 50/Opera 37, this property returned <code>idle</code> for an animation that had not yet started. Starting with Chrome 50/Opera 37, it shows <code>paused</code>."
             },
             "opera_android": {
-              "version_added": "26",
+              "version_added": "54",
               "notes": "Before Chrome 50/Opera 37, this property returned <code>idle</code> for an animation that had not yet started. Starting with Chrome 50/Opera 37, it shows <code>paused</code>."
             },
             "safari": {
@@ -857,11 +836,11 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": "4.0",
+              "version_added": "11.0",
               "notes": "Before Samsung Internet 5.0/Opera 37, this property returned <code>idle</code> for an animation that had not yet started. Starting with Samsung Internet 5.0/Opera 37, it shows <code>paused</code>."
             },
             "webview_android": {
-              "version_added": "39",
+              "version_added": "75",
               "notes": "Before Chrome 50/Opera 37, this property returned <code>idle</code> for an animation that had not yet started. Starting with Chrome 50/Opera 37, it shows <code>paused</code>."
             }
           },
@@ -1078,10 +1057,10 @@
           "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-reverse",
           "support": {
             "chrome": {
-              "version_added": "39"
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": "39"
+              "version_added": "75"
             },
             "edge": {
               "version_added": "79"
@@ -1096,10 +1075,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "26"
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": "26"
+              "version_added": "54"
             },
             "safari": {
               "version_added": "13.1"
@@ -1108,10 +1087,10 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": "39"
+              "version_added": "75"
             }
           },
           "status": {
@@ -1127,10 +1106,10 @@
           "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animation-starttime",
           "support": {
             "chrome": {
-              "version_added": "39"
+              "version_added": "75"
             },
             "chrome_android": {
-              "version_added": "39"
+              "version_added": "75"
             },
             "edge": {
               "version_added": "79"
@@ -1145,10 +1124,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "26"
+              "version_added": "62"
             },
             "opera_android": {
-              "version_added": "26"
+              "version_added": "54"
             },
             "safari": {
               "version_added": "13.1"
@@ -1157,10 +1136,10 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "11.0"
             },
             "webview_android": {
-              "version_added": "39"
+              "version_added": "75"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Animation` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v5.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Animation

The original data comes from the wiki migration, but the difference between the collector's results and the data was suspicious, so I researched this some more.  It appears that the API _was_ originally named ["AnimationPlayer"](https://source.chromium.org/chromium/chromium/src/+/5d4375dd23951f07259d66136a655dddb1783aa0), however researching this further, this was all while it was behind a flag.  The feature was [enabled by default in Chrome 75](https://source.chromium.org/chromium/chromium/src/+/d399276bec3bd28fd64802af04570f76feab3f12), so the old flag data meets irrelevance guidelines.

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
