### PR TITLE
RTCDataChannel - add link to docs on what transferrable means

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -1307,6 +1307,7 @@
       },
       "transferable": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Glossary/Transferable_objects",
           "spec_url": "https://w3c.github.io/webrtc-extensions/#rtcdatachannel-extensions",
           "support": {
             "chrome": {


### PR DESCRIPTION
As discussed in https://github.com/mdn/browser-compat-data/pull/16281/files#r873271737

