### PR TITLE
Document when to add version_removed to flag data

### DIFF
--- a/docs/data-guidelines.md
+++ b/docs/data-guidelines.md
@@ -242,6 +242,15 @@ These conditions represent minimum requirements for the removal of valid flag da
 
 This guideline was proposed in [#6670](https://github.com/mdn/browser-compat-data/pull/6670).
 
+## When to add `version_removed` to flagged support
+
+A `version_removed` should be added to support statements containing flags under one of the following conditions, whichever comes first:
+
+- The browser has enabled the feature or flag by default in a stable release (not beta or nightly).
+- The feature can no longer be enabled or disabled by toggling the flag.
+- The feature has been removed from the browser.
+- The flag has been removed from the browser.
+
 ## Initial versions for browsers
 
 The schema docs list [initial versions](../schemas/compat-data-schema.md#initial-versions) for BCD browsers. These are the earliest possible version numbers allowed to be used.


### PR DESCRIPTION
This PR introduces a guideline on when to set flag data as `version_removed`, which fixes #3318.
