### PR TITLE
Update Safari versions for api.ByteLengthQueuingStrategy.ByteLengthQueuingStrategy

### DIFF
--- a/api/ByteLengthQueuingStrategy.json
+++ b/api/ByteLengthQueuingStrategy.json
@@ -95,10 +95,12 @@
               "version_added": "43"
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10.1",
+              "version_removed": "15.4"
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": "10.3",
+              "version_removed": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "7.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `ByteLengthQueuingStrategy` member of the `ByteLengthQueuingStrategy` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ByteLengthQueuingStrategy/ByteLengthQueuingStrategy

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
