### PR TITLE
Add spec URLs for AuthenticatorAttestationResponse API

### DIFF
--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -117,6 +117,7 @@
       },
       "getAuthenticatorData": {
         "__compat": {
+          "spec_url": "https://w3c.github.io/webauthn/#dom-authenticatorattestationresponse-getauthenticatordata",
           "support": {
             "chrome": {
               "version_added": "85"
@@ -164,6 +165,7 @@
       },
       "getPublicKey": {
         "__compat": {
+          "spec_url": "https://w3c.github.io/webauthn/#dom-authenticatorattestationresponse-getpublickey",
           "support": {
             "chrome": {
               "version_added": "85"
@@ -211,6 +213,7 @@
       },
       "getPublicKeyAlgorithm": {
         "__compat": {
+          "spec_url": "https://w3c.github.io/webauthn/#dom-authenticatorattestationresponse-getpublickeyalgorithm",
           "support": {
             "chrome": {
               "version_added": "85"


### PR DESCRIPTION
This PR is a subset of #16051 that adds spec URLs for the AuthenticatorAttestationResponse API.
