### PR TITLE
Fix links in NetworkInformation API

### DIFF
--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -438,7 +438,7 @@
             },
             "chrome_android": {
               "version_added": "38",
-              "notes": "Removal proposed in <a href=' https://crbug.com/699892'>bug 699892</a>."
+              "notes": "Removal proposed in <a href='https://crbug.com/699892'>bug 699892</a>."
             },
             "edge": {
               "version_added": false
@@ -465,7 +465,7 @@
             },
             "opera_android": {
               "version_added": "25",
-              "notes": "Removal proposed in <a href=' https://crbug.com/699892'>bug 699892</a>."
+              "notes": "Removal proposed in <a href='https://crbug.com/699892'>bug 699892</a>."
             },
             "safari": {
               "version_added": false
@@ -475,7 +475,7 @@
             },
             "samsunginternet_android": {
               "version_added": "3.0",
-              "notes": "Removal proposed in <a href=' https://crbug.com/699892'>bug 699892</a>."
+              "notes": "Removal proposed in <a href='https://crbug.com/699892'>bug 699892</a>."
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
This PR removes the stray spaces in the URLs of a bug link for `api.NetworkInformation.typechange_event`.
