### PR TITLE
Remove experimental flags for CountQueuingStrategy

### DIFF
--- a/api/CountQueuingStrategy.json
+++ b/api/CountQueuingStrategy.json
@@ -50,7 +50,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -102,7 +102,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -208,7 +208,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
These features are supported by 3 engines (or 2 for one): removing the experimental flag.