### PR TITLE
Update Chromium versions for api.IDBRequest.error

### DIFF
--- a/api/IDBRequest.json
+++ b/api/IDBRequest.json
@@ -90,7 +90,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbrequest-error①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "21"
             },
             "chrome_android": {
               "version_added": "25"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `error` member of the `IDBRequest` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/IDBRequest/error

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
