### PR TITLE
Mark HTMLElement.contextMenu as never shipped in Chromium

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -874,12 +874,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/contextMenu",
           "support": {
             "chrome": {
-              "version_added": "45",
-              "version_removed": "61"
+              "version_added": false
             },
             "chrome_android": {
-              "version_added": "45",
-              "version_removed": "61"
+              "version_added": false
             },
             "edge": {
               "version_added": false
@@ -920,12 +918,10 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "5.0",
-              "version_removed": "8.0"
+              "version_added": false
             },
             "webview_android": {
-              "version_added": "45",
-              "version_removed": "61"
+              "version_added": false
             }
           },
           "status": {


### PR DESCRIPTION
Original source: https://github.com/mdn/browser-compat-data/pull/3502

However, this was behind a flag [RuntimeEnabled=ContextMenu] and never
shipped. Related bits like html.elements.menuitem and
html.global_attributes.contextmenu are already set to false.

Part of https://github.com/mdn/browser-compat-data/issues/7844.

