### PR TITLE
Add issue etiquette section to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/data-problem.yml
+++ b/.github/ISSUE_TEMPLATE/data-problem.yml
@@ -16,6 +16,15 @@ body:
 
         **Need help with a browser?**
         🙋 To get help with [Firefox](https://support.mozilla.org/en-US/kb/file-bug-report-or-feature-request-mozilla), [Chrome](https://support.google.com/chrome/answer/95315?hl=en-GB&ref_topic=7439544), [Safari](https://www.apple.com/feedback/safari.html), or another browser, check the browser's support site.
+        
+        ### Issue etiquette
+        
+        When opening an issue, please:
+        - Follow the project's [Code of Conduct](https://github.com/mdn/browser-compat-data/blob/main/CODE_OF_CONDUCT.md) as well as the [GitHub Community Guidelines](https://docs.github.com/en/site-policy/github-terms/github-community-guidelines). Failure to comply may result in exclusion from MDN Web Docs and/or GitHub.
+        - Check for an [existing issue](https://github.com/mdn/browser-compat-data/issues) first. If someone else has opened an issue describing the same problem, please upvote their issue rather than creating another one.
+        - Keep issues relevant to the project. Irrelevant issues will be automatically closed and marked as spam, and repeated offenses may result in exclusion from MDN Web Docs.
+        - Provide as much detail as possible. The more detail you are able to provide, the better!
+        - Write issues primarily in English. While translation tools are available, we will be able to provide better assistance with pre-translated content. You are more than welcome to include a version of the issue body in your preferred language alongside the English version.
 
         ---
   - type: dropdown


### PR DESCRIPTION
This PR adds an "issue etiquette" section to the "Data problem" issue template to remind users to follow appropriate etiquette when writing issues.