### PR TITLE
Update schema to remove "strict mode" warnings

### DIFF
--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -2,7 +2,6 @@
   "$schema": "http://json-schema.org/schema#",
 
   "definitions": {
-
     "browsers": {
       "type": "object",
       "properties": {
@@ -18,7 +17,9 @@
         "opera_android": { "$ref": "#/definitions/browser_statement" },
         "safari": { "$ref": "#/definitions/browser_statement" },
         "safari_ios": { "$ref": "#/definitions/browser_statement" },
-        "samsunginternet_android": { "$ref": "#/definitions/browser_statement" },
+        "samsunginternet_android": {
+          "$ref": "#/definitions/browser_statement"
+        },
         "webview_android": { "$ref": "#/definitions/browser_statement" }
       },
       "additionalProperties": false
@@ -63,7 +64,7 @@
         "release_notes": {
           "type": "string",
           "format": "uri",
-          "pattern": "^https:\/\/",
+          "pattern": "^https://",
           "description": "A link to the release notes or changelog for a given release."
         },
         "accepts_flags": {
@@ -72,7 +73,15 @@
         },
         "engine": {
           "type": "string",
-          "enum": ["Blink", "EdgeHTML", "Gecko", "Presto", "Trident", "WebKit", "V8"],
+          "enum": [
+            "Blink",
+            "EdgeHTML",
+            "Gecko",
+            "Presto",
+            "Trident",
+            "WebKit",
+            "V8"
+          ],
           "description": "Name of the browser's underlying engine."
         },
         "engine_version": {
@@ -81,7 +90,15 @@
         },
         "status": {
           "type": "string",
-          "enum": ["retired", "current", "exclusive", "beta", "nightly", "esr", "planned"],
+          "enum": [
+            "retired",
+            "current",
+            "exclusive",
+            "beta",
+            "nightly",
+            "esr",
+            "planned"
+          ],
           "description": "The status of the given browser release (e.g. current, retired, beta, nightly)."
         }
       },
@@ -90,8 +107,8 @@
   },
 
   "type": "object",
-    "properties": {
-      "browsers": { "$ref": "#/definitions/browsers" }
-    },
-    "additionalProperties": false
+  "properties": {
+    "browsers": { "$ref": "#/definitions/browsers" }
+  },
+  "additionalProperties": false
 }

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -35,9 +35,7 @@
               }
             },
             "additionalProperties": false,
-            "required": ["type", "name"],
-            "minProperties": 2,
-            "maxProperties": 3
+            "required": ["type", "name"]
           }
         },
         "partial_implementation": {

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -2,7 +2,6 @@
   "$schema": "http://json-schema.org/schema#",
 
   "definitions": {
-
     "simple_support_statement": {
       "type": "object",
       "properties": {
@@ -36,25 +35,38 @@
               }
             },
             "additionalProperties": false,
-            "required": ["type", "name"]
+            "required": ["type", "name"],
+            "minProperties": 0,
+            "maxProperties": 3
           }
         },
         "partial_implementation": {
-          "type": "boolean",
+          "const": true,
           "description": "A boolean value indicating whether or not the implementation of the sub-feature deviates from the specification in a way that may cause compatibility problems. It defaults to false (no interoperability problems expected). If set to true, it is recommended that you add a note explaining how it diverges from the standard (such as that it implements an old version of the standard, for example)."
         },
         "version_added": {
           "description": "A string (indicating which browser version added this feature), the value true (indicating support added in an unknown version), the value false (indicating the feature is not supported), or the value null (indicating support is unknown).",
-          "allOf": [
-            { "type": ["string", "boolean", "null"] },
-            { "not": { "enum": ["true", "false", "null"] } }
+          "anyOf": [
+            {
+              "type": "string",
+              "pattern": "^(≤?(\\d+)(\\.\\d+)*|preview)$"
+            },
+            {
+              "type": "boolean",
+              "nullable": true
+            }
           ]
         },
         "version_removed": {
           "description": "A string, indicating which browser version removed this feature, or the value true, indicating that the feature was removed in an unknown version.",
-          "allOf": [
-            { "type": ["string", "boolean"] },
-            { "not": { "enum": ["true", false] } }
+          "anyOf": [
+            {
+              "type": "string",
+              "pattern": "^(≤?(\\d+)(\\.\\d+)*|preview)$"
+            },
+            {
+              "const": true
+            }
           ]
         },
         "notes": {
@@ -76,12 +88,12 @@
       "required": ["version_added"],
       "anyOf": [
         {
-          "not": {"required": ["prefix", "alternative_name"]}
+          "not": { "required": ["prefix", "alternative_name"] }
         },
         {
           "oneOf": [
-            {"required": ["prefix"]},
-            {"required": ["alternative_name"]}
+            { "required": ["prefix"] },
+            { "required": ["alternative_name"] }
           ]
         }
       ],
@@ -174,7 +186,7 @@
     "spec_url_value": {
       "type": "string",
       "format": "uri",
-      "pattern": "(^https:\/\/[^#]+#.+)|(^https://www.khronos.org/registry/webgl/extensions/[^/]+/)"
+      "pattern": "(^https://[^#]+#.+)|(^https://www.khronos.org/registry/webgl/extensions/[^/]+/)"
     },
 
     "compat_statement": {
@@ -187,7 +199,7 @@
         "mdn_url": {
           "type": "string",
           "format": "uri",
-          "pattern": "^https:\/\/developer\\.mozilla\\.org\/docs\/",
+          "pattern": "^https://developer\\.mozilla\\.org/docs/",
           "description": "A URL that points to an MDN reference page documenting the feature. The URL should be language-agnostic."
         },
         "spec_url": {
@@ -223,7 +235,7 @@
         "mdn_url": {
           "type": "string",
           "format": "uri",
-          "pattern": "^https:\/\/developer\\.mozilla\\.org\/docs\/",
+          "pattern": "^https://developer\\.mozilla\\.org/docs/",
           "description": "A URL that points to an MDN reference page documenting the feature. The URL should be language-agnostic."
         },
         "support": { "$ref": "#/definitions/support_block" },
@@ -237,6 +249,7 @@
       "allOf": [
         { "$ref": "#/definitions/identifier" },
         {
+          "type": "object",
           "maxProperties": 1,
           "minProperties": 1
         }
@@ -247,6 +260,7 @@
       "allOf": [
         { "$ref": "#/definitions/webextensions_identifier" },
         {
+          "type": "object",
           "maxProperties": 1,
           "minProperties": 1
         }
@@ -258,8 +272,8 @@
       "properties": {
         "__compat": { "$ref": "#/definitions/compat_statement" }
       },
-      "patternProperties":{
-        "^(?!__compat)[a-zA-Z_0-9-$@]*$" : { "$ref": "#/definitions/identifier" }
+      "patternProperties": {
+        "^(?!__compat)[a-zA-Z_0-9-$@]*$": { "$ref": "#/definitions/identifier" }
       },
       "additionalProperties": false
     },
@@ -269,8 +283,10 @@
       "properties": {
         "__compat": { "$ref": "#/definitions/webextensions_compat_statement" }
       },
-      "patternProperties":{
-        "^(?!__compat)[a-zA-Z_0-9-$@]*$" : { "$ref": "#/definitions/webextensions_identifier" }
+      "patternProperties": {
+        "^(?!__compat)[a-zA-Z_0-9-$@]*$": {
+          "$ref": "#/definitions/webextensions_identifier"
+        }
       },
       "additionalProperties": false
     }
@@ -278,8 +294,12 @@
 
   "type": "object",
   "patternProperties": {
-    "^(?!__compat)(?!webextensions)[a-zA-Z_0-9-$@]*$": { "$ref": "#/definitions/primary_identifier" },
-    "^webextensions*$": { "$ref": "#/definitions/primary_webextensions_identifier" }
+    "^(?!__compat)(?!webextensions)[a-zA-Z_0-9-$@]*$": {
+      "$ref": "#/definitions/primary_identifier"
+    },
+    "^webextensions*$": {
+      "$ref": "#/definitions/primary_webextensions_identifier"
+    }
   },
   "additionalProperties": false,
   "maxProperties": 1,

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -36,7 +36,7 @@
             },
             "additionalProperties": false,
             "required": ["type", "name"],
-            "minProperties": 0,
+            "minProperties": 2,
             "maxProperties": 3
           }
         },


### PR DESCRIPTION
Since upgrading `ajv`, we are now getting warnings in regards to strict mode compatibility.  This PR aims to fix these issues by adjusting conflicting statements and adding missing ones.

Note: this also performs a Prettier format on the files -- I'd be happy to perform the Prettier formatting in a separate PR first if that helps.
