### PR TITLE
Fix Chromium versions for Symbol.unscopables

### DIFF
--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -1156,10 +1156,10 @@
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.unscopables",
             "support": {
               "chrome": {
-                "version_added": "45"
+                "version_added": "38"
               },
               "chrome_android": {
-                "version_added": "45"
+                "version_added": "38"
               },
               "deno": {
                 "version_added": "1.0"
@@ -1180,10 +1180,10 @@
                 "version_added": "0.12.0"
               },
               "opera": {
-                "version_added": "32"
+                "version_added": "25"
               },
               "opera_android": {
-                "version_added": "32"
+                "version_added": "25"
               },
               "safari": {
                 "version_added": "9"
@@ -1192,10 +1192,10 @@
                 "version_added": "9"
               },
               "samsunginternet_android": {
-                "version_added": "5.0"
+                "version_added": "3.0"
               },
               "webview_android": {
-                "version_added": "45"
+                "version_added": "38"
               }
             },
             "status": {


### PR DESCRIPTION
Confirmed by testing in Chrome 37+38:
https://mdn-bcd-collector.appspot.com/tests/javascript/builtins/Symbol/unscopables

This now matches Array.@@unscopables:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/@@unscopables#browser_compatibility

Part of https://github.com/mdn/browser-compat-data/issues/7844.