### PR TITLE
Mark Daniel as owner emeritus

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -101,7 +101,6 @@ An individual is invited to become an Owner by existing Owners. A nomination wil
 
 #### List of current Owners
 
-- Daniel Beck (@ddbeck)
 - Florian Scholz (@Elchi3), Open Web Docs
 - Philip Jägenstedt (@foolip), Google
 - Ruth John (@Rumyra), Mozilla
@@ -167,6 +166,7 @@ The moderator is responsible for summarizing the discussion of each agenda item 
 The `@mdn/browser-compat-data` project would like to thank the following former Owners and Peers for their contributions and the countless hours invested.
 
 - Chris David Mills (@chrisdavidmills), Mozilla
+- Daniel Beck (@ddbeck) (BCD co-owner until April 2022)
 - Eric Shepherd (@a2sheppy) (BCD peer until August 2020)
 - Estelle Weyl (@estelle) (Peer for CSS compat data)
 - John Whitlock (@jwhitlock) (Technical design of the former compat data project)


### PR DESCRIPTION
This PR moves Daniel to the owners emeriti section on our governance doc.  Thank you, Daniel, for all of your hard work on BCD!