### PR TITLE
Add "upstream" property to the browser schema

### DIFF
--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -3,6 +3,7 @@
     "chrome_android": {
       "name": "Chrome Android",
       "type": "mobile",
+      "upstream": "chrome",
       "pref_url": "chrome://flags",
       "releases": {
         "18": {

--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -3,6 +3,7 @@
     "edge": {
       "name": "Edge",
       "type": "desktop",
+      "upstream": "chrome",
       "pref_url": "about:flags",
       "accepts_webextensions": true,
       "releases": {

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -3,6 +3,7 @@
     "firefox_android": {
       "name": "Firefox for Android",
       "type": "mobile",
+      "upstream": "firefox",
       "pref_url": "about:config",
       "accepts_webextensions": true,
       "releases": {

--- a/browsers/oculus.json
+++ b/browsers/oculus.json
@@ -4,6 +4,7 @@
       "accepts_flags": true,
       "name": "Oculus Browser",
       "type": "xr",
+      "upstream": "chrome_android",
       "pref_url": "chrome://flags",
       "releases": {
         "5.0": {

--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -3,6 +3,7 @@
     "opera": {
       "name": "Opera",
       "type": "desktop",
+      "upstream": "chrome",
       "accepts_webextensions": true,
       "releases": {
         "2": {

--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -3,6 +3,7 @@
     "opera_android": {
       "name": "Opera Android",
       "type": "mobile",
+      "upstream": "chrome_android",
       "accepts_flags": false,
       "releases": {
         "10.1": {

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -3,6 +3,7 @@
     "safari_ios": {
       "name": "Safari on iOS",
       "type": "mobile",
+      "upstream": "safari",
       "accepts_webextensions": true,
       "releases": {
         "1": {

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -3,6 +3,7 @@
     "samsunginternet_android": {
       "name": "Samsung Internet",
       "type": "mobile",
+      "upstream": "chrome_android",
       "accepts_flags": false,
       "releases": {
         "1.0": {

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -3,6 +3,7 @@
     "webview_android": {
       "name": "WebView Android",
       "type": "mobile",
+      "upstream": "chrome_android",
       "accepts_flags": false,
       "releases": {
         "1": {

--- a/schemas/browsers-schema.md
+++ b/schemas/browsers-schema.md
@@ -45,6 +45,10 @@ The `name` string is a required property which should use the browser brand name
 
 The `type` string is a required property which indicates the platform category the browser runs on. Valid options are `"desktop"`, `"mobile"` and `"server"`.
 
+### `upstream`
+
+The `upstream` string is an optional property which indicates the upstream browser updates are derived from. For example, Firefox Android's upstream browser is Firefox (desktop), and Edge's upstream browser is Chrome. This is used for mirroring data between browsers. Valid options are any browser defined in the data.
+
 ### `accepts_flags`
 
 An optional boolean indicating whether the browser supports flags. If it is set to `false`, flag data will not be allowed for that browser.

--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -27,6 +27,10 @@
           "enum": ["desktop", "mobile", "xr", "server"],
           "description": "What type of browser this is (desktop, mobile, XR, or server engine)."
         },
+        "upstream": {
+          "type": "string",
+          "description": "The upstream browser this browser derives from (e.g. Firefox Android is derived from Firefox, Edge is derived from Chrome)."
+        },
         "accepts_flags": {
           "type": "boolean",
           "description": "Whether the browser supports flags."

--- a/scripts/mirror.js
+++ b/scripts/mirror.js
@@ -523,7 +523,7 @@ const doSetFeature = (
   }
 
   if (doBump) {
-    let source = getSource(browser);
+    let source = browsers[browser].upstream;
     let newValue = bumpVersion(comp[source], browser, targetVersion);
     if (newValue !== null) {
       newData[rootPath].__compat.support[browser] = newValue;

--- a/scripts/mirror.js
+++ b/scripts/mirror.js
@@ -714,6 +714,7 @@ if (esMain(import.meta)) {
         .positional('browser', {
           describe: 'The destination browser',
           type: 'string',
+          choices: Object.keys(browsers).filter((b) => browsers[b].upstream),
         })
         .positional('feature_or_path', {
           describe: 'Features, files, or folders to perform mirroring for',

--- a/test/linter/test-browsers-data.js
+++ b/test/linter/test-browsers-data.js
@@ -5,6 +5,9 @@ import chalk from 'chalk-template';
 
 import { Logger } from '../utils.js';
 
+import bcd from '../../index.js';
+const { browsers } = bcd;
+
 /**
  * @typedef {import('../../types').Identifier} Identifier
  * @typedef {import('../utils').Logger} Logger
@@ -19,18 +22,33 @@ function processData(data, logger) {
   // We only need to grab the first browser in the data
   // because each browser file only contains one browser
   const browser = Object.keys(data.browsers)[0];
-  const releases = data.browsers[browser].releases;
+  const browserData = data.browsers[browser];
 
   for (const status of ['current', 'beta', 'nightly']) {
-    const releasesForStatus = Object.entries(releases)
+    const releasesForStatus = Object.entries(browserData.releases)
       .filter(([, data]) => data.status == status)
       .map(([version]) => version);
 
     if (releasesForStatus.length > 1) {
       logger.error(
-        chalk`{red → {bold ${browser}} has multiple {bold ${status}} releases (${releasesForStatus.join(
+        chalk`{red {bold ${browser}} has multiple {bold ${status}} releases (${releasesForStatus.join(
           ', ',
         )}), which is {bold not} allowed.}`,
+      );
+    }
+  }
+
+  // Ensure the `upstream` property, if it exists, is valid
+  if (browserData.upstream) {
+    if (browserData.upstream === browser) {
+      logger.error(
+        chalk`{red The upstream for {bold ${browser}} is set to itself.}`,
+      );
+    }
+
+    if (!Object.keys(browsers).includes(browserData.upstream)) {
+      logger.error(
+        chalk`{red The upstream for {bold ${browser}} is an unknown browser (${browserData.upstream}).}`,
       );
     }
   }

--- a/types.d.ts
+++ b/types.d.ts
@@ -56,6 +56,11 @@ export interface BrowserStatement {
   type: BrowserTypes;
 
   /**
+   * The upstream browser
+   */
+  upstream?: string;
+
+  /**
    * Whether the browser supports flags to enable or disable features.
    */
   accepts_flags?: boolean;


### PR DESCRIPTION
This PR adds an "upstream" property to the browser data, which indicates the upstream browser.  This is copied directly from the `getSource()` function of the mirroring script, which has now been refactored to utilize this new property.
