### PR TITLE
Update Edge versions for Ink API

### DIFF
--- a/api/Ink.json
+++ b/api/Ink.json
@@ -11,7 +11,7 @@
             "version_added": "94"
           },
           "edge": {
-            "version_added": "94"
+            "version_added": "93"
           },
           "firefox": {
             "version_added": false
@@ -58,7 +58,7 @@
               "version_added": "94"
             },
             "edge": {
-              "version_added": "94"
+              "version_added": "93"
             },
             "firefox": {
               "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1849,7 +1849,7 @@
               "version_added": "94"
             },
             "edge": {
-              "version_added": "94"
+              "version_added": "93"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `Ink` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Ink

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
