### PR TITLE
Update Firefox versions for CacheStorage API

### DIFF
--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -17,11 +17,11 @@
             "version_added": "16"
           },
           "firefox": {
-            "version_added": "44",
+            "version_added": "41",
             "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
           },
           "firefox_android": {
-            "version_added": "44"
+            "version_added": "41"
           },
           "ie": {
             "version_added": false
@@ -69,11 +69,11 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "44",
+              "version_added": "41",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -119,11 +119,11 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "44",
+              "version_added": "41",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -169,11 +169,11 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "44",
+              "version_added": "41",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -233,11 +233,11 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "44",
+              "version_added": "41",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "41"
             },
             "ie": {
               "version_added": false
@@ -311,11 +311,11 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "44",
+              "version_added": "41",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "41"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `CacheStorage` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CacheStorage

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
