### PR TITLE
Add spec url for NDEFReadingEvent() ctor

### DIFF
--- a/api/NDEFReadingEvent.json
+++ b/api/NDEFReadingEvent.json
@@ -51,6 +51,7 @@
       "NDEFReadingEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NDEFReadingEvent/NDEFReadingEvent",
+          "spec_url": "https://w3c.github.io/web-nfc/#dom-ndefreadingevent-constructor",
           "description": "<code>NDEFReadingEvent()</code> constructor",
           "support": {
             "chrome": {


### PR DESCRIPTION
It was the only spec_url missing for this interface.