### PR TITLE
Add Firefox Android versions for api.IDBTransaction.commit

### DIFF
--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -207,7 +207,7 @@
               "version_added": "74"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox Android for the `commit` member of the `IDBTransaction` API by mirroring the data.
