### PR TITLE
Remove api.Document.getBoxObjectFor

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -5637,55 +5637,6 @@
           }
         }
       },
-      "getBoxObjectFor": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/getBoxObjectFor",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": "1",
-              "version_removed": "3.6"
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "getElementById": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/getElementById",


### PR DESCRIPTION
This feature is non-standard, Gecko-only, and removed from the web in… Firefox 3.6.

Time to go.