### PR TITLE
Add Chrome & Edge support for AudioContext outputLatency

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -705,7 +705,7 @@
               "version_added": false
             },
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,

--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -696,21 +696,15 @@
             "ie": {
               "version_added": false
             },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": false
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror",
           },
           "status": {

--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -685,12 +685,8 @@
             "chrome": {
               "version_added": "102"
             },
-            "chrome_android": {
-              "version_added": "102"
-            },
-            "edge": {
-              "version_added": "102"
-            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
             "firefox": {
               "version_added": "70"
             },
@@ -715,9 +711,7 @@
             "samsunginternet_android": {
               "version_added": false
             },
-            "webview_android": {
-              "version_added": false
-            }
+            "webview_android": "mirror",
           },
           "status": {
             "experimental": true,

--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -683,13 +683,13 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audiocontext-outputlatency",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "102"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "102"
             },
             "edge": {
-              "version_added": false
+              "version_added": "102"
             },
             "firefox": {
               "version_added": "70"


### PR DESCRIPTION
This PR adds Chrome and Edge support for AudioContext `outputLatency`. 
Source: https://chromiumdash.appspot.com/commit/8866a84d12e96c5fbb85ab8258f6fa80cb833843

FYI @hoch