### PR TITLE
Adds SerialPort.forget()

### DIFF
--- a/api/SerialPort.json
+++ b/api/SerialPort.json
@@ -203,6 +203,55 @@
           }
         }
       },
+      "forget": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SerialPort/forget",
+          "spec_url": "https://wicg.github.io/serial/#dom-serialport-forget",
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "102"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getInfo": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SerialPort/getInfo",

--- a/api/SerialPort.json
+++ b/api/SerialPort.json
@@ -209,13 +209,13 @@
           "spec_url": "https://wicg.github.io/serial/#dom-serialport-forget",
           "support": {
             "chrome": {
-              "version_added": "102"
+              "version_added": "103"
             },
             "chrome_android": {
               "version_added": false
             },
             "edge": {
-              "version_added": "102"
+              "version_added": "103"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Adds entry for `SerialPort.forget()`

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://groups.google.com/a/chromium.org/g/blink-dev/c/aBSGxh0LJVA/m/_pOq-q04EwAJ?pli=1

https://chromestatus.com/feature/5145811414417408

https://chromestatus.com/roadmap#:~:text=LATER-,Chrome%20103,-Beta%20coming%20May - Chrome 103 release date