### PR TITLE
Update diff script

### DIFF
--- a/scripts/diff.js
+++ b/scripts/diff.js
@@ -23,16 +23,8 @@ function getBaseAndHeadContents(baseCommit, basePath, headCommit, headPath) {
   return { base, head };
 }
 
-function stringifyValue(value) {
-  return Array.isArray(value)
-    ? 'typeof array'
-    : value && typeof value === 'object'
-    ? JSON.stringify(value)
-    : value;
-}
-
 function stringifyChange(lhs, rhs) {
-  return `${stringifyValue(lhs)} → ${stringifyValue(rhs)}`;
+  return `${JSON.stringify(lhs)} → ${JSON.stringify(rhs)}`;
 }
 
 /**

--- a/scripts/diff.js
+++ b/scripts/diff.js
@@ -21,20 +21,22 @@ function getBaseAndHeadContents(baseCommit, basePath, headCommit, headPath) {
   return { base, head };
 }
 
+function stringifyValue(value) {
+  return Array.isArray(value)
+    ? 'typeof array'
+    : value && typeof value === 'object'
+    ? 'typeof object'
+    : value;
+}
+
+function stringifyChange(lhs, rhs) {
+  return `${stringifyValue(lhs)} → ${stringifyValue(rhs)}`;
+}
+
 /**
  * @param {import("deep-diff").Diff<any, any>} diffItem
  */
 function describeByKind(diffItem) {
-  function stringifyValue(value) {
-    return Array.isArray(value)
-      ? 'typeof array'
-      : value && typeof value === 'object'
-      ? 'typeof object'
-      : value;
-  }
-  function stringifyChange(lhs, rhs) {
-    return `${stringifyValue(lhs)} → ${stringifyValue(rhs)}`;
-  }
   switch (diffItem.kind) {
     case 'N':
       return 'added';

--- a/scripts/diff.js
+++ b/scripts/diff.js
@@ -4,6 +4,8 @@
 import chalk from 'chalk-template';
 import deepDiff from 'deep-diff';
 import esMain from 'es-main';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 
 import { getMergeBase, getFileContent, getGitDiffStatuses } from './lib/git.js';
 
@@ -111,7 +113,27 @@ function getDiffs(base, head = '') {
 }
 
 if (esMain(import.meta)) {
-  let [base = 'origin/HEAD', head] = process.argv.slice(2);
+  const { argv } = yargs(hideBin(process.argv)).command(
+    '$0 [base] [head]',
+    'Print a formatted diff for changes between base and head commits',
+    (yargs) => {
+      yargs
+        .positional('base', {
+          describe:
+            'The base commit; may be commit hash or other git ref (e.g. "origin/main")',
+          type: 'string',
+          default: 'origin/main',
+        })
+        .positional('head', {
+          describe:
+            'The head commit that changes are applied to; may be commit hash or other git ref (e.g. "origin/main")',
+          type: 'string',
+          default: 'HEAD',
+        });
+    },
+  );
+
+  const { base, head } = argv;
   for (const [key, values] of getDiffs(getMergeBase(base, head), head)) {
     console.log(chalk`{bold ${key}}:`);
     for (const value of values) {

--- a/scripts/diff.js
+++ b/scripts/diff.js
@@ -8,6 +8,8 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 import { getMergeBase, getFileContent, getGitDiffStatuses } from './lib/git.js';
+import { query } from '../utils/index.js';
+import mirror from './release/mirror.js';
 
 // Note: This does not detect renamed files
 /**
@@ -25,7 +27,7 @@ function stringifyValue(value) {
   return Array.isArray(value)
     ? 'typeof array'
     : value && typeof value === 'object'
-    ? 'typeof object'
+    ? JSON.stringify(value)
     : value;
 }
 
@@ -34,9 +36,36 @@ function stringifyChange(lhs, rhs) {
 }
 
 /**
- * @param {import("deep-diff").Diff<any, any>} diffItem
+ * @param {{base: SupportStatement, head: SupportStatement}} diffItem
+ * @param {{base: Identifier, head: Identifier}} contents
+ * @param {Array.<string>} path
+ * @param {string} direction
  */
-function describeByKind(diffItem) {
+function doMirror(diff, contents, path, direction) {
+  const browser = path[path.length - 1];
+  const dataPath = path.slice(0, path.length - 3).join('.');
+  const data = contents[direction];
+
+  diff[direction] = mirror(browser, query(dataPath, data).__compat.support);
+}
+
+/**
+ * @param {import("deep-diff").Diff<any, any>} diffItem
+ * @param {{base: Identifier, head: Identifier}} contents
+ */
+function describeByKind(diffItem, contents) {
+  const diff = { base: diffItem.lhs, head: diffItem.rhs };
+
+  // Handle mirroring
+  let doesMirror = '';
+  if (diff.base === 'mirror') {
+    doesMirror = 'No longer mirrors';
+    doMirror(diff, contents, diffItem.path, 'base');
+  } else if (diff.head === 'mirror') {
+    doesMirror = 'Now mirrors';
+    doMirror(diff, contents, diffItem.path, 'head');
+  }
+
   switch (diffItem.kind) {
     case 'N':
       return 'added';
@@ -44,7 +73,9 @@ function describeByKind(diffItem) {
       return 'deleted';
     case 'A':
     case 'E':
-      return `edited (${stringifyChange(diffItem.lhs, diffItem.rhs)})`;
+      return `edited (${stringifyChange(diff.base, diff.head)})${
+        doesMirror && ` - ${doesMirror}`
+      }`;
   }
   throw new Error(`Unexpected kind ${diffItem.kind}.`);
 }
@@ -52,19 +83,22 @@ function describeByKind(diffItem) {
 /**
  * @param {import("deep-diff").Diff<any, any>} diffItem
  */
-function describeDiffItem(diffItem) {
+function describeDiffItem(diffItem, contents) {
   const path = diffItem.path.join('.');
   if (path.includes('.__compat.')) {
     const [name, member] = path.split('.__compat.');
     if (path.endsWith('.notes') && diffItem.kind === 'E') {
       return { name, description: `${member} is edited (prose change)` };
     } else {
-      return { name, description: `${member} is ${describeByKind(diffItem)}` };
+      return {
+        name,
+        description: `${member} is ${describeByKind(diffItem, contents)}`,
+      };
     }
   } else {
     return {
       name: diffItem.path.slice(0, -1).join('.'),
-      description: `${path} is ${describeByKind(diffItem)}`,
+      description: `${path} is ${describeByKind(diffItem, contents)}`,
     };
   }
 }
@@ -107,7 +141,9 @@ function getDiffs(base, head = '') {
         status.headPath,
       );
       namedDescriptions.push(
-        ...deepDiff.diff(contents.base, contents.head).map(describeDiffItem),
+        ...deepDiff
+          .diff(contents.base, contents.head)
+          .map((item) => describeDiffItem(item, contents)),
       );
     }
   }


### PR DESCRIPTION
This PR updates the diff script to provide a few quality of life updates, including performing mirroring within the diff (which will greatly help in validating upcoming changes to switch version numbers with `mirror`).

Depends on #16432.
