### PR TITLE
Update removal versions of webkitpointerlockchange/error events

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -7814,7 +7814,7 @@
               },
               {
                 "version_added": "22",
-                "version_removed": "45",
+                "version_removed": "38",
                 "prefix": "webkit"
               }
             ],
@@ -7824,7 +7824,7 @@
               },
               {
                 "version_added": "25",
-                "version_removed": "45",
+                "version_removed": "38",
                 "prefix": "webkit"
               }
             ],
@@ -7860,7 +7860,7 @@
               },
               {
                 "version_added": "15",
-                "version_removed": "32",
+                "version_removed": "25",
                 "prefix": "webkit"
               }
             ],
@@ -7870,7 +7870,7 @@
               },
               {
                 "version_added": "14",
-                "version_removed": "32",
+                "version_removed": "25",
                 "prefix": "webkit"
               }
             ],
@@ -7885,9 +7885,9 @@
                 "version_added": "3.0"
               },
               {
-                "prefix": "webkit",
                 "version_added": "1.5",
-                "version_removed": "5.0"
+                "version_removed": "3.0",
+                "prefix": "webkit"
               }
             ],
             "webview_android": [
@@ -7896,7 +7896,7 @@
               },
               {
                 "version_added": "≤37",
-                "version_removed": "45",
+                "version_removed": "38",
                 "prefix": "webkit"
               }
             ]
@@ -7923,7 +7923,7 @@
               },
               {
                 "version_added": "22",
-                "version_removed": "45",
+                "version_removed": "38",
                 "prefix": "webkit"
               }
             ],
@@ -7933,7 +7933,7 @@
               },
               {
                 "version_added": "25",
-                "version_removed": "45",
+                "version_removed": "38",
                 "prefix": "webkit"
               }
             ],
@@ -7969,7 +7969,7 @@
               },
               {
                 "version_added": "15",
-                "version_removed": "32",
+                "version_removed": "25",
                 "prefix": "webkit"
               }
             ],
@@ -7979,7 +7979,7 @@
               },
               {
                 "version_added": "14",
-                "version_removed": "32",
+                "version_removed": "25",
                 "prefix": "webkit"
               }
             ],
@@ -7994,9 +7994,9 @@
                 "version_added": "3.0"
               },
               {
-                "prefix": "webkit",
                 "version_added": "1.5",
-                "version_removed": "5.0"
+                "version_removed": "3.0",
+                "prefix": "webkit"
               }
             ],
             "webview_android": [
@@ -8005,7 +8005,7 @@
               },
               {
                 "version_added": "≤37",
-                "version_removed": "45",
+                "version_removed": "38",
                 "prefix": "webkit"
               }
             ]


### PR DESCRIPTION
Confirmed with these test:
https://mdn-bcd-collector.appspot.com/tests/api/Document/webkitpointerlockchange_event
https://mdn-bcd-collector.appspot.com/tests/api/Document/webkitpointerlockerror_event

Part of https://github.com/mdn/browser-compat-data/issues/7844.
