### PR TITLE
Skip over a failed PR features diff in release notes

### DIFF
--- a/scripts/release-notes.js
+++ b/scripts/release-notes.js
@@ -20,7 +20,14 @@ function main(argv) {
   for (const pull of pullsFromGitHub(startVersionTag, endVersionTag)) {
     process.stderr.write(`Diffing features for #${pull.number}`);
 
-    const diff = diffFeatures({ ref1: pull.mergeCommit });
+    try {
+      const diff = diffFeatures({ ref1: pull.mergeCommit });
+    } catch (e) {
+      console.error(
+        `${e}\n (Failed to diff features for #${pull.number}, skipping)`,
+      );
+      continue;
+    }
 
     console.error(
       ` (${diff.added.length} added, ${diff.removed.length} removed)`,


### PR DESCRIPTION
This PR adds a try-catch to our release-notes script to skip over any pull requests that fail feature enumeration.
