### PR TITLE
Update Samsung Internet/Safari versions for api.ServiceWorkerGlobalScope

### DIFF
--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -84,7 +84,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "10.0"
             },
             "webview_android": {
               "version_added": false
@@ -1193,10 +1193,10 @@
               "version_added": "57"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.4"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "samsunginternet_android": {
               "version_added": "12.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Samsung Internet and Safari for the `ServiceWorkerGlobalScope` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ServiceWorkerGlobalScope

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
