### PR TITLE
Remove irrelevant <textarea> attribute autocapitalize

### DIFF
--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -60,53 +60,6 @@
             "deprecated": false
           }
         },
-        "autocapitalize": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": false
-            }
-          }
-        },
         "autocomplete": {
           "__compat": {
             "support": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Remove irrelevant/odd data about `<textarea>` attribute `autocapitalize`. Note that there is a dedicated page about [`autocapitalize` global attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize).

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
Create `<textarea autocapitalize="...">` with any value `off`, `none`, `on`, `sentences`, `words`, or `characters` and notice that nothing changes.
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Vaguely related: https://github.com/mdn/content/pull/15034
<!-- ✅ After submitting, review the results of the "Checks" tab! -->
