### PR TITLE
MV3 addition of action key

### DIFF
--- a/webextensions/manifest/action.json
+++ b/webextensions/manifest/action.json
@@ -1,40 +1,46 @@
 {
   "webextensions": {
     "manifest": {
-      "browser_action": {
+      "action": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "88",
               "notes": [
-                "Available for use in Manifest V2 only.",
+                "Available for use in Manifest V3 or later.",
                 "If an extension defines a browser action, it is not allowed to define a page action as well."
               ]
             },
             "edge": {
-              "version_added": "14",
-              "notes": "Available for use in Manifest V2 only."
+              "version_added": "88",
+              "notes": "Available for use in Manifest V3 or later."
             },
             "firefox": {
-              "version_added": "48",
-              "notes": "Available for use in Manifest V2 only."
+              "version_added": "101",
+              "notes": [
+                "Available for use in Manifest V3 or later.",
+                "Extension developers can turn on Manifest V3 for testing purposes using the <code>extensions.manifestV3.enabled</code> preference."
+              ]
             },
             "firefox_android": {
-              "version_added": "55",
-              "notes": "Available for use in Manifest V2 only."
+              "version_added": "101",
+              "notes": [
+                "Available for use in Manifest V3 or later.",
+                "Extension developers can turn on Manifest V3 for testing purposes using the <code>extensions.manifestV3.enabled</code> preference."
+              ]
             },
             "opera": {
-              "version_added": true,
+              "version_added": "74",
               "notes": [
-                "Available for use in Manifest V2 only.",
+                "Available for use in Manifest V3 or later.",
                 "If an extension defines a browser action, it is not allowed to define a page action as well."
               ]
             },
             "safari": {
-              "version_added": "14",
+              "version_added": null,
               "notes": [
-                "Available for use in Manifest V2 only.",
+                "Available for use in Manifest V3 or later.",
                 "If an extension defines a browser action, it is not allowed to define a page action as well."
               ]
             }
@@ -44,22 +50,22 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "88"
               },
               "edge": {
-                "version_added": false
+                "version_added": "88"
               },
               "firefox": {
-                "version_added": "48"
+                "version_added": "101"
               },
               "firefox_android": {
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "74"
               },
               "safari": {
-                "version_added": false
+                "version_added": null
               }
             }
           }
@@ -68,22 +74,22 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "88"
               },
               "edge": {
-                "version_added": false
+                "version_added": "88"
               },
               "firefox": {
-                "version_added": "54"
+                "version_added": "101"
               },
               "firefox_android": {
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "74"
               },
               "safari": {
-                "version_added": false
+                "version_added": null
               }
             }
           }
@@ -92,11 +98,11 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "88",
                 "notes": "SVG icons are not supported."
               },
               "edge": {
-                "version_added": "14",
+                "version_added": "88",
                 "partial_implementation": true,
                 "notes": [
                   "SVG icons are not supported.",
@@ -104,17 +110,17 @@
                 ]
               },
               "firefox": {
-                "version_added": "48"
+                "version_added": "101"
               },
               "firefox_android": {
                 "version_added": false
               },
               "opera": {
-                "version_added": true,
+                "version_added": "74",
                 "notes": "SVG icons are not supported."
               },
               "safari": {
-                "version_added": "14",
+                "version_added": null,
                 "notes": "SVG icons are not supported. Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
               }
             }
@@ -124,22 +130,22 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "88"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "88"
               },
               "firefox": {
-                "version_added": "48"
+                "version_added": "101"
               },
               "firefox_android": {
-                "version_added": "57"
+                "version_added": "101"
               },
               "opera": {
-                "version_added": true
+                "version_added": "74"
               },
               "safari": {
-                "version_added": "14"
+                "version_added": null
               }
             }
           }
@@ -148,23 +154,23 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "88"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "88"
               },
               "firefox": {
-                "version_added": "48"
+                "version_added": "101"
               },
               "firefox_android": {
-                "version_added": "55",
+                "version_added": "101",
                 "notes": "Browser actions are presented as menu items, and the title is the menu item's label."
               },
               "opera": {
-                "version_added": true
+                "version_added": "74"
               },
               "safari": {
-                "version_added": "14"
+                "version_added": null
               }
             }
           }
@@ -173,22 +179,22 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "88"
               },
               "edge": {
-                "version_added": false
+                "version_added": "88"
               },
               "firefox": {
-                "version_added": "56"
+                "version_added": "101"
               },
               "firefox_android": {
                 "version_added": false
               },
               "opera": {
-                "version_added": false
+                "version_added": "74"
               },
               "safari": {
-                "version_added": false
+                "version_added": null
               }
             }
           }


### PR DESCRIPTION
#### Summary

Updates the `browser_action` key to indicate only supported in MV2 and added `action` (copy of `browser_action`) with note that supported from MV3 onwards.