### PR TITLE
FF101 RTCRtpEncodingParameters.maxFramerate supported

### DIFF
--- a/api/RTCRtpEncodingParameters.json
+++ b/api/RTCRtpEncodingParameters.json
@@ -291,6 +291,7 @@
       "maxFramerate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpEncodingParameters/maxFramerate",
+          "spec_url": "https://w3c.github.io/webrtc-extensions/#dom-rtcrtpencodingparameters-maxframerate",
           "support": {
             "chrome": {
               "version_added": false
@@ -302,10 +303,10 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "101"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "101"
             },
             "ie": {
               "version_added": false
@@ -395,6 +396,7 @@
       "ptime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpEncodingParameters/ptime",
+          "spec_url": "https://w3c.github.io/webrtc-extensions/#dom-rtcrtpencodingparameters-ptime",
           "support": {
             "chrome": {
               "version_added": false

--- a/test/spec-urls.test.js
+++ b/test/spec-urls.test.js
@@ -54,6 +54,9 @@ describe('spec_url data', () => {
       // Remove if it is in the main ECMA spec
       'https://tc39.es/proposal-hashbang/out.html',
 
+      // Remove if https://github.com/w3c/browser-specs/pull/605 is merged
+      'https://w3c.github.io/webrtc-extensions/',
+
       // Remove if https://github.com/w3c/mathml/issues/216 is resolved
       'https://w3c.github.io/mathml/',
     ];


### PR DESCRIPTION
FF101 supports `RTCRtpEncodingParameters.maxFramerate` - added by https://bugzilla.mozilla.org/show_bug.cgi?id=1611957

This is blocked because the [WebRTC Extensions](https://w3c.github.io/webrtc-extensions/#dom-rtcrtpencodingparameters-maxframerate) spec is not in W3C. I've created a PR for that, but I really don't know what I'm doing, so help/update appreciated:  https://github.com/w3c/browser-specs/pull/605.

@queengooborg Are you planning on merging in the `RTCRtpEncodingParameters` dictionary (i.e. we don't do dictionaries any more "as a rule"? I ask because this is an update to it and I'm not clear whether this is one of the few dictionaries we decided to keep, or just hasn't been addressed yet. Either way, I'll make this update first, and any structural fixes can come as a post-process.

Other docs work for this can be tracked in https://github.com/mdn/content/issues/15470