### PR TITLE
Parse JSON once per file in linter

### DIFF
--- a/test/lint.js
+++ b/test/lint.js
@@ -73,7 +73,7 @@ const checkFiles = (...files) => {
           // Set spinner to failure when first error is found
           // Setting on every error causes duplicate output
           spinner['stream'] = process.stderr;
-          spinner.fail(chalk`{red.bold ${relativeFilePath}}`);
+          spinner.fail(chalk`{red.bold ${filePath.full}}`);
 
           errors[filePath.full] = [];
         }

--- a/test/linter/test-browsers-data.js
+++ b/test/linter/test-browsers-data.js
@@ -1,8 +1,6 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs from 'node:fs';
-
 import chalk from 'chalk-template';
 
 import { Logger } from '../utils.js';
@@ -39,15 +37,10 @@ function processData(data, logger) {
 }
 
 /**
- * @param {string} filename
+ * @param {Identifier} data The contents of the file to test
  * @returns {boolean} If the file contains errors
  */
-export default function testBrowsersData(filename) {
-  /** @type {Identifier} */
-  const data = JSON.parse(
-    fs.readFileSync(new URL(filename, import.meta.url), 'utf-8'),
-  );
-
+export default function testBrowsersData(data) {
   const logger = new Logger('Browser Data');
 
   processData(data, logger);

--- a/test/linter/test-browsers-presence.js
+++ b/test/linter/test-browsers-presence.js
@@ -1,18 +1,12 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import chalk from 'chalk-template';
 
 import { Logger } from '../utils.js';
 
 import bcd from '../../index.js';
 const { browsers } = bcd;
-
-const dirname = fileURLToPath(new URL('.', import.meta.url));
 
 /**
  * @typedef {import('../../types').Identifier} Identifier
@@ -95,27 +89,14 @@ function processData(data, category, logger, path = '') {
 }
 
 /**
- * Test for issues within the browsers in the data within the specified file.
- *
- * @param {string} filename The file to test
+ * @param {Identifier} data The contents of the file to test
+ * @param {object} filePath The path info for the file being tested
  * @returns {boolean} If the file contains errors
  */
-export default function testBrowsersPresence(filename) {
-  const relativePath = path.relative(
-    path.resolve(dirname, '..', '..'),
-    filename,
-  );
-  const category =
-    relativePath.includes(path.sep) && relativePath.split(path.sep)[0];
-
-  /** @type {Identifier} */
-  const data = JSON.parse(
-    fs.readFileSync(new URL(filename, import.meta.url), 'utf-8'),
-  );
-
+export default function testBrowsersPresence(data, filePath) {
   const logger = new Logger('Browsers');
 
-  processData(data, category, logger);
+  processData(data, filePath.category, logger);
 
   logger.emit();
   return logger.hasErrors();

--- a/test/linter/test-consistency.js
+++ b/test/linter/test-consistency.js
@@ -1,7 +1,6 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs from 'node:fs';
 import compareVersions from 'compare-versions';
 import chalk from 'chalk-template';
 import { query } from '../../utils/index.js';
@@ -421,17 +420,10 @@ export class ConsistencyChecker {
 }
 
 /**
- * Test the version consistency within the file
- *
- * @param {string} filename The file to test
+ * @param {Identifier} data The contents of the file to test
  * @returns {boolean} If the file contains errors
  */
-export default function testConsistency(filename) {
-  /** @type {Identifier} */
-  const data = JSON.parse(
-    fs.readFileSync(new URL(filename, import.meta.url), 'utf-8'),
-  );
-
+export default function testConsistency(data) {
   const logger = new Logger('Consistency');
 
   const checker = new ConsistencyChecker();

--- a/test/linter/test-descriptions.js
+++ b/test/linter/test-descriptions.js
@@ -1,7 +1,6 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs from 'node:fs';
 import chalk from 'chalk-template';
 import { Logger } from '../utils.js';
 
@@ -102,15 +101,10 @@ function processData(data, logger) {
 /**
  * Test all of the descriptions through the data in a given filename.  This test only functions with files with API data; all other files are silently ignored
  *
- * @param {string} filename The file to test
- * @returns {boolean} Whether the file has errors
+ * @param {Identifier} data The contents of the file to test
+ * @returns {boolean} If the file contains errors
  */
-export default function testDescriptions(filename) {
-  /** @type {Identifier} */
-  const data = JSON.parse(
-    fs.readFileSync(new URL(filename, import.meta.url), 'utf-8'),
-  );
-
+export default function testDescriptions(data) {
   const logger = new Logger('Descriptions');
 
   processData(data, logger);

--- a/test/linter/test-links.js
+++ b/test/linter/test-links.js
@@ -1,7 +1,6 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs from 'node:fs';
 import chalk from 'chalk-template';
 import { IS_WINDOWS, indexToPos, indexToPosRaw, Logger } from '../utils.js';
 
@@ -17,13 +16,13 @@ import { IS_WINDOWS, indexToPos, indexToPosRaw, Logger } from '../utils.js';
 /**
  * Process the data for any errors within the links
  *
- * @param {string} filename The file to test
+ * @param {string} rawData The raw contents of the file to test
  * @returns {LinkError[]} A list of errors found in the links
  */
-export function processData(filename) {
+export function processData(rawData) {
   let errors = [];
 
-  let actual = fs.readFileSync(filename, 'utf-8').trim();
+  let actual = rawData;
 
   // prevent false positives from git.core.autocrlf on Windows
   if (IS_WINDOWS) {
@@ -245,14 +244,16 @@ function processLink(errors, actual, regexp, matchHandler) {
 /**
  * Test for any malformed links
  *
- * @param {string} filename The file to test
+ * @param {string} rawData The raw contents of the file to test
  * @returns {boolean} If the file contains errors
  */
-export default function testLinks(filename) {
+export default function testLinks(rawData) {
+  // XXX This should use the parsed JSON data
+
   const logger = new Logger('Links');
 
   /** @type {Object[]} */
-  let errors = processData(filename);
+  let errors = processData(rawData);
 
   for (const error of errors) {
     logger.error(

--- a/test/linter/test-notes.js
+++ b/test/linter/test-notes.js
@@ -1,8 +1,6 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs from 'node:fs';
-
 import chalk from 'chalk-template';
 import HTMLParser from '@desertnet/html-parser';
 
@@ -148,15 +146,10 @@ const processData = (data, logger, feature) => {
 /**
  * Test the data for notes errors
  *
- * @param {string} filename The file to test
- * @returns {boolean} Whether the file had any errors
+ * @param {Identifier} data The contents of the file to test
+ * @returns {boolean} If the file contains errors
  */
-const testNotes = (filename) => {
-  /** @type {Identifier} */
-  const data = JSON.parse(
-    fs.readFileSync(new URL(filename, import.meta.url), 'utf-8'),
-  );
-
+const testNotes = (data) => {
   const logger = new Logger('Notes');
 
   processData(data, logger);

--- a/test/linter/test-prefix.js
+++ b/test/linter/test-prefix.js
@@ -1,13 +1,8 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import chalk from 'chalk-template';
 import { Logger } from '../utils.js';
-
-const dirname = fileURLToPath(new URL('.', import.meta.url));
 
 /**
  * @typedef {import('../../types').Identifier} Identifier
@@ -73,23 +68,14 @@ function processData(data, category, logger) {
 /**
  * Test for issues with feature's prefix
  *
- * @param {string} filename The file to test
+ * @param {Identifier} data The contents of the file to test
+ * @param {object} filePath The path info for the file being tested
  * @returns {boolean} If the file contains errors
  */
-export default function testPrefix(filename) {
+export default function testPrefix(data, filePath) {
   const logger = new Logger('Prefix');
 
-  const relativePath = path.relative(
-    path.resolve(dirname, '..', '..'),
-    filename,
-  );
-  const category =
-    relativePath.includes(path.sep) && relativePath.split(path.sep)[0];
-  const data = JSON.parse(
-    fs.readFileSync(new URL(filename, import.meta.url), 'utf-8'),
-  );
-
-  processData(data, category, logger);
+  processData(data, filePath.category, logger);
 
   logger.emit();
   return logger.hasErrors();

--- a/test/linter/test-schema.js
+++ b/test/linter/test-schema.js
@@ -1,12 +1,14 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs from 'node:fs';
 import Ajv from 'ajv';
 import ajvErrors from 'ajv-errors';
 import ajvFormats from 'ajv-formats';
 import betterAjvErrors from 'better-ajv-errors';
 import { Logger } from '../utils.js';
+
+import compatDataSchema from './../../schemas/compat-data.schema.json' assert { type: 'json' };
+import browserDataSchema from './../../schemas/browsers.schema.json' assert { type: 'json' };
 
 /**
  * @typedef {import('../utils').Logger} Logger
@@ -22,20 +24,13 @@ ajvErrors(ajv);
 /**
  * Test a file to make sure it follows the defined schema
  *
- * @param {string} dataFilename The file to test
- * @param {string} [schemaFilename] A specific schema file to test with, if needed
+ * @param {Identifier} data The contents of the file to test
+ * @param {object} filePath The path info for the file being tested
  * @returns {boolean} If the file contains errors
  */
-export default function testSchema(
-  dataFilename,
-  schemaFilename = './../../schemas/compat-data.schema.json',
-) {
-  const schema = JSON.parse(
-    fs.readFileSync(new URL(schemaFilename, import.meta.url), 'utf-8'),
-  );
-  const data = JSON.parse(
-    fs.readFileSync(new URL(dataFilename, import.meta.url), 'utf-8'),
-  );
+export default function testSchema(data, filePath) {
+  const schema =
+    filePath.category === 'browsers' ? browserDataSchema : compatDataSchema;
 
   const logger = new Logger('JSON Schema');
 

--- a/test/linter/test-style.js
+++ b/test/linter/test-style.js
@@ -1,7 +1,6 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs from 'node:fs';
 import chalk from 'chalk-template';
 import { IS_WINDOWS, indexToPos, jsonDiff } from '../utils.js';
 import compareFeatures from '../../scripts/lib/compare-features.js';
@@ -62,11 +61,11 @@ function orderFeatures(key, value) {
 /**
  * Process the data for any styling errors that cannot be caught by Prettier or the schema
  *
- * @param {string} filename The file to test
+ * @param {string} rawData The raw contents of the file to test
  * @param {Logger} logger The logger to output errors to
  */
-function processData(filename, logger) {
-  let actual = fs.readFileSync(filename, 'utf-8').trim();
+function processData(rawData, logger) {
+  let actual = rawData;
   /** @type {import('../../types').CompatData} */
   const dataObject = JSON.parse(actual);
   let expected = JSON.stringify(dataObject, null, 2);
@@ -119,13 +118,13 @@ function processData(filename, logger) {
 /**
  * Test the data for any styling errors that cannot be caught by Prettier or the schema
  *
- * @param {string} filename The file to test
+ * @param {string} rawData The raw contents of the file to test
  * @returns {boolean} If the file contains errors
  */
-export default function testStyle(filename) {
+export default function testStyle(rawData) {
   const logger = new Logger('Style');
 
-  processData(filename, logger);
+  processData(rawData, logger);
 
   logger.emit();
   return logger.hasErrors();

--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -1,7 +1,6 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import fs from 'node:fs';
 import compareVersions from 'compare-versions';
 import chalk from 'chalk-template';
 import { Logger } from '../utils.js';
@@ -269,18 +268,10 @@ function findSupport(data, logger, relPath) {
 /**
  * Test for version errors
  *
- * @param {string} filename The file to test
+ * @param {Identifier} data The contents of the file to test
  * @returns {boolean} If the file contains errors
  */
-export default function testVersions(filename) {
-  /** @type {Identifier} */
-  const data = JSON.parse(
-    fs.readFileSync(
-      new URL(new URL(filename, import.meta.url), import.meta.url),
-      'utf-8',
-    ),
-  );
-
+export default function testVersions(data) {
   const logger = new Logger('Versions');
 
   findSupport(data, logger);


### PR DESCRIPTION
This PR updates our linter to only load and parse the JSON data once per file, rather than multiple times per each lint on each file.  This is a side effect of the ESM migration, where we used `require()` to parse the JSON data, thus utilizing NodeJS' built-in caching.  After switching to ESM, we then used `fs.readFileSync` and `JSON.parse`, which does not offer the same caching benefits.
