### PR TITLE
Utilize logger's built-in tip variable in linters

### DIFF
--- a/test/linter/test-links.js
+++ b/test/linter/test-links.js
@@ -251,7 +251,8 @@ function testLinks(filename) {
 
   for (const error of errors) {
     logger.error(
-      chalk`${error.posString} – ${error.issue} ({yellow ${error.actual}} → {green ${error.expected}}).\n{blue Tip: Run {bold npm run fix} to fix links automatically}`,
+      chalk`${error.posString} – ${error.issue} ({yellow ${error.actual}} → {green ${error.expected}}).`,
+      chalk`Run {bold npm run fix} to fix links automatically`,
     );
   }
 

--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -135,13 +135,8 @@ function checkVersions(supportData, relPath, logger) {
         for (const property of ['version_added', 'version_removed']) {
           if (!isValidVersion(browser, statement[property])) {
             logger.error(
-              chalk`{red → {bold ${relPath}} - {bold ${property}: "${
-                statement[property]
-              }"} is {bold NOT} a valid version number for {bold ${browser}}\n    Valid {bold ${browser}} versions are: ${validBrowserVersionsString}}${
-                browserTips[browser]
-                  ? chalk`\n    {blue {bold Tip:} ${browserTips[browser]}}`
-                  : ''
-              }`,
+              chalk`{red → {bold ${relPath}} - {bold ${property}: "${statement[property]}"} is {bold NOT} a valid version number for {bold ${browser}}\n    Valid {bold ${browser}} versions are: ${validBrowserVersionsString}}`,
+              browserTips[browser],
             );
           }
         }


### PR DESCRIPTION
This PR updates our linter files to take advantage of the logger's `tip` variable, rather than rendering the tips ourselves.
