### PR TITLE
Update Firefox versions for api.Selection.setBaseAndExtent

### DIFF
--- a/api/Selection.json
+++ b/api/Selection.json
@@ -1202,10 +1202,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "52"
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "52"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `setBaseAndExtent` member of the `Selection` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Selection/setBaseAndExtent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
