### PR TITLE
Update Firefox versions for api.SVGImageElement.decode

### DIFF
--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -113,10 +113,10 @@
               "version_added": "79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "68"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `decode` member of the `SVGImageElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGImageElement/decode

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
