### PR TITLE
Update Chromium versions for api.HTMLScriptElement.supports

### DIFF
--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -579,13 +579,13 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#dom-script-supports",
           "support": {
             "chrome": {
-              "version_added": "97"
+              "version_added": "96"
             },
             "chrome_android": {
-              "version_added": "97"
+              "version_added": "96"
             },
             "edge": {
-              "version_added": "97"
+              "version_added": "96"
             },
             "firefox": {
               "version_added": "94"
@@ -597,10 +597,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "83"
+              "version_added": "82"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "67"
             },
             "safari": {
               "version_added": false
@@ -609,10 +609,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "17.0"
             },
             "webview_android": {
-              "version_added": "97"
+              "version_added": "96"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `supports` member of the `HTMLScriptElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLScriptElement/supports

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
