### PR TITLE
Mark CanMakePaymentEvent.modifiers as deprecated/non-standard

### DIFF
--- a/api/CanMakePaymentEvent.json
+++ b/api/CanMakePaymentEvent.json
@@ -3,6 +3,7 @@
     "CanMakePaymentEvent": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanMakePaymentEvent",
+        "spec_url": "https://w3c.github.io/payment-handler/#the-canmakepaymentevent",
         "support": {
           "chrome": {
             "version_added": "70"
@@ -51,6 +52,7 @@
         "__compat": {
           "description": "<code>CanMakePaymentEvent()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanMakePaymentEvent/CanMakePaymentEvent",
+          "spec_url": "https://w3c.github.io/payment-handler/#dom-canmakepaymentevent-constructor",
           "support": {
             "chrome": {
               "version_added": "70"
@@ -99,6 +101,7 @@
       "methodData": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanMakePaymentEvent/methodData",
+          "spec_url": "https://w3c.github.io/payment-handler/#dom-canmakepaymentevent-methoddata",
           "support": {
             "chrome": {
               "version_added": "70"
@@ -149,13 +152,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanMakePaymentEvent/modifiers",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "70",
+              "notes": "See <a href='https://crbug.com/1317941'>bug 1317941</a>."
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "70"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": false
@@ -167,10 +171,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "49"
             },
             "safari": {
               "version_added": false
@@ -179,22 +183,23 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
             }
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
       "paymentRequestOrigin": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanMakePaymentEvent/paymentRequestOrigin",
+          "spec_url": "https://w3c.github.io/payment-handler/#dom-canmakepaymentevent-paymentrequestorigin",
           "support": {
             "chrome": {
               "version_added": "70"
@@ -243,6 +248,7 @@
       "respondWith": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanMakePaymentEvent/respondWith",
+          "spec_url": "https://w3c.github.io/payment-handler/#dom-canmakepaymentevent-respondwith",
           "support": {
             "chrome": {
               "version_added": "70"
@@ -291,6 +297,7 @@
       "topOrigin": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanMakePaymentEvent/topOrigin",
+          "spec_url": "https://w3c.github.io/payment-handler/#dom-canmakepaymentevent-toporigin",
           "support": {
             "chrome": {
               "version_added": "70"


### PR DESCRIPTION
It was removed from the spec long ago:
https://github.com/w3c/payment-handler/pull/315

However, it is in Chromium, confirmed in Chrome 70 and 100:
https://mdn-bcd-collector.appspot.com/tests/api/CanMakePaymentEvent

Link to a newly filed bug about removing it.

Add spec links for everything else.