### PR TITLE
Remove Opera Android flag for html.global_attributes.inert

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1177,14 +1177,7 @@
               ]
             },
             "opera_android": {
-              "version_added": "44",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": false
             },
             "safari": {
               "version_added": "15.5"


### PR DESCRIPTION
This PR removes the final Opera Android flag that wasn't removed from our data before disallowing flags.
