### PR TITLE
Update Firefox versions for CredentialsContainer API

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -15,10 +15,10 @@
             "version_added": "18"
           },
           "firefox": {
-            "version_added": "61"
+            "version_added": "60"
           },
           "firefox_android": {
-            "version_added": "61"
+            "version_added": "60"
           },
           "ie": {
             "version_added": false
@@ -63,10 +63,10 @@
               "version_added": "18"
             },
             "firefox": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "ie": {
               "version_added": false
@@ -112,10 +112,10 @@
               "version_added": "18"
             },
             "firefox": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "ie": {
               "version_added": false
@@ -175,10 +175,10 @@
               "version_added": "18"
             },
             "firefox": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "ie": {
               "version_added": false
@@ -252,10 +252,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `CredentialsContainer` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CredentialsContainer

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
