### PR TITLE
Mirror data for Firefox Android for Geolocation APIs

### DIFF
--- a/api/GeolocationCoordinates.json
+++ b/api/GeolocationCoordinates.json
@@ -45,10 +45,16 @@
               "alternative_name": "Coordinates"
             }
           ],
-          "firefox_android": {
-            "alternative_name": "Coordinates",
-            "version_added": "4"
-          },
+          "firefox_android": [
+            {
+              "version_added": "79"
+            },
+            {
+              "alternative_name": "Coordinates",
+              "version_added": "4",
+              "version_removed": "79"
+            }
+          ],
           "ie": {
             "alternative_name": "Coordinates",
             "version_added": "9"

--- a/api/GeolocationPosition.json
+++ b/api/GeolocationPosition.json
@@ -45,10 +45,16 @@
               "alternative_name": "Position"
             }
           ],
-          "firefox_android": {
-            "alternative_name": "Position",
-            "version_added": "4"
-          },
+          "firefox_android": [
+            {
+              "version_added": "79"
+            },
+            {
+              "alternative_name": "Position",
+              "version_added": "4",
+              "version_removed": "79"
+            }
+          ],
           "ie": {
             "alternative_name": "Position",
             "version_added": "9"

--- a/api/GeolocationPositionError.json
+++ b/api/GeolocationPositionError.json
@@ -45,10 +45,16 @@
               "alternative_name": "PositionError"
             }
           ],
-          "firefox_android": {
-            "alternative_name": "PositionError",
-            "version_added": "4"
-          },
+          "firefox_android": [
+            {
+              "version_added": "79"
+            },
+            {
+              "alternative_name": "PositionError",
+              "version_added": "4",
+              "version_removed": "79"
+            }
+          ],
           "ie": {
             "alternative_name": "PositionError",
             "version_added": "9"


### PR DESCRIPTION
This PR mirrors the data from Firefox desktop to Firefox Android for the Geolocation APIs.
