### PR TITLE
WebMidi in FF preview not FF100

### DIFF
--- a/api/MIDIAccess.json
+++ b/api/MIDIAccess.json
@@ -16,11 +16,10 @@
           },
           "firefox": [
             {
-              "version_added": "100"
+              "version_added": "preview"
             },
             {
               "version_added": "97",
-              "version_removed": "100",
               "flags": [
                 {
                   "type": "preference",
@@ -77,11 +76,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -139,11 +137,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -202,11 +199,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -264,11 +260,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/MIDIConnectionEvent.json
+++ b/api/MIDIConnectionEvent.json
@@ -16,11 +16,10 @@
           },
           "firefox": [
             {
-              "version_added": "100"
+              "version_added": "preview"
             },
             {
               "version_added": "97",
-              "version_removed": "100",
               "flags": [
                 {
                   "type": "preference",
@@ -78,11 +77,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -140,11 +138,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/MIDIInput.json
+++ b/api/MIDIInput.json
@@ -16,11 +16,10 @@
           },
           "firefox": [
             {
-              "version_added": "100"
+              "version_added": "preview"
             },
             {
               "version_added": "97",
-              "version_removed": "100",
               "flags": [
                 {
                   "type": "preference",
@@ -78,11 +77,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/MIDIInputMap.json
+++ b/api/MIDIInputMap.json
@@ -16,11 +16,10 @@
           },
           "firefox": [
             {
-              "version_added": "100"
+              "version_added": "preview"
             },
             {
               "version_added": "97",
-              "version_removed": "100",
               "flags": [
                 {
                   "type": "preference",
@@ -75,11 +74,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -135,11 +133,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -195,11 +192,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -255,11 +251,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -315,11 +310,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -375,11 +369,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -435,11 +428,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/MIDIMessageEvent.json
+++ b/api/MIDIMessageEvent.json
@@ -16,11 +16,10 @@
           },
           "firefox": [
             {
-              "version_added": "100"
+              "version_added": "preview"
             },
             {
               "version_added": "97",
-              "version_removed": "100",
               "flags": [
                 {
                   "type": "preference",
@@ -78,11 +77,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -140,11 +138,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/MIDIOutput.json
+++ b/api/MIDIOutput.json
@@ -16,11 +16,10 @@
           },
           "firefox": [
             {
-              "version_added": "100"
+              "version_added": "preview"
             },
             {
               "version_added": "97",
-              "version_removed": "100",
               "flags": [
                 {
                   "type": "preference",
@@ -78,11 +77,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -140,11 +138,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/MIDIOutputMap.json
+++ b/api/MIDIOutputMap.json
@@ -16,11 +16,10 @@
           },
           "firefox": [
             {
-              "version_added": "100"
+              "version_added": "preview"
             },
             {
               "version_added": "97",
-              "version_removed": "100",
               "flags": [
                 {
                   "type": "preference",
@@ -75,11 +74,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -135,11 +133,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -195,11 +192,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -255,11 +251,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -315,11 +310,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -375,11 +369,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -435,11 +428,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/MIDIPort.json
+++ b/api/MIDIPort.json
@@ -16,11 +16,10 @@
           },
           "firefox": [
             {
-              "version_added": "100"
+              "version_added": "preview"
             },
             {
               "version_added": "97",
-              "version_removed": "100",
               "flags": [
                 {
                   "type": "preference",
@@ -77,11 +76,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -139,11 +137,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -201,11 +198,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -263,11 +259,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -325,11 +320,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -387,11 +381,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -449,11 +442,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -512,11 +504,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -574,11 +565,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",
@@ -636,11 +626,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4927,11 +4927,10 @@
             },
             "firefox": [
               {
-                "version_added": "100"
+                "version_added": "preview"
               },
               {
                 "version_added": "97",
-                "version_removed": "100",
                 "flags": [
                   {
                     "type": "preference",


### PR DESCRIPTION
WebMidi got backed out of FF100 but is in early nightly: https://bugzilla.mozilla.org/show_bug.cgi?id=1765894. This updates everything to record that.

Part of https://github.com/mdn/content/issues/12792