### PR TITLE
Enforce NodeJS versions that support import assertions for contributors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "yargs": "~17.5.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=16.14.0 <17.0.0 || >=17.1.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "index.d.ts",
   "type": "module",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=16.14.0 <17.0.0 || >=17.1.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR updates the contributor engine version to enforce versions of NodeJS that support import assertions (https://nodejs.org/api/esm.html#import-assertions), which should help some contributors troubleshoot issues in their setup.
