### PR TITLE
Remove parenthesis in mdn_url

### DIFF
--- a/css/types/attr.json
+++ b/css/types/attr.json
@@ -3,7 +3,7 @@
     "types": {
       "attr": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/attr()",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/attr",
           "spec_url": "https://drafts.csswg.org/css-values-5/#attr-notation",
           "description": "<code>attr()</code>",
           "support": {

--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -101,7 +101,7 @@
         },
         "circle": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape/circle()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape/circle",
             "spec_url": "https://drafts.csswg.org/css-shapes/#funcdef-basic-shape-circle",
             "description": "<code>circle()</code>",
             "support": {
@@ -151,7 +151,7 @@
         },
         "ellipse": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape/ellipse()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape/ellipse",
             "spec_url": "https://drafts.csswg.org/css-shapes/#funcdef-basic-shape-ellipse",
             "description": "<code>ellipse()</code>",
             "support": {
@@ -201,7 +201,7 @@
         },
         "inset": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape/inset()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape/inset",
             "spec_url": "https://drafts.csswg.org/css-shapes/#funcdef-basic-shape-inset",
             "description": "<code>inset()</code>",
             "support": {
@@ -251,7 +251,7 @@
         },
         "path": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape#path()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/path",
             "spec_url": "https://drafts.csswg.org/css-shapes/#funcdef-basic-shape-path",
             "description": "<code>path()</code>",
             "support": {
@@ -356,7 +356,7 @@
         },
         "polygon": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape/polygon()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape/polygon",
             "spec_url": "https://drafts.csswg.org/css-shapes/#funcdef-basic-shape-polygon",
             "description": "<code>polygon()</code>",
             "support": {

--- a/css/types/calc.json
+++ b/css/types/calc.json
@@ -4,7 +4,7 @@
       "calc": {
         "__compat": {
           "description": "<code>calc()</code>",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/calc()",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/calc",
           "spec_url": "https://drafts.csswg.org/css-values/#calc-func",
           "support": {
             "chrome": [

--- a/css/types/clamp.json
+++ b/css/types/clamp.json
@@ -4,7 +4,7 @@
       "clamp": {
         "__compat": {
           "description": "<code>clamp()</code>",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/clamp()",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/clamp",
           "spec_url": "https://drafts.csswg.org/css-values/#calc-notation",
           "support": {
             "chrome": {

--- a/css/types/counter.json
+++ b/css/types/counter.json
@@ -3,7 +3,7 @@
     "types": {
       "counter": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/counter()",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/counter",
           "spec_url": "https://drafts.csswg.org/css-lists/#counter-functions",
           "description": "<code>counter()</code>",
           "support": {

--- a/css/types/counters.json
+++ b/css/types/counters.json
@@ -3,7 +3,7 @@
     "types": {
       "counters": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/counters()",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/counters",
           "spec_url": "https://drafts.csswg.org/css-lists/#counter-functions",
           "description": "<code>counters()</code>",
           "support": {

--- a/css/types/filter-function.json
+++ b/css/types/filter-function.json
@@ -51,7 +51,7 @@
         },
         "blur": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/blur()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/blur",
             "spec_url": "https://drafts.fxtf.org/filter-effects/#funcdef-filter-blur",
             "description": "<code>blur()</code>",
             "support": {
@@ -101,7 +101,7 @@
         },
         "brightness": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/brightness()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/brightness",
             "spec_url": "https://drafts.fxtf.org/filter-effects/#funcdef-filter-brightness",
             "description": "<code>brightness()</code>",
             "support": {
@@ -151,7 +151,7 @@
         },
         "contrast": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/contrast()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/contrast",
             "spec_url": "https://drafts.fxtf.org/filter-effects/#funcdef-filter-contrast",
             "description": "<code>contrast()</code>",
             "support": {
@@ -201,7 +201,7 @@
         },
         "drop-shadow": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/drop-shadow()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/drop-shadow",
             "spec_url": "https://drafts.fxtf.org/filter-effects/#funcdef-filter-drop-shadow",
             "description": "<code>drop-shadow()</code>",
             "support": {
@@ -251,7 +251,7 @@
         },
         "grayscale": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/grayscale()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/grayscale",
             "spec_url": "https://drafts.fxtf.org/filter-effects/#funcdef-filter-grayscale",
             "description": "<code>grayscale()</code>",
             "support": {
@@ -301,7 +301,7 @@
         },
         "hue-rotate": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/hue-rotate()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/hue-rotate",
             "spec_url": "https://drafts.fxtf.org/filter-effects/#funcdef-filter-hue-rotate",
             "description": "<code>hue-rotate()</code>",
             "support": {
@@ -351,7 +351,7 @@
         },
         "invert": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/invert()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/invert",
             "spec_url": "https://drafts.fxtf.org/filter-effects/#funcdef-filter-invert",
             "description": "<code>invert()</code>",
             "support": {
@@ -401,7 +401,7 @@
         },
         "opacity": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/opacity()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/opacity",
             "spec_url": "https://drafts.fxtf.org/filter-effects/#funcdef-filter-opacity",
             "description": "<code>opacity()</code>",
             "support": {
@@ -451,7 +451,7 @@
         },
         "saturate": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/saturate()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/saturate",
             "spec_url": "https://drafts.fxtf.org/filter-effects/#funcdef-filter-saturate",
             "description": "<code>saturate()</code>",
             "support": {
@@ -501,7 +501,7 @@
         },
         "sepia": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/sepia()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter-function/sepia",
             "spec_url": "https://drafts.fxtf.org/filter-effects/#funcdef-filter-sepia",
             "description": "<code>sepia()</code>",
             "support": {

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -52,7 +52,7 @@
         },
         "cross-fade": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/cross-fade()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/cross-fade",
             "spec_url": "https://drafts.csswg.org/css-images-4/#cross-fade-function",
             "description": "<code>cross-fade()</code>",
             "support": {
@@ -132,7 +132,7 @@
         },
         "element": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/element()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/element",
             "spec_url": "https://drafts.csswg.org/css-images-4/#element-notation",
             "description": "<code>element()</code>",
             "support": {
@@ -328,7 +328,7 @@
           "conic-gradient": {
             "__compat": {
               "description": "<code>conic-gradient()</code>",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient/conic-gradient()",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient/conic-gradient",
               "spec_url": "https://drafts.csswg.org/css-images-4/#conic-gradients",
               "support": {
                 "chrome": {
@@ -437,7 +437,7 @@
           "linear-gradient": {
             "__compat": {
               "description": "<code>linear-gradient()</code>",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient/linear-gradient()",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient/linear-gradient",
               "spec_url": "https://drafts.csswg.org/css-images/#linear-gradients",
               "support": {
                 "chrome": [
@@ -794,7 +794,7 @@
           "radial-gradient": {
             "__compat": {
               "description": "<code>radial-gradient()</code>",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient/radial-gradient()",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient/radial-gradient",
               "spec_url": "https://drafts.csswg.org/css-images/#radial-gradients",
               "support": {
                 "chrome": [
@@ -1105,7 +1105,7 @@
           "repeating-conic-gradient": {
             "__compat": {
               "description": "<code>repeating-conic-gradient()</code>",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient/repeating-conic-gradient()",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient/repeating-conic-gradient",
               "spec_url": "https://drafts.csswg.org/css-images-4/#repeating-gradients",
               "support": {
                 "chrome": {
@@ -1165,7 +1165,7 @@
           },
           "repeating-linear-gradient": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient/repeating-linear-gradient()",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient/repeating-linear-gradient",
               "spec_url": "https://drafts.csswg.org/css-images/#repeating-gradients",
               "description": "<code>repeating-linear-gradient()</code>",
               "support": {
@@ -1523,7 +1523,7 @@
           "repeating-radial-gradient": {
             "__compat": {
               "description": "<code>repeating-radial-gradient()</code>",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient/repeating-radial-gradient()",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient/repeating-radial-gradient",
               "spec_url": "https://drafts.csswg.org/css-images/#repeating-gradients",
               "support": {
                 "chrome": [
@@ -1839,7 +1839,7 @@
         },
         "image": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image/image()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image/image",
             "spec_url": "https://drafts.csswg.org/css-images-4/#image-notation",
             "description": "<code>image()</code>",
             "support": {
@@ -1894,7 +1894,7 @@
         },
         "image-set": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image/image-set()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image/image-set",
             "spec_url": "https://drafts.csswg.org/css-images-4/#image-set-notation",
             "description": "<code>image-set()</code>",
             "support": {
@@ -1977,7 +1977,7 @@
         },
         "paint": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image/paint()",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image/paint",
             "spec_url": "https://drafts.css-houdini.org/css-paint-api/#paint-notation",
             "description": "<code>paint()</code>",
             "support": {

--- a/css/types/max.json
+++ b/css/types/max.json
@@ -4,7 +4,7 @@
       "max": {
         "__compat": {
           "description": "<code>max()</code>",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max()",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max",
           "spec_url": "https://drafts.csswg.org/css-values/#calc-notation",
           "support": {
             "chrome": {

--- a/css/types/min.json
+++ b/css/types/min.json
@@ -4,7 +4,7 @@
       "min": {
         "__compat": {
           "description": "<code>min()</code>",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min()",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min",
           "spec_url": "https://drafts.csswg.org/css-values/#calc-notation",
           "support": {
             "chrome": {

--- a/css/types/url.json
+++ b/css/types/url.json
@@ -4,7 +4,7 @@
       "url": {
         "__compat": {
           "description": "<code>&lt;url&gt;</code>",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/url()",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/url",
           "spec_url": "https://drafts.csswg.org/css-values/#urls",
           "support": {
             "chrome": {


### PR DESCRIPTION
We removed parenthesis from MDN urls. This removes the one that were left in bcd.