### PR TITLE
Add workflow to catch for potential duplicates

### DIFF
--- a/.github/workflows/potential-duplicate-issues.yml
+++ b/.github/workflows/potential-duplicate-issues.yml
@@ -1,0 +1,31 @@
+name: Potential Duplicates
+on:
+  issues:
+    types: [opened, edited]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wow-actions/potential-duplicates@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Issue title filter work with anymatch https://www.npmjs.com/package/anymatch.
+          # Any matched issue will stop detection immediately.
+          # You can specify multi filters in each line.
+          filter: ''
+          # Exclude keywords in title before detecting.
+          exclude: ''
+          # Label to set, when potential duplicates are detected.
+          label: ''
+          # Get issues with state to compare. Supported state: 'all', 'closed', 'open'.
+          state: all
+          # If similarity is higher than this threshold([0,1]), issue will be marked as duplicate.
+          threshold: 0.6
+          # Reactions to be add to comment when potential duplicates are detected.
+          # Available reactions: "-1", "+1", "confused", "laugh", "heart", "hooray", "rocket", "eyes"
+          reactions: 'eyes, confused'
+          # Comment to post when potential duplicates are detected.
+          comment: >
+            Potential duplicates: {{#issues}}
+              - [#{{ number }}] {{ title }} ({{ accuracy }}%)
+            {{/issues}}


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to alert for potential duplicate issues.