### PR TITLE
Update Firefox versions for api.ImageBitmapRenderingContext.canvas

### DIFF
--- a/api/ImageBitmapRenderingContext.json
+++ b/api/ImageBitmapRenderingContext.json
@@ -61,10 +61,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "97"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "97"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `canvas` member of the `ImageBitmapRenderingContext` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ImageBitmapRenderingContext/canvas

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
