### PR TITLE
Update Safari versions for CountQueuingStrategy API

### DIFF
--- a/api/CountQueuingStrategy.json
+++ b/api/CountQueuingStrategy.json
@@ -89,10 +89,12 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10.1",
+              "version_removed": "15"
             },
             "safari_ios": {
-              "version_added": "10.3"
+              "version_added": "10.3",
+              "version_removed": "15"
             },
             "samsunginternet_android": {
               "version_added": "6.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `CountQueuingStrategy` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CountQueuingStrategy

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
