### PR TITLE
Chrome 100 is retired

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -694,7 +694,7 @@
         "100": {
           "release_date": "2022-03-29",
           "release_notes": "https://chromereleases.googleblog.com/2022/03/stable-channel-update-for-desktop_29.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "100"
         },


### PR DESCRIPTION
Chrome 100 was accidentally left marked as "current", when it should have been marked as "retired".  Caught by https://github.com/mdn/browser-compat-data/pull/6167.
