### PR TITLE
fix Atomics.waitAsync() version for Deno

### DIFF
--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -726,7 +726,7 @@
                 "version_added": "89"
               },
               "deno": {
-                "version_added": "1.4.5"
+                "version_added": "1.4"
               },
               "edge": {
                 "version_added": "87"

--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -726,7 +726,7 @@
                 "version_added": "89"
               },
               "deno": {
-                "version_added": false
+                "version_added": "1.4.5"
               },
               "edge": {
                 "version_added": "87"


### PR DESCRIPTION
This API has been supported since v1.4.5.

#### Summary
This commit adds `Atomics.waitAsync()` information for Deno, which has been available since v1.4.5.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
On Deno v1.4.4, `console.log(Atomics.waitAsync);` prints `undefined`. On Deno v1.4.5, it prints `[Function: waitAsync]`.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
V8 blog post for the API: https://v8.dev/features/atomics

#### Related issues
Refs: https://github.com/denoland/deno/issues/14687

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
