### PR TITLE
CSS border-left-color - remove link to undocumented -moz-border-left-colors

### DIFF
--- a/css/properties/border-left-color.json
+++ b/css/properties/border-left-color.json
@@ -17,11 +17,11 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-left-colors'><code>-moz-border-left-colors</code></a> CSS property that sets the bottom border to multiple colors."
+              "notes": "Firefox also supports the non-standard <code>-moz-border-left-colors</code> CSS property that sets the bottom border to multiple colors."
             },
             "firefox_android": {
               "version_added": "4",
-              "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-left-colors'><code>-moz-border-left-colors</code></a> CSS property that sets the bottom border to multiple colors."
+              "notes": "Firefox also supports the non-standard <code>-moz-border-left-colors</code> CSS property that sets the bottom border to multiple colors."
             },
             "ie": {
               "version_added": "4"


### PR DESCRIPTION
Part of fixing #14748

The property is deprecated and has no MDN docs. The link is therefore invalid and this is a little cleaner.