### PR TITLE
index.js: Always crawl relative to BCD root

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 const { fdir } = require('fdir');
 
 class DuplicateCompatError extends Error {
@@ -26,7 +27,7 @@ function load(...dirs) {
     const paths = new fdir()
       .withBasePath()
       .filter((fp) => fp.endsWith('.json'))
-      .crawl(dir)
+      .crawl(path.join(__dirname, dir))
       .sync();
 
     for (const fp of paths) {


### PR DESCRIPTION
This PR fixes an issue with `index.js` where the file crawling doesn't always occur relative to the root of BCD, specifically when importing the development version for other projects such as the mdn-bcd-collector.
