### PR TITLE
FF101 Prioritized Task Scheduling

### DIFF
--- a/api/Scheduler.json
+++ b/api/Scheduler.json
@@ -2,6 +2,7 @@
   "api": {
     "Scheduler": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Scheduler",
         "spec_url": "https://wicg.github.io/scheduling-apis/#scheduler",
         "support": {
           "chrome": {
@@ -13,9 +14,21 @@
           "edge": {
             "version_added": "94"
           },
-          "firefox": {
-            "version_added": false
-          },
+          "firefox": [
+            {
+              "version_added": "preview"
+            },
+            {
+              "version_added": "101",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.enable_web_task_scheduling",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
             "version_added": false
           },
@@ -49,6 +62,7 @@
       },
       "postTask": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Scheduler/postTask",
           "spec_url": "https://wicg.github.io/scheduling-apis/#dom-scheduler-posttask",
           "support": {
             "chrome": {
@@ -60,9 +74,21 @@
             "edge": {
               "version_added": "94"
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "101",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.enable_web_task_scheduling",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },

--- a/api/TaskController.json
+++ b/api/TaskController.json
@@ -2,6 +2,7 @@
   "api": {
     "TaskController": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/TaskController",
         "spec_url": "https://wicg.github.io/scheduling-apis/#sec-task-controller",
         "support": {
           "chrome": {
@@ -13,9 +14,21 @@
           "edge": {
             "version_added": "94"
           },
-          "firefox": {
-            "version_added": false
-          },
+          "firefox": [
+            {
+              "version_added": "preview"
+            },
+            {
+              "version_added": "101",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.enable_web_task_scheduling",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
             "version_added": false
           },
@@ -49,6 +62,7 @@
       },
       "TaskController": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TaskController/TaskController",
           "spec_url": "https://wicg.github.io/scheduling-apis/#dom-taskcontroller-taskcontroller",
           "description": "<code>TaskController()</code> constructor",
           "support": {
@@ -61,9 +75,21 @@
             "edge": {
               "version_added": "94"
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "101",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.enable_web_task_scheduling",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -98,6 +124,7 @@
       },
       "setPriority": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TaskController/setPriority",
           "spec_url": "https://wicg.github.io/scheduling-apis/#dom-taskcontroller-setpriority",
           "support": {
             "chrome": {
@@ -109,9 +136,21 @@
             "edge": {
               "version_added": "94"
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "101",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.enable_web_task_scheduling",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },

--- a/api/TaskPriorityChangeEvent.json
+++ b/api/TaskPriorityChangeEvent.json
@@ -2,6 +2,7 @@
   "api": {
     "TaskPriorityChangeEvent": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/TaskPriorityChangeEvent",
         "spec_url": "https://wicg.github.io/scheduling-apis/#sec-task-priority-change-event",
         "support": {
           "chrome": {
@@ -13,9 +14,21 @@
           "edge": {
             "version_added": "94"
           },
-          "firefox": {
-            "version_added": false
-          },
+          "firefox": [
+            {
+              "version_added": "preview"
+            },
+            {
+              "version_added": "101",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.enable_web_task_scheduling",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
             "version_added": false
           },
@@ -49,6 +62,7 @@
       },
       "TaskPriorityChangeEvent": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TaskPriorityChangeEvent/TaskPriorityChangeEvent",
           "spec_url": "https://wicg.github.io/scheduling-apis/#dom-taskprioritychangeevent-taskprioritychangeevent",
           "description": "<code>TaskPriorityChangeEvent()</code> constructor",
           "support": {
@@ -61,9 +75,21 @@
             "edge": {
               "version_added": "94"
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "101",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.enable_web_task_scheduling",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -98,6 +124,7 @@
       },
       "previousPriority": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TaskPriorityChangeEvent/previousPriority",
           "spec_url": "https://wicg.github.io/scheduling-apis/#dom-taskprioritychangeevent-previouspriority",
           "support": {
             "chrome": {
@@ -109,9 +136,21 @@
             "edge": {
               "version_added": "94"
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "101",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.enable_web_task_scheduling",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },

--- a/api/TaskSignal.json
+++ b/api/TaskSignal.json
@@ -2,6 +2,7 @@
   "api": {
     "TaskSignal": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/TaskSignal",
         "spec_url": "https://wicg.github.io/scheduling-apis/#tasksignal",
         "support": {
           "chrome": {
@@ -13,9 +14,21 @@
           "edge": {
             "version_added": "94"
           },
-          "firefox": {
-            "version_added": false
-          },
+          "firefox": [
+            {
+              "version_added": "preview"
+            },
+            {
+              "version_added": "101",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.enable_web_task_scheduling",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
             "version_added": false
           },
@@ -49,6 +62,7 @@
       },
       "priority": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TaskSignal/priority",
           "spec_url": "https://wicg.github.io/scheduling-apis/#dom-tasksignal-priority",
           "support": {
             "chrome": {
@@ -60,9 +74,21 @@
             "edge": {
               "version_added": "94"
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "101",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.enable_web_task_scheduling",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },
@@ -98,6 +124,7 @@
       "prioritychange_event": {
         "__compat": {
           "description": "<code>prioritychange</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/prioritychange_event",
           "spec_url": [
             "https://wicg.github.io/scheduling-apis/#ref-for-eventdef-tasksignal-prioritychange",
             "https://wicg.github.io/scheduling-apis/#dom-tasksignal-onprioritychange"
@@ -112,9 +139,21 @@
             "edge": {
               "version_added": "94"
             },
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "101",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.enable_web_task_scheduling",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
               "version_added": false
             },


### PR DESCRIPTION
FF101 supports the [prioritized task scheduling API](https://wicg.github.io/scheduling-apis/) behind a pref and in nightly - https://bugzilla.mozilla.org/show_bug.cgi?id=1734997

This adds the support statements in all the APIs and also placeholder URLS for where I will create the documentation for this.

Other docs work for this can be tracked in https://github.com/mdn/content/issues/15468

