### PR TITLE
Simplify bumpVersion() function in mirroring script

### DIFF
--- a/scripts/mirror.js
+++ b/scripts/mirror.js
@@ -379,18 +379,18 @@ const bumpVersion = (sourceData, destination, targetVersion) => {
     );
   }
 
-  let notesRepl;
-  if (destination.includes('opera')) {
-    notesRepl = [/Chrome/g, 'Opera'];
-  } else if (destination === 'samsunginternet_android') {
-    notesRepl = [/Chrome/g, 'Samsung Internet'];
-  }
-
   if (destination === 'edge') {
     newData = bumpEdge(sourceData);
   } else if (destination === 'webview_android') {
     newData = bumpWebView(sourceData);
   } else {
+    let notesRepl;
+    if (destination.includes('opera')) {
+      notesRepl = [/Chrome/g, 'Opera'];
+    } else if (destination === 'samsunginternet_android') {
+      notesRepl = [/Chrome/g, 'Samsung Internet'];
+    }
+
     newData = bumpGeneric(sourceData, destination, notesRepl);
   }
 

--- a/scripts/mirror.js
+++ b/scripts/mirror.js
@@ -317,14 +317,6 @@ const bumpGeneric = (sourceData, targetBrowser, sourceBrowser, notesRepl) => {
  * @param {SupportStatement} sourceData
  * @returns {SupportStatement}
  */
-const bumpChromeAndroid = (sourceData) => {
-  return bumpGeneric(sourceData, 'chrome_android', 'chrome');
-};
-
-/**
- * @param {SupportStatement} sourceData
- * @returns {SupportStatement}
- */
 const bumpEdge = (sourceData) => {
   if (
     typeof sourceData.version_removed === 'string' &&
@@ -335,52 +327,6 @@ const bumpEdge = (sourceData) => {
   }
 
   return bumpGeneric(sourceData, 'edge', 'chrome', [/Chrome/g, 'Edge']);
-};
-
-/**
- * @param {SupportStatement} sourceData
- * @returns {SupportStatement}
- */
-const bumpFirefoxAndroid = (sourceData) => {
-  return bumpGeneric(sourceData, 'firefox_android', 'firefox');
-};
-
-/**
- * @param {SupportStatement} sourceData
- * @returns {SupportStatement}
- */
-const bumpOpera = (sourceData) => {
-  return bumpGeneric(sourceData, 'opera', 'chrome', [/Chrome/g, 'Opera']);
-};
-
-/**
- * @param {SupportStatement} sourceData
- * @returns {SupportStatement}
- */
-const bumpOperaAndroid = (sourceData) => {
-  return bumpGeneric(sourceData, 'opera_android', 'chrome_android', [
-    /Chrome/g,
-    'Opera',
-  ]);
-};
-
-/**
- * @param {SupportStatement} sourceData
- * @returns {SupportStatement}
- */
-const bumpSafariiOS = (sourceData) => {
-  return bumpGeneric(sourceData, 'safari_ios', 'safari');
-};
-
-/**
- * @param {SupportStatement} sourceData
- * @returns {SupportStatement}
- */
-const bumpSamsungInternet = (sourceData) => {
-  return bumpGeneric(sourceData, 'samsunginternet_android', 'chrome_android', [
-    /Chrome/g,
-    'Samsung Internet',
-  ]);
 };
 
 /**
@@ -435,44 +381,26 @@ const bumpVersion = (sourceData, destination, targetVersion) => {
   }
 
   if (Array.isArray(sourceData)) {
-    newData = combineStatements(
+    return combineStatements(
       ...sourceData.map((data) =>
         bumpVersion(data, destination, targetVersion),
       ),
     );
+  }
+
+  let notesRepl;
+  if (destination.includes('opera')) {
+    notesRepl = [/Chrome/g, 'Opera'];
+  } else if (destination === 'samsunginternet_android') {
+    notesRepl = [/Chrome/g, 'Samsung Internet'];
+  }
+
+  if (destination === 'edge') {
+    newData = bumpEdge(sourceData);
+  } else if (destination === 'webview_android') {
+    newData = bumpWebView(sourceData);
   } else {
-    let bumpFunction = null;
-
-    switch (destination) {
-      case 'chrome_android':
-        bumpFunction = bumpChromeAndroid;
-        break;
-      case 'edge':
-        bumpFunction = bumpEdge;
-        break;
-      case 'firefox_android':
-        bumpFunction = bumpFirefoxAndroid;
-        break;
-      case 'opera':
-        bumpFunction = bumpOpera;
-        break;
-      case 'opera_android':
-        bumpFunction = bumpOperaAndroid;
-        break;
-      case 'safari_ios':
-        bumpFunction = bumpSafariiOS;
-        break;
-      case 'samsunginternet_android':
-        bumpFunction = bumpSamsungInternet;
-        break;
-      case 'webview_android':
-        bumpFunction = bumpWebView;
-        break;
-      default:
-        throw new Error(`Unknown target browser ${destination}!`);
-    }
-
-    newData = bumpFunction(sourceData);
+    newData = bumpGeneric(sourceData, destination, notesRepl);
   }
 
   if (targetVersion) {


### PR DESCRIPTION
This PR greatly simplifies the code in the mirroring script, removing the redundant extra functions within the script.
