### PR TITLE
Remove partial_implementation without notes

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -5351,8 +5351,7 @@
               ]
             },
             "firefox_android": {
-              "version_added": "79",
-              "partial_implementation": true
+              "version_added": "79"
             },
             "ie": {
               "version_added": false

--- a/css/properties/font-size.json
+++ b/css/properties/font-size.json
@@ -77,7 +77,6 @@
                   "version_added": "11"
                 },
                 {
-                  "partial_implementation": true,
                   "version_added": "9",
                   "version_removed": "10"
                 }


### PR DESCRIPTION
This PR removes `partial_implementation: true` wherever there are no notes.
