### PR TITLE
Update Safari versions for api.Text.assignedSlot

### DIFF
--- a/api/Text.json
+++ b/api/Text.json
@@ -128,10 +128,10 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10"
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": "10"
             },
             "samsunginternet_android": {
               "version_added": "6.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `assignedSlot` member of the `Text` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Text/assignedSlot

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
