### PR TITLE
Update Samsung Internet versions for HMDVRDevice API

### DIFF
--- a/api/HMDVRDevice.json
+++ b/api/HMDVRDevice.json
@@ -56,7 +56,7 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "8.0"
+            "version_added": false
           },
           "webview_android": {
             "version_added": false
@@ -124,7 +124,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "8.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -193,7 +193,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "8.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Samsung Internet for the `HMDVRDevice` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HMDVRDevice

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
