### PR TITLE
Update worker support for Notifications in Chromium

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -1334,10 +1334,10 @@
           "description": "Available in workers",
           "support": {
             "chrome": {
-              "version_added": "45"
+              "version_added": "42"
             },
             "chrome_android": {
-              "version_added": "45"
+              "version_added": "42"
             },
             "edge": {
               "version_added": "15"
@@ -1352,10 +1352,10 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "32"
+              "version_added": "29"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "29"
             },
             "safari": {
               "version_added": false
@@ -1364,7 +1364,7 @@
               "version_added": false
             },
             "samsunginternet_android": {
-              "version_added": "5.0"
+              "version_added": "4.0"
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
Original source: https://github.com/mdn/browser-compat-data/pull/1768

No evidence for the specific versions was given.

The mere exposure of Notification in dedicated workers can be confirmed
to be Chrome 41 with this test:
https://mdn-bcd-collector.appspot.com/tests/api/Notification?exposure=Worker

However, Notifications can't be created from dedicated workers in
Chromium, it makes more sense to match support in service workers, which
is one version later. That then matches notes and other data like
api.NotificationEvent and api.ServiceWorkerRegistration.showNotification.

Part of https://github.com/mdn/browser-compat-data/issues/7844.