### PR TITLE
Bump contributor NodeJS requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "index.d.ts",
   "type": "module",
   "engines": {
-    "node": ">=16.14.0 <17.0.0 || >=17.1.0"
+    "node": ">=16.15.0 <17.0.0 || >=17.5.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR bumps the contributor requirement for NodeJS to the versions that implemented JSON import support.  The docs regarding import assertions are misleading regarding when this was supported, so I've determined the version numbers based upon manual testing.
