### PR TITLE
Fix scripts/fix failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "format": "npx eslint \"**/*.js\" && npx prettier --check \"**/*.js\" \"**/*.ts\" \"**/*.md\" \"**/*.json\"",
     "format:fix": "npx eslint --fix \"**/*.js\" && npx prettier --write \"**/*.js\" \"**/*.ts\" \"**/*.md\" \"**/*.json\"",
     "lint": "node test/lint",
-    "fix": "npm run format:fix && node scripts/fix",
+    "fix": "npm run format:fix && node scripts/fix/index.js",
     "mirror": "node scripts/mirror",
     "stats": "node scripts/statistics",
     "release-build": "node scripts/release/build",

--- a/scripts/fix/browser-order.js
+++ b/scripts/fix/browser-order.js
@@ -3,7 +3,7 @@
 
 import fs from 'node:fs';
 
-import { IS_WINDOWS } from '../test/utils.js';
+import { IS_WINDOWS } from '../../test/utils.js';
 
 /**
  * @typedef {import('../../types').Identifier} Identifier

--- a/scripts/fix/index.js
+++ b/scripts/fix/index.js
@@ -66,5 +66,4 @@ if (esMain(import.meta)) {
   }
 }
 
-module.exports = load;
 export default load;

--- a/scripts/fix/index.js
+++ b/scripts/fix/index.js
@@ -67,3 +67,4 @@ if (esMain(import.meta)) {
 }
 
 module.exports = load;
+export default load;


### PR DESCRIPTION
It seems `es-main` cannot correctly detect index.js resolved by the directory path and returns false. But not sure it's intended to be a module, does it really need `esMain()`?