### PR TITLE
Mark Battery Status API as requiring secure context from Chrome 103

### DIFF
--- a/api/BatteryManager.json
+++ b/api/BatteryManager.json
@@ -537,6 +537,54 @@
             "deprecated": false
           }
         }
+      },
+      "secure_context_required": {
+        "__compat": {
+          "description": "Secure context required",
+          "support": {
+            "chrome": {
+              "version_added": "103"
+            },
+            "chrome_android": {
+              "version_added": "103"
+            },
+            "edge": {
+              "version_added": "103"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "103"
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1313,6 +1313,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "secure_context_required": {
+          "__compat": {
+            "description": "Secure context required",
+            "support": {
+              "chrome": {
+                "version_added": "103"
+              },
+              "chrome_android": {
+                "version_added": "103"
+              },
+              "edge": {
+                "version_added": "103"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "103"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "getGamepads": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Adds support data for secure context required in battery status.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

![image](https://user-images.githubusercontent.com/32498324/164509281-ab49360d-c125-4514-b268-74775d08ca58.png)

https://groups.google.com/a/chromium.org/g/blink-dev/c/w80tJL8uEV8 - Intent to Deprecate and Remove confirming version 103.

https://github.com/w3c/battery/pull/51 - MR to add requirement to spec

https://chromium.googlesource.com/chromium/src/+/3b29a4a747c49b2e84fcb3d1db9a3344c3b43961 - Chromium commit