### PR TITLE
Update Opera versions for MediaMetadata API

### DIFF
--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -41,7 +41,7 @@
             "version_added": "44"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "43"
           },
           "safari": {
             "version_added": "15"
@@ -90,7 +90,7 @@
               "version_added": "44"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "43"
             },
             "safari": {
               "version_added": "15"
@@ -139,7 +139,7 @@
               "version_added": "44"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "43"
             },
             "safari": {
               "version_added": "15"
@@ -188,7 +188,7 @@
               "version_added": "44"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "43"
             },
             "safari": {
               "version_added": "15"
@@ -237,7 +237,7 @@
               "version_added": "44"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "43"
             },
             "safari": {
               "version_added": "15"
@@ -286,7 +286,7 @@
               "version_added": "44"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "43"
             },
             "safari": {
               "version_added": "15"


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `MediaMetadata` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaMetadata

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
