### PR TITLE
Add Opera versions for CustomStateSet API

### DIFF
--- a/api/CustomStateSet.json
+++ b/api/CustomStateSet.json
@@ -496,7 +496,7 @@
               "version_added": "76"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "64"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Opera and Opera Android for the `CustomStateSet` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).  The collector obtains results based upon Opera Desktop 12.16 and 15, as well as the latest version of Opera Desktop and Opera Android.  Version numbers are then copied for Blink-based Opera versions from Chrome Desktop and Android respectively.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CustomStateSet

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
