### PR TITLE
Update Edge versions for IdleDetector API

### DIFF
--- a/api/IdleDetector.json
+++ b/api/IdleDetector.json
@@ -12,7 +12,8 @@
             "version_added": "94"
           },
           "edge": {
-            "version_added": "94"
+            "version_added": "94",
+            "version_removed": "96"
           },
           "firefox": {
             "version_added": false
@@ -61,7 +62,8 @@
               "version_added": "94"
             },
             "edge": {
-              "version_added": "94"
+              "version_added": "94",
+              "version_removed": "96"
             },
             "firefox": {
               "version_added": false
@@ -111,7 +113,8 @@
               "version_added": "94"
             },
             "edge": {
-              "version_added": "94"
+              "version_added": "94",
+              "version_removed": "96"
             },
             "firefox": {
               "version_added": false
@@ -160,7 +163,8 @@
               "version_added": "94"
             },
             "edge": {
-              "version_added": "94"
+              "version_added": "94",
+              "version_removed": "96"
             },
             "firefox": {
               "version_added": false
@@ -209,7 +213,8 @@
               "version_added": "94"
             },
             "edge": {
-              "version_added": "94"
+              "version_added": "94",
+              "version_removed": "96"
             },
             "firefox": {
               "version_added": false
@@ -258,7 +263,8 @@
               "version_added": "94"
             },
             "edge": {
-              "version_added": "94"
+              "version_added": "94",
+              "version_removed": "96"
             },
             "firefox": {
               "version_added": false
@@ -307,7 +313,8 @@
               "version_added": "94"
             },
             "edge": {
-              "version_added": "94"
+              "version_added": "94",
+              "version_removed": "96"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `IdleDetector` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.1).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/IdleDetector

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
