### PR TITLE
Mark HTMLInputElement.webkit* as standard

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -3281,7 +3281,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -3330,7 +3330,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
Despite their names, `HTMLInputElement.webkitdirectory` and `HTMLInputElement.webkitEntries` have been standardized with that name... (See the spec_url that was already set).