### PR TITLE
Update Firefox versions for AudioBuffer API

### DIFF
--- a/api/AudioBuffer.json
+++ b/api/AudioBuffer.json
@@ -119,10 +119,10 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "27"
             },
             "firefox_android": {
-              "version_added": "25"
+              "version_added": "27"
             },
             "ie": {
               "version_added": false
@@ -168,10 +168,10 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "27"
             },
             "firefox_android": {
-              "version_added": "25"
+              "version_added": "27"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `AudioBuffer` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v5.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AudioBuffer

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
