### PR TITLE
Update Chromium versions for api.CSSStyleDeclaration.length

### DIFF
--- a/api/CSSStyleDeclaration.json
+++ b/api/CSSStyleDeclaration.json
@@ -365,7 +365,7 @@
           "spec_url": "https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-length",
           "support": {
             "chrome": {
-              "version_added": "44"
+              "version_added": "1"
             },
             "chrome_android": {
               "version_added": "18"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `length` member of the `CSSStyleDeclaration` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v5.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CSSStyleDeclaration/length

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
