### PR TITLE
Tweak options for issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/data-problem.yml
+++ b/.github/ISSUE_TEMPLATE/data-problem.yml
@@ -22,7 +22,6 @@ body:
     id: type
     attributes:
       label: What type of issue is this?
-      required: true
       options:
         - Incorrect support data (ex. Chrome says "86" but support was added in "40")
         - Browser bug (a bug with a feature that may impact site compatibility)

--- a/.github/ISSUE_TEMPLATE/data-problem.yml
+++ b/.github/ISSUE_TEMPLATE/data-problem.yml
@@ -22,10 +22,11 @@ body:
     id: type
     attributes:
       label: What type of issue is this?
+      required: true
       options:
-        - label: Incorrect version number (ex. Chrome says "86" but support was added in "40")
-        - label: Browser bug (a bug with a feature that may impact site compatibility)
-        - label: I opened this on accident; please close me!
+        - Incorrect support data (ex. Chrome says "86" but support was added in "40")
+        - Browser bug (a bug with a feature that may impact site compatibility)
+        - Other
   - type: textarea
     id: problem
     attributes:


### PR DESCRIPTION
Small tweaks to the options available in the "What type of issue is this?" dropdown.  This PR makes it required, but replaces the last option with "Other" since we can't select a default option.