### PR TITLE
Fix Chromium versions for MIDIAccess.sysexEnabled

### DIFF
--- a/api/MIDIAccess.json
+++ b/api/MIDIAccess.json
@@ -250,10 +250,10 @@
           "spec_url": "https://webaudio.github.io/web-midi-api/#dom-midiaccess-sysexenabled",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "43"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "43"
             },
             "edge": {
               "version_added": "79"
@@ -280,10 +280,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "30"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "30"
             },
             "safari": {
               "version_added": false
@@ -292,10 +292,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "43"
             }
           },
           "status": {


### PR DESCRIPTION
Confirmed by testing in Chrome 43:
https://mdn-bcd-collector.appspot.com/tests/api/MIDIAccess

Chrome 45 was set in https://github.com/mdn/browser-compat-data/pull/3716
based on this:
https://storage.googleapis.com/chromium-find-releases-static/545.html#5455496fc3b82a0dc6645f78474f9ab5950a70bb

But that's wrong.

Part of https://github.com/mdn/browser-compat-data/issues/7844.