### PR TITLE
Mirror script: mirror from Chrome by default

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -82,16 +82,16 @@ Many browsers within BCD can be derived from other browsers given they share the
 
 The <browser> argument is the destination browser that values will be copied to. The script automatically determines what browser to copy from based upon the destination (see table below), but manual specification is possible through the `--source=""` argument.
 
-| Destination      | Default Source    |
-| ---------------- | ----------------- |
-| Chrome Android   | Chrome            |
-| Edge             | Internet Explorer |
-| Firefox Android  | Firefox           |
-| Opera            | Chrome            |
-| Opera Android    | Chrome Android    |
-| Safari iOS       | Safari            |
-| Samsung Internet | Chrome Android    |
-| WebView          | Chrome Android    |
+| Destination      | Default Source |
+| ---------------- | -------------- |
+| Chrome Android   | Chrome         |
+| Edge             | Chrome         |
+| Firefox Android  | Firefox        |
+| Opera            | Chrome         |
+| Opera Android    | Chrome Android |
+| Safari iOS       | Safari         |
+| Samsung Internet | Chrome Android |
+| WebView          | Chrome Android |
 
 The <feature_or_filename> argument is either the identifier of the feature to update (i.e. `css.at-rules.namespace`), a filename (`javascript/operators/arithmetic.json`), or an entire folder (`api`).
 

--- a/scripts/mirror.js
+++ b/scripts/mirror.js
@@ -112,6 +112,7 @@ const getSource = (browser, forced_source) => {
 
   switch (browser) {
     case 'chrome_android':
+    case 'edge':
     case 'opera':
       source = 'chrome';
       break;
@@ -122,9 +123,6 @@ const getSource = (browser, forced_source) => {
       break;
     case 'firefox_android':
       source = 'firefox';
-      break;
-    case 'edge':
-      source = 'ie';
       break;
     case 'safari_ios':
       source = 'safari';


### PR DESCRIPTION
This PR updates our mirroring script to mirror Edge's data from Chromium instead of Internet Explorer by default.