### PR TITLE
Update Firefox versions for api.RTCRtpSender.rtcpTransport

### DIFF
--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -358,10 +358,10 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": "34"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "34"
+              "version_added": false
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `rtcpTransport` member of the `RTCRtpSender` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCRtpSender/rtcpTransport

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._

Fixes #7032.