### PR TITLE
Update Firefox versions for width:fit-content

### DIFF
--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -187,14 +187,24 @@
                   "version_added": "79"
                 }
               ],
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": "3"
-              },
-              "firefox_android": {
-                "prefix": "-moz-",
-                "version_added": "4"
-              },
+              "firefox": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "3"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
fit-content was unprefixed in firefox 94

#### Test results and supporting details

https://hg.mozilla.org/mozilla-central/rev/7905b23762e5
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
