### PR TITLE
WebAssembly:Exception.stack and `option.traceStack` and platform support

### DIFF
--- a/javascript/builtins/webassembly/Exception.json
+++ b/javascript/builtins/webassembly/Exception.json
@@ -8,16 +8,16 @@
             "spec_url": "https://webassembly.github.io/exception-handling/js-api/#runtime-exceptions",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "95"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "deno": {
                 "version_added": false
               },
               "edge": {
-                "version_added": false
+                "version_added": "95"
               },
               "firefox": [
                 {
@@ -45,10 +45,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "81"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "67"
               },
               "safari": {
                 "version_added": "15.2"
@@ -57,10 +57,10 @@
                 "version_added": "15.2"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "17.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "95"
               }
             },
             "status": {
@@ -76,16 +76,16 @@
               "spec_url": "https://webassembly.github.io/exception-handling/js-api/#dom-exception-exception",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "95"
                 },
                 "chrome_android": {
-                  "version_added": false
+                  "version_added": "95"
                 },
                 "deno": {
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "95"
                 },
                 "firefox": [
                   {
@@ -113,10 +113,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "81"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "67"
                 },
                 "safari": {
                   "version_added": "15.2"
@@ -125,10 +125,10 @@
                   "version_added": "15.2"
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "17.0"
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "95"
                 }
               },
               "status": {
@@ -143,16 +143,16 @@
                 "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/Exception",
                 "support": {
                   "chrome": {
-                    "version_added": false
+                    "version_added": "95"
                   },
                   "chrome_android": {
-                    "version_added": false
+                    "version_added": "95"
                   },
                   "deno": {
                     "version_added": false
                   },
                   "edge": {
-                    "version_added": false
+                    "version_added": "95"
                   },
                   "firefox": [
                     {
@@ -180,10 +180,10 @@
                     "version_added": false
                   },
                   "opera": {
-                    "version_added": false
+                    "version_added": "81"
                   },
                   "opera_android": {
-                    "version_added": false
+                    "version_added": "67"
                   },
                   "safari": {
                     "version_added": "15.2"
@@ -192,10 +192,10 @@
                     "version_added": "15.2"
                   },
                   "samsunginternet_android": {
-                    "version_added": false
+                    "version_added": "17.0"
                   },
                   "webview_android": {
-                    "version_added": false
+                    "version_added": "95"
                   }
                 },
                 "status": {
@@ -212,16 +212,16 @@
               "spec_url": "https://webassembly.github.io/exception-handling/js-api/#dom-exception-getarg",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "95"
                 },
                 "chrome_android": {
-                  "version_added": false
+                  "version_added": "95"
                 },
                 "deno": {
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "95"
                 },
                 "firefox": [
                   {
@@ -249,10 +249,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "81"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "67"
                 },
                 "safari": {
                   "version_added": "15.2"
@@ -261,10 +261,10 @@
                   "version_added": "15.2"
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "17.0"
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "95"
                 }
               },
               "status": {
@@ -280,16 +280,16 @@
               "spec_url": "https://webassembly.github.io/exception-handling/js-api/#dom-exception-is",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "95"
                 },
                 "chrome_android": {
-                  "version_added": false
+                  "version_added": "95"
                 },
                 "deno": {
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "95"
                 },
                 "firefox": [
                   {
@@ -317,10 +317,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "81"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "67"
                 },
                 "safari": {
                   "version_added": "15.2"
@@ -329,10 +329,10 @@
                   "version_added": "15.2"
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "17.0"
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "95"
                 }
               },
               "status": {
@@ -348,16 +348,16 @@
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "95"
                 },
                 "chrome_android": {
-                  "version_added": false
+                  "version_added": "95"
                 },
                 "deno": {
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "95"
                 },
                 "firefox": [
                   {
@@ -385,10 +385,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "81"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "67"
                 },
                 "safari": {
                   "version_added": "15.2"
@@ -397,10 +397,10 @@
                   "version_added": "15.2"
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "17.0"
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "95"
                 }
               },
               "status": {

--- a/javascript/builtins/webassembly/Exception.json
+++ b/javascript/builtins/webassembly/Exception.json
@@ -42,7 +42,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "17.0.0"
               },
               "opera": {
                 "version_added": "81"
@@ -110,7 +110,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "17.0.0"
                 },
                 "opera": {
                   "version_added": "81"
@@ -177,7 +177,7 @@
                     "version_added": false
                   },
                   "nodejs": {
-                    "version_added": false
+                    "version_added": "17.0.0"
                   },
                   "opera": {
                     "version_added": "81"
@@ -246,7 +246,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "17.0.0"
                 },
                 "opera": {
                   "version_added": "81"
@@ -314,7 +314,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "17.0.0"
                 },
                 "opera": {
                   "version_added": "81"
@@ -382,7 +382,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "17.0.0"
                 },
                 "opera": {
                   "version_added": "81"

--- a/javascript/builtins/webassembly/Exception.json
+++ b/javascript/builtins/webassembly/Exception.json
@@ -136,6 +136,74 @@
                 "standard_track": true,
                 "deprecated": false
               }
+            },
+            "options_parameter_traceStack": {
+              "__compat": {
+                "description": "<code>options.traceStack</code> parameter",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/Exception",
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": {
+                    "version_added": false
+                  },
+                  "deno": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": [
+                    {
+                      "version_added": "100"
+                    },
+                    {
+                      "version_added": "98",
+                      "version_removed": "100",
+                      "flags": [
+                        {
+                          "type": "preference",
+                          "name": "javascript.options.wasm_exceptions",
+                          "value_to_set": "true"
+                        }
+                      ]
+                    }
+                  ],
+                  "firefox_android": {
+                    "version_added": "100"
+                  },
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": false
+                  },
+                  "opera": {
+                    "version_added": false
+                  },
+                  "opera_android": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": "15.2"
+                  },
+                  "safari_ios": {
+                    "version_added": "15.2"
+                  },
+                  "samsunginternet_android": {
+                    "version_added": false
+                  },
+                  "webview_android": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "deprecated": false
+                }
+              }
             }
           },
           "getArg": {
@@ -270,6 +338,74 @@
               "status": {
                 "experimental": false,
                 "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "stack": {
+            "__compat": {
+              "description": "Stack trace",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "deno": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": [
+                  {
+                    "version_added": "100"
+                  },
+                  {
+                    "version_added": "98",
+                    "version_removed": "100",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "javascript.options.wasm_exceptions",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
+                "firefox_android": {
+                  "version_added": "100"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": "15.2"
+                },
+                "safari_ios": {
+                  "version_added": "15.2"
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": false,
                 "deprecated": false
               }
             }

--- a/javascript/builtins/webassembly/Tag.json
+++ b/javascript/builtins/webassembly/Tag.json
@@ -8,16 +8,16 @@
             "spec_url": "https://webassembly.github.io/exception-handling/js-api/#tags",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "95"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "95"
               },
               "deno": {
                 "version_added": false
               },
               "edge": {
-                "version_added": false
+                "version_added": "95"
               },
               "firefox": [
                 {
@@ -45,10 +45,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "81"
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "67"
               },
               "safari": {
                 "version_added": "15.2"
@@ -57,10 +57,10 @@
                 "version_added": "15.2"
               },
               "samsunginternet_android": {
-                "version_added": false
+                "version_added": "17.0"
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "95"
               }
             },
             "status": {
@@ -76,16 +76,16 @@
               "spec_url": "https://webassembly.github.io/exception-handling/js-api/#dom-tag-tag",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "95"
                 },
                 "chrome_android": {
-                  "version_added": false
+                  "version_added": "95"
                 },
                 "deno": {
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "95"
                 },
                 "firefox": [
                   {
@@ -113,10 +113,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "81"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "67"
                 },
                 "safari": {
                   "version_added": "15.2"
@@ -125,10 +125,10 @@
                   "version_added": "15.2"
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "17.0"
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "95"
                 }
               },
               "status": {
@@ -144,16 +144,16 @@
               "spec_url": "https://webassembly.github.io/exception-handling/js-api/#dom-tag-type",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "95"
                 },
                 "chrome_android": {
-                  "version_added": false
+                  "version_added": "95"
                 },
                 "deno": {
                   "version_added": false
                 },
                 "edge": {
-                  "version_added": false
+                  "version_added": "95"
                 },
                 "firefox": [
                   {
@@ -181,10 +181,10 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": false
+                  "version_added": "81"
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": "67"
                 },
                 "safari": {
                   "version_added": "15.2"
@@ -193,10 +193,10 @@
                   "version_added": "15.2"
                 },
                 "samsunginternet_android": {
-                  "version_added": false
+                  "version_added": "17.0"
                 },
                 "webview_android": {
-                  "version_added": false
+                  "version_added": "95"
                 }
               },
               "status": {

--- a/javascript/builtins/webassembly/Tag.json
+++ b/javascript/builtins/webassembly/Tag.json
@@ -42,7 +42,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "17.0.0"
               },
               "opera": {
                 "version_added": "81"
@@ -110,7 +110,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "17.0.0"
                 },
                 "opera": {
                   "version_added": "81"
@@ -178,7 +178,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "17.0.0"
                 },
                 "opera": {
                   "version_added": "81"


### PR DESCRIPTION
1. This adds support for `WebAssembly:Exception.stack`, and  constructor `WebAssembly:Exception` constructor option `option.traceStack`. 
   - These are NOT in the spec yet but they are in [the explainer](https://github.com/WebAssembly/exception-handling/blob/main/proposals/exception-handling/Exceptions.md#api-additions), they are [intended to go into the spec](https://github.com/WebAssembly/exception-handling/issues/201) and they have been implemented in Firefox, Chromium, node, and probably Safari
   - Because they are not in the spec I indicated non-standard - but perhaps I should just put as standard since things are heading that way? I decided not to so that I can add the spec link later when one exists.

2. Support was added for this in chromium was added in version 95 : https://chromestatus.com/feature/4756734233018368

3. Support was added in node for v8 9.5 which corresponds to v17.0.0 : https://v8.dev/blog/v8-release-95#webassembly