### PR TITLE
Remove partial_implementation statements from text-decoration

### DIFF
--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -114,24 +114,12 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "36"
-                },
-                {
-                  "partial_implementation": true,
-                  "version_added": "6"
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "36"
-                },
-                {
-                  "partial_implementation": true,
-                  "version_added": "6"
-                }
-              ],
+              "firefox": {
+                "version_added": "6"
+              },
+              "firefox_android": {
+                "version_added": "6"
+              },
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR removes the `partial_implementation` statements from the `text-decoration` CSS property for Firefox.  They had come from the wiki migration with no explanation.
