### PR TITLE
Update Oculus browser release info

### DIFF
--- a/browsers/oculus.json
+++ b/browsers/oculus.json
@@ -110,11 +110,9 @@
           "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-161",
           "status": "retired"
         },
-        "17.0": {
+        "16.2": {
           "engine": "Blink",
-          "engine_version": "93",
-          "release_date": "2021-09-13",
-          "status": "retired"
+          "status": "current"
         }
       }
     }


### PR DESCRIPTION
This PR updates the release info for the Oculus browser based upon the support page: https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-162

Note that I have no clue which engine it is or what the release date was, as there's not a lot of public information about the Oculus browser.  I also removed the entry for "17.0" since there's no mention of it.
