### PR TITLE
Update CSSKeyframesRules versions for name/cssRules

### DIFF
--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -267,10 +267,10 @@
           "spec_url": "https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-cssrules",
           "support": {
             "chrome": {
-              "version_added": "44"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "44"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -285,22 +285,22 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "31"
+              "version_added": "12"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "12"
             },
             "safari": {
-              "version_added": "9.1"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "9.3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "44"
+              "version_added": "1"
             }
           },
           "status": {
@@ -414,10 +414,10 @@
           "spec_url": "https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-name",
           "support": {
             "chrome": {
-              "version_added": "44"
+              "version_added": "1"
             },
             "chrome_android": {
-              "version_added": "44"
+              "version_added": "18"
             },
             "edge": {
               "version_added": "12"
@@ -432,22 +432,22 @@
               "version_added": "10"
             },
             "opera": {
-              "version_added": "31"
+              "version_added": "12"
             },
             "opera_android": {
-              "version_added": "32"
+              "version_added": "12"
             },
             "safari": {
-              "version_added": "9.1"
+              "version_added": "4"
             },
             "safari_ios": {
-              "version_added": "9.3"
+              "version_added": "3.2"
             },
             "samsunginternet_android": {
-              "version_added": "4.0"
+              "version_added": "1.0"
             },
             "webview_android": {
-              "version_added": "44"
+              "version_added": "1"
             }
           },
           "status": {


### PR DESCRIPTION
This was wrong due to testing for attributes in prototypes.

This has been in WebKit since the very beginning of the feature:
https://github.com/WebKit/WebKit/commit/63f0b70d47ee8bc28d4f91eac6af5c2b33a18a2b

Copy the earliest versions of the parent feature. Also test
http://mdn-bcd-collector.appspot.com/tests/api/CSSKeyframesRule to
confirm support in the following browsers:

 - Chrome 15
 - IE 10
 - Opera 12.16
 - Safari 5

Part of https://github.com/mdn/browser-compat-data/issues/7755.
