### PR TITLE
Change HTMLMediaElement.volume support for safari_ios to partial_implementation

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -3768,7 +3768,13 @@
               "version_added": "3.1"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3",
+              "partial_implementation": true,
+              "notes": [
+                "`volume` returns a value and is writeable; however, the value is always 1, and setting a value has no effect on the volume of the media object.",
+                "On iOS 12 and below, setting a value on `volume` has no effect on the value of `volume`.",
+                "On iOS 13 and up, setting a value on `volume` *will* update the value of `volume`, but it will be reset to 1 asynchronously."
+              ]
             },
             "samsunginternet_android": {
               "version_added": "1.0"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -3771,7 +3771,7 @@
               "version_added": "3",
               "partial_implementation": true,
               "notes": [
-                "`volume` returns a value and is writeable; however, the value is always 1, and setting a value has no effect on the volume of the media object.",
+                "<code>volume</code> returns a value and is writable; however, the value is always 1, and setting a value has no effect on the volume of the media object.",
                 "On iOS 12 and below, setting a value on `volume` has no effect on the value of `volume`.",
                 "On iOS 13 and up, setting a value on `volume` *will* update the value of `volume`, but it will be reset to 1 asynchronously."
               ]

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -3771,7 +3771,7 @@
               "version_added": "3",
               "partial_implementation": true,
               "notes": [
-                "<code>volume</code> returns a value and is writable; however, the value is always 1, and setting a value has no effect on the volume of the media object.",
+                "<code>volume</code> returns a value and is writable; however, the value is always 1, and setting a value has no effect on the volume of the media object."
               ]
             },
             "samsunginternet_android": {

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -3772,8 +3772,6 @@
               "partial_implementation": true,
               "notes": [
                 "<code>volume</code> returns a value and is writable; however, the value is always 1, and setting a value has no effect on the volume of the media object.",
-                "On iOS 12 and below, setting a value on `volume` has no effect on the value of `volume`.",
-                "On iOS 13 and up, setting a value on `volume` *will* update the value of `volume`, but it will be reset to 1 asynchronously."
               ]
             },
             "samsunginternet_android": {

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -3770,9 +3770,7 @@
             "safari_ios": {
               "version_added": "3",
               "partial_implementation": true,
-              "notes": [
-                "<code>volume</code> returns a value and is writable; however, the value is always 1, and setting a value has no effect on the volume of the media object."
-              ]
+              "notes": "<code>volume</code> returns a value and is writable; however, the value is always 1, and setting a value has no effect on the volume of the media object."
             },
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

`HTMLMediaElement.volume` does not work on iOS browsers. While it returns a value and can be set, the value is always 1, and setting the value has no effect on the actual volume of the media.

I've chosen to reflect this by setting `partial_implementation` on the `safari_ios` browser along with clarifying notes.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
This app was tested on Safari iOS 11 - 15: https://0680re.csb.app/. The "Mute (Volume)" button attempts to programmatically set the volume to 0. 

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
There isn't a lot of official documentation around this. There is a reference to this behavior in https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/Using_HTML5_Audio_Video/Device-SpecificConsiderations/Device-SpecificConsiderations.html#//apple_ref/doc/uid/TP40009523-CH5-SW1; however, that doc is quite old, and is only concerned with Safari, even though other iOS browsers (like Chrome) also behave the same way.

This issue has been observed by others many times:
https://stackoverflow.com/questions/12553757/html5-ios-volumechange-event-not-fired
https://stackoverflow.com/questions/71308806/ionic-htmlaudioelement-cant-change-volume-on-ios
https://stackoverflow.com/questions/59417075/javascript-detect-if-volume-can-be-set

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
This was reported in https://github.com/mdn/browser-compat-data/issues/12001; however, that issue also brings up Chrome on iOS, which this PR doesn't support.

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

#### Additional Info & Questions

As mentioned above, this limitation on `volume` is an iOS level restriction, and applies to all browsers running on iOS, not just Safari (which is all this PR covers).

The compat data does not track, for example, Chrome on iOS (I'm curious as to the reason for this), so even if this PR were merged, the docs would still have no indication that setting `volume` would not work on Chrome on iOS. I'd like some input on whether I should also (in addition to this PR) open a PR in the MDN docs repo that discusses this behavior of `volume` on iOS more in-depth.
