### PR TITLE
Make "issue type" dropdown in template required

### DIFF
--- a/.github/ISSUE_TEMPLATE/data-problem.yml
+++ b/.github/ISSUE_TEMPLATE/data-problem.yml
@@ -22,6 +22,7 @@ body:
     id: type
     attributes:
       label: What type of issue is this?
+      required: true
       options:
         - Incorrect support data (ex. Chrome says "86" but support was added in "40")
         - Browser bug (a bug with a feature that may impact site compatibility)


### PR DESCRIPTION
This PR makes the dropdown to select the type of issue a required field.