### PR TITLE
Update Safari versions for api.HTMLMediaElement.encrypted_event

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -1207,10 +1207,10 @@
               "version_added": "29"
             },
             "safari": {
-              "version_added": "12.1"
+              "version_added": "13.1"
             },
             "safari_ios": {
-              "version_added": "12.2"
+              "version_added": "13.4"
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -1800,7 +1800,8 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "15",
+              "version_removed": "15> ≤85"
             },
             "opera_android": {
               "version_added": false
@@ -1854,7 +1855,7 @@
               "version_added": "29"
             },
             "safari": {
-              "version_added": "12.1"
+              "version_added": "13.1"
             },
             "safari_ios": {
               "version_added": "12.2"
@@ -2104,7 +2105,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤4.4.3"
             }
           },
           "status": {
@@ -2154,7 +2155,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤4.4.3"
             }
           },
           "status": {
@@ -2203,7 +2204,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤4.4.3"
             }
           },
           "status": {
@@ -2302,7 +2303,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤4.4.3"
             }
           },
           "status": {
@@ -2351,7 +2352,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤4.4.3"
             }
           },
           "status": {
@@ -2498,7 +2499,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤4.4.3"
             }
           },
           "status": {
@@ -2546,7 +2547,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤4.4.3"
             }
           },
           "status": {
@@ -2860,7 +2861,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤4.4.3"
             }
           },
           "status": {
@@ -2960,7 +2961,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤4.4.3"
             }
           },
           "status": {
@@ -3058,7 +3059,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤4.4.3"
             }
           },
           "status": {
@@ -3196,7 +3197,7 @@
               "version_added": "29"
             },
             "safari": {
-              "version_added": "12.1"
+              "version_added": "13.1"
             },
             "safari_ios": {
               "version_added": "12.2"
@@ -3250,7 +3251,7 @@
               "version_added": "36"
             },
             "opera_android": {
-              "version_added": "36"
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -3283,7 +3284,7 @@
               "version_added": "49"
             },
             "chrome_android": {
-              "version_added": "49"
+              "version_added": false
             },
             "edge": {
               "version_added": "17"
@@ -3301,7 +3302,7 @@
               "version_added": "36"
             },
             "opera_android": {
-              "version_added": "36"
+              "version_added": false
             },
             "safari": {
               "version_added": false
@@ -3310,7 +3311,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -3362,7 +3363,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤4.4.3"
             }
           },
           "status": {
@@ -3592,7 +3593,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "4.4"
+              "version_added": "4.4.3> ≤100"
             }
           },
           "status": {
@@ -3730,7 +3731,7 @@
               ]
             },
             "safari": {
-              "version_added": "8"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "8"
@@ -3788,7 +3789,7 @@
               "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤4.4.3"
             }
           },
           "status": {
@@ -3929,7 +3930,7 @@
               "version_added": "42"
             },
             "safari": {
-              "version_added": "12.1"
+              "version_added": "13.1"
             },
             "safari_ios": {
               "version_added": "12.2"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `encrypted_event` member of the `HTMLMediaElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLMediaElement/encrypted_event

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
