### PR TITLE
Remove non-standard and unsupported api.WorkerNavigator.fonts

### DIFF
--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -303,54 +303,6 @@
           }
         }
       },
-      "fonts": {
-        "__compat": {
-          "spec_url": "https://wicg.github.io/local-font-access/#dom-navigatorfonts-fonts",
-          "support": {
-            "chrome": {
-              "version_added": "69"
-            },
-            "chrome_android": {
-              "version_added": "69"
-            },
-            "edge": {
-              "version_added": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "56"
-            },
-            "opera_android": {
-              "version_added": "48"
-            },
-            "safari": {
-              "version_added": "15"
-            },
-            "safari_ios": {
-              "version_added": "15"
-            },
-            "samsunginternet_android": {
-              "version_added": "10.0"
-            },
-            "webview_android": {
-              "version_added": "69"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "hardwareConcurrency": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/hardwareConcurrency",


### PR DESCRIPTION
This was added in https://github.com/mdn/browser-compat-data/pull/14090
but appears to have been a mistake or bug.

The now-removed test for this was simple:
```js
(function() {
  var instance = navigator;
  return 'fonts' in instance;
})();
```

However, the test results from v4.0.0 of the collector are all false:
https://github.com/foolip/mdn-bcd-results/tree/1b5607ce99aff7d11bc07134e382930ad83436f5

This was determined by looking at "api.WorkerNavigator.fonts" in the
results, in particular for Chrome 69 and Safari 15, but there's not a
single true test result among the results.

It's unclear what went wrong, but this isn't supported, and never was.

This was removed from the spec here:
https://github.com/WICG/local-font-access/pull/70

This is the only instance of "local-font-access" in BCD so no other bits
of the API were added, at least not with spec URLs.