### PR TITLE
Fix file read errors from the linter on Windows

### DIFF
--- a/test/lint.js
+++ b/test/lint.js
@@ -82,9 +82,7 @@ const checkFiles = (...files) => {
       };
 
       try {
-        const rawFileData = fs
-          .readFileSync(file, 'utf-8')
-          .trim();
+        const rawFileData = fs.readFileSync(file, 'utf-8').trim();
         const fileData = JSON.parse(rawFileData);
 
         testSchema(fileData, filePath);


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
`file` is already an absolute path, no need to do anything more with it.

It somehow worked on Linux as the posix absolute path is compatible with `file:///` but the Windows `C:\` is not.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
