### PR TITLE
Fix chalk template in lint

### DIFF
--- a/test/lint.js
+++ b/test/lint.js
@@ -69,7 +69,7 @@ const checkFiles = (...files) => {
           // Set spinner to failure when first error is found
           // Setting on every error causes duplicate output
           spinner['stream'] = process.stderr;
-          spinner.fail(chalk.red.bold(relativeFilePath));
+          spinner.fail(chalk`{red.bold ${relativeFilePath}}`);
 
           errors[relativeFilePath] = [];
         }


### PR DESCRIPTION
This was broken in https://github.com/mdn/browser-compat-data/pull/15312
and this code path is only taken when there's a problem, so wasn't
discovered by CI.

