### PR TITLE
NodeJS v12 is no longer LTS

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -202,7 +202,7 @@
         "12.17.0": {
           "release_date": "2020-05-26",
           "release_notes": "https://nodejs.org/en/blog/release/v12.17.0/",
-          "status": "esr",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "7.8"
         },


### PR DESCRIPTION
As indicated by https://nodejs.org/en/about/releases/, NodeJS v12 is no longer in maintenance LTS.
