### PR TITLE
Update Chrome/Safari versions for api.HTMLAllCollection.length

### DIFF
--- a/api/HTMLAllCollection.json
+++ b/api/HTMLAllCollection.json
@@ -100,10 +100,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAllCollection/length",
           "support": {
             "chrome": {
-              "version_added": "44"
+              "version_added": "6"
             },
             "chrome_android": {
-              "version_added": "44"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -118,19 +118,19 @@
               "version_added": "11"
             },
             "opera": {
-              "version_added": "31"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "14"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "5"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "4"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "1.0"
             },
             "webview_android": {
               "version_added": "3"


### PR DESCRIPTION
This PR updates and corrects the real values for Chrome and Safari for the `length` member of the `HTMLAllCollection` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v5.0.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLAllCollection/length

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
