### PR TITLE
Fix DuplicateCompatError constructor argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const path = require('path');
 
 class DuplicateCompatError extends Error {
-  constructor(message) {
+  constructor(feature) {
     super(`${feature} already exists! Remove duplicate entries.`);
     this.name = 'DuplicateCompatError';
   }


### PR DESCRIPTION
If actually used, an error is thrown because `feature` is undefined,
which is very unhelpful.

