### PR TITLE
Use "mirror" for AbortController data

### DIFF
--- a/api/AbortController.json
+++ b/api/AbortController.json
@@ -8,9 +8,7 @@
           "chrome": {
             "version_added": "66"
           },
-          "chrome_android": {
-            "version_added": "66"
-          },
+          "chrome_android": "mirror",
           "deno": {
             "version_added": "1.0"
           },
@@ -20,21 +18,15 @@
           "firefox": {
             "version_added": "57"
           },
-          "firefox_android": {
-            "version_added": "57"
-          },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
           "nodejs": {
             "version_added": "15.0.0"
           },
-          "opera": {
-            "version_added": "53"
-          },
-          "opera_android": {
-            "version_added": "47"
-          },
+          "opera": "mirror",
+          "opera_android": "mirror",
           "safari": [
             {
               "version_added": "12.1"
@@ -45,22 +37,9 @@
               "notes": "Even though <code>window.AbortController</code> is defined, it doesn't really abort <code>fetch</code> requests. See <a href='https://webkit.org/b/174980'>bug 174980</a>."
             }
           ],
-          "safari_ios": [
-            {
-              "version_added": "12.2"
-            },
-            {
-              "version_added": "11.3",
-              "partial_implementation": true,
-              "notes": "Even though <code>window.AbortController</code> is defined, it doesn't really abort <code>fetch</code> requests. See <a href='https://webkit.org/b/174980'>bug 174980</a>."
-            }
-          ],
-          "samsunginternet_android": {
-            "version_added": "9.0"
-          },
-          "webview_android": {
-            "version_added": "66"
-          }
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
         },
         "status": {
           "experimental": false,
@@ -77,9 +56,7 @@
             "chrome": {
               "version_added": "66"
             },
-            "chrome_android": {
-              "version_added": "66"
-            },
+            "chrome_android": "mirror",
             "deno": {
               "version_added": "1.0"
             },
@@ -89,21 +66,15 @@
             "firefox": {
               "version_added": "57"
             },
-            "firefox_android": {
-              "version_added": "57"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "nodejs": {
               "version_added": "15.0.0"
             },
-            "opera": {
-              "version_added": "53"
-            },
-            "opera_android": {
-              "version_added": "47"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": [
               {
                 "version_added": "12.1"
@@ -114,22 +85,9 @@
                 "notes": "Even though <code>window.AbortController</code> is defined, it doesn't really abort <code>fetch</code> requests. See <a href='https://webkit.org/b/174980'>bug 174980</a>."
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "12.2"
-              },
-              {
-                "version_added": "11.3",
-                "partial_implementation": true,
-                "notes": "Even though <code>window.AbortController</code> is defined, it doesn't really abort <code>fetch</code> requests. See <a href='https://webkit.org/b/174980'>bug 174980</a>."
-              }
-            ],
-            "samsunginternet_android": {
-              "version_added": "9.0"
-            },
-            "webview_android": {
-              "version_added": "66"
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -146,9 +104,7 @@
             "chrome": {
               "version_added": "66"
             },
-            "chrome_android": {
-              "version_added": "66"
-            },
+            "chrome_android": "mirror",
             "deno": {
               "version_added": "1.0"
             },
@@ -158,21 +114,15 @@
             "firefox": {
               "version_added": "57"
             },
-            "firefox_android": {
-              "version_added": "57"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "nodejs": {
               "version_added": "15.0.0"
             },
-            "opera": {
-              "version_added": "53"
-            },
-            "opera_android": {
-              "version_added": "47"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": [
               {
                 "version_added": "12.1"
@@ -183,22 +133,9 @@
                 "notes": "Even though <code>window.AbortController</code> is defined, it doesn't really abort <code>fetch</code> requests. See <a href='https://webkit.org/b/174980'>bug 174980</a>."
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "12.2"
-              },
-              {
-                "version_added": "11.3",
-                "partial_implementation": true,
-                "notes": "Even though <code>window.AbortController</code> is defined, it doesn't really abort <code>fetch</code> requests. See <a href='https://webkit.org/b/174980'>bug 174980</a>."
-              }
-            ],
-            "samsunginternet_android": {
-              "version_added": "9.0"
-            },
-            "webview_android": {
-              "version_added": "66"
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -215,9 +152,7 @@
             "chrome": {
               "version_added": "66"
             },
-            "chrome_android": {
-              "version_added": "66"
-            },
+            "chrome_android": "mirror",
             "deno": {
               "version_added": "1.0"
             },
@@ -227,21 +162,15 @@
             "firefox": {
               "version_added": "57"
             },
-            "firefox_android": {
-              "version_added": "57"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "nodejs": {
               "version_added": "15.0.0"
             },
-            "opera": {
-              "version_added": "53"
-            },
-            "opera_android": {
-              "version_added": "47"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": [
               {
                 "version_added": "12.1"
@@ -252,22 +181,9 @@
                 "notes": "Even though <code>window.AbortController</code> is defined, it doesn't really abort <code>fetch</code> requests. See <a href='https://webkit.org/b/174980'>bug 174980</a>."
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "12.2"
-              },
-              {
-                "version_added": "11.3",
-                "partial_implementation": true,
-                "notes": "Even though <code>window.AbortController</code> is defined, it doesn't really abort <code>fetch</code> requests. See <a href='https://webkit.org/b/174980'>bug 174980</a>."
-              }
-            ],
-            "samsunginternet_android": {
-              "version_added": "9.0"
-            },
-            "webview_android": {
-              "version_added": "66"
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This uses the build-time mirroring recently implemented:
https://github.com/mdn/browser-compat-data/pull/16401

The resulting build/data.json is unchanged.
