### PR TITLE
Update Safari iOS versions for api.Document.selectstart_event

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -9567,7 +9567,7 @@
               "version_added": "1.3"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "1"
             },
             "samsunginternet_android": {
               "version_added": "1.0"
@@ -9936,16 +9936,16 @@
           "spec_url": "https://drafts.csswg.org/css-transitions/#transitioncancel",
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": "87"
             },
             "chrome_android": {
               "version_added": "74"
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "87"
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "52"
             },
             "firefox_android": {
               "version_added": "53"
@@ -9960,7 +9960,7 @@
               "version_added": "53"
             },
             "safari": {
-              "version_added": "13.1"
+              "version_added": "12"
             },
             "safari_ios": {
               "version_added": "13.4"
@@ -9986,13 +9986,13 @@
           "spec_url": "https://drafts.csswg.org/css-transitions/#transitionend",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "79"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "≤100"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "18"
             },
             "firefox": {
               "version_added": "51"
@@ -10005,10 +10005,10 @@
               "notes": "The <code>ontransitionend</code> attribute is not supported in IE. To listen to this event, use <code>document.addEventListener('transitionend', function() {});</code>."
             },
             "opera": {
-              "version_added": false
+              "version_added": "15> ≤85"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤68"
             },
             "safari": {
               "version_added": "11"
@@ -10017,10 +10017,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "≤16.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "4.4.3> ≤100"
             }
           },
           "status": {
@@ -10037,16 +10037,16 @@
           "spec_url": "https://drafts.csswg.org/css-transitions/#transitionrun",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "87"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "≤100"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "87"
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "52"
             },
             "firefox_android": {
               "version_added": "53"
@@ -10056,22 +10056,22 @@
               "notes": "The <code>ontransitionrun</code> attribute is not supported in IE. To listen to this event, use <code>document.addEventListener('transitionrun', function() {});</code>."
             },
             "opera": {
-              "version_added": false
+              "version_added": "15> ≤85"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤68"
             },
             "safari": {
-              "version_added": "13.1"
+              "version_added": "12"
             },
             "safari_ios": {
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "≤16.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "4.4.3> ≤100"
             }
           },
           "status": {
@@ -10088,16 +10088,16 @@
           "spec_url": "https://drafts.csswg.org/css-transitions/#transitionstart",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "87"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "≤100"
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": "52"
             },
             "firefox_android": {
               "version_added": "53"
@@ -10107,22 +10107,22 @@
               "notes": "The <code>ontransitionstart</code> attribute is not supported in IE. To listen to this event, use <code>document.addEventListener('transitionstart', function() {});</code>."
             },
             "opera": {
-              "version_added": false
+              "version_added": "15> ≤85"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤68"
             },
             "safari": {
-              "version_added": "13.1"
+              "version_added": "12"
             },
             "safari_ios": {
               "version_added": "13.4"
             },
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "≤16.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "4.4.3> ≤100"
             }
           },
           "status": {
@@ -10415,7 +10415,7 @@
             ],
             "webview_android": [
               {
-                "version_added": "4.4.3"
+                "version_added": "4.4.3> ≤100"
               },
               {
                 "version_added": "≤37",
@@ -10654,7 +10654,7 @@
           "spec_url": "https://w3c.github.io/uievents/#event-type-wheel",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "31"
             },
             "chrome_android": {
               "version_added": "61"
@@ -10679,10 +10679,10 @@
               "version_added": "45"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤15.4"
             },
             "samsunginternet_android": {
               "version_added": "8.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari iOS/iPadOS for the `selectstart_event` member of the `Document` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Document/selectstart_event

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
