### PR TITLE
Remove some new Firefox Android 79+ flag data

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -75,14 +75,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "83",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.forms.autocapitalize",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "ie": {
               "version_added": null

--- a/javascript/builtins/webassembly/Exception.json
+++ b/javascript/builtins/webassembly/Exception.json
@@ -35,22 +35,9 @@
                   ]
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "100"
-                },
-                {
-                  "version_added": "98",
-                  "version_removed": "100",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.wasm_exceptions",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox_android": {
+                "version_added": "100"
+              },
               "ie": {
                 "version_added": false
               },
@@ -116,22 +103,9 @@
                     ]
                   }
                 ],
-                "firefox_android": [
-                  {
-                    "version_added": "100"
-                  },
-                  {
-                    "version_added": "98",
-                    "version_removed": "100",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "javascript.options.wasm_exceptions",
-                        "value_to_set": "true"
-                      }
-                    ]
-                  }
-                ],
+                "firefox_android": {
+                  "version_added": "100"
+                },
                 "ie": {
                   "version_added": false
                 },
@@ -197,22 +171,9 @@
                     ]
                   }
                 ],
-                "firefox_android": [
-                  {
-                    "version_added": "100"
-                  },
-                  {
-                    "version_added": "98",
-                    "version_removed": "100",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "javascript.options.wasm_exceptions",
-                        "value_to_set": "true"
-                      }
-                    ]
-                  }
-                ],
+                "firefox_android": {
+                  "version_added": "100"
+                },
                 "ie": {
                   "version_added": false
                 },
@@ -278,22 +239,9 @@
                     ]
                   }
                 ],
-                "firefox_android": [
-                  {
-                    "version_added": "100"
-                  },
-                  {
-                    "version_added": "98",
-                    "version_removed": "100",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "javascript.options.wasm_exceptions",
-                        "value_to_set": "true"
-                      }
-                    ]
-                  }
-                ],
+                "firefox_android": {
+                  "version_added": "100"
+                },
                 "ie": {
                   "version_added": false
                 },

--- a/javascript/builtins/webassembly/Tag.json
+++ b/javascript/builtins/webassembly/Tag.json
@@ -35,22 +35,9 @@
                   ]
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "100"
-                },
-                {
-                  "version_added": "98",
-                  "version_removed": "100",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.wasm_exceptions",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox_android": {
+                "version_added": "100"
+              },
               "ie": {
                 "version_added": false
               },
@@ -116,22 +103,9 @@
                     ]
                   }
                 ],
-                "firefox_android": [
-                  {
-                    "version_added": "100"
-                  },
-                  {
-                    "version_added": "98",
-                    "version_removed": "100",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "javascript.options.wasm_exceptions",
-                        "value_to_set": "true"
-                      }
-                    ]
-                  }
-                ],
+                "firefox_android": {
+                  "version_added": "100"
+                },
                 "ie": {
                   "version_added": false
                 },
@@ -197,22 +171,9 @@
                     ]
                   }
                 ],
-                "firefox_android": [
-                  {
-                    "version_added": "100"
-                  },
-                  {
-                    "version_added": "98",
-                    "version_removed": "100",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "javascript.options.wasm_exceptions",
-                        "value_to_set": "true"
-                      }
-                    ]
-                  }
-                ],
+                "firefox_android": {
+                  "version_added": "100"
+                },
                 "ie": {
                   "version_added": false
                 },


### PR DESCRIPTION
These are not all such cases, only some simple ones.

Part of https://github.com/mdn/browser-compat-data/issues/9679.