### PR TITLE
Update Safari versions for api.File.File

### DIFF
--- a/api/File.json
+++ b/api/File.json
@@ -99,10 +99,10 @@
               "version_added": "25"
             },
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "10"
+              "version_added": "10.3"
             },
             "samsunginternet_android": {
               "version_added": "3.0"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `File` member of the `File` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/File/File

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
