### PR TITLE
Update WebView versions for URLPattern API

### DIFF
--- a/api/URLPattern.json
+++ b/api/URLPattern.json
@@ -93,7 +93,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "95"
           }
         },
         "status": {
@@ -196,7 +196,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "95"
             }
           },
           "status": {
@@ -299,7 +299,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "95"
             }
           },
           "status": {
@@ -402,7 +402,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "95"
             }
           },
           "status": {
@@ -505,7 +505,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "95"
             }
           },
           "status": {
@@ -608,7 +608,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "95"
             }
           },
           "status": {
@@ -711,7 +711,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "95"
             }
           },
           "status": {
@@ -814,7 +814,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "95"
             }
           },
           "status": {
@@ -917,7 +917,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "95"
             }
           },
           "status": {
@@ -1020,7 +1020,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "95"
             }
           },
           "status": {
@@ -1123,7 +1123,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "95"
             }
           },
           "status": {
@@ -1226,7 +1226,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "95"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for WebView Android for the `URLPattern` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/URLPattern

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
