### PR TITLE
Add Firefox Android versions for WindowEventHandlers API

### DIFF
--- a/api/WindowEventHandlers.json
+++ b/api/WindowEventHandlers.json
@@ -480,7 +480,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false
@@ -602,7 +602,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox Android for the `WindowEventHandlers` API by mirroring the data.
