### PR TITLE
Create workflow to label PRs needing rebase

### DIFF
--- a/.github/workflows/pr-rebase-needed.yml
+++ b/.github/workflows/pr-rebase-needed.yml
@@ -1,0 +1,20 @@
+name: "PR Needs Rebase"
+on:
+  # So that PRs touching the same files as the push are updated
+  push:
+  # So that the `dirtyLabel` is removed if conflicts are resolve
+  # We recommend `pull_request_target` so that github secrets are available.
+  # In `pull_request` we wouldn't be able to change labels of fork PRs
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for merge conflicts
+        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        with:
+          dirtyLabel: "rebase needed :construction:"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: "This pull request has merge conflicts that must be resolved before we can merge this."

--- a/.github/workflows/pr-rebase-needed.yml
+++ b/.github/workflows/pr-rebase-needed.yml
@@ -1,15 +1,11 @@
 name: "PR Needs Rebase"
 on:
-  # So that PRs touching the same files as the push are updated
   push:
-  # So that the `dirtyLabel` is removed if conflicts are resolve
-  # We recommend `pull_request_target` so that github secrets are available.
-  # In `pull_request` we wouldn't be able to change labels of fork PRs
   pull_request_target:
     types: [synchronize]
 
 jobs:
-  main:
+  label-rebase-needed:
     runs-on: ubuntu-latest
     steps:
       - name: Check for merge conflicts

--- a/.github/workflows/pr-rebase-needed.yml
+++ b/.github/workflows/pr-rebase-needed.yml
@@ -7,3 +7,5 @@ on:
 jobs:
   idle:
     uses: mdn/workflows/.github/workflows/pr-rebase-needed.yml@main
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-rebase-needed.yml
+++ b/.github/workflows/pr-rebase-needed.yml
@@ -5,12 +5,5 @@ on:
     types: [synchronize]
 
 jobs:
-  label-rebase-needed:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check for merge conflicts
-        uses: eps1lon/actions-label-merge-conflict@releases/2.x
-        with:
-          dirtyLabel: "rebase needed :construction:"
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          commentOnDirty: "This pull request has merge conflicts that must be resolved before we can merge this."
+  idle:
+    uses: mdn/workflows/.github/workflows/pr-rebase-needed.yml@main


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to automatically (un)label pull requests that have merge conflicts.  Fixes #5154.