### PR TITLE
Require all URLs in schema to start with https://

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -7,7 +7,7 @@
       "releases": {
         "1": {
           "release_date": "2004-11-09",
-          "release_notes": "http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/firefox/releases/1.0.html",
+          "release_notes": "https://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/firefox/releases/1.0.html",
           "status": "retired",
           "engine": "Gecko",
           "engine_version": "1.7"

--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -63,6 +63,7 @@
         "release_notes": {
           "type": "string",
           "format": "uri",
+          "pattern": "^https:\/\/",
           "description": "A link to the release notes or changelog for a given release."
         },
         "accepts_flags": {

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -174,7 +174,7 @@
     "spec_url_value": {
       "type": "string",
       "format": "uri",
-      "pattern": "(^http(s)?:\/\/[^#]+#.+)|(^https://www.khronos.org/registry/webgl/extensions/[^/]+/)"
+      "pattern": "(^https:\/\/[^#]+#.+)|(^https://www.khronos.org/registry/webgl/extensions/[^/]+/)"
     },
 
     "compat_statement": {


### PR DESCRIPTION
This isn't fixing any very important problem, mainly done because the
release_notes type was the only one in the schema without a format,
which would thus allow any scheme, including typos.

There was just a single http:// URL that needed to be updated, and that
already redirected to https://.