### PR TITLE
Update IE versions for api.Document.drag*/drop*_event

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -3505,7 +3505,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "opera": {
               "version_added": "12"
@@ -3561,7 +3561,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "opera": {
               "version_added": "12"
@@ -3612,7 +3612,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "opera": {
               "version_added": "12"
@@ -3712,7 +3712,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "opera": {
               "version_added": "12"
@@ -3762,7 +3762,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "opera": {
               "version_added": "12"
@@ -3812,7 +3812,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "opera": {
               "version_added": "12"
@@ -3862,7 +3862,7 @@
               "version_added": false
             },
             "ie": {
-              "version_added": "10"
+              "version_added": "9"
             },
             "opera": {
               "version_added": "12"


### PR DESCRIPTION
This PR updates and corrects the real values for Internet Explorer for the `drag*` and `drop* events of the `Document` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used:
https://mdn-bcd-collector.appspot.com/tests/api/Document/drag_event
https://mdn-bcd-collector.appspot.com/tests/api/Document/dragstart_event
https://mdn-bcd-collector.appspot.com/tests/api/Document/dragend_event
https://mdn-bcd-collector.appspot.com/tests/api/Document/dragenter_event
https://mdn-bcd-collector.appspot.com/tests/api/Document/dragexit_event
https://mdn-bcd-collector.appspot.com/tests/api/Document/dragleave_event
https://mdn-bcd-collector.appspot.com/tests/api/Document/dragover_event
https://mdn-bcd-collector.appspot.com/tests/api/Document/drop_event

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
