### PR TITLE
Add Firefox support for unprefixed preservesPitch

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2675,7 +2675,7 @@
               {
                 "prefix": "moz",
                 "version_added": "20",
-                "notes": "May be removed in a future release, see<a href='https://bugzil.la/1765201'>bug 1765201</a>."
+                "notes": "May be removed in a future release, see <a href='https://bugzil.la/1765201'>bug 1765201</a>."
               }
             ],
             "firefox_android": [

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2685,7 +2685,7 @@
               {
                 "prefix": "moz",
                 "version_added": "20",
-                "notes": "May be removed in a future release, see<a href='https://bugzil.la/1765201'>bug 1765201</a>."
+                "notes": "May be removed in a future release, see <a href='https://bugzil.la/1765201'>bug 1765201</a>."
               }
             ],
             "ie": {

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2668,16 +2668,26 @@
             "edge": {
               "version_added": "86"
             },
-            "firefox": {
-              "prefix": "moz",
-              "version_added": "20",
-              "notes": "See <a href='https://bugzil.la/1652950'>bug 1652950</a>."
-            },
-            "firefox_android": {
-              "prefix": "moz",
-              "version_added": "20",
-              "notes": "See <a href='https://bugzil.la/1652950'>bug 1652950</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "101"
+              },
+              {
+                "prefix": "moz",
+                "version_added": "20",
+                "notes": "Deprecated as of version 101. See <a href='https://bugzil.la/1652950'>bug 1652950</a> and <a href='https://bugzil.la/1765201'>bug 1765201</a>."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "101"
+              },
+              {
+                "prefix": "moz",
+                "version_added": "20",
+                "notes": "Deprecated as of version 101. See <a href='https://bugzil.la/1652950'>bug 1652950</a> and <a href='https://bugzil.la/1765201'>bug 1765201</a>."
+              }
+            ],
             "ie": {
               "version_added": false
             },

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2675,7 +2675,7 @@
               {
                 "prefix": "moz",
                 "version_added": "20",
-                "notes": "Deprecated as of version 101. See <a href='https://bugzil.la/1652950'>bug 1652950</a> and <a href='https://bugzil.la/1765201'>bug 1765201</a>."
+                "notes": "May be removed in a future release, see<a href='https://bugzil.la/1765201'>bug 1765201</a>."
               }
             ],
             "firefox_android": [
@@ -2685,7 +2685,7 @@
               {
                 "prefix": "moz",
                 "version_added": "20",
-                "notes": "Deprecated as of version 101. See <a href='https://bugzil.la/1652950'>bug 1652950</a> and <a href='https://bugzil.la/1765201'>bug 1765201</a>."
+                "notes": "May be removed in a future release, see<a href='https://bugzil.la/1765201'>bug 1765201</a>."
               }
             ],
             "ie": {


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Mark `mozPreservesPitch` as deprecated, add support information for unprefixed `preservesPitch`.
<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
Updated tests + checked results as per [Bug 1652950](https://bugzil.la/1652950).

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
[Bug 1652950](https://bugzil.la/1652950) (Complete) - Unprefix `mozPreservesPitch` and update related tests.
[Bug 1765201](https://bugzil.la/1765201) (Future work) - Remove support for deprecated `mozPreservesPitch`.
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
