### PR TITLE
Update Firefox versions for Cache API

### DIFF
--- a/api/Cache.json
+++ b/api/Cache.json
@@ -17,11 +17,11 @@
             "version_added": "16"
           },
           "firefox": {
-            "version_added": "39",
+            "version_added": "41",
             "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
           },
           "firefox_android": {
-            "version_added": "39"
+            "version_added": "41"
           },
           "ie": {
             "version_added": false
@@ -71,11 +71,11 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "39",
+              "version_added": "41",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "39"
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -127,11 +127,11 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "39",
+              "version_added": "41",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "39"
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -181,11 +181,11 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "39",
+              "version_added": "41",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "39"
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -231,11 +231,11 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "39",
+              "version_added": "41",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "39"
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -281,11 +281,11 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "39",
+              "version_added": "41",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "39"
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -331,11 +331,11 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "39",
+              "version_added": "41",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "39"
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -384,11 +384,11 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "39",
+              "version_added": "41",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "39"
+              "version_added": "41"
             },
             "ie": {
               "version_added": false

--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -17,11 +17,11 @@
             "version_added": "16"
           },
           "firefox": {
-            "version_added": "44",
+            "version_added": "41",
             "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
           },
           "firefox_android": {
-            "version_added": "44"
+            "version_added": "41"
           },
           "ie": {
             "version_added": false
@@ -69,11 +69,11 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "44",
+              "version_added": "41",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -119,11 +119,11 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "44",
+              "version_added": "41",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -169,11 +169,11 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "44",
+              "version_added": "41",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -233,11 +233,11 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "44",
+              "version_added": "41",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -311,11 +311,11 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "44",
+              "version_added": "41",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "41"
             },
             "ie": {
               "version_added": false

--- a/api/_globals/caches.json
+++ b/api/_globals/caches.json
@@ -18,10 +18,10 @@
             "version_added": "16"
           },
           "firefox": {
-            "version_added": "42"
+            "version_added": "41"
           },
           "firefox_android": {
-            "version_added": "42"
+            "version_added": "41"
           },
           "ie": {
             "version_added": false
@@ -68,10 +68,10 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "42"
+              "version_added": "41"
             },
             "firefox_android": {
-              "version_added": "42"
+              "version_added": "41"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `Cache` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Cache

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
