### PR TITLE
Fix bad link for rgb_hexadecimal_notation (mdn/content#16116)

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -986,7 +986,7 @@
         },
         "rgb_hexadecimal_notation": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/hexadecimal_rgb",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/hex-color",
             "spec_url": "https://drafts.csswg.org/css-color/#hex-notation",
             "description": "RGB hexadecimal notation (<code>#RRGGBB</code>, <code>#RGB</code>, …)",
             "support": {


### PR DESCRIPTION
#### Summary

Updates a bad link for `/css/types/color.json`'s `rgb_hexadecimal_notation`.

Replace `https://developer.mozilla.org/docs/Web/CSS/color_value/hexadecimal_rgb` with `https://developer.mozilla.org/docs/Web/CSS/hex-color`.

#### Related issues
[Issue #16116 in content's repository](https://github.com/mdn/content/issues/16116).

> Incorrect link to https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hexadecimal_rgb part way through content
