### PR TITLE
Update Chromium versions for MediaStream/MediaStreamTrack's clone()

### DIFF
--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -385,10 +385,10 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediastream-clone",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "35"
             },
             "edge": {
               "version_added": "12"
@@ -403,10 +403,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "22"
             },
             "safari": {
               "version_added": "11"
@@ -415,10 +415,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "37"
             }
           },
           "status": {

--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -103,10 +103,10 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-clone",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "35"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "35"
             },
             "edge": {
               "version_added": "12"
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "22"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "22"
             },
             "safari": {
               "version_added": "11"
@@ -133,10 +133,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "37"
             }
           },
           "status": {


### PR DESCRIPTION
Original source: https://github.com/mdn/browser-compat-data/pull/3958

However, https://chromium.googlesource.com/chromium/src/+/776e9a66223e95141b0b8bc6c6f9a847cd5fd8c4
was long before Chrome 45. Support was tested using
`webkitMediaStream.prototype.clone` and `MediaStreamTrack.prototype.clone`
in Chrome 34 and 35. (One interface was prefixed at the time.)

Part of https://github.com/mdn/browser-compat-data/issues/7844.

