### PR TITLE
Update Chromium versions for Client.postMessage

### DIFF
--- a/api/Client.json
+++ b/api/Client.json
@@ -155,10 +155,10 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#dom-client-postmessage-message-options",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "40"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "40"
             },
             "edge": {
               "version_added": "17"
@@ -174,10 +174,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "27"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "27"
             },
             "safari": {
               "version_added": "11.1"
@@ -186,10 +186,10 @@
               "version_added": "11.3"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "40"
             }
           },
           "status": {


### PR DESCRIPTION
Original source: https://github.com/mdn/browser-compat-data/pull/1059

No source was given, but it might have been this:
https://storage.googleapis.com/chromium-find-releases-static/f77.html#f777755953e905594276a99cf64fc3848406d5f6

However, that commit was in time for Chrome 36 or 37, well before
Service Workers were first enabled. So match the parent feature.

Part of https://github.com/mdn/browser-compat-data/issues/7844.

