### PR TITLE
Mirroring: apply suggestions from code review

### DIFF
--- a/scripts/release/mirror.js
+++ b/scripts/release/mirror.js
@@ -361,7 +361,9 @@ export const bumpSupport = (sourceData, destination) => {
 const mirrorSupport = (destination, data) => {
   const upstream = browsers[destination].upstream;
   if (!upstream) {
-    throw new Error(`Upstream is not defined for ${browser}, cannot mirror!`);
+    throw new Error(
+      `Upstream is not defined for ${destination}, cannot mirror!`,
+    );
   }
   return bumpSupport(data[upstream], destination);
 };

--- a/scripts/release/mirror.js
+++ b/scripts/release/mirror.js
@@ -368,7 +368,7 @@ const mirrorSupport = (destination, data) => {
 
   if (data[upstream] == 'mirror') {
     // Perform mirroring upstream if needed
-    data[upstream] = bumpData(upstream, data);
+    data[upstream] = mirrorSupport(upstream, data);
   }
 
   return bumpSupport(data[upstream], destination);

--- a/scripts/release/mirror.js
+++ b/scripts/release/mirror.js
@@ -317,7 +317,7 @@ const bumpWebView = (sourceData) => {
  * @param {SupportStatement} data
  * @param {string} destination
  */
-export const bumpVersion = (sourceData, destination) => {
+export const bumpSupport = (sourceData, destination) => {
   let newData = null;
 
   if (sourceData == null) {
@@ -326,7 +326,7 @@ export const bumpVersion = (sourceData, destination) => {
 
   if (Array.isArray(sourceData)) {
     return combineStatements(
-      ...sourceData.map((data) => bumpVersion(data, destination)),
+      ...sourceData.map((data) => bumpSupport(data, destination)),
     );
   }
 
@@ -350,12 +350,20 @@ export const bumpVersion = (sourceData, destination) => {
     return { version_added: false };
   }
 
+  if (newData.version_added === newData.version_removed) {
+    // If version_added and version_removed are the same, feature is unsupported
+    return { ...newData, version_added: false, version_removed: undefined };
+  }
+
   return newData;
 };
 
-const bumpData = (destination, data) => {
+const mirrorSupport = (destination, data) => {
   const upstream = browsers[destination].upstream;
-  return bumpVersion(data[upstream], destination);
+  if (!upstream) {
+    throw new Error(`Upstream is not defined for ${browser}, cannot mirror!`);
+  }
+  return bumpSupport(data[upstream], destination);
 };
 
-export default bumpData;
+export default mirrorSupport;

--- a/scripts/release/mirror.js
+++ b/scripts/release/mirror.js
@@ -365,6 +365,12 @@ const mirrorSupport = (destination, data) => {
       `Upstream is not defined for ${destination}, cannot mirror!`,
     );
   }
+
+  if (data[upstream] == 'mirror') {
+    // Perform mirroring upstream if needed
+    data[upstream] = bumpData(upstream, data);
+  }
+
   return bumpSupport(data[upstream], destination);
 };
 


### PR DESCRIPTION
This PR applies suggestions from the code review in #16401 and fixes #16418, performing the following changes:

- `bumpData` -> `mirrorSupport`
- `bumpVersion` -> `bumpSupport`
- Throw an error if upstream isn't defined for destination browser
- Statements with `version_added` and `version_removed` matching will now become `version_added: false`
