### PR TITLE
Remove unused function

### DIFF
--- a/test/linter/test-browsers-presence.js
+++ b/test/linter/test-browsers-presence.js
@@ -27,11 +27,6 @@ const browsers = {
   'webextensions-mobile': ['firefox_android', 'safari_ios'],
 };
 
-function hasVersionAddedOnly(statement) {
-  const keys = Object.keys(statement);
-  return keys.length === 1 && keys[0] === 'version_added';
-}
-
 /**
  * Check the data for any disallowed browsers or if it's missing required browsers
  *


### PR DESCRIPTION
This PR removes an unused function that was accidentally re-added between moving a test from the browsers presence tests to the versions tests and moving all functions to top level.
