### PR TITLE
Fix arguments passed into mirroring script bumpVersion()

### DIFF
--- a/scripts/mirror.js
+++ b/scripts/mirror.js
@@ -524,7 +524,7 @@ const doSetFeature = (
 
   if (doBump) {
     let source = getSource(browser);
-    let newValue = bumpVersion(comp[source], browser, source, targetVersion);
+    let newValue = bumpVersion(comp[source], browser, targetVersion);
     if (newValue !== null) {
       newData[rootPath].__compat.support[browser] = newValue;
     }


### PR DESCRIPTION
This PR fixes the call to `bumpVersion()` in the mirroring script.