### PR TITLE
Simplify release bundle by removing index.js

### DIFF
--- a/scripts/release-build.js
+++ b/scripts/release-build.js
@@ -24,12 +24,6 @@ async function writeData() {
   await fs.writeFile(dest, data);
 }
 
-async function writeIndex() {
-  const dest = path.resolve(directory, 'index.js');
-  const content = `module.exports = require("./data.json");\n`;
-  await fs.writeFile(dest, content);
-}
-
 // Returns an array of promises for copying of all files that don't need transformation
 async function copyFiles() {
   for (const file of verbatimFiles) {
@@ -41,7 +35,7 @@ async function copyFiles() {
 
 function createManifest() {
   const full = require('../package.json');
-  const minimal = { main: 'index.js' };
+  const minimal = { main: 'data.json' };
 
   const minimalKeys = [
     'name',
@@ -89,7 +83,6 @@ async function main() {
 
   await writeManifest();
   await writeData();
-  await writeIndex();
   await copyFiles();
 
   console.log('Data bundle is ready');


### PR DESCRIPTION
This PR simplifies the released bundles of BCD by ommitting the redundant `index.js`.  In doing so, this will allow for ESM users to import BCD into their projects without having to specify the `data.json` file in their import.  Tested to make sure this approach works in NodeJS v18, v16, v14, v12, and even v4, all successfully importing BCD.
