### PR TITLE
Rename individual input types from input-* to type_*

### DIFF
--- a/html/elements/input/button.json
+++ b/html/elements/input/button.json
@@ -2,7 +2,7 @@
   "html": {
     "elements": {
       "input": {
-        "input-button": {
+        "type_button": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/button",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#button-state-(type=button)",

--- a/html/elements/input/checkbox.json
+++ b/html/elements/input/checkbox.json
@@ -2,7 +2,7 @@
   "html": {
     "elements": {
       "input": {
-        "input-checkbox": {
+        "type_checkbox": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/checkbox",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type=checkbox)",

--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -2,7 +2,7 @@
   "html": {
     "elements": {
       "input": {
-        "input-color": {
+        "type_color": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/color",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#color-state-(type=color)",

--- a/html/elements/input/date.json
+++ b/html/elements/input/date.json
@@ -2,7 +2,7 @@
   "html": {
     "elements": {
       "input": {
-        "input-date": {
+        "type_date": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/date",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#date-state-(type=date)",

--- a/html/elements/input/datetime-local.json
+++ b/html/elements/input/datetime-local.json
@@ -2,7 +2,7 @@
   "html": {
     "elements": {
       "input": {
-        "input-datetime-local": {
+        "type_datetime-local": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/datetime-local",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#local-date-and-time-state-(type=datetime-local)",

--- a/html/elements/input/email.json
+++ b/html/elements/input/email.json
@@ -2,7 +2,7 @@
   "html": {
     "elements": {
       "input": {
-        "input-email": {
+        "type_email": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/email",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#email-state-(type=email)",

--- a/html/elements/input/file.json
+++ b/html/elements/input/file.json
@@ -2,7 +2,7 @@
   "html": {
     "elements": {
       "input": {
-        "input-file": {
+        "type_file": {
           "__compat": {
             "description": "<code>type=\"file\"</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/file",

--- a/html/elements/input/hidden.json
+++ b/html/elements/input/hidden.json
@@ -2,7 +2,7 @@
   "html": {
     "elements": {
       "input": {
-        "input-hidden": {
+        "type_hidden": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/hidden",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#hidden-state-(type=hidden)",

--- a/html/elements/input/image.json
+++ b/html/elements/input/image.json
@@ -2,7 +2,7 @@
   "html": {
     "elements": {
       "input": {
-        "input-image": {
+        "type_image": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/image",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#image-button-state-(type=image)",

--- a/html/elements/input/month.json
+++ b/html/elements/input/month.json
@@ -2,7 +2,7 @@
   "html": {
     "elements": {
       "input": {
-        "input-month": {
+        "type_month": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/month",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#month-state-(type=month)",

--- a/html/elements/input/number.json
+++ b/html/elements/input/number.json
@@ -2,7 +2,7 @@
   "html": {
     "elements": {
       "input": {
-        "input-number": {
+        "type_number": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/number",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#number-state-(type=number)",

--- a/html/elements/input/password.json
+++ b/html/elements/input/password.json
@@ -2,7 +2,7 @@
   "html": {
     "elements": {
       "input": {
-        "input-password": {
+        "type_password": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/password",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#password-state-(type=password)",

--- a/html/elements/input/radio.json
+++ b/html/elements/input/radio.json
@@ -2,7 +2,7 @@
   "html": {
     "elements": {
       "input": {
-        "input-radio": {
+        "type_radio": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/radio",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#radio-button-state-(type=radio)",

--- a/html/elements/input/range.json
+++ b/html/elements/input/range.json
@@ -2,7 +2,7 @@
   "html": {
     "elements": {
       "input": {
-        "input-range": {
+        "type_range": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/range",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#range-state-(type=range)",

--- a/html/elements/input/reset.json
+++ b/html/elements/input/reset.json
@@ -2,7 +2,7 @@
   "html": {
     "elements": {
       "input": {
-        "input-reset": {
+        "type_reset": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/reset",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#reset-button-state-(type=reset)",

--- a/html/elements/input/search.json
+++ b/html/elements/input/search.json
@@ -2,7 +2,7 @@
   "html": {
     "elements": {
       "input": {
-        "input-search": {
+        "type_search": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/search",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#text-(type=text)-state-and-search-state-(type=search)",

--- a/html/elements/input/submit.json
+++ b/html/elements/input/submit.json
@@ -2,7 +2,7 @@
   "html": {
     "elements": {
       "input": {
-        "input-submit": {
+        "type_submit": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/submit",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#submit-button-state-(type=submit)",

--- a/html/elements/input/tel.json
+++ b/html/elements/input/tel.json
@@ -2,7 +2,7 @@
   "html": {
     "elements": {
       "input": {
-        "input-tel": {
+        "type_tel": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/tel",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#telephone-state-(type=tel)",

--- a/html/elements/input/text.json
+++ b/html/elements/input/text.json
@@ -2,7 +2,7 @@
   "html": {
     "elements": {
       "input": {
-        "input-text": {
+        "type_text": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/text",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#text-(type=text)-state-and-search-state-(type=search)",

--- a/html/elements/input/time.json
+++ b/html/elements/input/time.json
@@ -2,7 +2,7 @@
   "html": {
     "elements": {
       "input": {
-        "input-time": {
+        "type_time": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/time",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#time-state-(type=time)",

--- a/html/elements/input/url.json
+++ b/html/elements/input/url.json
@@ -2,7 +2,7 @@
   "html": {
     "elements": {
       "input": {
-        "input-url": {
+        "type_url": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/url",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#url-state-(type=url)",

--- a/html/elements/input/week.json
+++ b/html/elements/input/week.json
@@ -2,7 +2,7 @@
   "html": {
     "elements": {
       "input": {
-        "input-week": {
+        "type_week": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input/week",
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#week-state-(type=week)",


### PR DESCRIPTION
This PR updates the name of the individual input types from `input-*` to `type_*` to maintain consistency with other similar features.  Fixes #7646.
