### PR TITLE
FF102 window.sidebar alias of window.external moved behind pref

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -2232,7 +2232,7 @@
                 "notes": "From Firefox 78 <code>AddSearchProvider()</code> does nothing, as the specification requires."
               },
               {
-                "version_added": "101",
+                "version_added": "102",
                 "alternative_name": "sidebar",
                 "flags": [
                   {

--- a/api/Window.json
+++ b/api/Window.json
@@ -2232,7 +2232,19 @@
                 "notes": "From Firefox 78 <code>AddSearchProvider()</code> does nothing, as the specification requires."
               },
               {
+                "version_added": "101",
+                "alternative_name": "sidebar",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.window.sidebar.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
                 "version_added": "1",
+                "version_removed": "102",
                 "alternative_name": "sidebar"
               }
             ],
@@ -2243,6 +2255,7 @@
               },
               {
                 "version_added": "4",
+                "version_removed": "102"
                 "alternative_name": "sidebar"
               }
             ],

--- a/api/Window.json
+++ b/api/Window.json
@@ -2255,7 +2255,7 @@
               },
               {
                 "version_added": "4",
-                "version_removed": "102"
+                "version_removed": "102",
                 "alternative_name": "sidebar"
               }
             ],


### PR DESCRIPTION
FF102 removes [`Window.sidebar`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sidebar) behind a preference in https://bugzilla.mozilla.org/show_bug.cgi?id=1768486

Looking at BCD this is an FF alias for [`Window.external`](https://developer.mozilla.org/en-US/docs/Web/API/Window/external), which is still supported, albeit deprecated. Note though that `sidebar` historically had more functionality than `external` but now they are both equally disabled :-)

Anyway, this PR updates `window.external` entry to remove the unpreff-ed `sidebar` alias and add an entry for the pref. For FF android it just removes the alias.

Other docs work for this can be tracked in https://github.com/mdn/content/issues/16149