### PR TITLE
Add Chromium versions for api.CanvasRenderingContext2D.createConicGradient

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -493,28 +493,38 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/createConicGradient",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-createconicgradient-dev",
           "support": {
-            "chrome": {
-              "version_added": "86",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#new-canvas-2d-api"
-                }
-              ],
-              "notes": "See <a href='https://crbug.com/1284417'>bug 1284417</a>."
-            },
-            "chrome_android": {
-              "version_added": "86",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#new-canvas-2d-api"
-                }
-              ],
-              "notes": "See <a href='https://crbug.com/1284417'>bug 1284417</a>."
-            },
+            "chrome": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "86",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#new-canvas-2d-api"
+                  }
+                ],
+                "notes": "See <a href='https://crbug.com/1284417'>bug 1284417</a>."
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "99"
+              },
+              {
+                "version_added": "86",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#new-canvas-2d-api"
+                  }
+                ],
+                "notes": "See <a href='https://crbug.com/1284417'>bug 1284417</a>."
+              }
+            ],
             "edge": {
-              "version_added": false,
+              "version_added": "99",
               "notes": "See <a href='https://crbug.com/1284417'>bug 1284417</a>."
             },
             "firefox": [
@@ -539,11 +549,11 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false,
+              "version_added": "85",
               "notes": "See <a href='https://crbug.com/1284417'>bug 1284417</a>."
             },
             "opera_android": {
-              "version_added": false,
+              "version_added": "68",
               "notes": "See <a href='https://crbug.com/1284417'>bug 1284417</a>."
             },
             "safari": {
@@ -557,7 +567,7 @@
               "notes": "See <a href='https://crbug.com/1284417'>bug 1284417</a>."
             },
             "webview_android": {
-              "version_added": false,
+              "version_added": "99",
               "notes": "See <a href='https://crbug.com/1284417'>bug 1284417</a>."
             }
           },

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -504,8 +504,7 @@
                     "type": "preference",
                     "name": "#new-canvas-2d-api"
                   }
-                ],
-                "notes": "See <a href='https://crbug.com/1284417'>bug 1284417</a>."
+                ]
               }
             ],
             "chrome_android": [
@@ -519,13 +518,11 @@
                     "type": "preference",
                     "name": "#new-canvas-2d-api"
                   }
-                ],
-                "notes": "See <a href='https://crbug.com/1284417'>bug 1284417</a>."
+                ]
               }
             ],
             "edge": {
-              "version_added": "99",
-              "notes": "See <a href='https://crbug.com/1284417'>bug 1284417</a>."
+              "version_added": "99"
             },
             "firefox": [
               {
@@ -549,12 +546,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "85",
-              "notes": "See <a href='https://crbug.com/1284417'>bug 1284417</a>."
+              "version_added": "85"
             },
             "opera_android": {
-              "version_added": "68",
-              "notes": "See <a href='https://crbug.com/1284417'>bug 1284417</a>."
+              "version_added": "68"
             },
             "safari": {
               "version_added": "15"
@@ -563,12 +558,10 @@
               "version_added": "15"
             },
             "samsunginternet_android": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/1284417'>bug 1284417</a>."
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "99",
-              "notes": "See <a href='https://crbug.com/1284417'>bug 1284417</a>."
+              "version_added": "99"
             }
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `createConicGradient` member of the `CanvasRenderingContext2D` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CanvasRenderingContext2D/createConicGradient

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
