### PR TITLE
Update Chromium versions for api.BeforeInstallPromptEvent.prompt

### DIFF
--- a/api/BeforeInstallPromptEvent.json
+++ b/api/BeforeInstallPromptEvent.json
@@ -149,10 +149,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BeforeInstallPromptEvent/prompt",
           "support": {
             "chrome": {
-              "version_added": "44"
+              "version_added": "45"
             },
             "chrome_android": {
-              "version_added": "44"
+              "version_added": "45"
             },
             "edge": {
               "version_added": "79"
@@ -167,7 +167,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "31"
+              "version_added": "32"
             },
             "opera_android": {
               "version_added": "32"
@@ -182,7 +182,7 @@
               "version_added": "5.0"
             },
             "webview_android": {
-              "version_added": "44"
+              "version_added": "45"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `prompt` member of the `BeforeInstallPromptEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v5.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/BeforeInstallPromptEvent/prompt

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
