### PR TITLE
Add more options for issue type in "data-problem"

### DIFF
--- a/.github/ISSUE_TEMPLATE/data-problem.yml
+++ b/.github/ISSUE_TEMPLATE/data-problem.yml
@@ -27,7 +27,7 @@ body:
         - Incorrect support data (ex. Chrome says "86" but support was added in "40")
         - Browser bug (a bug with a feature that may impact site compatibility)
         - Missing compatibility data
-        - Missing specification
+        - Missing specification link (no spec_url property)
         - Other
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/data-problem.yml
+++ b/.github/ISSUE_TEMPLATE/data-problem.yml
@@ -26,6 +26,8 @@ body:
       options:
         - Incorrect support data (ex. Chrome says "86" but support was added in "40")
         - Browser bug (a bug with a feature that may impact site compatibility)
+        - Missing compatibility data
+        - Missing specification
         - Other
   - type: textarea
     id: problem


### PR DESCRIPTION
This PR offers two additional dropdown options for a "data problem" issue's type, namely "missing compatibility data" and "missing specification".  These two are common occurrences.