### PR TITLE
Add data for CSS HDR media queries

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -605,6 +605,55 @@
             }
           }
         },
+        "dynamic-range": {
+          "__compat": {
+            "description": "<code>dynamic-range</code> media feature",
+            "spec_url": "https://www.w3.org/TR/mediaqueries-5/#dynamic-range",
+            "support": {
+              "chrome": {
+                "version_added": "98"
+              },
+              "chrome_android": {
+                "version_added": "98"
+              },
+              "edge": {
+                "version_added": "98"
+              },
+              "firefox": {
+                "version_added": "100"
+              },
+              "firefox_android": {
+                "version_added": "100"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "84"
+              },
+              "opera_android": {
+                "version_added": "68"
+              },
+              "safari": {
+                "version_added": "13.1"
+              },
+              "safari_ios": {
+                "version_added": "13.4"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "98"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "forced-colors": {
           "__compat": {
             "description": "<code>forced-colors</code> media feature",
@@ -1746,6 +1795,55 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "video-dynamic-range": {
+          "__compat": {
+            "description": "<code>video-dynamic-range</code> media feature",
+            "spec_url": "https://www.w3.org/TR/mediaqueries-5/#video-dynamic-range",
+            "support": {
+              "chrome": {
+                "version_added": "98"
+              },
+              "chrome_android": {
+                "version_added": "98"
+              },
+              "edge": {
+                "version_added": "98"
+              },
+              "firefox": {
+                "version_added": "100"
+              },
+              "firefox_android": {
+                "version_added": "100"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "84"
+              },
+              "opera_android": {
+                "version_added": "68"
+              },
+              "safari": {
+                "version_added": "13.1"
+              },
+              "safari_ios": {
+                "version_added": "13.4"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "98"
+              }
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
This PR adds the `dynamic-range` and `video-dynamic-range` CSS media query features to BCD to go along with https://github.com/mdn/content/issues/14405.

Data comes from the following:
https://bugzilla.mozilla.org/show_bug.cgi?id=1751217
https://chromestatus.com/feature/5680926106320896
https://webkit.org/blog/10247/new-webkit-features-in-safari-13-1/#:~:text=for%20more%20information.-,More%20CSS%20Additions,-There%20are%20a
