### PR TITLE
Add Firefox Android versions for api.IDBCursor.request

### DIFF
--- a/api/IDBCursor.json
+++ b/api/IDBCursor.json
@@ -513,7 +513,7 @@
               "version_added": "77"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox Android for the `request` member of the `IDBCursor` API by mirroring the data.
