### PR TITLE
Use fast-json-stable-stringify for built package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "browser-specs": "~3.10.0",
         "chalk": "~4.1.0",
         "compare-versions": "~4.1.1",
+        "fast-json-stable-stringify": "~2.1.0",
         "html-validate": "~7.0.0",
         "mdn-confluence": "~2.2.2",
         "mocha": "~10.0.0",
@@ -756,6 +757,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
     "node_modules/fill-range": {
@@ -2446,6 +2453,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
     "fill-range": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "browser-specs": "~3.10.0",
     "chalk": "~4.1.0",
     "compare-versions": "~4.1.1",
+    "fast-json-stable-stringify": "~2.1.0",
     "html-validate": "~7.0.0",
     "mdn-confluence": "~2.2.2",
     "mocha": "~10.0.0",

--- a/scripts/release-build.js
+++ b/scripts/release-build.js
@@ -6,6 +6,8 @@
 const fs = require('fs').promises;
 const path = require('path');
 
+const stringify = require('fast-json-stable-stringify');
+
 const directory = './build/';
 
 const verbatimFiles = ['LICENSE', 'README.md', 'index.d.ts', 'types.d.ts'];
@@ -13,7 +15,7 @@ const verbatimFiles = ['LICENSE', 'README.md', 'index.d.ts', 'types.d.ts'];
 // Returns a string representing data ready for writing to JSON file
 function createDataBundle() {
   const bcd = require('../index.js');
-  const string = JSON.stringify(bcd);
+  const string = stringify(bcd);
   return string;
 }
 


### PR DESCRIPTION
The intention of this is to make the output independent of which order
we traverse files, how we apply mixins, etc. With this change, fewer
internal changes will result in changes to the output, and a lack of
changes to the built output can be used to test if internal refactoring
is really a no-op.

