### PR TITLE
Replace hyphens with underscores in some subfeature names

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -1057,7 +1057,7 @@
           }
         }
       },
-      "sctp-sdp-21": {
+      "sctp_sdp_21": {
         "__compat": {
           "description": "Support for sctp-sdp-21 format",
           "support": {

--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -297,7 +297,7 @@
           }
         }
       },
-      "pinch-to-zoom_support": {
+      "pinch_to_zoom_support": {
         "__compat": {
           "description": "Pinch-to-zoom maps to <code>WheelEvent</code> + <code>ctrl</code> key.",
           "support": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -2821,7 +2821,7 @@
             "deprecated": false
           }
         },
-        "pseudo-element_support": {
+        "pseudo_element_support": {
           "__compat": {
             "description": "Pseudo-element support",
             "support": {
@@ -2917,7 +2917,7 @@
             "deprecated": false
           }
         },
-        "pseudo-element_support": {
+        "pseudo_element_support": {
           "__compat": {
             "description": "Pseudo-element support",
             "support": {

--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -141,7 +141,7 @@
             "deprecated": false
           }
         },
-        "Atomic_operations_on_non-shared_buffers": {
+        "Atomic_operations_on_non_shared_buffers": {
           "__compat": {
             "description": "Atomic operations on non-shared <code>ArrayBuffer</code> objects",
             "support": {

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -1094,7 +1094,7 @@
               "deprecated": false
             }
           },
-          "dom-objects": {
+          "dom_objects": {
             "__compat": {
               "description": "<code>toStringTag</code> available on all DOM prototype objects",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag#toStringTag_available_on_all_DOM_prototype_objects",


### PR DESCRIPTION
Although not enforced by any lint, the dominant convention in BCD is to
use underscores in subfeatures describing some behavior, as opposed to
the directly observable API surface. This makes it more obvious that
it's not the name of an API, and can be mostly ignored when working on
mdn-bcd-collector.

Rename some of the subfeatures that currently use hyphens for no very
good reason. Some still remain that are named by some code name, like
"default_same-origin", but the remaining names include at least one
underscore, which is good enough for filtering.