### PR TITLE
Remove incorrect notes about FontFace's load()/loaded promises

### DIFF
--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -397,28 +397,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/load",
           "spec_url": "https://drafts.csswg.org/css-font-loading/#font-face-load",
           "support": {
-            "chrome": [
-              {
-                "version_added": "45"
-              },
-              {
-                "version_added": "35",
-                "version_removed": "45",
-                "partial_implementation": true,
-                "notes": "Before Chrome 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification."
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "45"
-              },
-              {
-                "version_added": "35",
-                "version_removed": "45",
-                "partial_implementation": true,
-                "notes": "Before Chrome 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification."
-              }
-            ],
+            "chrome": {
+              "version_added": "35"
+            },
+            "chrome_android": {
+              "version_added": "35"
+            },
             "edge": {
               "version_added": "79"
             },
@@ -431,56 +415,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "32"
-              },
-              {
-                "version_added": "22",
-                "version_removed": "32",
-                "partial_implementation": true,
-                "notes": "Before Opera 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification."
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "32"
-              },
-              {
-                "version_added": "22",
-                "version_removed": "32",
-                "partial_implementation": true,
-                "notes": "Before Opera 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification."
-              }
-            ],
+            "opera": {
+              "version_added": "22"
+            },
+            "opera_android": {
+              "version_added": "22"
+            },
             "safari": {
               "version_added": "10"
             },
             "safari_ios": {
               "version_added": "10"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "5.0"
-              },
-              {
-                "partial_implementation": true,
-                "version_added": "4.0",
-                "version_removed": "5.0",
-                "notes": "Before Samsung Internet 5.0, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification."
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "45"
-              },
-              {
-                "version_added": "37",
-                "version_removed": "45",
-                "partial_implementation": true,
-                "notes": "Before WebView 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification."
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "37"
+            }
           },
           "status": {
             "experimental": false,
@@ -494,28 +446,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFace/loaded",
           "spec_url": "https://drafts.csswg.org/css-font-loading/#dom-fontface-loaded",
           "support": {
-            "chrome": [
-              {
-                "version_added": "45"
-              },
-              {
-                "version_added": "35",
-                "version_removed": "45",
-                "partial_implementation": true,
-                "notes": "Before Chrome 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification."
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "45"
-              },
-              {
-                "version_added": "35",
-                "version_removed": "45",
-                "partial_implementation": true,
-                "notes": "Before Chrome 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification."
-              }
-            ],
+            "chrome": {
+              "version_added": "35"
+            },
+            "chrome_android": {
+              "version_added": "35"
+            },
             "edge": {
               "version_added": "79"
             },
@@ -528,56 +464,24 @@
             "ie": {
               "version_added": false
             },
-            "opera": [
-              {
-                "version_added": "32"
-              },
-              {
-                "version_added": "22",
-                "version_removed": "32",
-                "partial_implementation": true,
-                "notes": "Before Opera 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification."
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "32"
-              },
-              {
-                "version_added": "22",
-                "version_removed": "32",
-                "partial_implementation": true,
-                "notes": "Before Opera 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification."
-              }
-            ],
+            "opera": {
+              "version_added": "22"
+            },
+            "opera_android": {
+              "version_added": "22"
+            },
             "safari": {
               "version_added": "10"
             },
             "safari_ios": {
               "version_added": "10"
             },
-            "samsunginternet_android": [
-              {
-                "version_added": "5.0"
-              },
-              {
-                "partial_implementation": true,
-                "version_added": "4.0",
-                "version_removed": "5.0",
-                "notes": "Before Samsung Internet 5.0, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification."
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "45"
-              },
-              {
-                "version_added": "37",
-                "version_removed": "45",
-                "partial_implementation": true,
-                "notes": "Before WebView 45, the returned promise resolved with void instead of a <code>FontFace</code> object as required by the specification."
-              }
-            ]
+            "samsunginternet_android": {
+              "version_added": "4.0"
+            },
+            "webview_android": {
+              "version_added": "37"
+            }
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
The source of this is https://github.com/mdn/browser-compat-data/pull/3560.

That linked to the IDL cleanup:
https://chromium.googlesource.com/chromium/src/+/4e5bd2dafd23ae978222f7e4a73225a89a567f55

That made no actual, observable changes, as noted:

> There are no changes to the generated code, other than order.

Part of https://github.com/mdn/browser-compat-data/issues/7844.

