### PR TITLE
Add subfeatures for RTCDataChannel.binaryType values

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -146,7 +146,7 @@
         },
         "blob_value": {
           "__compat": {
-            "description": "<code>blob</code> value",
+            "description": "<code>Blob</code> value",
             "support": {
               "chrome": {
                 "version_added": false,

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -95,6 +95,109 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "arraybuffer_value": {
+          "__compat": {
+            "description": "<code>arraybuffer</code> value",
+            "support": {
+              "chrome": {
+                "version_added": "24"
+              },
+              "chrome_android": {
+                "version_added": "25"
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "22"
+              },
+              "firefox_android": {
+                "version_added": "22"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "15"
+              },
+              "opera_android": {
+                "version_added": "14"
+              },
+              "safari": {
+                "version_added": "11"
+              },
+              "safari_ios": {
+                "version_added": "11"
+              },
+              "samsunginternet_android": {
+                "version_added": "1.5"
+              },
+              "webview_android": {
+                "version_added": "≤37"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "blob_value": {
+          "__compat": {
+            "description": "<code>blob</code> value",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</code>."
+              },
+              "chrome_android": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</code>."
+              },
+              "edge": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</code>."
+              },
+              "firefox": {
+                "version_added": "22"
+              },
+              "firefox_android": {
+                "version_added": "22"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</code>."
+              },
+              "opera_android": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</code>."
+              },
+              "safari": {
+                "version_added": "11"
+              },
+              "safari_ios": {
+                "version_added": "11"
+              },
+              "samsunginternet_android": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</code>."
+              },
+              "webview_android": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</code>."
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "bufferedAmount": {

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -98,7 +98,7 @@
         },
         "arraybuffer_value": {
           "__compat": {
-            "description": "<code>arraybuffer</code> value",
+            "description": "<code>ArrayBuffer</code> value",
             "support": {
               "chrome": {
                 "version_added": "24"


### PR DESCRIPTION
This PR fixes #6770 by adding subfeatures for the different `binaryType` values of the RTCDataChannel API.
