### PR TITLE
Update Chromium versions for PermissionStatus API

### DIFF
--- a/api/PermissionStatus.json
+++ b/api/PermissionStatus.json
@@ -105,13 +105,13 @@
           "spec_url": "https://w3c.github.io/permissions/#dom-permissionstatus-name",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "97"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "97"
             },
             "edge": {
-              "version_added": false
+              "version_added": "97"
             },
             "firefox": {
               "version_added": "93"
@@ -123,10 +123,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "83"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `PermissionStatus` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PermissionStatus

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
