### PR TITLE
Errors are serializable

### DIFF
--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -600,6 +600,63 @@
             }
           }
         },
+        "serializable_object": {
+          "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/structured-data.html#serializable-objects",
+            "description": "<code>Error</code> is serializable",
+            "support": {
+              "chrome": {
+                "version_added": "77"
+              },
+              "chrome_android": {
+                "version_added": "77"
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1556604'>bug 1556604</a>."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1556604'>bug 1556604</a>."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "64"
+              },
+              "opera_android": {
+                "version_added": "55"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "12.0"
+              },
+              "webview_android": {
+                "version_added": "77"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "stack": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/stack",

--- a/javascript/builtins/EvalError.json
+++ b/javascript/builtins/EvalError.json
@@ -110,6 +110,63 @@
               "deprecated": false
             }
           }
+        },
+        "serializable_object": {
+          "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/structured-data.html#serializable-objects",
+            "description": "<code>EvalError</code> is serializable",
+            "support": {
+              "chrome": {
+                "version_added": "77"
+              },
+              "chrome_android": {
+                "version_added": "77"
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1556604'>bug 1556604</a>."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1556604'>bug 1556604</a>."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "64"
+              },
+              "opera_android": {
+                "version_added": "55"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "12.0"
+              },
+              "webview_android": {
+                "version_added": "77"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/javascript/builtins/RangeError.json
+++ b/javascript/builtins/RangeError.json
@@ -110,6 +110,63 @@
               "deprecated": false
             }
           }
+        },
+        "serializable_object": {
+          "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/structured-data.html#serializable-objects",
+            "description": "<code>RangeError</code> is serializable",
+            "support": {
+              "chrome": {
+                "version_added": "77"
+              },
+              "chrome_android": {
+                "version_added": "77"
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1556604'>bug 1556604</a>."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1556604'>bug 1556604</a>."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "64"
+              },
+              "opera_android": {
+                "version_added": "55"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "12.0"
+              },
+              "webview_android": {
+                "version_added": "77"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/javascript/builtins/ReferenceError.json
+++ b/javascript/builtins/ReferenceError.json
@@ -110,6 +110,63 @@
               "deprecated": false
             }
           }
+        },
+        "serializable_object": {
+          "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/structured-data.html#serializable-objects",
+            "description": "<code>ReferenceError</code> is serializable",
+            "support": {
+              "chrome": {
+                "version_added": "77"
+              },
+              "chrome_android": {
+                "version_added": "77"
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1556604'>bug 1556604</a>."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1556604'>bug 1556604</a>."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "64"
+              },
+              "opera_android": {
+                "version_added": "55"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "12.0"
+              },
+              "webview_android": {
+                "version_added": "77"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/javascript/builtins/SyntaxError.json
+++ b/javascript/builtins/SyntaxError.json
@@ -110,6 +110,63 @@
               "deprecated": false
             }
           }
+        },
+        "serializable_object": {
+          "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/structured-data.html#serializable-objects",
+            "description": "<code>SyntaxError</code> is serializable",
+            "support": {
+              "chrome": {
+                "version_added": "77"
+              },
+              "chrome_android": {
+                "version_added": "77"
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1556604'>bug 1556604</a>."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1556604'>bug 1556604</a>."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "64"
+              },
+              "opera_android": {
+                "version_added": "55"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "12.0"
+              },
+              "webview_android": {
+                "version_added": "77"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/javascript/builtins/TypeError.json
+++ b/javascript/builtins/TypeError.json
@@ -110,6 +110,63 @@
               "deprecated": false
             }
           }
+        },
+        "serializable_object": {
+          "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/structured-data.html#serializable-objects",
+            "description": "<code>TypeError</code> is serializable",
+            "support": {
+              "chrome": {
+                "version_added": "77"
+              },
+              "chrome_android": {
+                "version_added": "77"
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1556604'>bug 1556604</a>."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1556604'>bug 1556604</a>."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "64"
+              },
+              "opera_android": {
+                "version_added": "55"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "12.0"
+              },
+              "webview_android": {
+                "version_added": "77"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/javascript/builtins/URIError.json
+++ b/javascript/builtins/URIError.json
@@ -110,6 +110,63 @@
               "deprecated": false
             }
           }
+        },
+        "serializable_object": {
+          "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/structured-data.html#serializable-objects",
+            "description": "<code>URIError</code> is serializable",
+            "support": {
+              "chrome": {
+                "version_added": "77"
+              },
+              "chrome_android": {
+                "version_added": "77"
+              },
+              "deno": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1556604'>bug 1556604</a>."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1556604'>bug 1556604</a>."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "64"
+              },
+              "opera_android": {
+                "version_added": "55"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": "12.0"
+              },
+              "webview_android": {
+                "version_added": "77"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Chrome makes the following types serializable (see https://chromestatus.com/feature/5745988251680768 ): DOMException, Error, EvalError, RangeError, ReferenceError, SyntaxError, TypeError, and URIError

Note, I can't find evidence that this is supported by Nodejs or deno.

This follows on from #16148

And it is technically part of the whole story in https://github.com/mdn/content/issues/15638