### PR TITLE
Remove release-level "accepts_flags" property from schema

### DIFF
--- a/schemas/browsers-schema.md
+++ b/schemas/browsers-schema.md
@@ -71,10 +71,6 @@ The release objects consist of the following properties:
 
 - An optional `release_notes` property which points to release notes. It needs to be a valid URL.
 
-- An optional `accepts_flags` boolean property indicating whether the release supports flags.
-
-  This is a hint to data contributors and tools. A `true` value does not mean that there exists any flag data for the release and a `false` value does not guarantee a lack of flag data for the release.
-
 - An optional `engine` property which is the name of the browser's engine.
 
 - An optional `engine_version` property which is the version of the browser's engine. This may or may not differ from the browser version.

--- a/schemas/browsers-schema.md
+++ b/schemas/browsers-schema.md
@@ -43,7 +43,7 @@ The `name` string is a required property which should use the browser brand name
 
 ### `accepts_flags`
 
-An optional boolean indicating whether the browser supports flags. This is a hint to data contributors and tools. A `true` value does not mean that there exists any flag data for the browser and a `false` value does not guarantee a lack of flag data for the browser.
+An optional boolean indicating whether the browser supports flags. If it is set to `false`, flag data will not be allowed for that browser.
 
 ### `pref_url`
 

--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -67,10 +67,6 @@
           "pattern": "^https://",
           "description": "A link to the release notes or changelog for a given release."
         },
-        "accepts_flags": {
-          "type": "boolean",
-          "description": "Whether the release supports flags."
-        },
         "engine": {
           "type": "string",
           "enum": [


### PR DESCRIPTION
This PR removes the release-level `accepts_flags` property from browser data from the schema.  This property isn't used for linting and hasn't been adopted in browser data, as we already have a browser-wide `accepts_flags` statement.

Note: this can be included in a patch release as we have no data affected by this change.