### PR TITLE
Copy notes for Firefox for PushManager.subscribe()

### DIFF
--- a/api/PushManager.json
+++ b/api/PushManager.json
@@ -327,7 +327,7 @@
             },
             "firefox_android": {
               "version_added": "48",
-              "notes": "Push enabled by default."
+              "notes": "From Firefox Android 79 onwards, can only be called in response to a user gesture such as a <code>click</code> event."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR copies the applicable note from Firefox desktop to Firefox Android for PushManager.subscribe().
