### PR TITLE
Updates opera browser to version 86

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -650,19 +650,26 @@
         "85": {
           "release_date": "2022-03-23",
           "release_notes": "https://blogs.opera.com/desktop/2022/03/opera-85/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "99"
         },
         "86": {
-          "status": "beta",
+          "release_date": "2022-04-20",
+          "release_notes": "https://blogs.opera.com/desktop/2022/04/opera-86-stable/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "100"
         },
         "87": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "101"
+        },
+        "88": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "102"
         }
       }
     }


### PR DESCRIPTION
Hello!

According to this [release note](https://blogs.opera.com/desktop/2022/04/opera-86-stable/), opera browser has updated to version 86.

Fixes #16013.