### PR TITLE
Update Samsung Internet versions for HTMLShadowElement API

### DIFF
--- a/api/HTMLShadowElement.json
+++ b/api/HTMLShadowElement.json
@@ -42,7 +42,8 @@
             "version_added": false
           },
           "samsunginternet_android": {
-            "version_added": "3.0"
+            "version_added": "3.0",
+            "version_removed": "15.0"
           },
           "webview_android": {
             "version_added": "37",
@@ -95,7 +96,8 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "3.0"
+              "version_added": "3.0",
+              "version_removed": "15.0"
             },
             "webview_android": {
               "version_added": "37",


### PR DESCRIPTION
This PR updates and corrects the real values for Samsung Internet for the `HTMLShadowElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1), followed by mirroring.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLShadowElement

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
