### PR TITLE
Add Opera versions for api.AbortSignal.reason

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -308,10 +308,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "84"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Opera and Opera Android for the `reason` member of the `AbortSignal` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).  The collector obtains results based upon Opera Desktop 12.16 and 15, as well as the latest version of Opera Desktop and Opera Android.  Version numbers are then copied for Blink-based Opera versions from Chrome Desktop and Android respectively.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AbortSignal/reason

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
