### PR TITLE
Use strict asserts everywhere

### DIFF
--- a/scripts/release-build.test.js
+++ b/scripts/release-build.test.js
@@ -1,5 +1,5 @@
 'use strict';
-const assert = require('assert');
+const assert = require('assert').strict;
 const { execSync } = require('child_process');
 
 const prebuiltPath = '../build';

--- a/test/compare-features.test.js
+++ b/test/compare-features.test.js
@@ -45,6 +45,6 @@ describe('compare-features script', () => {
       '43',
     ];
 
-    assert.deepStrictEqual(actual, expected);
+    assert.deepEqual(actual, expected);
   });
 });

--- a/test/spec-urls.test.js
+++ b/test/spec-urls.test.js
@@ -1,5 +1,5 @@
 'use strict';
-const assert = require('assert');
+const assert = require('assert').strict;
 const specData = require('browser-specs');
 const { walk } = require('../utils');
 
@@ -61,7 +61,7 @@ describe('spec_url data', () => {
       if (![...allowList].find(host => spec.startsWith(host)))
         rejectedSpecs.push(spec);
     }
-    assert.deepStrictEqual(
+    assert.deepEqual(
       rejectedSpecs,
       [],
       `Invalid specification host(s) found. Try a more current specification URL and/or

--- a/test/test-regexes.js
+++ b/test/test-regexes.js
@@ -1,5 +1,5 @@
 'use strict';
-const assert = require('assert');
+const assert = require('assert').strict;
 
 /**
  * @typedef {import('../types').Identifier} Identifier

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,5 +1,5 @@
 'use strict';
-const assert = require('assert');
+const assert = require('assert').strict;
 const { escapeInvisibles } = require('./utils.js');
 
 describe('utils', () => {
@@ -49,7 +49,7 @@ describe('utils', () => {
       } else {
         [char, expected = char] = data;
       }
-      assert.strictEqual(escapeInvisibles(char), expected);
+      assert.equal(escapeInvisibles(char), expected);
     }
   });
 });

--- a/utils/walkingUtils.test.js
+++ b/utils/walkingUtils.test.js
@@ -17,7 +17,7 @@ describe('joinPath()', function () {
 
 describe('isBrowser()', function () {
   it('returns true for browser-like objects', function () {
-    assert.ok(isBrowser(bcd.browsers.firefox));
+    assert.equal(isBrowser(bcd.browsers.firefox), true);
   });
 
   it('returns false for feature-like objects', function () {
@@ -31,6 +31,6 @@ describe('isFeature()', function () {
   });
 
   it('returns true for feature-like objects', function () {
-    assert.ok(isFeature(query('html.elements.a')));
+    assert.equal(isFeature(query('html.elements.a')), true);
   });
 });


### PR DESCRIPTION
This is already used in some places, and makes the assert.* calls
shorter and nicer.