### PR TITLE
Update Safari versions for `animationcancel` event

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -616,10 +616,10 @@
               "notes": "The <code>onanimationcancel</code> property is not supported. To listen to this event, use <code>document.addEventListener('animationcancel', function() {});</code>. See <a href='https://crbug.com/868224'>bug 868224</a>."
             },
             "safari": {
-              "version_added": "13.1"
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": "13.4"
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": "13.0",

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -194,10 +194,10 @@
               "notes": "The <code>onanimationcancel</code> property is not supported. To listen to this event, use <code>element.addEventListener('animationcancel', function() {});</code>. See <a href='https://crbug.com/868224'>bug 868224</a>."
             },
             "safari": {
-              "version_added": "13.1"
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": "13.4"
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": "13.0",

--- a/api/Window.json
+++ b/api/Window.json
@@ -253,10 +253,10 @@
               "notes": "The <code>onanimationcancel</code> property is not supported. To listen to this event, use <code>window.addEventListener('animationcancel', function() {});</code>. See <a href='https://crbug.com/868224'>bug 868224</a>."
             },
             "safari": {
-              "version_added": "13.1"
+              "version_added": "12"
             },
             "safari_ios": {
-              "version_added": "13.4"
+              "version_added": "12"
             },
             "samsunginternet_android": {
               "version_added": "13.0",


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `animationcancel_event` member of various APIs, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used:
https://mdn-bcd-collector.appspot.com/tests/api/Document/animationcancel_event
https://mdn-bcd-collector.appspot.com/tests/api/HTMLElement/animationcancel_event
https://mdn-bcd-collector.appspot.com/tests/api/Window/animationcancel_event

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
