### PR TITLE
api.AbortSignal.timeout - node support in 17.3.0

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -415,7 +415,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": false
+              "version_added": "17.3.0"
             },
             "opera": {
               "version_added": false

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -349,14 +349,14 @@
         "17.0.0": {
           "release_date": "2021-10-19",
           "release_notes": "https://nodejs.org/en/blog/release/v17.0.0/",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "9.5"
         },
         "17.2.0": {
           "release_date": "2021-11-30",
           "release_notes": "https://nodejs.org/en/blog/release/v17.2.0/",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "9.6"
         },

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -352,6 +352,20 @@
           "status": "current",
           "engine": "V8",
           "engine_version": "9.5"
+        },
+        "17.2.0": {
+          "release_date": "2021-11-30",
+          "release_notes": "https://nodejs.org/en/blog/release/v17.2.0/",
+          "status": "current",
+          "engine": "V8",
+          "engine_version": "9.6"
+        },
+        "17.3.0": {
+          "release_date": "2021-12-17",
+          "release_notes": "https://nodejs.org/en/blog/release/v17.3.0/",
+          "status": "current",
+          "engine": "V8",
+          "engine_version": "9.6"
         }
       }
     }


### PR DESCRIPTION
From Node docs here https://nodejs.org/api/globals.html#static-method-abortsignaltimeoutdelay `AbortSignal.timeout()` is supported from 17.3.0.

This won't merge because node versions above 17.0.0 are not yet supported.

This follows on from the comment here: https://github.com/mdn/browser-compat-data/pull/15644#issuecomment-1097434698