### PR TITLE
Update Chromium versions for MediaQueryList

### DIFF
--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -55,10 +55,10 @@
           "description": "<code>EventListener</code> objects as parameters",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "39"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "39"
             },
             "edge": {
               "version_added": "≤79"
@@ -73,10 +73,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": false
+              "version_added": "26"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "26"
             },
             "safari": {
               "version_added": "14"
@@ -85,10 +85,10 @@
               "version_added": "14"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "39"
             }
           },
           "status": {
@@ -103,10 +103,10 @@
           "description": "<code>MediaQueryList</code> inherits <code>EventTarget</code>",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "39"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "39"
             },
             "edge": {
               "version_added": "16"
@@ -121,10 +121,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "26"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "26"
             },
             "safari": {
               "version_added": "14"
@@ -133,10 +133,10 @@
               "version_added": "14"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "39"
             }
           },
           "status": {
@@ -205,10 +205,10 @@
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-mediaquerylist-onchange",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "39"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "39"
             },
             "edge": {
               "version_added": "79"
@@ -223,10 +223,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "26"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "26"
             },
             "safari": {
               "version_added": "14"
@@ -235,10 +235,10 @@
               "version_added": "14"
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "4.0"
             },
             "webview_android": {
-              "version_added": "45"
+              "version_added": "39"
             }
           },
           "status": {


### PR DESCRIPTION
Original source: https://github.com/mdn/browser-compat-data/pull/3255

https://chromium.googlesource.com/chromium/src/+/5fc555b830a9b5b1536e242d8754d7e507bcc75a
was used as the source, which is the right commit but it wasn't first in
Chrome 45 but earlier.

At the time, the MediaQueryList interface had [NoInterfaceObject], but
because MediaQueryListEvent was implemented/exposed at the same time, we
can assume that the versions should match. Chrome 39 was confirmed with
this test:
https://mdn-bcd-collector.appspot.com/tests/api/MediaQueryListEvent

The data for MediaQueryListEvent already matches.

Part of https://github.com/mdn/browser-compat-data/issues/7844.

