### PR TITLE
Update spec URLs for filter-effects spec

### DIFF
--- a/api/SVGComponentTransferFunctionElement.json
+++ b/api/SVGComponentTransferFunctionElement.json
@@ -50,7 +50,7 @@
       },
       "amplitude": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgcomponenttransferfunctionelement-amplitude",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgcomponenttransferfunctionelement-amplitude",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -98,7 +98,7 @@
       },
       "exponent": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgcomponenttransferfunctionelement-exponent",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgcomponenttransferfunctionelement-exponent",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -146,7 +146,7 @@
       },
       "intercept": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgcomponenttransferfunctionelement-intercept",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgcomponenttransferfunctionelement-intercept",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -194,7 +194,7 @@
       },
       "offset": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgcomponenttransferfunctionelement-offset",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgcomponenttransferfunctionelement-offset",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -242,7 +242,7 @@
       },
       "slope": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgcomponenttransferfunctionelement-slope",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgcomponenttransferfunctionelement-slope",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -290,7 +290,7 @@
       },
       "tableValues": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgcomponenttransferfunctionelement-tablevalues",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgcomponenttransferfunctionelement-tablevalues",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -338,7 +338,7 @@
       },
       "type": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgcomponenttransferfunctionelement-type",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgcomponenttransferfunctionelement-type",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/SVGFEBlendElement.json
+++ b/api/SVGFEBlendElement.json
@@ -50,7 +50,7 @@
       },
       "in1": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeblendelement-in1",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeblendelement-in1",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -98,7 +98,7 @@
       },
       "in2": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeblendelement-in2",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeblendelement-in2",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -146,7 +146,7 @@
       },
       "mode": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeblendelement-mode",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeblendelement-mode",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/SVGFEColorMatrixElement.json
+++ b/api/SVGFEColorMatrixElement.json
@@ -51,7 +51,7 @@
       "in1": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEColorMatrixElement/in1",
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfecolormatrixelement-in1",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfecolormatrixelement-in1",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -100,7 +100,7 @@
       "type": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEColorMatrixElement/type",
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfecolormatrixelement-type",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfecolormatrixelement-type",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -149,7 +149,7 @@
       "values": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEColorMatrixElement/values",
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfecolormatrixelement-values",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfecolormatrixelement-values",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/SVGFEComponentTransferElement.json
+++ b/api/SVGFEComponentTransferElement.json
@@ -50,7 +50,7 @@
       },
       "in1": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfecomponenttransferelement-in1",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfecomponenttransferelement-in1",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/SVGFECompositeElement.json
+++ b/api/SVGFECompositeElement.json
@@ -50,7 +50,7 @@
       },
       "in1": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfecompositeelement-in1",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfecompositeelement-in1",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -98,7 +98,7 @@
       },
       "in2": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfecompositeelement-in2",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfecompositeelement-in2",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -146,7 +146,7 @@
       },
       "k1": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfecompositeelement-k1",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfecompositeelement-k1",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -194,7 +194,7 @@
       },
       "k2": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfecompositeelement-k2",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfecompositeelement-k2",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -242,7 +242,7 @@
       },
       "k3": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfecompositeelement-k3",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfecompositeelement-k3",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -290,7 +290,7 @@
       },
       "k4": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfecompositeelement-k4",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfecompositeelement-k4",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -338,7 +338,7 @@
       },
       "operator": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfecompositeelement-operator",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfecompositeelement-operator",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/SVGFEConvolveMatrixElement.json
+++ b/api/SVGFEConvolveMatrixElement.json
@@ -50,7 +50,7 @@
       },
       "bias": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeconvolvematrixelement-bias",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeconvolvematrixelement-bias",
           "support": {
             "chrome": {
               "version_added": "6"
@@ -98,7 +98,7 @@
       },
       "divisor": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeconvolvematrixelement-divisor",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeconvolvematrixelement-divisor",
           "support": {
             "chrome": {
               "version_added": "6"
@@ -146,7 +146,7 @@
       },
       "edgeMode": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeconvolvematrixelement-edgemode",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeconvolvematrixelement-edgemode",
           "support": {
             "chrome": {
               "version_added": "6"
@@ -194,7 +194,7 @@
       },
       "in1": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeconvolvematrixelement-in1",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeconvolvematrixelement-in1",
           "support": {
             "chrome": {
               "version_added": "6"
@@ -242,7 +242,7 @@
       },
       "kernelMatrix": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeconvolvematrixelement-kernelmatrix",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeconvolvematrixelement-kernelmatrix",
           "support": {
             "chrome": {
               "version_added": "6"
@@ -290,7 +290,7 @@
       },
       "kernelUnitLengthX": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeconvolvematrixelement-kernelunitlengthx",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeconvolvematrixelement-kernelunitlengthx",
           "support": {
             "chrome": {
               "version_added": "6"
@@ -338,7 +338,7 @@
       },
       "kernelUnitLengthY": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeconvolvematrixelement-kernelunitlengthy",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeconvolvematrixelement-kernelunitlengthy",
           "support": {
             "chrome": {
               "version_added": "6"
@@ -386,7 +386,7 @@
       },
       "orderX": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeconvolvematrixelement-orderx",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeconvolvematrixelement-orderx",
           "support": {
             "chrome": {
               "version_added": "6"
@@ -434,7 +434,7 @@
       },
       "orderY": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeconvolvematrixelement-ordery",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeconvolvematrixelement-ordery",
           "support": {
             "chrome": {
               "version_added": "6"
@@ -482,7 +482,7 @@
       },
       "preserveAlpha": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeconvolvematrixelement-preservealpha",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeconvolvematrixelement-preservealpha",
           "support": {
             "chrome": {
               "version_added": "6"
@@ -530,7 +530,7 @@
       },
       "targetX": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeconvolvematrixelement-targetx",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeconvolvematrixelement-targetx",
           "support": {
             "chrome": {
               "version_added": "6"
@@ -578,7 +578,7 @@
       },
       "targetY": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeconvolvematrixelement-targety",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeconvolvematrixelement-targety",
           "support": {
             "chrome": {
               "version_added": "6"

--- a/api/SVGFEDiffuseLightingElement.json
+++ b/api/SVGFEDiffuseLightingElement.json
@@ -50,7 +50,7 @@
       },
       "diffuseConstant": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfediffuselightingelement-diffuseconstant",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfediffuselightingelement-diffuseconstant",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -98,7 +98,7 @@
       },
       "in1": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfediffuselightingelement-in1",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfediffuselightingelement-in1",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -146,7 +146,7 @@
       },
       "kernelUnitLengthX": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfediffuselightingelement-kernelunitlengthx",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfediffuselightingelement-kernelunitlengthx",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -194,7 +194,7 @@
       },
       "kernelUnitLengthY": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfediffuselightingelement-kernelunitlengthy",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfediffuselightingelement-kernelunitlengthy",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -242,7 +242,7 @@
       },
       "surfaceScale": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfediffuselightingelement-surfacescale",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfediffuselightingelement-surfacescale",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/SVGFEDisplacementMapElement.json
+++ b/api/SVGFEDisplacementMapElement.json
@@ -50,7 +50,7 @@
       },
       "in1": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfedisplacementmapelement-in1",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfedisplacementmapelement-in1",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -98,7 +98,7 @@
       },
       "in2": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfedisplacementmapelement-in2",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfedisplacementmapelement-in2",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -146,7 +146,7 @@
       },
       "scale": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfedisplacementmapelement-scale",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfedisplacementmapelement-scale",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -194,7 +194,7 @@
       },
       "xChannelSelector": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfedisplacementmapelement-xchannelselector",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfedisplacementmapelement-xchannelselector",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -242,7 +242,7 @@
       },
       "yChannelSelector": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfedisplacementmapelement-ychannelselector",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfedisplacementmapelement-ychannelselector",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/SVGFEDistantLightElement.json
+++ b/api/SVGFEDistantLightElement.json
@@ -50,7 +50,7 @@
       },
       "azimuth": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfedistantlightelement-azimuth",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfedistantlightelement-azimuth",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -98,7 +98,7 @@
       },
       "elevation": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfedistantlightelement-elevation",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfedistantlightelement-elevation",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/SVGFEDropShadowElement.json
+++ b/api/SVGFEDropShadowElement.json
@@ -50,7 +50,7 @@
       },
       "dx": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfedropshadowelement-dx",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfedropshadowelement-dx",
           "support": {
             "chrome": {
               "version_added": "13"
@@ -98,7 +98,7 @@
       },
       "dy": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfedropshadowelement-dy",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfedropshadowelement-dy",
           "support": {
             "chrome": {
               "version_added": "13"
@@ -146,7 +146,7 @@
       },
       "in1": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfedropshadowelement-in1",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfedropshadowelement-in1",
           "support": {
             "chrome": {
               "version_added": "13"
@@ -194,7 +194,7 @@
       },
       "setStdDeviation": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfedropshadowelement-setstddeviation",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfedropshadowelement-setstddeviation",
           "support": {
             "chrome": {
               "version_added": "13"
@@ -242,7 +242,7 @@
       },
       "stdDeviationX": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfedropshadowelement-stddeviationx",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfedropshadowelement-stddeviationx",
           "support": {
             "chrome": {
               "version_added": "13"
@@ -290,7 +290,7 @@
       },
       "stdDeviationY": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfedropshadowelement-stddeviationy",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfedropshadowelement-stddeviationy",
           "support": {
             "chrome": {
               "version_added": "13"

--- a/api/SVGFEGaussianBlurElement.json
+++ b/api/SVGFEGaussianBlurElement.json
@@ -50,7 +50,7 @@
       },
       "edgeMode": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfegaussianblurelement-edgemode",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfegaussianblurelement-edgemode",
           "support": {
             "chrome": {
               "version_added": false
@@ -98,7 +98,7 @@
       },
       "in1": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfegaussianblurelement-in1",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfegaussianblurelement-in1",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -146,7 +146,7 @@
       },
       "setStdDeviation": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfegaussianblurelement-setstddeviation",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfegaussianblurelement-setstddeviation",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -194,7 +194,7 @@
       },
       "stdDeviationX": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfegaussianblurelement-stddeviationx",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfegaussianblurelement-stddeviationx",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -242,7 +242,7 @@
       },
       "stdDeviationY": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfegaussianblurelement-stddeviationy",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfegaussianblurelement-stddeviationy",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/SVGFEImageElement.json
+++ b/api/SVGFEImageElement.json
@@ -98,7 +98,7 @@
       },
       "preserveAspectRatio": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeimageelement-preserveaspectratio",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeimageelement-preserveaspectratio",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/SVGFEMergeNodeElement.json
+++ b/api/SVGFEMergeNodeElement.json
@@ -50,7 +50,7 @@
       },
       "in1": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfemergenodeelement-in1",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfemergenodeelement-in1",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/SVGFEMorphologyElement.json
+++ b/api/SVGFEMorphologyElement.json
@@ -50,7 +50,7 @@
       },
       "in1": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfemorphologyelement-in1",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfemorphologyelement-in1",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -98,7 +98,7 @@
       },
       "operator": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfemorphologyelement-operator",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfemorphologyelement-operator",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -146,7 +146,7 @@
       },
       "radiusX": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfemorphologyelement-radiusx",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfemorphologyelement-radiusx",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -194,7 +194,7 @@
       },
       "radiusY": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfemorphologyelement-radiusy",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfemorphologyelement-radiusy",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/SVGFEOffsetElement.json
+++ b/api/SVGFEOffsetElement.json
@@ -50,7 +50,7 @@
       },
       "dx": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeoffsetelement-dx",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeoffsetelement-dx",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -98,7 +98,7 @@
       },
       "dy": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeoffsetelement-dy",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeoffsetelement-dy",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -146,7 +146,7 @@
       },
       "in1": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeoffsetelement-in1",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeoffsetelement-in1",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/SVGFEPointLightElement.json
+++ b/api/SVGFEPointLightElement.json
@@ -50,7 +50,7 @@
       },
       "x": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfepointlightelement-x",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfepointlightelement-x",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -98,7 +98,7 @@
       },
       "y": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfepointlightelement-y",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfepointlightelement-y",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -146,7 +146,7 @@
       },
       "z": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfepointlightelement-z",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfepointlightelement-z",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/SVGFESpecularLightingElement.json
+++ b/api/SVGFESpecularLightingElement.json
@@ -50,7 +50,7 @@
       },
       "in1": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfespecularlightingelement-in1",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfespecularlightingelement-in1",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -98,7 +98,7 @@
       },
       "kernelUnitLengthX": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfespecularlightingelement-kernelunitlengthx",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfespecularlightingelement-kernelunitlengthx",
           "support": {
             "chrome": {
               "version_added": "45"
@@ -146,7 +146,7 @@
       },
       "kernelUnitLengthY": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfespecularlightingelement-kernelunitlengthy",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfespecularlightingelement-kernelunitlengthy",
           "support": {
             "chrome": {
               "version_added": "45"
@@ -194,7 +194,7 @@
       },
       "specularConstant": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfespecularlightingelement-specularconstant",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfespecularlightingelement-specularconstant",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -242,7 +242,7 @@
       },
       "specularExponent": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfespecularlightingelement-specularexponent",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfespecularlightingelement-specularexponent",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -290,7 +290,7 @@
       },
       "surfaceScale": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfespecularlightingelement-surfacescale",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfespecularlightingelement-surfacescale",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/SVGFESpotLightElement.json
+++ b/api/SVGFESpotLightElement.json
@@ -50,7 +50,7 @@
       },
       "limitingConeAngle": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfespotlightelement-limitingconeangle",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfespotlightelement-limitingconeangle",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -98,7 +98,7 @@
       },
       "pointsAtX": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfespotlightelement-pointsatx",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfespotlightelement-pointsatx",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -146,7 +146,7 @@
       },
       "pointsAtY": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfespotlightelement-pointsaty",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfespotlightelement-pointsaty",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -194,7 +194,7 @@
       },
       "pointsAtZ": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfespotlightelement-pointsatz",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfespotlightelement-pointsatz",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -242,7 +242,7 @@
       },
       "specularExponent": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfespotlightelement-specularexponent",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfespotlightelement-specularexponent",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -290,7 +290,7 @@
       },
       "x": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfespotlightelement-x",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfespotlightelement-x",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -338,7 +338,7 @@
       },
       "y": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfespotlightelement-y",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfespotlightelement-y",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -386,7 +386,7 @@
       },
       "z": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfespotlightelement-z",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfespotlightelement-z",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/SVGFETileElement.json
+++ b/api/SVGFETileElement.json
@@ -50,7 +50,7 @@
       },
       "in1": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfetileelement-in1",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfetileelement-in1",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/SVGFETurbulenceElement.json
+++ b/api/SVGFETurbulenceElement.json
@@ -50,7 +50,7 @@
       },
       "baseFrequencyX": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeturbulenceelement-basefrequencyx",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeturbulenceelement-basefrequencyx",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -98,7 +98,7 @@
       },
       "baseFrequencyY": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeturbulenceelement-basefrequencyy",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeturbulenceelement-basefrequencyy",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -146,7 +146,7 @@
       },
       "numOctaves": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeturbulenceelement-numoctaves",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeturbulenceelement-numoctaves",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -194,7 +194,7 @@
       },
       "seed": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeturbulenceelement-seed",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeturbulenceelement-seed",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -242,7 +242,7 @@
       },
       "stitchTiles": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeturbulenceelement-stitchtiles",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeturbulenceelement-stitchtiles",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -290,7 +290,7 @@
       },
       "type": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfeturbulenceelement-type",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfeturbulenceelement-type",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/SVGFilterElement.json
+++ b/api/SVGFilterElement.json
@@ -50,7 +50,7 @@
       },
       "filterUnits": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfilterelement-filterunits",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfilterelement-filterunits",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -98,7 +98,7 @@
       },
       "height": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfilterelement-height",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfilterelement-height",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -193,7 +193,7 @@
       },
       "primitiveUnits": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfilterelement-primitiveunits",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfilterelement-primitiveunits",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -241,7 +241,7 @@
       },
       "width": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfilterelement-width",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfilterelement-width",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -289,7 +289,7 @@
       },
       "x": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfilterelement-x",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfilterelement-x",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -337,7 +337,7 @@
       },
       "y": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#dom-svgfilterelement-y",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfilterelement-y",
           "support": {
             "chrome": {
               "version_added": "5"


### PR DESCRIPTION
These should all be using the spec URL for the un-leveled spec at https://drafts.fxtf.org/filter-effects rather than the leveled spec at https://drafts.fxtf.org/filter-effects-1