### PR TITLE
Default support for prefers-contrast from FF101

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1448,18 +1448,23 @@
               "edge": {
                 "version_added": "96"
               },
-              "firefox": {
-                "version_added": "80",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.prefers-contrast.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "101"
+                },
+                {
+                  "version_added": "80",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.prefers-contrast.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": {
-                "version_added": false
+                "version_added": "101"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
In FF101, the `layout.css.prefers-contrast.enabled` flag is set to true by default.

This PR updates the feature's [browser compat data](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-contrast#browser_compatibility) to reflect the default support from FF101.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
https://bugzilla.mozilla.org/show_bug.cgi?id=1656363

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Doc issue tracking this update: https://github.com/mdn/content/issues/15466
Other related doc PR: https://github.com/mdn/content/pull/16109

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
