### PR TITLE
Update Chromium versions for api.WritableStreamDefaultController.signal

### DIFF
--- a/api/WritableStreamDefaultController.json
+++ b/api/WritableStreamDefaultController.json
@@ -145,16 +145,16 @@
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-ws-default-controller-signal①",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "98"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "98"
             },
             "deno": {
               "version_added": "1.16"
             },
             "edge": {
-              "version_added": false
+              "version_added": "98"
             },
             "firefox": [
               {
@@ -182,10 +182,10 @@
               "version_added": "16.5.0"
             },
             "opera": {
-              "version_added": false
+              "version_added": "84"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "68"
             },
             "safari": {
               "version_added": false
@@ -197,7 +197,7 @@
               "version_added": false
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "98"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `signal` member of the `WritableStreamDefaultController` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WritableStreamDefaultController/signal

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
