### PR TITLE
DOMException is serialisable 

### DIFF
--- a/api/DOMException.json
+++ b/api/DOMException.json
@@ -259,6 +259,67 @@
             "deprecated": false
           }
         }
+      },
+      "not_serializable": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/structured-data.html#serializable-objects",
+          "description": "Not serializable",
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "version_removed": "77"
+            },
+            "chrome_android": {
+              "version_added": "18",
+              "version_removed": "77"
+            },
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "12",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": "1",
+              "version_removed": "101"
+            },
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "101"
+            },
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "64"
+            },
+            "opera_android": {
+              "version_added": "≤12.1",
+              "version_removed": "55"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "version_removed": "12.0"
+            },
+            "webview_android": {
+              "version_added": "1",
+              "version_removed": "77"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
DOMException (and other errors) is serialisable in the current HTML spec: https://github.com/whatwg/html/pull/4665.
- Support was added in Chrome 77 - https://chromestatus.com/feature/5745988251680768
- Support was added in FF101 https://bugzilla.mozilla.org/show_bug.cgi?id=1561357

What this PR does is add a "negative subfeature", which is something Daniel suggested for spec updates that change old behaviour. Rather than saying "X supports serialisation from this version" it says "X does supports not_serialisation from first version to version removed". The theory is that after a time you can remove the subfeature and just have the assumption everything supports serialisation.

Anyway, that's what I did for this. The only one I am not sure how to get is deno. 

IFF you are OK with this approach we can merge and I will update the other serializable errors that are [supported by chrome](https://chromestatus.com/feature/5745988251680768) (but not firefox): Error, EvalError, RangeError, ReferenceError, SyntaxError, TypeError, and URIError. 

