### PR TITLE
Update Opera versions for FileSystemWritableFileStream API

### DIFF
--- a/api/FileSystemWritableFileStream.json
+++ b/api/FileSystemWritableFileStream.json
@@ -24,7 +24,7 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "72"
           },
           "opera_android": {
             "version_added": false
@@ -72,7 +72,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "72"
             },
             "opera_android": {
               "version_added": false
@@ -121,7 +121,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "72"
             },
             "opera_android": {
               "version_added": false
@@ -170,7 +170,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "72"
             },
             "opera_android": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `FileSystemWritableFileStream` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1), followed by mirroring.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FileSystemWritableFileStream

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
