### PR TITLE
Mark TransitionEvent as non-experimental

### DIFF
--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -83,7 +83,7 @@
           ]
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -132,7 +132,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -181,7 +181,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -289,7 +289,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -338,7 +338,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
The three major browser engines support it -> no more experimental