### PR TITLE
Update Chromium versions for HTMLObjectElement API

### DIFF
--- a/api/HTMLObjectElement.json
+++ b/api/HTMLObjectElement.json
@@ -828,10 +828,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/reportValidity",
           "support": {
             "chrome": {
-              "version_added": "39"
+              "version_added": "40"
             },
             "chrome_android": {
-              "version_added": "39"
+              "version_added": "40"
             },
             "edge": {
               "version_added": "18"
@@ -846,10 +846,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "26"
+              "version_added": "27"
             },
             "opera_android": {
-              "version_added": "26"
+              "version_added": "27"
             },
             "safari": {
               "version_added": "10.1"
@@ -861,7 +861,7 @@
               "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "39"
+              "version_added": "40"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `HTMLObjectElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLObjectElement

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
