### PR TITLE
Update Chromium versions for MediaStream.active and events

### DIFF
--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -188,10 +188,10 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediastream-active",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "42"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "42"
             },
             "edge": {
               "version_added": "12"
@@ -206,10 +206,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "29"
             },
             "safari": {
               "version_added": "11"
@@ -218,10 +218,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "42"
             }
           },
           "status": {
@@ -237,10 +237,10 @@
           "description": "<code>active</code> event",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "42"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "42"
             },
             "edge": {
               "version_added": "12"
@@ -255,10 +255,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "29"
             },
             "safari": {
               "version_added": false
@@ -267,10 +267,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "42"
             }
           },
           "status": {
@@ -682,10 +682,10 @@
           "description": "<code>inactive</code> event",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "42"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "42"
             },
             "edge": {
               "version_added": "12"
@@ -700,10 +700,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "29"
             },
             "safari": {
               "version_added": false
@@ -712,10 +712,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "42"
             }
           },
           "status": {


### PR DESCRIPTION
This is based on testing Chrome 41 and 42 with a staging version of
mdn-bcd-collector with these updated tests:
https://github.com/foolip/mdn-bcd-collector/pull/1991

Part of https://github.com/mdn/browser-compat-data/issues/7844.

