### PR TITLE
Update Firefox versions for PushSubscription API

### DIFF
--- a/api/PushSubscription.json
+++ b/api/PushSubscription.json
@@ -115,10 +115,10 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "96"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "96"
             },
             "ie": {
               "version_added": false
@@ -314,7 +314,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "46"
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "48"


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `PushSubscription` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PushSubscription

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
