### PR TITLE
Ff101transform streams

### DIFF
--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -296,9 +296,21 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "101",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.transform_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },

--- a/api/TransformStream.json
+++ b/api/TransformStream.json
@@ -17,9 +17,21 @@
           "edge": {
             "version_added": "79"
           },
-          "firefox": {
-            "version_added": false
-          },
+          "firefox": [
+            {
+              "version_added": "preview"
+            },
+            {
+              "version_added": "101",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.transform_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
             "version_added": false
           },
@@ -76,9 +88,21 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "101",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.transform_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -131,9 +155,21 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "101",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.transform_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -186,9 +222,21 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "101",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.transform_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },

--- a/api/TransformStreamDefaultController.json
+++ b/api/TransformStreamDefaultController.json
@@ -25,9 +25,21 @@
           "edge": {
             "version_added": "79"
           },
-          "firefox": {
-            "version_added": false
-          },
+          "firefox": [
+            {
+              "version_added": "preview"
+            },
+            {
+              "version_added": "101",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.transform_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
             "version_added": false
           },
@@ -79,9 +91,21 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "101",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.transform_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -134,9 +158,21 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "101",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.transform_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -189,9 +225,21 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "101",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.transform_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -244,9 +292,21 @@
             "edge": {
               "version_added": "79"
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "101",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.transform_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },


### PR DESCRIPTION
FF101 enables [TransformStream](https://developer.mozilla.org/en-US/docs/Web/API/TransformStream), [TransformStreamDefaultController](https://developer.mozilla.org/en-US/docs/Web/API/TransformStreamDefaultController),[ReadableStream.pipeThrough](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/pipeThrough) on nightly using the `dom.streams.transform_streams.enabled` preference - see https://bugzilla.mozilla.org/show_bug.cgi?id=1764099

To support this the FF entry (everywhere) has version added preview and a separate version added 101 with preference. The preference was actually added in 99 but the bug just describes it as a "framework" so I don't think it was a proper implementation. Hence 101.

FF android all still false as it does not support preferences and is not an allowed preview target (not sure why, since FF android nightly does exist)

Other docs work for this can be tracked in https://github.com/mdn/content/issues/15469#issuecomment-1115528753