### PR TITLE
Add linter for incorrect feature statuses

### DIFF
--- a/scripts/fix-status.js
+++ b/scripts/fix-status.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+/**
+ * Return a new feature object whose first-level properties have been
+ * ordered according to Array.prototype.sort, and so will be
+ * stringified in that order as well. This relies on guaranteed "own"
+ * property ordering, which is insertion order for non-integer keys
+ * (which is our case).
+ *
+ * @param {string} key The key in the object
+ * @param {*} value The value of the key
+ *
+ * @returns {*} The new value
+ */
+
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const { platform } = require('os');
+
+/** Determines if the OS is Windows */
+const IS_WINDOWS = platform() === 'win32';
+
+const fixStatus = (key, value) => {
+  const status = value && value.__compat && value.__compat.status;
+  if (status && status.experimental && status.deprecated) {
+    status.experimental = false;
+  }
+  return value;
+};
+
+/**
+ * @param {Promise<void>} filename
+ */
+const fixStatusFromFile = filename => {
+  let actual = fs.readFileSync(filename, 'utf-8').trim();
+  let expected = JSON.stringify(JSON.parse(actual, fixStatus), null, 2);
+
+  if (IS_WINDOWS) {
+    // prevent false positives from git.core.autocrlf on Windows
+    actual = actual.replace(/\r/g, '');
+    expected = expected.replace(/\r/g, '');
+  }
+
+  if (actual !== expected) {
+    fs.writeFileSync(filename, expected + '\n', 'utf-8');
+  }
+};
+
+if (require.main === module) {
+  /**
+   * @param {string[]} files
+   */
+  function load(...files) {
+    for (let file of files) {
+      if (file.indexOf(__dirname) !== 0) {
+        file = path.resolve(__dirname, '..', file);
+      }
+
+      if (!fs.existsSync(file)) {
+        continue; // Ignore non-existent files
+      }
+
+      if (fs.statSync(file).isFile()) {
+        if (path.extname(file) === '.json') {
+          fixStatusFromFile(file);
+        }
+
+        continue;
+      }
+
+      const subFiles = fs.readdirSync(file).map(subfile => {
+        return path.join(file, subfile);
+      });
+
+      load(...subFiles);
+    }
+  }
+
+  if (process.argv[2]) {
+    load(process.argv[2]);
+  } else {
+    load(
+      'api',
+      'css',
+      'html',
+      'http',
+      'svg',
+      'javascript',
+      'mathml',
+      'test',
+      'webdriver',
+      'webextensions',
+    );
+  }
+}
+
+module.exports = fixStatusFromFile;

--- a/scripts/fix-status.js
+++ b/scripts/fix-status.js
@@ -24,7 +24,7 @@ const { platform } = require('os');
 const IS_WINDOWS = platform() === 'win32';
 
 const fixStatus = (key, value) => {
-  const status = value && value.__compat && value.__compat.status;
+  const status = value?.__compat?.status;
   if (status && status.experimental && status.deprecated) {
     status.experimental = false;
   }

--- a/scripts/fix.js
+++ b/scripts/fix.js
@@ -4,6 +4,7 @@ const path = require('path');
 const fixBrowserOrder = require('./fix-browser-order');
 const fixFeatureOrder = require('./fix-feature-order');
 const format = require('./fix-format');
+const fixStatusFromFile = require('./fix-status');
 
 /**
  * @param {string[]} files
@@ -23,6 +24,7 @@ function load(...files) {
       if (path.extname(file) === '.json') {
         fixBrowserOrder(file);
         fixFeatureOrder(file);
+        fixStatusFromFile(file);
       }
 
       continue;

--- a/test/lint.js
+++ b/test/lint.js
@@ -14,6 +14,7 @@ const {
   testVersions,
   testConsistency,
   testDescriptions,
+  testStatus,
 } = require('./linter/index.js');
 const { IS_CI } = require('./utils.js');
 const testMigrations = require('./test-migrations');
@@ -62,7 +63,8 @@ function load(...files) {
           hasConsistencyErrors = false,
           hasRealValueErrors = false,
           hasPrefixErrors = false,
-          hasDescriptionsErrors = false;
+          hasDescriptionsErrors = false,
+          hasStatusErrors = false;
         const relativeFilePath = path.relative(process.cwd(), file);
 
         const spinner = ora({
@@ -102,6 +104,7 @@ function load(...files) {
             hasRealValueErrors = testRealValues(file);
             hasPrefixErrors = testPrefix(file);
             hasDescriptionsErrors = testDescriptions(file);
+            hasStatusErrors = testStatus(file);
           }
         } catch (e) {
           hasSyntaxErrors = true;
@@ -119,6 +122,7 @@ function load(...files) {
           hasRealValueErrors,
           hasPrefixErrors,
           hasDescriptionsErrors,
+          hasStatusErrors,
         ].some(x => !!x);
 
         if (fileHasErrors) {

--- a/test/linter/index.js
+++ b/test/linter/index.js
@@ -8,6 +8,7 @@ const testStyle = require('./test-style.js');
 const testVersions = require('./test-versions.js');
 const { testConsistency } = require('./test-consistency.js');
 const testDescriptions = require('./test-descriptions.js');
+const testStatus = require('./test-status.js');
 
 module.exports = {
   testBrowsers,
@@ -19,4 +20,5 @@ module.exports = {
   testVersions,
   testConsistency,
   testDescriptions,
+  testStatus,
 };

--- a/test/linter/test-status.js
+++ b/test/linter/test-status.js
@@ -10,7 +10,7 @@ const { Logger } = require('./utils.js');
  * @param {Logger} logger
  */
 function checkStatus(data, logger, path = []) {
-  const status = data.__compat && data.__compat.status;
+  const status = data.__compat?.status;
   if (status && status.experimental && status.deprecated) {
     logger.error(
       chalk`{red Unexpected simultaneous experimental and deprecated status in ${path.join(

--- a/test/linter/test-status.js
+++ b/test/linter/test-status.js
@@ -12,19 +12,16 @@ const { Logger } = require('./utils.js');
  */
 function checkStatus(data, logger, path = '') {
   const compat = data.__compat;
-  if (compat) {
-    const status = compat.status;
-    if (status) {
-      if (compat.spec_url && status.standard_track === false) {
-        logger.error(
-          chalk`{red → {bold ${path}} is marked as {bold non-standard}, but has a {bold spec_url}}`,
-        );
-      }
-      if (status.experimental && status.deprecated) {
-        logger.error(
-          chalk`{red → Unexpected simultaneous experimental and deprecated status in {bold ${path}}}`,
-        );
-      }
+  if (compat?.status) {
+    if (compat.spec_url && compat.status.standard_track === false) {
+      logger.error(
+        chalk`{red → {bold ${path}} is marked as {bold non-standard}, but has a {bold spec_url}}`,
+      );
+    }
+    if (compat.status.experimental && compat.status.deprecated) {
+      logger.error(
+        chalk`{red → Unexpected simultaneous experimental and deprecated status in {bold ${path}}}`,
+      );
     }
   }
 

--- a/test/linter/test-status.js
+++ b/test/linter/test-status.js
@@ -15,6 +15,11 @@ function checkStatus(data, logger, path = '') {
   if (compat) {
     const status = compat.status;
     if (status) {
+      if (compat.spec_url && status.standard_track === false) {
+        logger.error(
+          chalk`{red → {bold ${path}} is marked as {bold non-standard}, but has a {bold spec_url}}`,
+        );
+      }
       if (status.experimental && status.deprecated) {
         logger.error(
           chalk`{red → Unexpected simultaneous experimental and deprecated status in {bold ${path}}}`,

--- a/test/linter/test-status.js
+++ b/test/linter/test-status.js
@@ -1,0 +1,45 @@
+const chalk = require('chalk');
+const { Logger } = require('./utils.js');
+
+/**
+ * @typedef {import('../../types').Identifier} Identifier
+ */
+
+/**
+ * @param {Identifier} data
+ * @param {Logger} logger
+ */
+function checkStatus(data, logger, path = []) {
+  const status = data.__compat && data.__compat.status;
+  if (status && status.experimental && status.deprecated) {
+    logger.error(
+      chalk`{red Unexpected simultaneous experimental and deprecated status in ${path.join(
+        '.',
+      )}}`,
+    );
+  }
+  for (const member in data) {
+    if (member === '__compat') {
+      continue;
+    }
+    checkStatus(data[member], logger, [...path, member]);
+  }
+}
+
+/**
+ * @param {string} filename
+ * @returns {boolean} If the file contains errors
+ */
+function testStatus(filename) {
+  /** @type {Identifier} */
+  const data = require(filename);
+
+  const logger = new Logger('Flag consistency');
+
+  checkStatus(data, logger);
+
+  logger.emit();
+  return logger.hasErrors();
+}
+
+module.exports = testStatus;


### PR DESCRIPTION
This PR is a cherry-pick from #6813 and #11430 to add a new linter to test the status of a feature, enforcing the following:

- Experimental and depcrecated cannot both be `true`
- Standard track must be `true` if there is a spec URL

This should also provide a better foundation for #11506 for long-term linting.  Note that this PR will fail tests for now as we have conflicting data.
