### PR TITLE
Remove data about RTCIceCandidateStats.networkType

### DIFF
--- a/api/RTCIceCandidateStats.json
+++ b/api/RTCIceCandidateStats.json
@@ -257,54 +257,6 @@
           }
         }
       },
-      "networkType": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidateStats/networkType",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "port": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidateStats/port",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Remove data about [`RTCIceCandidateStats.networkType`](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidateStats/networkType) since it was never supported by any browser and was removed from the spec.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
 - Firefox:
   - [Introduced it as "unsupported" in 2018](https://github.com/mozilla/gecko-dev/commit/3a4a5d27d6f7390a81d1a48511cd9268dc21fa19) 
   - [Still lists it as "unsupported"](https://github.com/mozilla/gecko-dev/blob/master/dom/media/webrtc/tests/mochitests/stats.js)
 - Chromium:
   - TBD
 - Safari:
   - [Started working on it in 2018, but did not expose it](https://github.com/WebKit/WebKit/commit/172d69874bd08533a15a27d69dfb89d0c040d873#diff-17a6b3565eb3ffd74d31b08c107c8712914aa8412e2590621bd81c0800727ad0R178)
   - [Still does not expose it](https://github.com/WebKit/WebKit/blob/main/Source/WebCore/Modules/mediastream/RTCStatsReport.idl#L281)
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
https://github.com/mdn/content/pull/15127
<!-- ✅ After submitting, review the results of the "Checks" tab! -->
