### PR TITLE
Remove cursor media track constraint

### DIFF
--- a/api/MediaTrackConstraints.json
+++ b/api/MediaTrackConstraints.json
@@ -207,55 +207,6 @@
           }
         }
       },
-      "cursor": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/cursor",
-          "spec_url": "https://w3c.github.io/mediacapture-screen-share/#dom-mediatrackconstraintset-cursor",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "deviceId": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackConstraints/deviceId",

--- a/api/MediaTrackSupportedConstraints.json
+++ b/api/MediaTrackSupportedConstraints.json
@@ -209,55 +209,6 @@
           }
         }
       },
-      "cursor": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackSupportedConstraints/cursor",
-          "spec_url": "https://w3c.github.io/mediacapture-screen-share/#dom-mediatracksupportedconstraints-cursor",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "deviceId": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaTrackSupportedConstraints/deviceId",


### PR DESCRIPTION
This is not implemented anywhere, as indicated by the data, and
confirmed by searching for "cursor" in IDL files in Chromium, Gecko
and WebKit source, not finding anything related.
