### PR TITLE
Update Opera versions for api.ValidityState.tooLong

### DIFF
--- a/api/ValidityState.json
+++ b/api/ValidityState.json
@@ -366,10 +366,10 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "5"


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `tooLong` member of the `ValidityState` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ValidityState/tooLong

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
