### PR TITLE
EXT_texture_compression_bptc and EXT_texture_compression_rgtc added in Chrome 82.

### DIFF
--- a/api/EXT_texture_compression_bptc.json
+++ b/api/EXT_texture_compression_bptc.json
@@ -6,7 +6,7 @@
         "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_texture_compression_bptc/",
         "support": {
           "chrome": {
-            "version_added": "82"
+            "version_added": "83"
           },
           "chrome_android": {
             "version_added": "83"

--- a/api/EXT_texture_compression_bptc.json
+++ b/api/EXT_texture_compression_bptc.json
@@ -9,7 +9,7 @@
             "version_added": "82"
           },
           "chrome_android": {
-            "version_added": "82"
+            "version_added": "83"
           },
           "edge": {
             "version_added": "88"
@@ -39,7 +39,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": "82"
+            "version_added": "83"
           }
         },
         "status": {

--- a/api/EXT_texture_compression_bptc.json
+++ b/api/EXT_texture_compression_bptc.json
@@ -6,13 +6,13 @@
         "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_texture_compression_bptc/",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "82"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "82"
           },
           "edge": {
-            "version_added": false
+            "version_added": "88"
           },
           "firefox": {
             "version_added": "68"
@@ -39,7 +39,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "82"
           }
         },
         "status": {

--- a/api/EXT_texture_compression_bptc.json
+++ b/api/EXT_texture_compression_bptc.json
@@ -6,13 +6,13 @@
         "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_texture_compression_bptc/",
         "support": {
           "chrome": {
-            "version_added": "83"
+            "version_added": "92"
           },
           "chrome_android": {
-            "version_added": "83"
+            "version_added": "92"
           },
           "edge": {
-            "version_added": "88"
+            "version_added": "92"
           },
           "firefox": {
             "version_added": "68"
@@ -24,10 +24,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "78"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "65"
           },
           "safari": {
             "version_added": false
@@ -39,7 +39,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": "83"
+            "version_added": "92"
           }
         },
         "status": {

--- a/api/EXT_texture_compression_rgtc.json
+++ b/api/EXT_texture_compression_rgtc.json
@@ -6,13 +6,13 @@
         "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_texture_compression_rgtc/",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "82"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "82"
           },
           "edge": {
-            "version_added": false
+            "version_added": "88"
           },
           "firefox": {
             "version_added": "65",
@@ -41,7 +41,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": false
+            "version_added": "82"
           }
         },
         "status": {

--- a/api/EXT_texture_compression_rgtc.json
+++ b/api/EXT_texture_compression_rgtc.json
@@ -6,7 +6,7 @@
         "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_texture_compression_rgtc/",
         "support": {
           "chrome": {
-            "version_added": "82"
+            "version_added": "83"
           },
           "chrome_android": {
             "version_added": "83"

--- a/api/EXT_texture_compression_rgtc.json
+++ b/api/EXT_texture_compression_rgtc.json
@@ -9,7 +9,7 @@
             "version_added": "82"
           },
           "chrome_android": {
-            "version_added": "82"
+            "version_added": "83"
           },
           "edge": {
             "version_added": "88"
@@ -41,7 +41,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": "82"
+            "version_added": "83"
           }
         },
         "status": {

--- a/api/EXT_texture_compression_rgtc.json
+++ b/api/EXT_texture_compression_rgtc.json
@@ -6,13 +6,13 @@
         "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_texture_compression_rgtc/",
         "support": {
           "chrome": {
-            "version_added": "83"
+            "version_added": "92"
           },
           "chrome_android": {
-            "version_added": "83"
+            "version_added": "92"
           },
           "edge": {
-            "version_added": "88"
+            "version_added": "92"
           },
           "firefox": {
             "version_added": "65",
@@ -26,10 +26,10 @@
             "version_added": false
           },
           "opera": {
-            "version_added": false
+            "version_added": "78"
           },
           "opera_android": {
-            "version_added": false
+            "version_added": "65"
           },
           "safari": {
             "version_added": "14.1"
@@ -41,7 +41,7 @@
             "version_added": false
           },
           "webview_android": {
-            "version_added": "83"
+            "version_added": "92"
           }
         },
         "status": {


### PR DESCRIPTION
#### Summary
EXT_texture_compression_bptc and EXT_texture_compression_rgtc were added in Chrome 82.

#### Test results and supporting details
Verified that it works on my machine in Chrome and Edge latest. This is the Chromium commit that added support: https://chromiumdash.appspot.com/commits?commit=de2f6f382d1d4371c69b5359eb2f2763fe6df427