### PR TITLE
Deprecate the param element and HTMLParamElement API

### DIFF
--- a/api/HTMLParamElement.json
+++ b/api/HTMLParamElement.json
@@ -3,7 +3,7 @@
     "HTMLParamElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLParamElement",
-        "spec_url": "https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlparamelement",
+        "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#htmlparamelement",
         "support": {
           "chrome": {
             "version_added": "1"
@@ -45,7 +45,7 @@
         "status": {
           "experimental": false,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "name": {
@@ -92,7 +92,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -188,7 +188,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/html/elements/param.json
+++ b/html/elements/param.json
@@ -4,7 +4,7 @@
       "param": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/param",
-          "spec_url": "https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-param-element",
+          "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#the-param-element",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -46,7 +46,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         },
         "name": {
@@ -92,7 +92,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },
@@ -186,7 +186,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
https://github.com/whatwg/html/commit/04a11f2 (https://github.com/whatwg/html/pull/7816) obsoletes the HTML `param` element and the `HTMLParamElement` API.
Related MDN change: https://github.com/mdn/content/pull/15225