### PR TITLE
Remove mdn_url from Node.hasAttributes

### DIFF
--- a/api/Node.json
+++ b/api/Node.json
@@ -453,7 +453,6 @@
       },
       "hasAttributes": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/hasAttributes",
           "support": {
             "chrome": {
               "version_added": "1",


### PR DESCRIPTION
As this is only implemented in IE, and removed from other engines, this will never be documented on mdn/content. Let's remove the entry.