### PR TITLE
Fix mdn_urls in <transform-function>

### DIFF
--- a/css/types/transform-function.json
+++ b/css/types/transform-function.json
@@ -56,7 +56,7 @@
         },
         "matrix": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/matrix()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/matrix",
             "spec_url": "https://drafts.csswg.org/css-transforms/#funcdef-transform-matrix",
             "description": "<code>matrix()</code>",
             "support": {
@@ -107,7 +107,7 @@
         },
         "matrix3d": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/matrix3d()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/matrix3d",
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#funcdef-matrix3d",
             "description": "<code>matrix3d()</code>",
             "support": {
@@ -158,7 +158,7 @@
         },
         "perspective": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/perspective()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/perspective",
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#funcdef-perspective",
             "description": "<code>perspective()</code>",
             "support": {
@@ -208,7 +208,7 @@
         },
         "rotate": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/rotate()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/rotate",
             "spec_url": "https://drafts.csswg.org/css-transforms/#funcdef-transform-rotate",
             "description": "<code>rotate()</code>",
             "support": {
@@ -258,7 +258,7 @@
         },
         "rotate3d": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/rotate3d()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/rotate3d",
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#funcdef-rotate3d",
             "description": "<code>rotate3d()</code>",
             "support": {
@@ -308,7 +308,7 @@
         },
         "rotateX": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/rotateX()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/rotateX",
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#funcdef-rotatex",
             "description": "<code>rotateX()</code>",
             "support": {
@@ -358,7 +358,7 @@
         },
         "rotateY": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/rotateY()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/rotateY",
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#funcdef-rotatey",
             "description": "<code>rotateY()</code>",
             "support": {
@@ -408,7 +408,7 @@
         },
         "rotateZ": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/rotateZ()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/rotateZ",
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#funcdef-rotatez",
             "description": "<code>rotateZ()</code>",
             "support": {
@@ -458,7 +458,7 @@
         },
         "scale": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/scale()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/scale",
             "spec_url": "https://drafts.csswg.org/css-transforms/#funcdef-transform-scale",
             "description": "<code>scale()</code>",
             "support": {
@@ -508,7 +508,7 @@
         },
         "scale3d": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/scale3d()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/scale3d",
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#funcdef-scale3d",
             "description": "<code>scale3d()</code>",
             "support": {
@@ -558,7 +558,7 @@
         },
         "scaleX": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/scaleX()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/scaleX",
             "spec_url": "https://drafts.csswg.org/css-transforms/#funcdef-transform-scalex",
             "description": "<code>scaleX()</code>",
             "support": {
@@ -608,7 +608,7 @@
         },
         "scaleY": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/scaleY()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/scaleY",
             "spec_url": "https://drafts.csswg.org/css-transforms/#funcdef-transform-scaley",
             "description": "<code>scaleY()</code>",
             "support": {
@@ -658,7 +658,7 @@
         },
         "scaleZ": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/scaleZ()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/scaleZ",
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#funcdef-scalez",
             "description": "<code>scaleZ()</code>",
             "support": {
@@ -708,7 +708,7 @@
         },
         "skew": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/skew()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/skew",
             "spec_url": "https://drafts.csswg.org/css-transforms/#funcdef-transform-skew",
             "description": "<code>skew()</code>",
             "support": {
@@ -759,7 +759,7 @@
         },
         "skewX": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/skewX()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/skewX",
             "spec_url": "https://drafts.csswg.org/css-transforms/#funcdef-transform-skewx",
             "description": "<code>skewX()</code>",
             "support": {
@@ -809,7 +809,7 @@
         },
         "skewY": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/skewY()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/skewY",
             "spec_url": "https://drafts.csswg.org/css-transforms/#funcdef-transform-skewy",
             "description": "<code>skewY()</code>",
             "support": {
@@ -859,7 +859,7 @@
         },
         "translate": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/translate()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/translate",
             "spec_url": "https://drafts.csswg.org/css-transforms/#funcdef-transform-translate",
             "description": "<code>translate()</code>",
             "support": {
@@ -909,7 +909,7 @@
         },
         "translate3d": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/translate3d()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/translate3d",
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#funcdef-translate3d",
             "description": "<code>translate3d()</code>",
             "support": {
@@ -959,7 +959,7 @@
         },
         "translateX": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/translateX()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/translateX",
             "spec_url": "https://drafts.csswg.org/css-transforms/#funcdef-transform-translatex",
             "description": "<code>translateX()</code>",
             "support": {
@@ -1009,7 +1009,7 @@
         },
         "translateY": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/translateY()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/translateY",
             "spec_url": "https://drafts.csswg.org/css-transforms/#funcdef-transform-translatey",
             "description": "<code>translateY()</code>",
             "support": {
@@ -1059,7 +1059,7 @@
         },
         "translateZ": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/translateZ()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-function/translateZ",
             "spec_url": "https://drafts.csswg.org/css-transforms-2/#funcdef-translatez",
             "description": "<code>translateZ()</code>",
             "support": {


### PR DESCRIPTION
Most of the pages have been moved on MDN (removing the parenthesis in the slug).

This fixes it.