### PR TITLE
Update Safari versions for ShadowRoot API

### DIFF
--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -30,10 +30,10 @@
             "version_added": "41"
           },
           "safari": {
-            "version_added": "10.1"
+            "version_added": "10"
           },
           "safari_ios": {
-            "version_added": "10.3"
+            "version_added": "10"
           },
           "samsunginternet_android": {
             "version_added": "6.0"
@@ -174,10 +174,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "6.0"
@@ -223,10 +223,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "6.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `ShadowRoot` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ShadowRoot

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
