### PR TITLE
Don't fix ESLint issues when running `npm run format`

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "diff": "node scripts/diff.js",
     "unittest": "c8 mocha --recursive \"{,!(node_modules)/**}/*.test.js\"",
     "coverage": "c8 report -r lcov && open-cli coverage/lcov-report/index.html",
-    "format": "npx eslint --fix \"**/*.js\" && npx prettier --check \"**/*.js\" \"**/*.ts\" \"**/*.md\" \"**/*.json\"",
+    "format": "npx eslint \"**/*.js\" && npx prettier --check \"**/*.js\" \"**/*.ts\" \"**/*.md\" \"**/*.json\"",
     "format:fix": "npx eslint --fix \"**/*.js\" && npx prettier --write \"**/*.js\" \"**/*.ts\" \"**/*.md\" \"**/*.json\"",
     "lint": "node test/lint",
     "fix": "npm run format:fix && node scripts/fix",


### PR DESCRIPTION
The `format` command is intended just to test the files, not fix them.
