### PR TITLE
Remove Safari partial_implementation statements for font-feature-settings

### DIFF
--- a/css/properties/font-feature-settings.json
+++ b/css/properties/font-feature-settings.json
@@ -64,26 +64,12 @@
                 "version_added": "14"
               }
             ],
-            "safari": [
-              {
-                "version_added": "9.1"
-              },
-              {
-                "partial_implementation": true,
-                "version_added": "4",
-                "version_removed": "6"
-              }
-            ],
-            "safari_ios": [
-              {
-                "version_added": "9.3"
-              },
-              {
-                "partial_implementation": true,
-                "version_added": "3.2",
-                "version_removed": "6"
-              }
-            ],
+            "safari": {
+              "version_added": "9.1"
+            },
+            "safari_ios": {
+              "version_added": "9.3"
+            },
             "samsunginternet_android": {
               "version_added": "5.0"
             },


### PR DESCRIPTION
This PR removes the `partial_implementation` statements for Safari from the `font-feature-settings` CSS property.  In my quick manual testing, I didn't find support for this property, prefixed or unprefixed.
