### PR TITLE
Sanitizer API fixes for FF and Chrome

### DIFF
--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -154,6 +154,76 @@
           }
         }
       },
+      "getConfiguration": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Sanitizer/getConfiguration",
+          "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-getconfiguration",
+          "support": {
+            "chrome": {
+              "version_added": "93",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "93",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "79",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "sanitize": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Sanitizer/sanitize",
@@ -260,14 +330,7 @@
               ]
             },
             "firefox": {
-              "version_added": "94",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.sanitizer.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
This fixes some compatibility data:
1. FF does not support  `Sanitize.sanitizeFor()` as was marked - verified by testing and also you can see it is missing in the IDL: https://searchfox.org/mozilla-central/source/dom/webidl/Sanitizer.webidl
2. FF does not support  `Sanitize.getConfiguration()`  - verified by testing and also you can see it is missing in the IDL: https://searchfox.org/mozilla-central/source/dom/webidl/Sanitizer.webidl
3.  Chrome does support  `Sanitize.getConfiguration()`  - verified by testing on browserstack (came in the same version as everything else).

Note that Chrome 102 is supposed to ship this feature: https://chromestatus.com/feature/5786893650231296
However I have not added that as it is a beta and did not appear to be true during initial testing.