### PR TITLE
Skip clean install in diff-features if it fails

### DIFF
--- a/scripts/diff-features.js
+++ b/scripts/diff-features.js
@@ -109,8 +109,12 @@ function enumerateFeatures(ref = 'HEAD') {
 
   console.error(`Enumerating features for ${ref} (${hash})`);
   try {
-    execSync(`git worktree add ${worktree} ${hash}`);
     execSync(`npm ci`, { cwd: worktree });
+  } catch (e) {
+    // If the clean install fails, proceed anyways
+  }
+  try {
+    execSync(`git worktree add ${worktree} ${hash}`);
     execSync(`node ./scripts/enumerate-features.js --data-from=${worktree}`);
 
     return JSON.parse(fs.readFileSync('.features.json', { encoding: 'utf-8' }));


### PR DESCRIPTION
This PR tells the `enumerateFeatures()` function within `diff-features` to skip the clean install if it fails for any reason.  A clean install isn't really needed when enumerating features.
