### PR TITLE
Update Safari versions for api.ValidityState.badInput

### DIFF
--- a/api/ValidityState.json
+++ b/api/ValidityState.json
@@ -78,7 +78,7 @@
               "version_added": "14"
             },
             "safari": {
-              "version_added": "11"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "7"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `badInput` member of the `ValidityState` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ValidityState/badInput

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
