### PR TITLE
Update Firefox versions for NavigationPreloadManager API

### DIFF
--- a/api/NavigationPreloadManager.json
+++ b/api/NavigationPreloadManager.json
@@ -16,7 +16,7 @@
           },
           "firefox": [
             {
-              "version_added": "preview"
+              "version_added": "99"
             },
             {
               "version_added": "97",
@@ -30,7 +30,7 @@
             }
           ],
           "firefox_android": {
-            "version_added": false
+            "version_added": "99"
           },
           "ie": {
             "version_added": false
@@ -76,7 +76,7 @@
             },
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "99"
               },
               {
                 "version_added": "97",
@@ -90,7 +90,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "99"
             },
             "ie": {
               "version_added": false
@@ -137,7 +137,7 @@
             },
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "99"
               },
               {
                 "version_added": "97",
@@ -151,7 +151,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "99"
             },
             "ie": {
               "version_added": false
@@ -198,7 +198,7 @@
             },
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "99"
               },
               {
                 "version_added": "97",
@@ -212,7 +212,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "99"
             },
             "ie": {
               "version_added": false
@@ -259,7 +259,7 @@
             },
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "99"
               },
               {
                 "version_added": "97",
@@ -273,7 +273,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "99"
             },
             "ie": {
               "version_added": false

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -362,11 +362,10 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+              "version_added": "99"
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "99"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `NavigationPreloadManager` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/NavigationPreloadManager

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
