### PR TITLE
Update Chromium versions for IDB APIs

### DIFF
--- a/api/IDBCursor.json
+++ b/api/IDBCursor.json
@@ -104,7 +104,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbcursor-advance①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -154,7 +154,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbcursor-continue①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -253,7 +253,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbcursor-delete①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -600,7 +600,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbcursor-update①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"

--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -90,7 +90,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbindex-count①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -140,7 +140,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbindex-get①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -294,7 +294,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbindex-getkey①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -688,7 +688,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbindex-opencursor②",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -738,7 +738,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbindex-openkeycursor①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"

--- a/api/IDBKeyRange.json
+++ b/api/IDBKeyRange.json
@@ -104,7 +104,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbkeyrange-bound①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -253,7 +253,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbkeyrange-lowerbound①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -353,7 +353,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbkeyrange-only①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -453,7 +453,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbkeyrange-upperbound①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"

--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -90,7 +90,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbobjectstore-add①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -190,7 +190,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbobjectstore-clear③",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -240,7 +240,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbobjectstore-count①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -290,7 +290,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbobjectstore-createindex①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -340,7 +340,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbobjectstore-delete①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -390,7 +390,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbobjectstore-deleteindex①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -440,7 +440,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbobjectstore-get①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -637,7 +637,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#dom-idbobjectstore-index",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -885,7 +885,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbobjectstore-opencursor②",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -991,7 +991,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbobjectstore-put①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"

--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -90,7 +90,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbtransaction-abort②",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -600,7 +600,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbtransaction-objectstore①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for various IDB APIs, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/IDBCursor

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
