### PR TITLE
Order properties within schema to match our ordering

### DIFF
--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -5,6 +5,31 @@
     "simple_support_statement": {
       "type": "object",
       "properties": {
+        "version_added": {
+          "description": "A string (indicating which browser version added this feature), the value true (indicating support added in an unknown version), the value false (indicating the feature is not supported), or the value null (indicating support is unknown).",
+          "anyOf": [
+            {
+              "type": "string",
+              "pattern": "^(≤?(\\d+)(\\.\\d+)*|preview)$"
+            },
+            {
+              "type": "boolean",
+              "nullable": true
+            }
+          ]
+        },
+        "version_removed": {
+          "description": "A string, indicating which browser version removed this feature, or the value true, indicating that the feature was removed in an unknown version.",
+          "anyOf": [
+            {
+              "type": "string",
+              "pattern": "^(≤?(\\d+)(\\.\\d+)*|preview)$"
+            },
+            {
+              "const": true
+            }
+          ]
+        },
         "prefix": {
           "type": "string",
           "description": "A prefix to add to the sub-feature name (defaults to empty string). If applicable, leading and trailing '-' must be included."
@@ -41,31 +66,6 @@
         "partial_implementation": {
           "const": true,
           "description": "A boolean value indicating whether or not the implementation of the sub-feature deviates from the specification in a way that may cause compatibility problems. It defaults to false (no interoperability problems expected). If set to true, it is recommended that you add a note explaining how it diverges from the standard (such as that it implements an old version of the standard, for example)."
-        },
-        "version_added": {
-          "description": "A string (indicating which browser version added this feature), the value true (indicating support added in an unknown version), the value false (indicating the feature is not supported), or the value null (indicating support is unknown).",
-          "anyOf": [
-            {
-              "type": "string",
-              "pattern": "^(≤?(\\d+)(\\.\\d+)*|preview)$"
-            },
-            {
-              "type": "boolean",
-              "nullable": true
-            }
-          ]
-        },
-        "version_removed": {
-          "description": "A string, indicating which browser version removed this feature, or the value true, indicating that the feature was removed in an unknown version.",
-          "anyOf": [
-            {
-              "type": "string",
-              "pattern": "^(≤?(\\d+)(\\.\\d+)*|preview)$"
-            },
-            {
-              "const": true
-            }
-          ]
         },
         "notes": {
           "description": "A string or array of strings containing additional information.",


### PR DESCRIPTION
This PR is a minor change that just reorders the properties in the schema to match our own property ordering.
