### PR TITLE
Update Firefox Android versions for api.Document.hasStorageAccess

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -6114,7 +6114,7 @@
               "version_added": "65"
             },
             "firefox_android": {
-              "version_added": "79"
+              "version_added": "65"
             },
             "ie": {
               "version_added": false

--- a/api/Document.json
+++ b/api/Document.json
@@ -6114,7 +6114,7 @@
               "version_added": "65"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "79"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox Android for the `hasStorageAccess` member of the `Document` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1), followed by mirroring.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Document/hasStorageAccess

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
