### PR TITLE
HTMLCanvasElement.mozGetAsFile - removed from all platforms

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -1083,56 +1083,6 @@
           }
         }
       },
-      "mozGetAsFile": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/mozGetAsFile",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": "4",
-              "version_removed": "74",
-              "notes": "<code>mozGetAsFile()</code> was deprecated in Firefox 26 (in 2013) and was removed entirely in Firefox 74."
-            },
-            "firefox_android": {
-              "version_added": "4"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "mozOpaque": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/mozOpaque",


### PR DESCRIPTION
As discussed in https://github.com/mdn/content/issues/16152#issuecomment-1129140999 , `HTMLCanvasElement.mozGetAsFile` has been removed in FF102. It was  behind a flag since FF101 and is not present in any other platform. Therefore it is now old enough (2 years) to remove from BCD.

Other docs work for this can be tracked in https://github.com/mdn/content/issues/16152