### PR TITLE
HTMLInputElement.showPicker() - FF101 and OperaAndroid 68

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2155,12 +2155,10 @@
               "version_added": "99"
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1745005'>bug 1745005</a>."
+              "version_added": "101"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1745005'>bug 1745005</a>."
+              "version_added": "101"
             },
             "ie": {
               "version_added": false
@@ -2169,7 +2167,7 @@
               "version_added": "85"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "safari": {
               "version_added": false,

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2185,7 +2185,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
[HTMLInputElement.showPicker()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/showPicker) support added in FF101 in https://bugzilla.mozilla.org/show_bug.cgi?id=1745005

Opera for Android also supports this in v68 (corresponds to Chrome 99 - tested).

This is part of docs work in https://github.com/mdn/content/issues/15407