### PR TITLE
Proposal: Drop requirement for peers to use forks

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -32,7 +32,6 @@ Peers are community members who have shown that they are committed to the contin
 
 Peers:
 
-- Are expected to work on public branches of their forks and submit pull requests to the main branch.
 - Must submit pull requests for all their changes.
 - May label and close issues.
 - May merge other people's pull requests that relate to compat data updates.


### PR DESCRIPTION
I’m submitting this PR as a proposal for consideration from the owners. As a BCD peer, I’d very much prefer to be able to create PR branches directly in the BCD repo rather than needing to instead create PR branches in my fork.

For the sake of comparison, in the mdn/content repo, all contributors with write/push access to the repo can create PR branches directly in the mdn/content repo itself (and a number of contributors create branches there regularly) rather than needing to instead create PR branches in their forks. (And for mdn/content repo governance, we don’t have a formal/policy distinction between owners and peers — instead we just have contributors with push/write access vs external contributors who don’t).

In the 17 months that we’ve been following that policy of allowing contributors with push/write access to create PR branches directly in the mdn/content repo, I’m not aware of any problems that it’s caused. So I would expect that allowing BCD peers to create PR branches directly in the BCD repo would not cause any problems either.
