### PR TITLE
Remove irrelevant notes for api.MediaDevices.getDisplayMedia

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -195,8 +195,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": false,
-              "notes": "API is available, but will always fail with <code>NotAllowedError</code>."
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -217,8 +216,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false,
-              "notes": "API is available, but will always fail with <code>NotAllowedError</code>."
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
This PR removes the now-irrelevant notes for Firefox Android and WebView Android regarding availability of MediaDevices.getUserMedia().  The method was removed entirely in Chromium 88 and Firefox Android 79, so it isn't separated into multiple support statements to reflect the method's history (especially since it always rejected).  Fixes #8821.
