### PR TITLE
Update Chromium versions for ApplicationCache API

### DIFF
--- a/api/ApplicationCache.json
+++ b/api/ApplicationCache.json
@@ -39,10 +39,12 @@
             "version_added": "3"
           },
           "samsunginternet_android": {
-            "version_added": "1.0"
+            "version_added": "1.0",
+            "version_removed": "14.0"
           },
           "webview_android": {
-            "version_added": "≤37"
+            "version_added": "≤37",
+            "version_removed": "85"
           }
         },
         "status": {
@@ -90,10 +92,12 @@
               "version_added": "6"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.0",
+              "version_removed": "14.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤37",
+              "version_removed": "85"
             }
           },
           "status": {
@@ -143,10 +147,12 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.0",
+              "version_removed": "14.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤37",
+              "version_removed": "85"
             }
           },
           "status": {
@@ -196,10 +202,12 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.0",
+              "version_removed": "14.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤37",
+              "version_removed": "85"
             }
           },
           "status": {
@@ -249,10 +257,12 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.0",
+              "version_removed": "14.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤37",
+              "version_removed": "85"
             }
           },
           "status": {
@@ -302,10 +312,12 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.0",
+              "version_removed": "14.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤37",
+              "version_removed": "85"
             }
           },
           "status": {
@@ -355,10 +367,12 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.0",
+              "version_removed": "14.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤37",
+              "version_removed": "85"
             }
           },
           "status": {
@@ -408,10 +422,12 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.0",
+              "version_removed": "14.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤37",
+              "version_removed": "85"
             }
           },
           "status": {
@@ -461,10 +477,12 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.0",
+              "version_removed": "14.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤37",
+              "version_removed": "85"
             }
           },
           "status": {
@@ -513,10 +531,12 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.0",
+              "version_removed": "14.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤37",
+              "version_removed": "85"
             }
           },
           "status": {
@@ -565,10 +585,12 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.0",
+              "version_removed": "14.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤37",
+              "version_removed": "85"
             }
           },
           "status": {
@@ -617,10 +639,12 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.0",
+              "version_removed": "14.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤37",
+              "version_removed": "85"
             }
           },
           "status": {
@@ -670,10 +694,12 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.0",
+              "version_removed": "14.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤37",
+              "version_removed": "85"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates the values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `ApplicationCache` API by mirroring the data.
