### PR TITLE
Rename fetchpriority properties to fetchPriority

### DIFF
--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -486,18 +486,21 @@
           }
         }
       },
-      "fetchpriority": {
+      "fetchPriority": {
         "__compat": {
           "spec_url": "https://wicg.github.io/priority-hints/#iframe",
           "support": {
             "chrome": {
-              "version_added": "101"
+              "version_added": "101",
+              "alternative_name": "fetchpriority"
             },
             "chrome_android": {
-              "version_added": "101"
+              "version_added": "101",
+              "alternative_name": "fetchpriority"
             },
             "edge": {
-              "version_added": "101"
+              "version_added": "101",
+              "alternative_name": "fetchpriority"
             },
             "firefox": {
               "version_added": false
@@ -524,11 +527,12 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "101"
+              "version_added": "101",
+              "alternative_name": "fetchpriority"
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -492,18 +492,21 @@
           }
         }
       },
-      "fetchpriority": {
+      "fetchPriority": {
         "__compat": {
           "spec_url": "https://wicg.github.io/priority-hints/#img",
           "support": {
             "chrome": {
-              "version_added": "101"
+              "version_added": "101",
+              "alternative_name": "fetchpriority"
             },
             "chrome_android": {
-              "version_added": "101"
+              "version_added": "101",
+              "alternative_name": "fetchpriority"
             },
             "edge": {
-              "version_added": "101"
+              "version_added": "101",
+              "alternative_name": "fetchpriority"
             },
             "firefox": {
               "version_added": false
@@ -530,11 +533,12 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "101"
+              "version_added": "101",
+              "alternative_name": "fetchpriority"
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -246,18 +246,21 @@
           }
         }
       },
-      "fetchpriority": {
+      "fetchPriority": {
         "__compat": {
           "spec_url": "https://wicg.github.io/priority-hints/#link",
           "support": {
             "chrome": {
-              "version_added": "101"
+              "version_added": "101",
+              "alternative_name": "fetchpriority"
             },
             "chrome_android": {
-              "version_added": "101"
+              "version_added": "101",
+              "alternative_name": "fetchpriority"
             },
             "edge": {
-              "version_added": "101"
+              "version_added": "101",
+              "alternative_name": "fetchpriority"
             },
             "firefox": {
               "version_added": false
@@ -284,11 +287,12 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "101"
+              "version_added": "101",
+              "alternative_name": "fetchpriority"
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -284,18 +284,21 @@
           }
         }
       },
-      "fetchpriority": {
+      "fetchPriority": {
         "__compat": {
           "spec_url": "https://wicg.github.io/priority-hints/#script",
           "support": {
             "chrome": {
-              "version_added": "101"
+              "version_added": "101",
+              "alternative_name": "fetchpriority"
             },
             "chrome_android": {
-              "version_added": "101"
+              "version_added": "101",
+              "alternative_name": "fetchpriority"
             },
             "edge": {
-              "version_added": "101"
+              "version_added": "101",
+              "alternative_name": "fetchpriority"
             },
             "firefox": {
               "version_added": false
@@ -322,11 +325,12 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": "101"
+              "version_added": "101",
+              "alternative_name": "fetchpriority"
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Request.json
+++ b/api/Request.json
@@ -1126,7 +1126,7 @@
             }
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -470,7 +470,7 @@
               }
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -403,7 +403,7 @@
               }
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -240,7 +240,7 @@
               }
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -242,7 +242,7 @@
               }
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
These IDL attributes were renamed in the spec:
https://github.com/WICG/priority-hints/pull/71

However, they remain all-lowercase in Chromium and are about to be
released in Chrome 101, so capture that in the data.

Also mark all of this experimental, per guidelines:
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#choosing-an-experimental-status