### PR TITLE
Updates chrome to version 101

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -700,21 +700,28 @@
         },
         "101": {
           "release_date": "2022-04-26",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2022/04/stable-channel-update-for-desktop_26.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "101"
         },
         "102": {
           "release_date": "2022-05-24",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "102"
         },
         "103": {
           "release_date": "2022-06-21",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Blink",
           "engine_version": "103"
+        },
+        "104": {
+          "release_date": "2022-08-02",
+          "status": "planned",
+          "engine": "Blink",
+          "engine_version": "104"
         }
       }
     }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -530,27 +530,34 @@
         "100": {
           "release_date": "2022-03-29",
           "release_notes": "https://chromereleases.googleblog.com/2022/03/chrome-for-android-update_0283137014.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "100"
         },
         "101": {
           "release_date": "2022-04-26",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2022/04/chrome-for-android-update_01711927518.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "101"
         },
         "102": {
           "release_date": "2022-05-24",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "102"
         },
         "103": {
           "release_date": "2022-06-21",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Blink",
           "engine_version": "103"
+        },
+        "104": {
+          "release_date": "2022-08-02",
+          "status": "planned",
+          "engine": "Blink",
+          "engine_version": "104"
         }
       }
     }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -1,64 +1,99 @@
 {
   "browsers": {
-    "webview_android": {
-      "name": "WebView Android",
-      "accepts_flags": false,
+    "chrome_android": {
+      "name": "Chrome Android",
+      "pref_url": "chrome://flags",
       "releases": {
-        "1": {
-          "release_date": "2008-09-23",
-          "release_notes": "https://en.wikipedia.org/wiki/Android_version_history#Android_1.0_(API_1)",
+        "18": {
+          "release_date": "2012-06-27",
+          "release_notes": "https://chromereleases.googleblog.com/2012/06/chrome-for-android-out-of-beta.html",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "523.12"
+          "engine_version": "535.19"
         },
-        "1.5": {
-          "release_date": "2009-04-27",
-          "release_notes": "https://en.wikipedia.org/wiki/Android_Cupcake",
+        "25": {
+          "release_date": "2013-02-27",
+          "release_notes": "https://chromereleases.googleblog.com/2013/02/chrome-for-android-update.html",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "525.20"
+          "engine_version": "537.22"
         },
-        "2": {
-          "release_date": "2009-10-26",
-          "release_notes": "https://en.wikipedia.org/wiki/Android_Eclair",
+        "26": {
+          "release_date": "2013-04-03",
+          "release_notes": "https://chromereleases.googleblog.com/2013/04/chrome-for-android-stable-channel-update.html",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "530.17"
+          "engine_version": "537.31"
         },
-        "2.2": {
-          "release_date": "2010-05-20",
-          "release_notes": "https://en.wikipedia.org/wiki/Android_Froyo",
+        "27": {
+          "release_date": "2013-05-22",
+          "release_notes": "https://chromereleases.googleblog.com/2013/05/chrome-for-android-update.html",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "533.1"
+          "engine_version": "537.36"
         },
-        "3": {
-          "release_date": "2011-02-22",
-          "release_notes": "https://en.wikipedia.org/wiki/Android_Honeycomb",
+        "28": {
+          "release_date": "2013-07-10",
+          "release_notes": "https://chromereleases.googleblog.com/2013/07/chrome-for-android-update.html",
           "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "534.13"
+          "engine": "Blink",
+          "engine_version": "28"
         },
-        "4": {
-          "release_date": "2011-10-18",
-          "release_notes": "https://en.wikipedia.org/wiki/Android_Ice_Cream_Sandwich",
+        "29": {
+          "release_date": "2013-08-21",
+          "release_notes": "https://chromereleases.googleblog.com/2013/08/chrome-for-android-update.html",
           "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "534.30"
+          "engine": "Blink",
+          "engine_version": "29"
         },
-        "4.4": {
-          "release_date": "2013-12-09",
+        "30": {
+          "release_date": "2013-10-02",
           "release_notes": "https://chromereleases.googleblog.com/2013/10/chrome-for-android-update.html",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "30"
         },
-        "4.4.3": {
-          "release_date": "2014-06-02",
+        "31": {
+          "release_date": "2013-11-14",
+          "release_notes": "https://chromereleases.googleblog.com/2013/11/chrome-for-android-update.html",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "31"
+        },
+        "32": {
+          "release_date": "2014-01-15",
+          "release_notes": "https://chromereleases.googleblog.com/2014/01/chrome-for-android-update.html",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "32"
+        },
+        "33": {
+          "release_date": "2014-02-26",
           "release_notes": "https://chromereleases.googleblog.com/2014/02/chrome-for-android-update.html",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "33"
+        },
+        "34": {
+          "release_date": "2014-04-02",
+          "release_notes": "https://chromereleases.googleblog.com/2014/04/chrome-for-android-update.html",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "34"
+        },
+        "35": {
+          "release_date": "2014-05-20",
+          "release_notes": "https://chromereleases.googleblog.com/2014/05/chrome-for-android-update.html",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "35"
+        },
+        "36": {
+          "release_date": "2014-07-16",
+          "release_notes": "https://chromereleases.googleblog.com/2014/07/chrome-for-android-update.html",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "36"
         },
         "37": {
           "release_date": "2014-09-03",
@@ -255,14 +290,14 @@
           "engine_version": "64"
         },
         "65": {
-          "release_date": "2017-03-06",
+          "release_date": "2018-03-06",
           "release_notes": "https://chromereleases.googleblog.com/2018/03/chrome-for-android-update.html",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "65"
         },
         "66": {
-          "release_date": "2017-04-17",
+          "release_date": "2018-04-17",
           "release_notes": "https://chromereleases.googleblog.com/2018/04/chrome-for-android-update.html",
           "status": "retired",
           "engine": "Blink",
@@ -495,27 +530,34 @@
         "100": {
           "release_date": "2022-03-29",
           "release_notes": "https://chromereleases.googleblog.com/2022/03/chrome-for-android-update_0283137014.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "100"
         },
         "101": {
           "release_date": "2022-04-26",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2022/04/chrome-for-android-update_01711927518.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "101"
         },
         "102": {
           "release_date": "2022-05-24",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "102"
         },
         "103": {
           "release_date": "2022-06-21",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Blink",
           "engine_version": "103"
+        },
+        "104": {
+          "release_date": "2022-08-02",
+          "status": "planned",
+          "engine": "Blink",
+          "engine_version": "104"
         }
       }
     }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -1,99 +1,64 @@
 {
   "browsers": {
-    "chrome_android": {
-      "name": "Chrome Android",
-      "pref_url": "chrome://flags",
+    "webview_android": {
+      "name": "WebView Android",
+      "accepts_flags": false,
       "releases": {
-        "18": {
-          "release_date": "2012-06-27",
-          "release_notes": "https://chromereleases.googleblog.com/2012/06/chrome-for-android-out-of-beta.html",
+        "1": {
+          "release_date": "2008-09-23",
+          "release_notes": "https://en.wikipedia.org/wiki/Android_version_history#Android_1.0_(API_1)",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "535.19"
+          "engine_version": "523.12"
         },
-        "25": {
-          "release_date": "2013-02-27",
-          "release_notes": "https://chromereleases.googleblog.com/2013/02/chrome-for-android-update.html",
+        "1.5": {
+          "release_date": "2009-04-27",
+          "release_notes": "https://en.wikipedia.org/wiki/Android_Cupcake",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "537.22"
+          "engine_version": "525.20"
         },
-        "26": {
-          "release_date": "2013-04-03",
-          "release_notes": "https://chromereleases.googleblog.com/2013/04/chrome-for-android-stable-channel-update.html",
+        "2": {
+          "release_date": "2009-10-26",
+          "release_notes": "https://en.wikipedia.org/wiki/Android_Eclair",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "537.31"
+          "engine_version": "530.17"
         },
-        "27": {
-          "release_date": "2013-05-22",
-          "release_notes": "https://chromereleases.googleblog.com/2013/05/chrome-for-android-update.html",
+        "2.2": {
+          "release_date": "2010-05-20",
+          "release_notes": "https://en.wikipedia.org/wiki/Android_Froyo",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "537.36"
+          "engine_version": "533.1"
         },
-        "28": {
-          "release_date": "2013-07-10",
-          "release_notes": "https://chromereleases.googleblog.com/2013/07/chrome-for-android-update.html",
+        "3": {
+          "release_date": "2011-02-22",
+          "release_notes": "https://en.wikipedia.org/wiki/Android_Honeycomb",
           "status": "retired",
-          "engine": "Blink",
-          "engine_version": "28"
+          "engine": "WebKit",
+          "engine_version": "534.13"
         },
-        "29": {
-          "release_date": "2013-08-21",
-          "release_notes": "https://chromereleases.googleblog.com/2013/08/chrome-for-android-update.html",
+        "4": {
+          "release_date": "2011-10-18",
+          "release_notes": "https://en.wikipedia.org/wiki/Android_Ice_Cream_Sandwich",
           "status": "retired",
-          "engine": "Blink",
-          "engine_version": "29"
+          "engine": "WebKit",
+          "engine_version": "534.30"
         },
-        "30": {
-          "release_date": "2013-10-02",
+        "4.4": {
+          "release_date": "2013-12-09",
           "release_notes": "https://chromereleases.googleblog.com/2013/10/chrome-for-android-update.html",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "30"
         },
-        "31": {
-          "release_date": "2013-11-14",
-          "release_notes": "https://chromereleases.googleblog.com/2013/11/chrome-for-android-update.html",
-          "status": "retired",
-          "engine": "Blink",
-          "engine_version": "31"
-        },
-        "32": {
-          "release_date": "2014-01-15",
-          "release_notes": "https://chromereleases.googleblog.com/2014/01/chrome-for-android-update.html",
-          "status": "retired",
-          "engine": "Blink",
-          "engine_version": "32"
-        },
-        "33": {
-          "release_date": "2014-02-26",
+        "4.4.3": {
+          "release_date": "2014-06-02",
           "release_notes": "https://chromereleases.googleblog.com/2014/02/chrome-for-android-update.html",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "33"
-        },
-        "34": {
-          "release_date": "2014-04-02",
-          "release_notes": "https://chromereleases.googleblog.com/2014/04/chrome-for-android-update.html",
-          "status": "retired",
-          "engine": "Blink",
-          "engine_version": "34"
-        },
-        "35": {
-          "release_date": "2014-05-20",
-          "release_notes": "https://chromereleases.googleblog.com/2014/05/chrome-for-android-update.html",
-          "status": "retired",
-          "engine": "Blink",
-          "engine_version": "35"
-        },
-        "36": {
-          "release_date": "2014-07-16",
-          "release_notes": "https://chromereleases.googleblog.com/2014/07/chrome-for-android-update.html",
-          "status": "retired",
-          "engine": "Blink",
-          "engine_version": "36"
         },
         "37": {
           "release_date": "2014-09-03",
@@ -290,14 +255,14 @@
           "engine_version": "64"
         },
         "65": {
-          "release_date": "2018-03-06",
+          "release_date": "2017-03-06",
           "release_notes": "https://chromereleases.googleblog.com/2018/03/chrome-for-android-update.html",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "65"
         },
         "66": {
-          "release_date": "2018-04-17",
+          "release_date": "2017-04-17",
           "release_notes": "https://chromereleases.googleblog.com/2018/04/chrome-for-android-update.html",
           "status": "retired",
           "engine": "Blink",


### PR DESCRIPTION
Chrome has updated to version 101.

According to https://chromiumdash.appspot.com/schedule, the release date of Chrome 104 is 02/08/2022.

Fixes #16037.