### PR TITLE
Update Chromium versions for IDBIndex API

### DIFF
--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -90,7 +90,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbindex-count①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -140,7 +140,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbindex-get①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -294,7 +294,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbindex-getkey①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -688,7 +688,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbindex-opencursor②",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"
@@ -738,7 +738,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbindex-openkeycursor①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "25"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `IDBIndex` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/IDBIndex

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
