### PR TITLE
Use `npm ci` in workflows vs. `npm install`

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 16.x
-    - run: npm install
+    - run: npm ci
     - run: npm test
       env:
         FORCE_COLOR: 3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         node-version: 16.x
         registry-url: "https://registry.npmjs.org/"
-    - run: npm install
+    - run: npm ci
     - run: npm test
     - run: npm run release-build
     - run: npm publish build/ --access public


### PR DESCRIPTION
This PR updates our workflows to run `npm ci` instead of `npm install`, which is what's recommended for CI services (since it will ensure package-lock.json is up to date).
