### PR TITLE
Remove partial_implementation from webextensions.api.Events.event

### DIFF
--- a/webextensions/api/events.json
+++ b/webextensions/api/events.json
@@ -10,8 +10,7 @@
                 "version_added": true
               },
               "edge": {
-                "version_added": "14",
-                "partial_implementation": true
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": false


### PR DESCRIPTION
This PR removes `partial_implementation from webextensions.api.Events.event.  It was added in #1686, but it seems to be due to the fact that some subfeatures weren't supported.
