### PR TITLE
Remove partial_implementation from Indexed DB APIs

### DIFF
--- a/api/IDBCursor.json
+++ b/api/IDBCursor.json
@@ -42,8 +42,7 @@
             "version_added": "22"
           },
           "ie": {
-            "version_added": "10",
-            "partial_implementation": true
+            "version_added": "10"
           },
           "opera": [
             {
@@ -167,8 +166,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -217,8 +215,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -316,8 +313,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -366,8 +362,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -416,8 +411,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -514,8 +508,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -613,8 +606,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -663,8 +655,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"

--- a/api/IDBCursorWithValue.json
+++ b/api/IDBCursorWithValue.json
@@ -42,8 +42,7 @@
             "version_added": "22"
           },
           "ie": {
-            "version_added": "10",
-            "partial_implementation": true
+            "version_added": "10"
           },
           "opera": {
             "version_added": "15"
@@ -153,8 +152,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"

--- a/api/IDBDatabase.json
+++ b/api/IDBDatabase.json
@@ -42,8 +42,7 @@
             "version_added": "22"
           },
           "ie": {
-            "version_added": "10",
-            "partial_implementation": true
+            "version_added": "10"
           },
           "opera": {
             "version_added": "15"
@@ -153,8 +152,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -256,8 +254,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -306,8 +303,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -356,8 +352,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -406,8 +401,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -456,8 +450,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -506,8 +499,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -560,8 +552,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"

--- a/api/IDBFactory.json
+++ b/api/IDBFactory.json
@@ -42,8 +42,7 @@
             "version_added": "22"
           },
           "ie": {
-            "version_added": "10",
-            "partial_implementation": true
+            "version_added": "10"
           },
           "opera": {
             "version_added": "15"
@@ -153,8 +152,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -254,8 +252,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -304,8 +301,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"

--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -42,8 +42,7 @@
             "version_added": "22"
           },
           "ie": {
-            "version_added": "10",
-            "partial_implementation": true
+            "version_added": "10"
           },
           "opera": {
             "version_added": "15"
@@ -153,8 +152,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -203,8 +201,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -357,8 +354,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -455,8 +451,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -553,8 +548,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -603,8 +597,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -701,8 +694,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -751,8 +743,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -801,8 +792,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -851,8 +841,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"

--- a/api/IDBKeyRange.json
+++ b/api/IDBKeyRange.json
@@ -42,8 +42,7 @@
             "version_added": "22"
           },
           "ie": {
-            "version_added": "10",
-            "partial_implementation": true
+            "version_added": "10"
           },
           "opera": [
             {
@@ -167,8 +166,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -266,8 +264,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -316,8 +313,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -366,8 +362,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -416,8 +411,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -466,8 +460,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -516,8 +509,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -566,8 +558,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"

--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -42,8 +42,7 @@
             "version_added": "22"
           },
           "ie": {
-            "version_added": "10",
-            "partial_implementation": true
+            "version_added": "10"
           },
           "opera": {
             "version_added": "15"
@@ -153,8 +152,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -203,8 +201,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -253,8 +250,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -303,8 +299,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -353,8 +348,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -403,8 +397,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -453,8 +446,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -503,8 +495,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -700,8 +691,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -750,8 +740,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -800,8 +789,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -850,8 +838,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -948,8 +935,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -1004,8 +990,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -1054,8 +1039,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -1104,8 +1088,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"

--- a/api/IDBOpenDBRequest.json
+++ b/api/IDBOpenDBRequest.json
@@ -42,8 +42,7 @@
             "version_added": "22"
           },
           "ie": {
-            "version_added": "10",
-            "partial_implementation": true
+            "version_added": "10"
           },
           "opera": {
             "version_added": "15"
@@ -157,8 +156,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -211,8 +209,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"

--- a/api/IDBRequest.json
+++ b/api/IDBRequest.json
@@ -42,8 +42,7 @@
             "version_added": "22"
           },
           "ie": {
-            "version_added": "10",
-            "partial_implementation": true
+            "version_added": "10"
           },
           "opera": {
             "version_added": "15"
@@ -153,8 +152,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -255,8 +253,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -305,8 +302,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -355,8 +351,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -405,8 +400,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -459,8 +453,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -509,8 +502,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"

--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -42,8 +42,7 @@
             "version_added": "22"
           },
           "ie": {
-            "version_added": "10",
-            "partial_implementation": true
+            "version_added": "10"
           },
           "opera": {
             "version_added": "15"
@@ -153,8 +152,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -208,8 +206,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -311,8 +308,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -361,8 +357,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -460,8 +455,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -563,8 +557,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -613,8 +606,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -663,8 +655,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"

--- a/api/IDBVersionChangeEvent.json
+++ b/api/IDBVersionChangeEvent.json
@@ -40,8 +40,7 @@
             "version_added": "22"
           },
           "ie": {
-            "version_added": "10",
-            "partial_implementation": true
+            "version_added": "10"
           },
           "opera": [
             {
@@ -211,8 +210,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"
@@ -261,8 +259,7 @@
               "version_added": "22"
             },
             "ie": {
-              "version_added": "10",
-              "partial_implementation": true
+              "version_added": "10"
             },
             "opera": {
               "version_added": "15"

--- a/api/_globals/indexedDB.json
+++ b/api/_globals/indexedDB.json
@@ -30,8 +30,7 @@
             "version_added": "22"
           },
           "ie": {
-            "version_added": "10",
-            "partial_implementation": true
+            "version_added": "10"
           },
           "opera": {
             "version_added": "15"


### PR DESCRIPTION
This PR removes the `partial_implementation` from IE for the Indexed DB.  These were added from the wiki migration with no explanation as to why they were marked partial.
