### PR TITLE
RTCRtpEncodingParameters.maxFramerate - off spec zero value

### DIFF
--- a/api/RTCRtpEncodingParameters.json
+++ b/api/RTCRtpEncodingParameters.json
@@ -303,10 +303,14 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "101"
+              "version_added": "101",
+              "partial_implementation": true,
+              "notes": "Zero is treated as 'no fps limit' (see <a href='https://bugzil.la/1611957'>bug 1611957</a>)."
             },
             "firefox_android": {
-              "version_added": "101"
+              "version_added": "101",
+              "partial_implementation": true,
+              "notes": "Zero is treated as 'no fps limit' (see <a href='https://bugzil.la/1611957'>bug 1611957</a>)."
             },
             "ie": {
               "version_added": false

--- a/test/spec-urls.test.js
+++ b/test/spec-urls.test.js
@@ -54,7 +54,7 @@ describe('spec_url data', () => {
       // Remove if it is in the main ECMA spec
       'https://tc39.es/proposal-hashbang/out.html',
 
-      // Remove if https://github.com/w3c/browser-specs/pull/605 is merged
+      // Remove if https://github.com/w3c/webrtc-extensions/issues/108 is closed
       'https://w3c.github.io/webrtc-extensions/',
 
       // Remove if https://github.com/w3c/mathml/issues/216 is resolved


### PR DESCRIPTION
FF101 added support for [RTCRtpEncodingParameters.maxFramerate](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpEncodingParameters/maxFramerate), which we updated in #16200

This is supposed to be valid for a 0 value, but FF instead sets this as "no limit on frame rate". This is because the upstream libwebrtc library used will crash if a 0 value is passed (see https://bugzilla.mozilla.org/show_bug.cgi?id=1611957#c10)

To fix this I have marked the API as "partial" and added a note.

Related docs work can be tracked in https://github.com/mdn/content/issues/15470