### PR TITLE
Update Chromium versions for api.Element.createShadowRoot

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2230,6 +2230,7 @@
             "chrome": [
               {
                 "version_added": "35",
+                "version_removed": "88",
                 "notes": "In Chrome 45, the ability to have multiple shadow roots was deprecated."
               },
               {
@@ -2241,6 +2242,7 @@
             "chrome_android": [
               {
                 "version_added": "35",
+                "version_removed": "88",
                 "notes": "In Chrome 45, the ability to have multiple shadow roots was deprecated."
               },
               {
@@ -2250,7 +2252,8 @@
               }
             ],
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "version_removed": "88"
             },
             "firefox": {
               "version_added": false
@@ -2264,6 +2267,7 @@
             "opera": [
               {
                 "version_added": "22",
+                "version_removed": "74",
                 "notes": "In Opera 32, the ability to have multiple shadow roots was deprecated."
               },
               {
@@ -2275,6 +2279,7 @@
             "opera_android": [
               {
                 "version_added": "22",
+                "version_removed": "63",
                 "notes": "In Opera 32, the ability to have multiple shadow roots was deprecated."
               },
               {
@@ -2292,6 +2297,7 @@
             "samsunginternet_android": [
               {
                 "version_added": "3.0",
+                "version_removed": "15.0",
                 "notes": "In Samsung Internet 5.0, the ability to have multiple shadow roots was deprecated."
               },
               {
@@ -2303,6 +2309,7 @@
             "webview_android": [
               {
                 "version_added": "37",
+                "version_removed": "88",
                 "notes": "In version 45, the ability to have multiple shadow roots was deprecated."
               },
               {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `createShadowRoot` member of the `Element` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Element/createShadowRoot

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
