### PR TITLE
Update Firefox notes for Notification.requestPermission()

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -886,14 +886,14 @@
             "firefox": {
               "version_added": "22",
               "notes": [
-                "From Firefox 70 onwards, cannot be called from a cross-origin IFrame.",
+                "From Firefox 70 onwards, cannot be called from a cross-origin <code>iframe</code>.",
                 "From Firefox 72 onwards, can only be called in response to a user gesture such as a <code>click</code> event."
               ]
             },
             "firefox_android": {
               "version_added": "22",
               "notes": [
-                "From Firefox Android 79 onwards, cannot be called from a cross-origin IFrame.",
+                "From Firefox Android 79 onwards, cannot be called from a cross-origin <code>iframe</code>.",
                 "From Firefox Android 79 onwards, can only be called in response to a user gesture such as a <code>click</code> event."
               ]
             },

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -891,7 +891,11 @@
               ]
             },
             "firefox_android": {
-              "version_added": "22"
+              "version_added": "22",
+              "notes": [
+                "From Firefox Android 79 onwards, cannot be called from a cross-origin IFrame.",
+                "From Firefox Android 79 onwards, can only be called in response to a user gesture such as a <code>click</code> event."
+              ]
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR copies the notes on Notification.requestPermission() from Firefox desktop to Firefox Android, as well as fixes an odd capitalization issue.