### PR TITLE
scheduler global property

### DIFF
--- a/api/_globals/scheduler.json
+++ b/api/_globals/scheduler.json
@@ -1,0 +1,65 @@
+{
+  "api": {
+    "scheduler": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/scheduler",
+        "spec_url": "https://wicg.github.io/scheduling-apis/#dom-windoworworkerglobalscope-scheduler",
+        "support": {
+          "chrome": {
+            "version_added": "94"
+          },
+          "chrome_android": {
+            "version_added": "94"
+          },
+          "edge": {
+            "version_added": "94"
+          },
+          "firefox": [
+            {
+              "version_added": "preview"
+            },
+            {
+              "version_added": "101",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.enable_web_task_scheduling",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "opera": {
+            "version_added": "80"
+          },
+          "opera_android": {
+            "version_added": "66"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "17.0"
+          },
+          "webview_android": {
+            "version_added": "94"
+          }
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The prioritised scheduling API was mostly present in BCD and I added FF101 updates in #16177.

BUT, access to the API is via the `scheduler` property on the global object - e.g. `this` or `window` on main thread. This adds BCD entry for the global scheduler.

@queengooborg Question for you. The spec actually adds this to [WindowOrWorderGlobalScope](https://wicg.github.io/scheduling-apis/#sec-patches-html-windoworworkerglobalscope) mixin which we don't document. One place obviously that goes is Window (as documented here). But where do I add the worker entries both for BCD and docs - this could be the top level scope objects (all of them) or somewhere else. Advice appreciated!