### PR TITLE
Updates chrome to version 102

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -703,27 +703,34 @@
         "101": {
           "release_date": "2022-04-26",
           "release_notes": "https://chromereleases.googleblog.com/2022/04/stable-channel-update-for-desktop_26.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "101"
         },
         "102": {
           "release_date": "2022-05-24",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2022/05/stable-channel-update-for-desktop_24.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "102"
         },
         "103": {
           "release_date": "2022-06-21",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "103"
         },
         "104": {
           "release_date": "2022-08-02",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Blink",
           "engine_version": "104"
+        },
+        "105": {
+          "release_date": "2022-08-30",
+          "status": "planned",
+          "engine": "Blink",
+          "engine_version": "105"
         }
       }
     }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -539,27 +539,34 @@
         "101": {
           "release_date": "2022-04-26",
           "release_notes": "https://chromereleases.googleblog.com/2022/04/chrome-for-android-update_01711927518.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "101"
         },
         "102": {
           "release_date": "2022-05-24",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2022/05/chrome-for-android-update_01678544884.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "102"
         },
         "103": {
           "release_date": "2022-06-21",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "103"
         },
         "104": {
           "release_date": "2022-08-02",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Blink",
           "engine_version": "104"
+        },
+        "105": {
+          "release_date": "2022-08-30",
+          "status": "planned",
+          "engine": "Blink",
+          "engine_version": "105"
         }
       }
     }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -504,27 +504,34 @@
         "101": {
           "release_date": "2022-04-26",
           "release_notes": "https://chromereleases.googleblog.com/2022/04/chrome-for-android-update_01711927518.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "101"
         },
         "102": {
           "release_date": "2022-05-24",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2022/05/chrome-for-android-update_01678544884.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "102"
         },
         "103": {
           "release_date": "2022-06-21",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "103"
         },
         "104": {
           "release_date": "2022-08-02",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Blink",
           "engine_version": "104"
+        },
+        "105": {
+          "release_date": "2022-08-30",
+          "status": "planned",
+          "engine": "Blink",
+          "engine_version": "105"
         }
       }
     }


### PR DESCRIPTION
Updates chrome to version 102.

According to https://chromiumdash.appspot.com/schedule, the release date of Chrome 105 is 30/08/2022.

😉