### PR TITLE
FullscreenOptions in element.requestFullscreen isn't supported on Firefox

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -5905,10 +5905,10 @@
                 "version_added": "79"
               },
               "firefox": {
-                "version_added": "64"
+                "version_added": false
               },
               "firefox_android": {
-                "version_added": "64"
+                "version_added": false
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
#### Summary
Gecko doesn't support `FullscreenOptions` yet.
See https://searchfox.org/mozilla-central/rev/8fe6930c0832009b3162bebee7d4ede1a4c8c9a8/dom/webidl/Element.webidl#309

#### Test results and supporting details
WPT such as http://wpt.live/fullscreen/api/element-request-fullscreen-options.html is failure.