### PR TITLE
Ignore .test.js files in c8 coverage reports

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,5 +1,10 @@
 {
   "all": true,
   "include": ["**/scripts/**", "**/test/**", "**/utils/**"],
-  "exclude": ["**/.nyc_output/**", "**/coverage/**", "**/node_modules/**"]
+  "exclude": [
+    "**/.nyc_output/**",
+    "**/coverage/**",
+    "**/node_modules/**",
+    "**/**.test.js"
+  ]
 }


### PR DESCRIPTION
This PR udpates the .c8rc.json file to ignore the test script files in coverage reports.  The test script files test other files, no need to test the tests of the tests.  :P
