### PR TITLE
Add linter for obsolete data

### DIFF
--- a/test/linter/index.js
+++ b/test/linter/index.js
@@ -9,6 +9,7 @@ import testConsistency from './test-consistency.js';
 import testDescriptions from './test-descriptions.js';
 import testLinks from './test-links.js';
 import testNotes from './test-notes.js';
+import testObsolete from './test-obsolete.js';
 import testPrefix from './test-prefix.js';
 import testSchema from './test-schema.js';
 import testStatus from './test-status.js';
@@ -22,6 +23,7 @@ export default new Linters([
   testDescriptions,
   testLinks,
   testNotes,
+  testObsolete,
   testPrefix,
   testSchema,
   testStatus,

--- a/test/linter/test-obsolete.js
+++ b/test/linter/test-obsolete.js
@@ -5,6 +5,12 @@ import chalk from 'chalk-template';
 import bcd from '../../index.js';
 const { browsers } = bcd;
 
+/**
+ * List of feature keys which are expected to fail this test.
+ * This list is needed for two reasons:
+ *  - some entries indeed should be removed (like api.VR*)
+ *  - some entries are currently just stubs and should be expanded and will pass test later
+ */
 const exceptions = [
   'api.VRDisplay.hardwareUnitId',
   'api.VREyeParameters.recommendedFieldOfView',
@@ -24,7 +30,7 @@ const exceptions = [
   'svg.elements.view.zoomAndPan',
 ];
 
-function neverImplemented(support) {
+export function neverImplemented(support) {
   for (const s in support) {
     let data = support[s];
     if (!Array.isArray(data)) data = [data];
@@ -33,6 +39,11 @@ function neverImplemented(support) {
   return true;
 }
 
+const errorTime = new Date(),
+  warningTime = new Date();
+errorTime.setFullYear(errorTime.getFullYear() - 2.5);
+warningTime.setFullYear(warningTime.getFullYear() - 2);
+
 /**
  * @param {*} browsers
  * @param {*} support
@@ -40,8 +51,6 @@ function neverImplemented(support) {
  */
 function implementedAndRemoved(browsers, support) {
   let result = 'error';
-  const warningTime = new Date().getTime() - 2 * 365 * 24 * 60 * 60 * 1000;
-  const errorTime = new Date().getTime() - 2.5 * 365 * 24 * 60 * 60 * 1000;
   for (const browser in support) {
     let data = support[browser];
     if (!Array.isArray(data)) data = [data];
@@ -50,7 +59,7 @@ function implementedAndRemoved(browsers, support) {
       if (!d.version_removed) return false;
       const releaseDate = new Date(
         browsers[browser].releases[d.version_removed].release_date,
-      ).getTime();
+      );
       // Feature was recently supported, no need to show warning
       if (warningTime < releaseDate) return false;
       // Feature was supported sufficiently recently to not show an error
@@ -99,12 +108,9 @@ function processData(logger, data, browsers, path) {
 
 export default {
   name: 'Obsolete',
-  description: 'Test for osolete data in each support statement',
+  description: 'Test for obsolete data in each support statement',
   scope: 'feature',
   check(logger, { data, path }) {
     processData(logger, data, browsers, path.full);
-  },
-  internals: {
-    neverImplemented,
   },
 };

--- a/test/linter/test-obsolete.js
+++ b/test/linter/test-obsolete.js
@@ -1,0 +1,104 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+import chalk from 'chalk-template';
+import bcd from '../../index.js';
+const { browsers } = bcd;
+
+const exceptions = [
+  'api.VRDisplay.hardwareUnitId',
+  'api.VREyeParameters.recommendedFieldOfView',
+  'api.VREyeParameters.renderRect',
+  'api.VRFieldOfView.VRFieldOfView',
+  'api.VRPose.hasOrientation',
+  'api.VRPose.hasPosition',
+  'css.types.length.lh',
+  'css.types.length.rlh',
+  'http.headers.Cache-Control.stale-if-error',
+  'http.headers.Feature-Policy.layout-animations',
+  'http.headers.Feature-Policy.legacy-image-formats',
+  'http.headers.Feature-Policy.oversized-images',
+  'http.headers.Feature-Policy.unoptimized-images',
+  'http.headers.Feature-Policy.unsized-media',
+  'svg.attributes.presentation.color-rendering',
+  'svg.elements.view.zoomAndPan',
+];
+
+function neverImplemented(support) {
+  for (const s in support) {
+    let data = support[s];
+    if (!Array.isArray(data)) data = [data];
+    for (const d of data) if (d.version_added) return false;
+  }
+  return true;
+}
+
+function implementedAndRemoved(browsers, support) {
+  for (const browser in support) {
+    let data = support[browser];
+    if (!Array.isArray(data)) data = [data];
+    for (const d of data) {
+      if (!d.version_removed) return false;
+      if (
+        d.version_removed &&
+        new Date(
+          browsers[browser].releases[d.version_removed].release_date,
+        ).getTime() >
+          new Date().getTime() - 2 * 365 * 24 * 60 * 60 * 1000
+      )
+        return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * @param {string} name
+ * @param {CompatStatement} data The data to test
+ * @param {Logger} logger
+ * @param {boolean} shouldFail
+ * @returns {void}
+ */
+function processData(logger, data, browsers, path) {
+  if (data && data.support) {
+    const { support, status } = data;
+    const shouldFail = exceptions.includes(path);
+
+    const abandoned = status && status.standard_track === false;
+    const rule1Fail = abandoned && neverImplemented(support);
+    if (rule1Fail && !shouldFail) {
+      console.error(path);
+      logger.error(
+        chalk`feature was never implemented in any browser and the specification has been abandoned.`,
+      );
+      return;
+    }
+
+    const rule2Fail = implementedAndRemoved(browsers, support);
+    if (rule2Fail && !shouldFail) {
+      console.error(path);
+      logger.error(
+        chalk`feature was implemented and has since been removed from all browsers dating back two or more years ago.`,
+      );
+      return;
+    }
+
+    if (!rule1Fail && !rule2Fail && shouldFail) {
+      logger.error(
+        chalk`Please remove this file from list of exceptions: ${path}`,
+      );
+    }
+  }
+}
+
+export default {
+  name: 'Obsolete',
+  description: 'Test for osolete data in each support statement',
+  scope: 'feature',
+  check(logger, { data, path }) {
+    processData(logger, data, browsers, path.full);
+  },
+  internals: {
+    neverImplemented,
+  },
+};

--- a/test/linter/test-obsolete.test.js
+++ b/test/linter/test-obsolete.test.js
@@ -3,9 +3,7 @@
 
 import assert from 'node:assert/strict';
 
-import testObsolete from './test-obsolete.js';
-const { internals } = testObsolete;
-const { neverImplemented } = internals;
+import { neverImplemented } from './test-obsolete.js';
 
 describe('neverImplemented', function () {
   it('returns false for features which were implemented', () => {

--- a/test/linter/test-obsolete.test.js
+++ b/test/linter/test-obsolete.test.js
@@ -1,0 +1,49 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+import assert from 'node:assert/strict';
+
+import testObsolete from './test-obsolete.js';
+const { internals } = testObsolete;
+const { neverImplemented } = internals;
+
+describe('neverImplemented', function () {
+  it('returns false for features which were implemented', () => {
+    assert.equal(
+      neverImplemented({
+        browser: { version_added: '1' },
+      }),
+      false,
+    );
+    assert.equal(
+      neverImplemented({
+        chrome: { version_added: '1', prefix: 'webkit' },
+      }),
+      false,
+    );
+    assert.equal(
+      neverImplemented({
+        chrome: [
+          { version_added: '1', version_removed: '15' },
+          { version_added: '17' },
+        ],
+      }),
+      false,
+    );
+  });
+
+  it('returns true for features which were not implemented', () => {
+    assert.equal(
+      neverImplemented({
+        browser: { version_added: null },
+      }),
+      true,
+    );
+    assert.equal(
+      neverImplemented({
+        chrome: { version_added: false },
+      }),
+      true,
+    );
+  });
+});


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Adds linter which checks for guideline called [Removal of irrelevant features](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features).

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
It is a linter, not data.
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A
<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Please note: currently this linter checks only the original two rules:
- a feature was never implemented in any browser and the specification has been abandoned.
- a feature was implemented and has since been removed from all browsers dating back two or more years ago.
I'm not sure how to interpret the third rule:
- a feature is unsupported in all releases in the past five years.

As written, the third rule seems to imply the second rule: if a feature meets the third rule -- it hasn't been supported for 5 years --  then it seems to me it meets the second rule -- it might have been implemented but hasn't been supported for 2 years.