### PR TITLE
Fix notes in RTCDataChannel

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -150,15 +150,15 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</code>."
+                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</a>."
               },
               "chrome_android": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</code>."
+                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</a>."
               },
               "edge": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</code>."
+                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</a>."
               },
               "firefox": {
                 "version_added": "22"
@@ -171,11 +171,11 @@
               },
               "opera": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</code>."
+                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</a>."
               },
               "opera_android": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</code>."
+                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</a>."
               },
               "safari": {
                 "version_added": "11"
@@ -185,11 +185,11 @@
               },
               "samsunginternet_android": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</code>."
+                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</a>."
               },
               "webview_android": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</code>."
+                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</a>."
               }
             },
             "status": {


### PR DESCRIPTION
This PR fixes the HTML in the notes introduced in #16042, which fail the recently-merged lint.  This will be self-merged as it fixes a failing test on `main`.
