### PR TITLE
Update Firefox versions for api.Navigator.credentials

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1027,10 +1027,10 @@
               "version_added": "18"
             },
             "firefox": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "firefox_android": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `credentials` member of the `Navigator` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Navigator/credentials

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
