### PR TITLE
Update Firefox versions for Gamepad API

### DIFF
--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -308,10 +308,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "55"
+              "version_added": "56"
             },
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "56"
             },
             "ie": {
               "version_added": false
@@ -358,10 +358,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "55"
+              "version_added": "56"
             },
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "56"
             },
             "ie": {
               "version_added": false
@@ -555,10 +555,10 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "55"
+              "version_added": "56"
             },
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "56"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `Gamepad` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Gamepad

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
