### PR TITLE
Ignore coverage folder in Prettier check

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,4 @@ LICENSE
 /package-lock.json
 /CODE_OF_CONDUCT.md
 build/
+coverage/


### PR DESCRIPTION
This PR tells Prettier to ignore the `coverage/` folder generated by c8.
