### PR TITLE
Add Safari versions for api.BroadcastChannel.messageerror_event

### DIFF
--- a/api/BroadcastChannel.json
+++ b/api/BroadcastChannel.json
@@ -275,11 +275,11 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": false,
+              "version_added": "15.4",
               "notes": "See <a href='https://webkit.org/b/171216'>bug 171216</a>."
             },
             "safari_ios": {
-              "version_added": false,
+              "version_added": "15.4",
               "notes": "See <a href='https://webkit.org/b/171216'>bug 171216</a>."
             },
             "samsunginternet_android": {

--- a/api/BroadcastChannel.json
+++ b/api/BroadcastChannel.json
@@ -275,12 +275,10 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": "15.4",
-              "notes": "See <a href='https://webkit.org/b/171216'>bug 171216</a>."
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": "15.4",
-              "notes": "See <a href='https://webkit.org/b/171216'>bug 171216</a>."
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `messageerror_event` member of the `BroadcastChannel` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/BroadcastChannel/messageerror_event

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
