### PR TITLE
Update browser versions for <feComposite operator="lighter">

### DIFF
--- a/svg/elements/feComposite.json
+++ b/svg/elements/feComposite.json
@@ -387,18 +387,18 @@
               "deprecated": false
             }
           },
-          "lighter": {
+          "lighter_value": {
             "__compat": {
               "description": "<code>lighter</code> value",
               "support": {
                 "chrome": {
-                  "version_added": "45"
+                  "version_added": "41"
                 },
                 "chrome_android": {
-                  "version_added": "45"
+                  "version_added": "41"
                 },
                 "edge": {
-                  "version_added": "≤18"
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": "86"
@@ -410,22 +410,22 @@
                   "version_added": false
                 },
                 "opera": {
-                  "version_added": "32"
+                  "version_added": "28"
                 },
                 "opera_android": {
-                  "version_added": "32"
+                  "version_added": "28"
                 },
                 "safari": {
-                  "version_added": "6"
+                  "version_added": "10"
                 },
                 "safari_ios": {
-                  "version_added": "6"
+                  "version_added": "10"
                 },
                 "samsunginternet_android": {
-                  "version_added": "5.0"
+                  "version_added": "4.0"
                 },
                 "webview_android": {
-                  "version_added": "45"
+                  "version_added": "41"
                 }
               },
               "status": {


### PR DESCRIPTION
Original source: https://github.com/mdn/browser-compat-data/pull/9074

This demo was used to test:
https://yari-demos.prod.mdn.mozit.cloud/en-US/docs/Web/SVG/Element/feComposite/_sample_.example.html

The following support was confirmed with BrowserStack:
 - Chrome 41 (not in 40)
 - Edge 79 (not in 18)
 - Firefox 86 (not in 85)
 - Safari 10.1 (not in 9.1)

The precise Safari version was determined by source:
https://trac.webkit.org/changeset/195745/webkit
https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/Configurations/Version.xcconfig?rev=195745

WebKit trunk version 602.1.18 maps to Safari 10 (using WebKit 602.1.50).

Part of https://github.com/mdn/browser-compat-data/issues/7844.
