### PR TITLE
Add mdn/spec urls to BluetoothUUID

### DIFF
--- a/api/BluetoothUUID.json
+++ b/api/BluetoothUUID.json
@@ -2,6 +2,8 @@
   "api": {
     "BluetoothUUID": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/Web/API/BluetoothUUID",
+        "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#bluetoothuuid",
         "support": {
           "chrome": [
             {
@@ -94,6 +96,8 @@
       },
       "canonicalUUID": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/Web/API/BluetoothUUID/canonicalUUID",
+          "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothuuid-canonicaluuid",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -141,6 +145,8 @@
       },
       "getCharacteristic": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/Web/API/BluetoothUUID/getCharacteristic",
+          "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothuuid-getcharacteristic",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -188,6 +194,8 @@
       },
       "getDescriptor": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/Web/API/BluetoothUUID/getDescriptor",
+          "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothuuid-getdescriptor",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -235,6 +243,8 @@
       },
       "getService": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/Web/API/BluetoothUUID/getService",
+          "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothuuid-getservice",
           "support": {
             "chrome": {
               "version_added": "56"

--- a/api/BluetoothUUID.json
+++ b/api/BluetoothUUID.json
@@ -2,7 +2,7 @@
   "api": {
     "BluetoothUUID": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/Web/API/BluetoothUUID",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothUUID",
         "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#bluetoothuuid",
         "support": {
           "chrome": [
@@ -96,7 +96,7 @@
       },
       "canonicalUUID": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/Web/API/BluetoothUUID/canonicalUUID",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothUUID/canonicalUUID",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothuuid-canonicaluuid",
           "support": {
             "chrome": {
@@ -145,7 +145,7 @@
       },
       "getCharacteristic": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/Web/API/BluetoothUUID/getCharacteristic",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothUUID/getCharacteristic",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothuuid-getcharacteristic",
           "support": {
             "chrome": {
@@ -194,7 +194,7 @@
       },
       "getDescriptor": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/Web/API/BluetoothUUID/getDescriptor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothUUID/getDescriptor",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothuuid-getdescriptor",
           "support": {
             "chrome": {
@@ -243,7 +243,7 @@
       },
       "getService": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/Web/API/BluetoothUUID/getService",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/BluetoothUUID/getService",
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothuuid-getservice",
           "support": {
             "chrome": {


### PR DESCRIPTION
Both mdn and spec urls were missing. The pages are existing for ages on MDN.

(Detected while fixing mdn/content#15603)