### PR TITLE
Mark Push API as shipped in Firefox for Android 48

### DIFF
--- a/api/PushEvent.json
+++ b/api/PushEvent.json
@@ -18,15 +18,9 @@
             "version_added": "44",
             "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
           },
-          "firefox_android": [
-            {
-              "version_added": "44"
-            },
-            {
-              "version_added": "48",
-              "notes": "Push enabled by default."
-            }
-          ],
+          "firefox_android": {
+            "version_added": "48"
+          },
           "ie": {
             "version_added": false
           },
@@ -75,15 +69,9 @@
               "version_added": "44",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
-            "firefox_android": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "48",
-                "notes": "Push enabled by default."
-              }
-            ],
+            "firefox_android": {
+              "version_added": "48"
+            },
             "ie": {
               "version_added": false
             },
@@ -131,15 +119,9 @@
               "version_added": "44",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
-            "firefox_android": [
-              {
-                "version_added": "44"
-              },
-              {
-                "version_added": "48",
-                "notes": "Push enabled by default."
-              }
-            ],
+            "firefox_android": {
+              "version_added": "48"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/PushManager.json
+++ b/api/PushManager.json
@@ -19,8 +19,7 @@
             "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
           },
           "firefox_android": {
-            "version_added": "48",
-            "notes": "Push enabled by default."
+            "version_added": "48"
           },
           "ie": {
             "version_added": false
@@ -119,8 +118,7 @@
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "48",
-              "notes": "Push enabled by default."
+              "version_added": "48"
             },
             "ie": {
               "version_added": false
@@ -169,8 +167,7 @@
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "48",
-              "notes": "Push enabled by default."
+              "version_added": "48"
             },
             "ie": {
               "version_added": false
@@ -220,8 +217,7 @@
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "48",
-              "notes": "Push enabled by default."
+              "version_added": "48"
             },
             "ie": {
               "version_added": false
@@ -270,8 +266,7 @@
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "48",
-              "notes": "Push enabled by default."
+              "version_added": "48"
             },
             "ie": {
               "version_added": false
@@ -320,8 +315,7 @@
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "48",
-              "notes": "Push enabled by default."
+              "version_added": "48"
             },
             "ie": {
               "version_added": false
@@ -426,8 +420,7 @@
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "48",
-              "notes": "Push enabled by default."
+              "version_added": "48"
             },
             "ie": {
               "version_added": false
@@ -476,8 +469,7 @@
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "48",
-              "notes": "Push enabled by default."
+              "version_added": "48"
             },
             "ie": {
               "version_added": false

--- a/api/PushSubscriptionOptions.json
+++ b/api/PushSubscriptionOptions.json
@@ -18,7 +18,7 @@
             "version_added": "44"
           },
           "firefox_android": {
-            "version_added": "44"
+            "version_added": "48"
           },
           "ie": {
             "version_added": false
@@ -67,7 +67,7 @@
               "version_added": "44"
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "48"
             },
             "ie": {
               "version_added": false

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -1029,7 +1029,7 @@
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "48"
             },
             "ie": {
               "version_added": false
@@ -1084,7 +1084,7 @@
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "48"
             },
             "ie": {
               "version_added": false

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -516,7 +516,7 @@
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
             },
             "firefox_android": {
-              "version_added": "44"
+              "version_added": "48"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
The "Push enabled by default." notes don't really make sense as used,
since it means the API wasn't supported before that. So change all parts
of the API to be enabled in Firefox for Android 48.

The version wasn't confirmed with testing, but per
https://bugzilla.mozilla.org/show_bug.cgi?id=1278435 the API was enabled
separately for Android, and 48 is the earliest affected version, along
with 49 and 50.
