### PR TITLE
Simplify IE data for font-size rem values

### DIFF
--- a/css/properties/font-size.json
+++ b/css/properties/font-size.json
@@ -72,16 +72,9 @@
               "firefox_android": {
                 "version_added": "31"
               },
-              "ie": [
-                {
-                  "version_added": "11"
-                },
-                {
-                  "partial_implementation": true,
-                  "version_added": "9",
-                  "version_removed": "10"
-                }
-              ],
+              "ie": {
+                "version_added": "9"
+              },
               "opera": {
                 "version_added": "28"
               },


### PR DESCRIPTION
This PR simplifies the data for the `font-size` CSS property for Internet Explorer.  The `partial_implementation` statement came from the wiki migration, but there's no explanation of why, and other `rem` value properties in BCD don't have a `partial_implementation` statement.
