### PR TITLE
Missing spec_url for Document.createAttributeNS

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -1944,6 +1944,7 @@
       "createAttributeNS": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/createAttributeNS",
+          "spec_url": "https://dom.spec.whatwg.org/#dom-document-createattributens",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
The spec_url was missing.

We noticed it when creating the missing MDN page in mdn/content#15527