### PR TITLE
Fix Chromium versions for @media (display-mode: ...)

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -560,10 +560,10 @@
             "spec_url": "https://drafts.csswg.org/mediaqueries-5/#display-mode",
             "support": {
               "chrome": {
-                "version_added": "45"
+                "version_added": "42"
               },
               "chrome_android": {
-                "version_added": "45"
+                "version_added": "42"
               },
               "edge": {
                 "version_added": "79"
@@ -580,10 +580,10 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "32"
+                "version_added": "29"
               },
               "opera_android": {
-                "version_added": "32"
+                "version_added": "29"
               },
               "safari": {
                 "version_added": "13"
@@ -592,10 +592,10 @@
                 "version_added": "12.2"
               },
               "samsunginternet_android": {
-                "version_added": "5.0"
+                "version_added": "4.0"
               },
               "webview_android": {
-                "version_added": "45"
+                "version_added": "42"
               }
             },
             "status": {


### PR DESCRIPTION
Original source: https://github.com/mdn/browser-compat-data/pull/4369

The source given, which is unfortunately wrong:
https://storage.googleapis.com/chromium-find-releases-static/02b.html#02b80e73d179e8b87d007b197766fa5fca1a80ee

Chrome 42 was confirmed by testing and commit date:
https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=10306
https://chromium.googlesource.com/chromium/src/+/02b80e73d179e8b87d007b197766fa5fca1a80ee
https://www.chromium.org/developers/calendar/

Part of https://github.com/mdn/browser-compat-data/issues/7844.
