### PR TITLE
Update spec URLs for CSPViolationReportBody

### DIFF
--- a/api/CSPViolationReportBody.json
+++ b/api/CSPViolationReportBody.json
@@ -3,7 +3,7 @@
     "CSPViolationReportBody": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody",
-        "spec_url": "https://www.w3.org/TR/CSP3/#cspviolationreportbody",
+        "spec_url": "https://w3c.github.io/webappsec-csp/#cspviolationreportbody",
         "support": {
           "chrome": {
             "version_added": "74"
@@ -51,7 +51,7 @@
       "blockedURL": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/blockedURL",
-          "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-blockedurl",
+          "spec_url": "https://w3c.github.io/webappsec-csp/#dom-cspviolationreportbody-blockedurl",
           "support": {
             "chrome": {
               "version_added": "74"
@@ -100,7 +100,7 @@
       "columnNumber": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/columnNumber",
-          "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-columnnumber",
+          "spec_url": "https://w3c.github.io/webappsec-csp/#dom-cspviolationreportbody-columnnumber",
           "support": {
             "chrome": {
               "version_added": "74"
@@ -149,7 +149,7 @@
       "disposition": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/disposition",
-          "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-disposition",
+          "spec_url": "https://w3c.github.io/webappsec-csp/#dom-cspviolationreportbody-disposition",
           "support": {
             "chrome": {
               "version_added": "74"
@@ -198,7 +198,7 @@
       "documentURL": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/documentURL",
-          "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-documenturl",
+          "spec_url": "https://w3c.github.io/webappsec-csp/#dom-cspviolationreportbody-documenturl",
           "support": {
             "chrome": {
               "version_added": "74"
@@ -247,7 +247,7 @@
       "effectiveDirective": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/effectiveDirective",
-          "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-effectivedirective",
+          "spec_url": "https://w3c.github.io/webappsec-csp/#dom-cspviolationreportbody-effectivedirective",
           "support": {
             "chrome": {
               "version_added": "74"
@@ -296,7 +296,7 @@
       "lineNumber": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/lineNumber",
-          "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-linenumber",
+          "spec_url": "https://w3c.github.io/webappsec-csp/#dom-cspviolationreportbody-linenumber",
           "support": {
             "chrome": {
               "version_added": "74"
@@ -345,7 +345,7 @@
       "originalPolicy": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/originalPolicy",
-          "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-originalpolicy",
+          "spec_url": "https://w3c.github.io/webappsec-csp/#dom-cspviolationreportbody-originalpolicy",
           "support": {
             "chrome": {
               "version_added": "74"
@@ -394,7 +394,7 @@
       "referrer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/referrer",
-          "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-referrer",
+          "spec_url": "https://w3c.github.io/webappsec-csp/#dom-cspviolationreportbody-referrer",
           "support": {
             "chrome": {
               "version_added": "74"
@@ -443,7 +443,7 @@
       "sample": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/sample",
-          "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-sample",
+          "spec_url": "https://w3c.github.io/webappsec-csp/#dom-cspviolationreportbody-sample",
           "support": {
             "chrome": {
               "version_added": "74"
@@ -492,7 +492,7 @@
       "sourceFile": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/sourceFile",
-          "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-sourcefile",
+          "spec_url": "https://w3c.github.io/webappsec-csp/#dom-cspviolationreportbody-sourcefile",
           "support": {
             "chrome": {
               "version_added": "74"
@@ -541,7 +541,7 @@
       "statusCode": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/statusCode",
-          "spec_url": "https://www.w3.org/TR/CSP3/#dom-cspviolationreportbody-statuscode",
+          "spec_url": "https://w3c.github.io/webappsec-csp/#dom-cspviolationreportbody-statuscode",
           "support": {
             "chrome": {
               "version_added": "74"
@@ -590,7 +590,7 @@
       "toJSON": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSPViolationReportBody/toJSON",
-          "spec_url": "https://www.w3.org/TR/CSP3/#cspviolationreportbody",
+          "spec_url": "https://w3c.github.io/webappsec-csp/#cspviolationreportbody",
           "support": {
             "chrome": {
               "version_added": "74"


### PR DESCRIPTION
These should all be using the URL for the current spec at https://w3c.github.io/webappsec-csp rather than the outdated https://www.w3.org/TR/CSP3 version.