### PR TITLE
Add Opera Android versions for border-* CSS properties

### DIFF
--- a/css/properties/border-block-style.json
+++ b/css/properties/border-block-style.json
@@ -76,14 +76,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "62"
             },
             "safari": {
               "version_added": "14.1"

--- a/css/properties/border-block-width.json
+++ b/css/properties/border-block-width.json
@@ -75,21 +75,9 @@
                 ]
               }
             ],
-            "opera_android": [
-              {
-                "version_added": false
-              },
-              {
-                "version_added": "48",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              }
-            ],
+            "opera_android": {
+              "version_added": "62"
+            },
             "safari": {
               "version_added": "14.1"
             },

--- a/css/properties/border-block.json
+++ b/css/properties/border-block.json
@@ -76,14 +76,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "62"
             },
             "safari": {
               "version_added": "14.1"

--- a/css/properties/border-inline-color.json
+++ b/css/properties/border-inline-color.json
@@ -76,14 +76,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "62"
             },
             "safari": {
               "version_added": "14.1"

--- a/css/properties/border-inline-style.json
+++ b/css/properties/border-inline-style.json
@@ -76,14 +76,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "62"
             },
             "safari": {
               "version_added": "14.1"

--- a/css/properties/border-inline-width.json
+++ b/css/properties/border-inline-width.json
@@ -76,14 +76,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "62"
             },
             "safari": {
               "version_added": "14.1"

--- a/css/properties/border-inline.json
+++ b/css/properties/border-inline.json
@@ -76,14 +76,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "62"
             },
             "safari": {
               "version_added": "14.1"


### PR DESCRIPTION
This PR corrects data for Opera Android for the `border-*` CSS properties by mirroring the data.  Note that the flags are removed in the process, as Opera Android doesn't support flags.

Part of work for #15568.