### PR TITLE
Don't add reactions to potential duplicate comment

### DIFF
--- a/.github/workflows/potential-duplicate-issues.yml
+++ b/.github/workflows/potential-duplicate-issues.yml
@@ -23,7 +23,7 @@ jobs:
           threshold: 0.6
           # Reactions to be add to comment when potential duplicates are detected.
           # Available reactions: "-1", "+1", "confused", "laugh", "heart", "hooray", "rocket", "eyes"
-          reactions: 'eyes, confused'
+          reactions: ''
           # Comment to post when potential duplicates are detected.
           comment: >
             Potential duplicates: {{#issues}}


### PR DESCRIPTION
This PR updates the potential duplicates catcher to not add any reactions to its comment, just to keep it cleaner.