### PR TITLE
Remove irrelevant feature Text.replaceWholeText

### DIFF
--- a/api/Text.json
+++ b/api/Text.json
@@ -147,65 +147,6 @@
           }
         }
       },
-      "replaceWholeText": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Text/replaceWholeText",
-          "support": {
-            "chrome": {
-              "version_added": "1",
-              "version_removed": "45"
-            },
-            "chrome_android": {
-              "version_added": "18",
-              "version_removed": "45"
-            },
-            "edge": {
-              "version_added": "12",
-              "version_removed": "79"
-            },
-            "firefox": {
-              "version_added": "1",
-              "version_removed": "10"
-            },
-            "firefox_android": {
-              "version_added": "4",
-              "version_removed": "10"
-            },
-            "ie": {
-              "version_added": "9"
-            },
-            "opera": {
-              "version_added": "15",
-              "version_removed": "32"
-            },
-            "opera_android": {
-              "version_added": "14",
-              "version_removed": "32"
-            },
-            "safari": {
-              "version_added": "4",
-              "version_removed": "10.1"
-            },
-            "safari_ios": {
-              "version_added": "3",
-              "version_removed": "10.3"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.0",
-              "version_removed": "5.0"
-            },
-            "webview_android": {
-              "version_added": "≤37",
-              "version_removed": "45"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "splitText": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Text/splitText",


### PR DESCRIPTION
It's been removed in all browsers (except IE) for more than 2 years.

