### PR TITLE
Update Opera versions for api.CanvasPattern.setTransform

### DIFF
--- a/api/CanvasPattern.json
+++ b/api/CanvasPattern.json
@@ -72,10 +72,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "9"
+              "version_added": "55"
             },
             "opera_android": {
-              "version_added": "10.1"
+              "version_added": "48"
             },
             "safari": {
               "version_added": "11.1"


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `setTransform` member of the `CanvasPattern` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CanvasPattern/setTransform

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
