### PR TITLE
Add Opera versions for margin-padding CSS property

### DIFF
--- a/css/properties/margin-block.json
+++ b/css/properties/margin-block.json
@@ -76,14 +76,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "62"
             },
             "safari": {
               "version_added": "14.1"

--- a/css/properties/margin-inline.json
+++ b/css/properties/margin-inline.json
@@ -76,14 +76,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "62"
             },
             "safari": {
               "version_added": "14.1"

--- a/css/properties/padding-block.json
+++ b/css/properties/padding-block.json
@@ -76,14 +76,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "62"
             },
             "safari": {
               "version_added": "14.1"

--- a/css/properties/padding-inline.json
+++ b/css/properties/padding-inline.json
@@ -76,14 +76,7 @@
               }
             ],
             "opera_android": {
-              "version_added": "48",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "62"
             },
             "safari": {
               "version_added": "14.1"


### PR DESCRIPTION
This PR corrects data for Opera Android for the `margin-*` and `padding-*` CSS properties by mirroring the data.  Note that the flags are removed in the process, as Opera Android doesn't support flags.

Part of work for #15568.