### PR TITLE
Update Firefox Android versions for api.File.type

### DIFF
--- a/api/File.json
+++ b/api/File.json
@@ -297,7 +297,7 @@
               "version_added": "3.6"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "4"
             },
             "ie": {
               "version_added": "10"


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox Android for the `type` member of the `File` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1), followed by mirroring.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/File/type

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
