### PR TITLE
Add mdn links for fetchPriority properties

### DIFF
--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -488,6 +488,7 @@
       },
       "fetchPriority": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/fetchPriority",
           "spec_url": "https://wicg.github.io/priority-hints/#iframe",
           "support": {
             "chrome": {

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -494,6 +494,7 @@
       },
       "fetchPriority": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLImageElement/fetchPriority",
           "spec_url": "https://wicg.github.io/priority-hints/#img",
           "support": {
             "chrome": {

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -248,6 +248,7 @@
       },
       "fetchPriority": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/fetchPriority",
           "spec_url": "https://wicg.github.io/priority-hints/#link",
           "support": {
             "chrome": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
This adds urls to the properties which fixes the missing links in the three tables like:

https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement#browser_compatibility

They were already missing from the first commits in #15489 from @pmeenan 
