### PR TITLE
Update Chromium versions for api.IDBDatabase.close_event

### DIFF
--- a/api/IDBDatabase.json
+++ b/api/IDBDatabase.json
@@ -144,10 +144,10 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "31"
+              "version_added": "30"
             },
             "chrome_android": {
-              "version_added": "31"
+              "version_added": "30"
             },
             "edge": {
               "version_added": "79"
@@ -162,7 +162,7 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "18"
+              "version_added": "17"
             },
             "opera_android": {
               "version_added": "18"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `close_event` member of the `IDBDatabase` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/IDBDatabase/close_event

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
