### PR TITLE
Mark screen orientation unlock as partial in desktop browsers

### DIFF
--- a/api/ScreenOrientation.json
+++ b/api/ScreenOrientation.json
@@ -267,16 +267,22 @@
           "spec_url": "https://w3c.github.io/screen-orientation/#dom-screenorientation-unlock",
           "support": {
             "chrome": {
-              "version_added": "38"
+              "version_added": "38",
+              "partial_implementation": true,
+              "notes": "Always throws <code>NotSupportedError</code>."
             },
             "chrome_android": {
               "version_added": "38"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "partial_implementation": true,
+              "notes": "Always throws <code>NotSupportedError</code>."
             },
             "firefox": {
-              "version_added": "43"
+              "version_added": "43",
+              "partial_implementation": true,
+              "notes": "Always throws <code>NotSupportedError</code>."
             },
             "firefox_android": {
               "version_added": "43"
@@ -285,7 +291,9 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "25"
+              "version_added": "25",
+              "partial_implementation": true,
+              "notes": "Always throws <code>NotSupportedError</code>."
             },
             "opera_android": {
               "version_added": "25"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

We correctly noted issues on desktop browsers for lock but not unlock, this PR fixes that.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Fixes https://github.com/mdn/browser-compat-data/issues/15854
