### PR TITLE
Add missing api.Element.requestPointerLock.options_unadjustedMovement_parameter feature

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -6104,13 +6104,13 @@
             "description": "<code>options.unadjustedMovement</code> parameter",
             "support": {
               "chrome": {
-                "version_added": "81"
+                "version_added": "92"
               },
               "chrome_android": {
-                "version_added": "81"
+                "version_added": "92"
               },
               "edge": {
-                "version_added": "81"
+                "version_added": "92"
               },
               "firefox": {
                 "version_added": false
@@ -6122,10 +6122,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "68"
+                "version_added": "78"
               },
               "opera_android": {
-                "version_added": "58"
+                "version_added": "65"
               },
               "safari": {
                 "version_added": false
@@ -6134,10 +6134,10 @@
                 "version_added": false
               },
               "samsunginternet_android": {
-                "version_added": "13.0"
+                "version_added": "16.0"
               },
               "webview_android": {
-                "version_added": "81"
+                "version_added": "92"
               }
             },
             "status": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -6098,6 +6098,54 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "options_unadjustedMovement_parameter": {
+          "__compat": {
+            "description": "<code>options.unadjustedMovement</code> parameter",
+            "support": {
+              "chrome": {
+                "version_added": "81"
+              },
+              "chrome_android": {
+                "version_added": "81"
+              },
+              "edge": {
+                "version_added": "81"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "68"
+              },
+              "opera_android": {
+                "version_added": "58"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "13.0"
+              },
+              "webview_android": {
+                "version_added": "81"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
         }
       },
       "scroll": {


### PR DESCRIPTION
This PR adds the missing `requestPointerLock.options_unadjustedMovement_parameter` member of the Element API, populating the results using data from ChromeStatus (https://chromestatus.com/feature/5723553087356928).  I couldn't find any bugs or information for Firefox or Safari.

Fixes #7021.

Marked as needing a content update because this option isn't mentioned in the content.