### PR TITLE
Update Chromium versions for MediaStream.getTracks

### DIFF
--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -534,10 +534,10 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediastream-gettracks",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "38"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "38"
             },
             "edge": {
               "version_added": "12"
@@ -552,10 +552,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "25"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "25"
             },
             "safari": {
               "version_added": "11"
@@ -564,10 +564,10 @@
               "version_added": "11"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "3.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "38"
             }
           },
           "status": {


### PR DESCRIPTION
Original source: https://github.com/mdn/browser-compat-data/pull/3958

However, https://chromium.googlesource.com/chromium/src/+/e99d73de1761aec44e23381e565ee48430d9a699
was long before Chrome 45. Support was tested using
`webkitMediaStream.prototype.getTracks` in Chrome 37 and 38.

Part of https://github.com/mdn/browser-compat-data/issues/7844.

