### PR TITLE
Remove experimental flag for `ExtendableEvent`

### DIFF
--- a/api/ExtendableEvent.json
+++ b/api/ExtendableEvent.json
@@ -44,7 +44,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -94,7 +94,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -143,7 +143,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -190,7 +190,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
Supported by all browsers but IE for years. Not experimental anymore.