### PR TITLE
Update Chromium versions for Clipboard API

### DIFF
--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -6,10 +6,10 @@
         "spec_url": "https://w3c.github.io/clipboard-apis/#clipboard-interface",
         "support": {
           "chrome": {
-            "version_added": "66"
+            "version_added": "61"
           },
           "chrome_android": {
-            "version_added": "66"
+            "version_added": "61"
           },
           "edge": {
             "version_added": "79"
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": "53"
+            "version_added": "48"
           },
           "opera_android": {
-            "version_added": "47"
+            "version_added": "45"
           },
           "safari": {
             "version_added": "13.1"
@@ -36,10 +36,10 @@
             "version_added": "13.4"
           },
           "samsunginternet_android": {
-            "version_added": "9.0"
+            "version_added": "8.0"
           },
           "webview_android": {
-            "version_added": "66"
+            "version_added": "61"
           }
         },
         "status": {
@@ -65,7 +65,7 @@
                 "notes": "From version 76, the <code>image/png</code> MIME type is supported."
               },
               {
-                "version_added": "66",
+                "version_added": "61",
                 "partial_implementation": true,
                 "notes": "Images are not supported."
               }
@@ -82,7 +82,7 @@
                 "notes": "From version 84, the <code>image/png</code> MIME type is supported."
               },
               {
-                "version_added": "66",
+                "version_added": "61",
                 "partial_implementation": true,
                 "notes": "Images are not supported."
               }
@@ -138,10 +138,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "63"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "54"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "13.1"
@@ -150,7 +150,7 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": "12.0"
+              "version_added": "8.0"
             },
             "webview_android": [
               {
@@ -159,7 +159,7 @@
                 "notes": "From version 84, the <code>image/png</code> MIME type is supported."
               },
               {
-                "version_added": "66",
+                "version_added": "61",
                 "partial_implementation": true,
                 "notes": "Images are not supported."
               }
@@ -178,10 +178,10 @@
           "spec_url": "https://w3c.github.io/clipboard-apis/#dom-clipboard-readtext",
           "support": {
             "chrome": {
-              "version_added": "66"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "66"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -198,10 +198,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "53"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "47"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "13.1"
@@ -210,10 +210,10 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": "9.0"
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "66"
+              "version_added": "61"
             }
           },
           "status": {
@@ -229,11 +229,11 @@
           "spec_url": "https://w3c.github.io/clipboard-apis/#dom-clipboard-write",
           "support": {
             "chrome": {
-              "version_added": "66",
+              "version_added": "61",
               "notes": "From version 76, the <code>image/png</code> MIME type is supported."
             },
             "chrome_android": {
-              "version_added": "66",
+              "version_added": "61",
               "notes": "From version 84, the <code>image/png</code> MIME type is supported."
             },
             "edge": {
@@ -274,10 +274,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "63"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "54"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "13.1"
@@ -286,10 +286,10 @@
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": "12.0"
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "66",
+              "version_added": "61",
               "notes": "From version 84, the <code>image/png</code> MIME type is supported."
             }
           },
@@ -306,10 +306,10 @@
           "spec_url": "https://w3c.github.io/clipboard-apis/#dom-clipboard-writetext",
           "support": {
             "chrome": {
-              "version_added": "66"
+              "version_added": "61"
             },
             "chrome_android": {
-              "version_added": "66"
+              "version_added": "61"
             },
             "edge": {
               "version_added": "79"
@@ -326,10 +326,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "53"
+              "version_added": "48"
             },
             "opera_android": {
-              "version_added": "47"
+              "version_added": "45"
             },
             "safari": {
               "version_added": "13.1",
@@ -340,10 +340,10 @@
               "notes": "Must be called within user gesture event handlers such as <code>pointerdown</code> or <code>pointerup</code>."
             },
             "samsunginternet_android": {
-              "version_added": "9.0"
+              "version_added": "8.0"
             },
             "webview_android": {
-              "version_added": "66"
+              "version_added": "61"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Clipboard` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Clipboard

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
