### PR TITLE
Fix Chrome/Edge versions for showNotification's options.actions parameter

### DIFF
--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -653,13 +653,13 @@
             "description": "<code>options.actions</code> parameter",
             "support": {
               "chrome": {
-                "version_added": "45"
+                "version_added": "48"
               },
               "chrome_android": {
-                "version_added": "45"
+                "version_added": "48"
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": "18"
               },
               "firefox": {
                 "version_added": false
@@ -671,10 +671,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "32"
+                "version_added": "35"
               },
               "opera_android": {
-                "version_added": "32"
+                "version_added": "35"
               },
               "safari": {
                 "version_added": false


### PR DESCRIPTION
Original source: https://github.com/mdn/browser-compat-data/pull/1255

However, both the orignally suggested 47 and the updated 45 are wrong,
and no evidence is given for either version.

This was enabled together with Notifications.maxActions in 48:
https://storage.googleapis.com/chromium-find-releases-static/2a3.html#2a381fb7a46742b05d199c6614624b1bf1432ebb

We can also confirm 48 is correct with this test:
https://mdn-bcd-collector.appspot.com/tests/api/Notification/maxActions

