### PR TITLE
FF101 HTMLMediaElement.canPlayType() and friends av1 codec support

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -471,14 +471,14 @@
               "version_added": "3",
               "notes": [
                 "<code>codecs</code> string can contain any subset of optional parameters (should be all or none).",
-                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character).",
+                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character)."
               ]
             },
             "chrome_android": {
               "version_added": "18",
               "notes": [
                 "<code>codecs</code> string can contain any subset of optional parameters (should be all or none).",
-                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character).",
+                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character)."
               ]
             },
             "edge": {

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -468,17 +468,28 @@
           "description": "<code>canPlayType()</code>",
           "support": {
             "chrome": {
-              "version_added": "3"
+              "version_added": "3",
+              "notes": [
+                "<code>codecs</code> string can contain any subset of optional parameters (should be all or none).",
+                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character).",
+              ]
             },
             "chrome_android": {
-              "version_added": "18"
+              "version_added": "18",
+              "notes": [
+                "<code>codecs</code> string can contain any subset of optional parameters (should be all or none).",
+                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character).",
+              ]
             },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
               "version_added": "3.5",
-              "notes": "Before Firefox 28, <code>canPlayType()</code> returned <code>probably</code> when asked about WebM audio or video files without the <code>codecs</code> parameter. Since multiple codecs are supported, this is not enough information to determine if a file can be played, so <code>maybe</code> is now correctly returned."
+              "notes": [
+                "Before Firefox 28, <code>canPlayType()</code> returned <code>probably</code> when asked about WebM audio or video files without the <code>codecs</code> parameter. Since multiple codecs are supported, this is not enough information to determine if a file can be played, so <code>maybe</code> is now correctly returned.",
+                "Before Firefox 101, <code>canPlayType()</code> ignored <code>codecs</code> parameter options for <code>av01</code> codecs (treating them as <code>av1</code>)."
+              ]
             },
             "firefox_android": {
               "version_added": "4"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -482,7 +482,11 @@
               ]
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": [
+                "<code>codecs</code> string can contain any subset of optional parameters (should be all or none).",
+                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character)."
+              ]
             },
             "firefox": {
               "version_added": "3.5",
@@ -492,16 +496,28 @@
               ]
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": [
+                "Before Firefox 28, <code>canPlayType()</code> returned <code>probably</code> when asked about WebM audio or video files without the <code>codecs</code> parameter. Since multiple codecs are supported, this is not enough information to determine if a file can be played, so <code>maybe</code> is now correctly returned.",
+                "Before Firefox 101, <code>canPlayType()</code> ignored <code>codecs</code> parameter options for <code>av01</code> codecs (treating them as <code>av1</code>)."
+              ]
             },
             "ie": {
               "version_added": "9"
             },
             "opera": {
-              "version_added": "≤12.1"
+              "version_added": "≤12.1",
+              "notes": [
+                "<code>codecs</code> string can contain any subset of optional parameters (should be all or none).",
+                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character)."
+              ]
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": "≤12.1",
+              "notes": [
+                "<code>codecs</code> string can contain any subset of optional parameters (should be all or none).",
+                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character)."
+              ]
             },
             "safari": {
               "version_added": "4"
@@ -510,10 +526,18 @@
               "version_added": "3"
             },
             "samsunginternet_android": {
-              "version_added": "1.0"
+              "version_added": "1.0",
+              "notes": [
+                "<code>codecs</code> string can contain any subset of optional parameters (should be all or none).",
+                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character)."
+              ]
             },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤37",
+              "notes": [
+                "<code>codecs</code> string can contain any subset of optional parameters (should be all or none).",
+                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character)."
+              ]
             }
           },
           "status": {

--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -54,28 +54,50 @@
           "spec_url": "https://w3c.github.io/media-capabilities/#ref-for-dom-mediacapabilities-decodinginfo",
           "support": {
             "chrome": {
-              "version_added": "66"
+              "version_added": "66",
+              "notes": [
+                "<code>codecs</code> string can contain any subset of optional parameters (should be all or none).",
+                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character)."
+              ]
             },
             "chrome_android": {
-              "version_added": "66"
+              "version_added": "66",
+              "notes": [
+                "<code>codecs</code> string can contain any subset of optional parameters (should be all or none).",
+                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character)."
+              ]
             },
             "edge": {
-              "version_added": "79"
+              "version_added": "79",
+              "notes": [
+                "<code>codecs</code> string can contain any subset of optional parameters (should be all or none).",
+                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character)."
+              ]
             },
             "firefox": {
-              "version_added": "63"
+              "version_added": "63",
+              "notes": "Before Firefox 101, <code>decodingInfo()</code> ignored <code>codecs</code> parameter options for <code>av01</code> codecs (treating them as <code>av1</code>)."
             },
             "firefox_android": {
-              "version_added": "63"
+              "version_added": "63",
+              "notes": "Before Firefox 101, <code>decodingInfo()</code> ignored <code>codecs</code> parameter options for <code>av01</code> codecs (treating them as <code>av1</code>)."
             },
             "ie": {
               "version_added": false
             },
             "opera": {
-              "version_added": "53"
+              "version_added": "53",
+              "notes": [
+                "<code>codecs</code> string can contain any subset of optional parameters (should be all or none).",
+                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character)."
+              ]
             },
             "opera_android": {
-              "version_added": "48"
+              "version_added": "48",
+              "notes": [
+                "<code>codecs</code> string can contain any subset of optional parameters (should be all or none).",
+                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character)."
+              ]
             },
             "safari": {
               "version_added": "13"
@@ -84,10 +106,18 @@
               "version_added": "13"
             },
             "samsunginternet_android": {
-              "version_added": "9.0"
+              "version_added": "9.0",
+              "notes": [
+                "<code>codecs</code> string can contain any subset of optional parameters (should be all or none).",
+                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character)."
+              ]
             },
             "webview_android": {
-              "version_added": "66"
+              "version_added": "66",
+              "notes": [
+                "<code>codecs</code> string can contain any subset of optional parameters (should be all or none).",
+                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character)."
+              ]
             }
           },
           "status": {

--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -417,29 +417,51 @@
           "spec_url": "https://w3c.github.io/media-source/#dom-mediasource-istypesupported",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "23",
+              "notes": [
+                "<code>codecs</code> string can contain any subset of optional parameters (should be all or none).",
+                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character)."
+              ]
             },
             "chrome_android": {
-              "version_added": "25"
+              "version_added": "25",
+              "notes": [
+                "<code>codecs</code> string can contain any subset of optional parameters (should be all or none).",
+                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character)."
+              ]
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": [
+                "<code>codecs</code> string can contain any subset of optional parameters (should be all or none).",
+                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character)."
+              ]
             },
             "firefox": {
-              "version_added": "42"
+              "version_added": "42",
+              "notes": "Before Firefox 101, <code>isTypeSupported()</code> ignored <code>codecs</code> parameter options for <code>av01</code> codecs (treating them as <code>av1</code>)."
             },
             "firefox_android": {
-              "version_added": "41"
+              "version_added": "41",
+              "notes": "Before Firefox 101, <code>isTypeSupported()</code> ignored <code>codecs</code> parameter options for <code>av01</code> codecs (treating them as <code>av1</code>)."
             },
             "ie": {
               "version_added": "11",
               "notes": "Only works on Windows 8+."
             },
             "opera": {
-              "version_added": "15"
+              "version_added": "15",
+              "notes": [
+                "<code>codecs</code> string can contain any subset of optional parameters (should be all or none).",
+                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character)."
+              ]
             },
             "opera_android": {
-              "version_added": "14"
+              "version_added": "14",
+              "notes": [
+                "<code>codecs</code> string can contain any subset of optional parameters (should be all or none).",
+                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character)."
+              ]
             },
             "safari": {
               "version_added": "8"
@@ -450,10 +472,18 @@
               "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },
             "samsunginternet_android": {
-              "version_added": "1.5"
+              "version_added": "1.5",
+              "notes": [
+                "<code>codecs</code> string can contain any subset of optional parameters (should be all or none).",
+                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character)."
+              ]
             },
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": "4.4.3",
+              "notes": [
+                "<code>codecs</code> string can contain any subset of optional parameters (should be all or none).",
+                "Errors if <code>codecs</code> string contains unexpected characters (should evaluate string up to character)."
+              ]
             }
           },
           "status": {


### PR DESCRIPTION
@queengooborg This is my attempt to address the av1 codec string compatibility issues in #16173. 

I abandoned attempt to do this as a subfeature. While we can determine when AV1 is supported (and some subset of the codecs using this test file  [this file](https://bug1757861.bmoattachments.org/attachment.cgi?id=9271759)), we actually can't determine when/if a system has these particular behaviours with respect to the codec parameter options (or at least I do not have time/ability to write test code.

So this add notes for just the `canPlayType()` method for FF and Chrome. If you are OK with the approach, I will roll this out to the other chromiums and then the other methods. 

Note, 
- it _might_ be reasonable to add subfeatures just for broad codec/type/container support - e.g. av1 was introduced in Chrome 70. I think that would be somewhat useful to know and could be tested.
- Unlike previous discussions of media features, this is doable because it is specific to a function, not "across the platform". 
- However I am not sure how _useful_ it is to know that we can use this mime type with this message, if we don't know the detail of the codecs. 

Fixes #16173