### PR TITLE
DOMException.code is deprecated

### DIFF
--- a/api/DOMException.json
+++ b/api/DOMException.json
@@ -152,7 +152,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
From https://github.com/mdn/browser-compat-data/pull/16148#issuecomment-1120719668

[FF14 release notes](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/14) say:
> [DOMException.code](https://developer.mozilla.org/en-US/docs/Web/API/DOMException) is now deprecated per latest DOM Level 4 specification.

The doc itself says:

> returns a short that contains one of the [error code constants](https://developer.mozilla.org/en-US/docs/Web/API/DOMException#error_names), or 0 if none match. This field is used for historical reasons. New DOM exceptions don't use this anymore: they put this info in the [DOMException.name](https://developer.mozilla.org/en-US/docs/Web/API/DOMException/name) attribute.

The [spec](https://webidl.spec.whatwg.org/#idl-DOMException-error-names) refers to the Legacy code name and value - and it is the value that is in DOMException.code.

So I think that it is the case that this is not something code should rely on, even though the "deprecation" is at least 10 years old.