### PR TITLE
Add .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,12 @@
+*.json
+!/*.json
+!/schemas/*.json
+
+LICENSE
+.*ignore
+.git*
+.editorconfig
+/package-lock.json
+/CODE_OF_CONDUCT.md
+build/
+coverage/


### PR DESCRIPTION
This PR adds a `.eslintignore` to our project to ensure ESLint won't be run for undesired files, such as those in the build folder.
