### PR TITLE
HTMLInputElement.showPicker - subfeatures for supported inputs

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2189,6 +2189,456 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "color_input": {
+          "__compat": {
+            "description": "<code>color</code> input",
+            "support": {
+              "chrome": {
+                "version_added": "99"
+              },
+              "chrome_android": {
+                "version_added": "99"
+              },
+              "edge": {
+                "version_added": "99"
+              },
+              "firefox": {
+                "version_added": "101"
+              },
+              "firefox_android": {
+                "version_added": "101"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "85"
+              },
+              "opera_android": {
+                "version_added": "68"
+              },
+              "safari": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "safari_ios": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "99"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "month_input": {
+          "__compat": {
+            "description": "<code>month</code> input",
+            "support": {
+              "chrome": {
+                "version_added": "99"
+              },
+              "chrome_android": {
+                "version_added": "99"
+              },
+              "edge": {
+                "version_added": "99"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "85"
+              },
+              "opera_android": {
+                "version_added": "68"
+              },
+              "safari": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "safari_ios": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "99"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "week_input": {
+          "__compat": {
+            "description": "<code>week</code> input",
+            "support": {
+              "chrome": {
+                "version_added": "99"
+              },
+              "chrome_android": {
+                "version_added": "99"
+              },
+              "edge": {
+                "version_added": "99"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "85"
+              },
+              "opera_android": {
+                "version_added": "68"
+              },
+              "safari": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "safari_ios": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "99"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "autocomplete_input": {
+          "__compat": {
+            "description": "<code>autocomplete</code> input",
+            "support": {
+              "chrome": {
+                "version_added": "99"
+              },
+              "chrome_android": {
+                "version_added": "99"
+              },
+              "edge": {
+                "version_added": "99"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "85"
+              },
+              "opera_android": {
+                "version_added": "68"
+              },
+              "safari": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "safari_ios": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "99"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "datalist_input": {
+          "__compat": {
+            "description": "<code>datalist</code> input",
+            "support": {
+              "chrome": {
+                "version_added": "99"
+              },
+              "chrome_android": {
+                "version_added": "99"
+              },
+              "edge": {
+                "version_added": "99"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "85"
+              },
+              "opera_android": {
+                "version_added": "68"
+              },
+              "safari": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "safari_ios": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "99"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "time_input": {
+          "__compat": {
+            "description": "<code>time</code> input",
+            "support": {
+              "chrome": {
+                "version_added": "99"
+              },
+              "chrome_android": {
+                "version_added": "99"
+              },
+              "edge": {
+                "version_added": "99"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "85"
+              },
+              "opera_android": {
+                "version_added": "68"
+              },
+              "safari": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "safari_ios": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "99"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "date_input": {
+          "__compat": {
+            "description": "<code>date</code> input",
+            "support": {
+              "chrome": {
+                "version_added": "99"
+              },
+              "chrome_android": {
+                "version_added": "99"
+              },
+              "edge": {
+                "version_added": "99"
+              },
+              "firefox": {
+                "version_added": "101"
+              },
+              "firefox_android": {
+                "version_added": "101"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "85"
+              },
+              "opera_android": {
+                "version_added": "68"
+              },
+              "safari": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "safari_ios": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "99"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "datetime_local_input": {
+          "__compat": {
+            "description": "<code>datetime-local</code> input",
+            "support": {
+              "chrome": {
+                "version_added": "99"
+              },
+              "chrome_android": {
+                "version_added": "99"
+              },
+              "edge": {
+                "version_added": "99"
+              },
+              "firefox": {
+                "version_added": "101"
+              },
+              "firefox_android": {
+                "version_added": "101"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "85"
+              },
+              "opera_android": {
+                "version_added": "68"
+              },
+              "safari": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "safari_ios": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "99"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "file_input": {
+          "__compat": {
+            "description": "<code>file</code> input",
+            "support": {
+              "chrome": {
+                "version_added": "99"
+              },
+              "chrome_android": {
+                "version_added": "99"
+              },
+              "edge": {
+                "version_added": "99"
+              },
+              "firefox": {
+                "version_added": "101"
+              },
+              "firefox_android": {
+                "version_added": "101"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "85"
+              },
+              "opera_android": {
+                "version_added": "68"
+              },
+              "safari": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "safari_ios": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "99"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "size": {

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2190,156 +2190,6 @@
             "deprecated": false
           }
         },
-        "color_input": {
-          "__compat": {
-            "description": "<code>color</code> input",
-            "support": {
-              "chrome": {
-                "version_added": "99"
-              },
-              "chrome_android": {
-                "version_added": "99"
-              },
-              "edge": {
-                "version_added": "99"
-              },
-              "firefox": {
-                "version_added": "101"
-              },
-              "firefox_android": {
-                "version_added": "101"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "85"
-              },
-              "opera_android": {
-                "version_added": "68"
-              },
-              "safari": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
-              },
-              "safari_ios": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": "99"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "month_input": {
-          "__compat": {
-            "description": "<code>month</code> input",
-            "support": {
-              "chrome": {
-                "version_added": "99"
-              },
-              "chrome_android": {
-                "version_added": "99"
-              },
-              "edge": {
-                "version_added": "99"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "85"
-              },
-              "opera_android": {
-                "version_added": "68"
-              },
-              "safari": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
-              },
-              "safari_ios": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": "99"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "week_input": {
-          "__compat": {
-            "description": "<code>week</code> input",
-            "support": {
-              "chrome": {
-                "version_added": "99"
-              },
-              "chrome_android": {
-                "version_added": "99"
-              },
-              "edge": {
-                "version_added": "99"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": "85"
-              },
-              "opera_android": {
-                "version_added": "68"
-              },
-              "safari": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
-              },
-              "safari_ios": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": "99"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "autocomplete_input": {
           "__compat": {
             "description": "<code>autocomplete</code> input",
@@ -2390,9 +2240,9 @@
             }
           }
         },
-        "datalist_input": {
+        "color_input": {
           "__compat": {
-            "description": "<code>datalist</code> input",
+            "description": "<code>color</code> input",
             "support": {
               "chrome": {
                 "version_added": "99"
@@ -2404,10 +2254,10 @@
                 "version_added": "99"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "101"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "101"
               },
               "ie": {
                 "version_added": false
@@ -2440,9 +2290,9 @@
             }
           }
         },
-        "time_input": {
+        "datalist_input": {
           "__compat": {
-            "description": "<code>time</code> input",
+            "description": "<code>datalist</code> input",
             "support": {
               "chrome": {
                 "version_added": "99"
@@ -2608,6 +2458,156 @@
               },
               "firefox_android": {
                 "version_added": "101"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "85"
+              },
+              "opera_android": {
+                "version_added": "68"
+              },
+              "safari": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "safari_ios": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "99"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "month_input": {
+          "__compat": {
+            "description": "<code>month</code> input",
+            "support": {
+              "chrome": {
+                "version_added": "99"
+              },
+              "chrome_android": {
+                "version_added": "99"
+              },
+              "edge": {
+                "version_added": "99"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "85"
+              },
+              "opera_android": {
+                "version_added": "68"
+              },
+              "safari": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "safari_ios": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "99"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "time_input": {
+          "__compat": {
+            "description": "<code>time</code> input",
+            "support": {
+              "chrome": {
+                "version_added": "99"
+              },
+              "chrome_android": {
+                "version_added": "99"
+              },
+              "edge": {
+                "version_added": "99"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "85"
+              },
+              "opera_android": {
+                "version_added": "68"
+              },
+              "safari": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "safari_ios": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": "99"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "week_input": {
+          "__compat": {
+            "description": "<code>week</code> input",
+            "support": {
+              "chrome": {
+                "version_added": "99"
+              },
+              "chrome_android": {
+                "version_added": "99"
+              },
+              "edge": {
+                "version_added": "99"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
FF101 supports [HTMLInputElement.showPicker()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/showPicker) but it doesn't support it for every possible input element.

This is in-line with the spec, which states that _ideally_ all input elements that have a picker should work with showPicker, but that this is up to the implementation.

That is still a compatibility issue for developers since there is no way programmatically to work out whether the method will work (or did succeed) for a particular picker.

So what I've done is added a subfeature for each of the types that the spec indicates are normally supported. At the moment Chromium supports all of them and FF supports a subset.