### PR TITLE
Update WebView versions for GamepadHapticActuator API

### DIFF
--- a/api/GamepadHapticActuator.json
+++ b/api/GamepadHapticActuator.json
@@ -85,7 +85,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "68"
             }
           },
           "status": {
@@ -182,7 +182,7 @@
               "version_added": "10.0"
             },
             "webview_android": {
-              "version_added": false
+              "version_added": "68"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for WebView Android for the `GamepadHapticActuator` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1), followed by mirroring.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/GamepadHapticActuator

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
