### PR TITLE
Fix mirroring script for Chrome to Edge

### DIFF
--- a/scripts/mirror.js
+++ b/scripts/mirror.js
@@ -288,7 +288,7 @@ const bumpEdge = (originalData, sourceData, source) => {
               newData.version_added = '≤79';
             }
           } else {
-            newData.version_added == sourceData.version_added;
+            newData.version_added = sourceData.version_added;
           }
         }
       } else if (chromeFalse) {


### PR DESCRIPTION
This PR fixes an issue with the mirroring script where Edge won't properly mirror data from Chrome.

Closes #16132.