### PR TITLE
Update Chromium versions for api.DedicatedWorkerGlobalScope.name

### DIFF
--- a/api/DedicatedWorkerGlobalScope.json
+++ b/api/DedicatedWorkerGlobalScope.json
@@ -271,10 +271,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/workers.html#dom-dedicatedworkerglobalscope-name-dev",
           "support": {
             "chrome": {
-              "version_added": "71"
+              "version_added": "70"
             },
             "chrome_android": {
-              "version_added": "71"
+              "version_added": "70"
             },
             "deno": {
               "version_added": "1.0"
@@ -292,10 +292,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "58"
+              "version_added": "57"
             },
             "opera_android": {
-              "version_added": "50"
+              "version_added": "49"
             },
             "safari": {
               "version_added": "12.1"
@@ -307,7 +307,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": "71"
+              "version_added": "70"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `name` member of the `DedicatedWorkerGlobalScope` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DedicatedWorkerGlobalScope/name

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
