### PR TITLE
Update comment on potential duplicates

### DIFF
--- a/.github/workflows/potential-duplicate-issues.yml
+++ b/.github/workflows/potential-duplicate-issues.yml
@@ -27,5 +27,5 @@ jobs:
           # Comment to post when potential duplicates are detected.
           comment: >
             Potential duplicates: {{#issues}}
-              - [#{{ number }}] {{ title }} ({{ accuracy }}%)
+              - #{{ number }} - ({{ accuracy }}%)
             {{/issues}}


### PR DESCRIPTION
This PR simplifies the comment applied when potential duplicates are found.  The title is duplicated twice, since GitHub now adds the title for us.