### PR TITLE
Fix consistency in webextensions.api.webRequest

### DIFF
--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -1409,10 +1409,10 @@
                     "version_added": false
                   },
                   "firefox": {
-                    "version_added": "48"
+                    "version_added": "54"
                   },
                   "firefox_android": {
-                    "version_added": "48"
+                    "version_added": "54"
                   },
                   "opera": {
                     "version_added": false
@@ -1936,6 +1936,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }
@@ -4092,6 +4095,9 @@
                   },
                   "safari": {
                     "version_added": "14"
+                  },
+                  "safari_ios": {
+                    "version_added": false
                   }
                 }
               }


### PR DESCRIPTION
This PR fixes the consistency in the `webRequest` webextensions API.  Caught by #16169.
