### PR TITLE
Update Chrome/Safari versions for PaymentRequest API

### DIFF
--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -408,7 +408,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/shippingAddress",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "53"
@@ -439,10 +439,10 @@
               "version_added": "44"
             },
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "11.3"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -464,7 +464,7 @@
           "description": "<code>shippingaddresschange</code> event",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "53"
@@ -575,7 +575,7 @@
           "description": "<code>shippingoptionchange</code> event",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "60"
             },
             "chrome_android": {
               "version_added": "53"


### PR DESCRIPTION
This PR updates and corrects the real values for Chrome and Safari for the `PaymentRequest` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PaymentRequest

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
