### PR TITLE
Add Firefox versions for ElementInternals API

### DIFF
--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -65,10 +65,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "98"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "98"
             },
             "ie": {
               "version_added": false
@@ -238,10 +238,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "98"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "98"
             },
             "ie": {
               "version_added": false
@@ -349,10 +349,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "98"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "98"
             },
             "ie": {
               "version_added": false
@@ -495,10 +495,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "98"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "98"
             },
             "ie": {
               "version_added": false
@@ -544,10 +544,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "98"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "98"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `ElementInternals` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ElementInternals

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
