### PR TITLE
Add missing mdn_url for AudioEncoder.flush()

### DIFF
--- a/api/AudioEncoder.json
+++ b/api/AudioEncoder.json
@@ -296,6 +296,7 @@
       },
       "flush": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/AudioEncoder/flush",
           "spec_url": "https://w3c.github.io/webcodecs/#dom-audioencoder-flush",
           "support": {
             "chrome": {

--- a/api/AudioEncoder.json
+++ b/api/AudioEncoder.json
@@ -296,7 +296,7 @@
       },
       "flush": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/AudioEncoder/flush",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioEncoder/flush",
           "spec_url": "https://w3c.github.io/webcodecs/#dom-audioencoder-flush",
           "support": {
             "chrome": {


### PR DESCRIPTION
The page does exists [`AudioEncoder.flush()`](https://developer.mozilla.org/en-US/docs/Web/API/AudioEncoder/flush)