### PR TITLE
Manifest theme key update

### DIFF
--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -1331,6 +1331,62 @@
                 "version_added": false
               }
             }
+          },
+          "color_scheme": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme#properties",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "100"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                }
+              }
+            }
+          },
+          "content_color_scheme": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme#properties",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": "100"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
#### Summary
Details about the `color_scheme` and `content_color_scheme` properties are added to [theme](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme) manifest key.

Related content update is in [Manifest theme key update #16568 ](https://github.com/mdn/content/pull/16568).

#### Motivation
To document the changes made in [Bug 1750932](https://bugzilla.mozilla.org/show_bug.cgi?id=1750932) Allow themes to override global color scheme heuristics.

#### Test results and supporting details
Passed `npm test`