### PR TITLE
Marking IE11 as retired

### DIFF
--- a/browsers/ie.json
+++ b/browsers/ie.json
@@ -56,7 +56,7 @@
         },
         "11": {
           "release_date": "2013-10-17",
-          "status": "current",
+          "status": "retired",
           "engine": "Trident",
           "engine_version": "7.0"
         }


### PR DESCRIPTION
The [ie.json](https://github.com/mdn/browser-compat-data/blob/main/browsers/ie.json) browser file still says that IE11 is "current".

This commit changes the status to "retired" given the [formal desktop app retirement coming up on June 15 2022](https://docs.microsoft.com/en-us/lifecycle/announcements/internet-explorer-11-end-of-support).

This PR should, in theory, wait until June 15 to get merged, although I don't think there's a risk with merging it earlier than this.