### PR TITLE
Implement next-gen linter

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,14 +7,9 @@ import { fileURLToPath } from 'node:url';
 
 import { fdir } from 'fdir';
 
-const dirname = fileURLToPath(new URL('.', import.meta.url));
+import extend from './scripts/lib/extend.js';
 
-class DuplicateCompatError extends Error {
-  constructor(feature) {
-    super(`${feature} already exists! Remove duplicate entries.`);
-    this.name = 'DuplicateCompatError';
-  }
-}
+const dirname = fileURLToPath(new URL('.', import.meta.url));
 
 /**
  * Recursively load one or more directories passed as arguments.
@@ -43,30 +38,6 @@ function load(...dirs) {
   }
 
   return result;
-}
-
-function isPlainObject(v) {
-  return typeof v === 'object' && v !== null && !Array.isArray(v);
-}
-
-function extend(target, source, feature = '') {
-  if (!isPlainObject(target) || !isPlainObject(source)) {
-    throw new Error('Both target and source must be plain objects');
-  }
-
-  // iterate over own enumerable properties
-  for (const [key, value] of Object.entries(source)) {
-    // recursively extend if target has the same key, otherwise just assign
-    if (Object.prototype.hasOwnProperty.call(target, key)) {
-      if (key == '__compat') {
-        // If attempting to merge __compat, we have a double-entry
-        throw new DuplicateCompatError(feature);
-      }
-      extend(target[key], value, feature + `${feature ? '.' : ''}${key}`);
-    } else {
-      target[key] = value;
-    }
-  }
 }
 
 export default load(

--- a/scripts/lib/extend.js
+++ b/scripts/lib/extend.js
@@ -1,0 +1,33 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+class DuplicateCompatError extends Error {
+  constructor(feature) {
+    super(`${feature} already exists! Remove duplicate entries.`);
+    this.name = 'DuplicateCompatError';
+  }
+}
+
+function isPlainObject(v) {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+export default function extend(target, source, feature = '') {
+  if (!isPlainObject(target) || !isPlainObject(source)) {
+    throw new Error('Both target and source must be plain objects');
+  }
+
+  // iterate over own enumerable properties
+  for (const [key, value] of Object.entries(source)) {
+    // recursively extend if target has the same key, otherwise just assign
+    if (Object.prototype.hasOwnProperty.call(target, key)) {
+      if (key == '__compat') {
+        // If attempting to merge __compat, we have a double-entry
+        throw new DuplicateCompatError(feature);
+      }
+      extend(target[key], value, feature + `${feature ? '.' : ''}${key}`);
+    } else {
+      target[key] = value;
+    }
+  }
+}

--- a/test/lint.js
+++ b/test/lint.js
@@ -6,41 +6,26 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import esMain from 'es-main';
-import ora from 'ora';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import chalk from 'chalk-template';
 
-import {
-  testBrowsersData,
-  testBrowsersPresence,
-  testConsistency,
-  testDescriptions,
-  testLinks,
-  testNotes,
-  testPrefix,
-  testSchema,
-  testStatus,
-  testStyle,
-  testVersions,
-} from './linter/index.js';
-import { IS_CI, pluralize } from './utils.js';
+import linters from './linter/index.js';
+import extend from '../scripts/lib/extend.js';
+import { walk } from '../utils/index.js';
+import { pluralize } from './utils.js';
 
 const dirname = fileURLToPath(new URL('.', import.meta.url));
 
-/** @type {object} */
-const spinner = ora({
-  stream: process.stdout,
-});
-
 /**
- * Recursively checks files for any errors.
+ * Recursively load
  *
  * @param {string[]} files The files to test
- * @returns {object} Errors by relative file path.
+ * @returns {{messages: object, data: Identifier}}
  */
-const checkFiles = (...files) => {
-  let errors = {};
+const loadAndCheckFiles = (...files) => {
+  const data = {};
+
   for (let file of files) {
     if (file.indexOf(dirname) !== 0) {
       file = path.resolve(dirname, '..', file);
@@ -58,71 +43,33 @@ const checkFiles = (...files) => {
       filePath.category =
         filePath.full.includes(path.sep) && filePath.full.split(path.sep)[0];
 
-      spinner.text = filePath.full;
-
-      if (!IS_CI) {
-        // Continuous integration environments don't allow overwriting
-        // previous lines using VT escape sequences, which is how
-        // the spinner animation is implemented.
-        spinner.start();
-      }
-
-      // Catch console errors and report them as file errors
-      const console_error = console.error;
-      console.error = (...args) => {
-        if (!(filePath.full in errors)) {
-          // Set spinner to failure when first error is found
-          // Setting on every error causes duplicate output
-          spinner['stream'] = process.stderr;
-          spinner.fail(chalk`{red.bold ${filePath.full}}`);
-
-          errors[filePath.full] = [];
-        }
-        console_error(...args);
-        errors[filePath.full].push(...args);
-      };
-
       try {
         const rawFileData = fs.readFileSync(file, 'utf-8').trim();
         const fileData = JSON.parse(rawFileData);
 
-        testSchema(fileData, filePath);
-        testLinks(rawFileData);
+        linters.runScope('file', {
+          data: fileData,
+          rawdata: rawFileData,
+          path: filePath,
+        });
 
-        if (file.indexOf('browsers' + path.sep) !== -1) {
-          testBrowsersData(fileData);
-        } else {
-          testBrowsersPresence(fileData, filePath);
-          testConsistency(fileData);
-          testDescriptions(fileData);
-          testPrefix(fileData, filePath);
-          testStatus(fileData);
-          testStyle(rawFileData);
-          testVersions(fileData);
-          testNotes(fileData);
-        }
+        extend(data, fileData);
       } catch (e) {
+        console.error(`Couldn't load ${filePath.full}!`);
         console.error(e);
-      }
-
-      // Reset console.error
-      console.error = console_error;
-
-      if (!(filePath.full in errors)) {
-        spinner.succeed();
       }
     }
 
     if (fs.statSync(file).isDirectory()) {
-      const subFiles = fs.readdirSync(file).map((subfile) => {
-        return path.join(file, subfile);
-      });
+      const subFiles = fs
+        .readdirSync(file)
+        .map((subfile) => path.join(file, subfile));
 
-      errors = { ...errors, ...checkFiles(...subFiles) };
+      extend(data, loadAndCheckFiles(...subFiles));
     }
   }
 
-  return errors;
+  return data;
 };
 
 /**
@@ -145,25 +92,74 @@ const main = (
     'webextensions',
   ],
 ) => {
-  const errors = checkFiles(...files);
+  let hasErrors = false;
 
-  const filesWithErrors = Object.keys(errors).length;
+  const data = loadAndCheckFiles(...files);
 
-  if (filesWithErrors) {
-    console.error('');
+  for (const browser in data.browsers) {
+    linters.runScope('browser', {
+      data: data.browsers[browser],
+      path: {
+        full: `browsers.${browser}`,
+        category: 'browsers',
+      },
+    });
+  }
+
+  const walker = walk(undefined, data);
+  for (const feature of walker) {
+    linters.runScope('feature', {
+      data: feature.compat,
+      path: {
+        full: feature.path,
+        category: feature.path.split('.')[0],
+      },
+    });
+  }
+
+  linters.runScope('tree', {
+    data,
+    path: {
+      full: '',
+    },
+  });
+
+  for (const [linter, messages] of Object.entries(linters.messages)) {
+    if (!messages.length) continue;
+
+    const errors = messages.filter((m) => m.level === 'error');
+    const warnings = messages.filter((m) => m.level === 'warning');
+
     console.error(
-      chalk`{red Problems in {bold ${pluralize('file', filesWithErrors)}}:}`,
+      chalk`{${errors.length ? 'red' : 'yellow'} ${linter} - {bold ${pluralize(
+        'problem',
+        messages.length,
+      )}} (${pluralize('error', errors.length)}, ${pluralize(
+        'warning',
+        warnings.length,
+      )}):}`,
     );
 
-    for (const [fp, errorMsgs] of Object.entries(errors)) {
-      console.error(chalk`{red.bold ✖ ${fp}}`);
-      for (const error of errorMsgs) {
-        console.error(error);
+    for (const error of errors) {
+      hasErrors = true;
+
+      console.error(chalk`{red  ✖ ${error.path} - Error → ${error.message}}`);
+      if (error.tip) {
+        console.error(chalk`{blue    ◆ Tip: ${error.tip}}`);
+      }
+    }
+
+    for (const warning of warnings) {
+      console.warn(
+        chalk`{red  ✖ ${warning.path} - Warning → ${warning.message}}`,
+      );
+      if (warning.tip) {
+        console.warn(chalk`{blue    ◆ Tip: ${warning.tip}}`);
       }
     }
   }
 
-  return filesWithErrors > 0;
+  return hasErrors;
 };
 
 if (esMain(import.meta)) {

--- a/test/linter/index.js
+++ b/test/linter/index.js
@@ -1,6 +1,8 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
+import { Linters } from '../utils.js';
+
 import testBrowsersData from './test-browsers-data.js';
 import testBrowsersPresence from './test-browsers-presence.js';
 import testConsistency from './test-consistency.js';
@@ -13,7 +15,7 @@ import testStatus from './test-status.js';
 import testStyle from './test-style.js';
 import testVersions from './test-versions.js';
 
-export {
+export default new Linters([
   testBrowsersData,
   testBrowsersPresence,
   testConsistency,
@@ -25,4 +27,4 @@ export {
   testStatus,
   testStyle,
   testVersions,
-};
+]);

--- a/test/linter/test-browsers-data.js
+++ b/test/linter/test-browsers-data.js
@@ -3,8 +3,6 @@
 
 import chalk from 'chalk-template';
 
-import { Logger } from '../utils.js';
-
 import bcd from '../../index.js';
 const { browsers } = bcd;
 
@@ -14,18 +12,14 @@ const { browsers } = bcd;
  */
 
 /**
- * @param {Identifier} data
+ * @param {string} browser
+ * @param {BrowserStatement} data
  * @param {Logger} logger The logger to output errors to
  * @returns {void}
  */
-function processData(data, logger) {
-  // We only need to grab the first browser in the data
-  // because each browser file only contains one browser
-  const browser = Object.keys(data.browsers)[0];
-  const browserData = data.browsers[browser];
-
+function processData(browser, data, logger) {
   for (const status of ['current', 'beta', 'nightly']) {
-    const releasesForStatus = Object.entries(browserData.releases)
+    const releasesForStatus = Object.entries(data.releases)
       .filter(([, data]) => data.status == status)
       .map(([version]) => version);
 
@@ -39,32 +33,28 @@ function processData(data, logger) {
   }
 
   // Ensure the `upstream` property, if it exists, is valid
-  if (browserData.upstream) {
-    if (browserData.upstream === browser) {
+  if (data.upstream) {
+    if (data.upstream === browser) {
       logger.error(
         chalk`{red The upstream for {bold ${browser}} is set to itself.}`,
       );
     }
 
-    if (!Object.keys(browsers).includes(browserData.upstream)) {
+    if (!Object.keys(browsers).includes(data.upstream)) {
       logger.error(
         chalk`{red The upstream for {bold ${browser}} is an unknown browser (${
-          browserData.upstream
+          data.upstream
         }) Valid options are: ${Object.keys(browsers).join(', ')}.}`,
       );
     }
   }
 }
 
-/**
- * @param {Identifier} data The contents of the file to test
- * @returns {boolean} If the file contains errors
- */
-export default function testBrowsersData(data) {
-  const logger = new Logger('Browser Data');
-
-  processData(data, logger);
-
-  logger.emit();
-  return logger.hasErrors();
-}
+export default {
+  name: 'Browser Data',
+  description: 'Test the browser data',
+  scope: 'browser',
+  check(logger, { data, path: { browser } }) {
+    processData(browser, data, logger);
+  },
+};

--- a/test/linter/test-browsers-presence.js
+++ b/test/linter/test-browsers-presence.js
@@ -3,8 +3,6 @@
 
 import chalk from 'chalk-template';
 
-import { Logger } from '../utils.js';
-
 import bcd from '../../index.js';
 const { browsers } = bcd;
 
@@ -23,8 +21,8 @@ const { browsers } = bcd;
  * @returns {void}
  */
 function processData(data, category, logger, path = '') {
-  if (data.__compat && data.__compat.support) {
-    const support = data.__compat.support;
+  if (data.support) {
+    const support = data.support;
     const definedBrowsers = Object.keys(support);
 
     let displayBrowsers = Object.keys(browsers).filter(
@@ -76,28 +74,14 @@ function processData(data, category, logger, path = '') {
       );
     }
   }
-  for (const key in data) {
-    if (key === '__compat') continue;
-
-    processData(
-      data[key],
-      category,
-      logger,
-      path && path.length > 0 ? `${path}.${key}` : key,
-    );
-  }
 }
 
-/**
- * @param {Identifier} data The contents of the file to test
- * @param {object} filePath The path info for the file being tested
- * @returns {boolean} If the file contains errors
- */
-export default function testBrowsersPresence(data, filePath) {
-  const logger = new Logger('Browsers');
-
-  processData(data, filePath.category, logger);
-
-  logger.emit();
-  return logger.hasErrors();
-}
+export default {
+  name: 'Browser Presence',
+  description:
+    'Test the presence of browser data within compatibility statements',
+  scope: 'feature',
+  check(logger, { data, path: { category } }) {
+    processData(data, category, logger);
+  },
+};

--- a/test/linter/test-consistency.js
+++ b/test/linter/test-consistency.js
@@ -4,7 +4,6 @@
 import compareVersions from 'compare-versions';
 import chalk from 'chalk-template';
 import { query } from '../../utils/index.js';
-import { Logger } from '../utils.js';
 
 /**
  * @typedef {import('../../types').CompatStatement} CompatStatement
@@ -43,7 +42,7 @@ export class ConsistencyChecker {
    * @returns {ConsistencyError[]} Any errors found within the data
    */
   check(data) {
-    return this.checkSubfeatures(data);
+    return this.checkSubfeatures({ ...data, browsers: undefined });
   }
 
   /**
@@ -91,6 +90,8 @@ export class ConsistencyChecker {
     const subfeatures = [];
     const keys = Object.keys(data).filter((key) => key != '__compat');
     for (const key of keys) {
+      if (data[key] === undefined) continue;
+
       if ('__compat' in data[key]) {
         // If the subfeature has compat data
         subfeatures.push(key);
@@ -419,39 +420,33 @@ export class ConsistencyChecker {
   }
 }
 
-/**
- * @param {Identifier} data The contents of the file to test
- * @returns {boolean} If the file contains errors
- */
-export default function testConsistency(data) {
-  const logger = new Logger('Consistency');
+export default {
+  name: 'Consistency',
+  description: 'Test the version consistency between parent and child',
+  scope: 'tree',
+  check(logger, { data }) {
+    const checker = new ConsistencyChecker();
+    const allErrors = checker.check(data);
 
-  const checker = new ConsistencyChecker();
-  const allErrors = checker.check(data);
+    for (const { path, errors } of allErrors) {
+      for (const { errortype, browser, parent_value, subfeatures } of errors) {
+        let errorMessage = '';
+        if (errortype == 'unsupported') {
+          errorMessage += chalk`No support in {bold ${browser}}, but support is declared in the following sub-feature(s):`;
+        } else if (errortype == 'support_unknown') {
+          errorMessage += chalk`Unknown support in parent for {bold ${browser}}, but support is declared in the following sub-feature(s):`;
+        } else if (errortype == 'subfeature_earlier_implementation') {
+          errorMessage += chalk`Basic support in {bold ${browser}} was declared implemented in a later version ({bold ${parent_value}}) than the following sub-feature(s):`;
+        }
 
-  for (const { path, errors } of allErrors) {
-    let errorMessage = chalk`{bold ${errors.length}} × ${path
-      .slice(0, 1)
-      .join('.')}.{bold ${path[path.length - 1]}}: `;
-    for (const { errortype, browser, parent_value, subfeatures } of errors) {
-      if (errortype == 'unsupported') {
-        errorMessage += chalk`\n{red       → No support in {bold ${browser}}, but support is declared in the following sub-feature(s):}`;
-      } else if (errortype == 'support_unknown') {
-        errorMessage += chalk`\n{red       → Unknown support in parent for {bold ${browser}}, but support is declared in the following sub-feature(s):}`;
-      } else if (errortype == 'subfeature_earlier_implementation') {
-        errorMessage += chalk`\n{red       → Basic support in {bold ${browser}} was declared implemented in a later version ({bold ${parent_value}}) than the following sub-feature(s):}`;
+        for (const subfeature of subfeatures) {
+          errorMessage += chalk`\n{red         → {bold ${path.join('.')}.${
+            subfeature[0]
+          }}: ${subfeature[1] === undefined ? '[Array]' : subfeature[1]}}`;
+        }
+
+        logger.error(errorMessage, { path: path.join('.') });
       }
-
-      for (const subfeature of subfeatures) {
-        errorMessage += chalk`\n{red         → {bold ${path.join('.')}.${
-          subfeature[0]
-        }}: ${subfeature[1] === undefined ? '[Array]' : subfeature[1]}}`;
-      }
-
-      logger.error(errorMessage);
     }
-  }
-
-  logger.emit();
-  return logger.hasErrors();
-}
+  },
+};

--- a/test/linter/test-descriptions.js
+++ b/test/linter/test-descriptions.js
@@ -2,7 +2,6 @@
  * See LICENSE file for more information. */
 
 import chalk from 'chalk-template';
-import { Logger } from '../utils.js';
 
 /**
  * @typedef {import('../../types').Identifier} Identifier
@@ -13,13 +12,13 @@ import { Logger } from '../utils.js';
  *
  * @param {string} ruleName The name of the error
  * @param {string} name The name of the API method
- * @param {Identifier} feature - The feature's compat data.
+ * @param {CompatStatement} compat The compat data to test
  * @param {string} expected Expected description
  * @param {Logger} logger The logger to output errors to
  * @returns {void}
  */
-function checkDescription(ruleName, name, method, expected, logger) {
-  const actual = method.__compat.description || '';
+function checkDescription(ruleName, name, compat, expected, logger) {
+  const actual = compat.description || '';
   if (actual != expected) {
     logger.error(chalk`{red → Incorrect ${ruleName} description for {bold ${name}}
       Actual: {yellow "${actual}"}
@@ -30,85 +29,71 @@ function checkDescription(ruleName, name, method, expected, logger) {
 /**
  * Process API data and check for any incorrect descriptions in said data, logging any errors
  *
- * @param {Identifier} apiData The data to test
- * @param {string} apiName The name of the API
+ * @param {CompatStatement} data The data to test
+ * @param {object} path The path of the feature
  * @param {Logger} logger The logger to output errors to
  * @returns {void}
  */
-function processApiData(apiData, apiName, logger) {
-  for (const featureName in apiData) {
-    const feature = apiData[featureName];
-    if (featureName == apiName) {
-      checkDescription(
-        'constructor',
-        `${apiName}()`,
-        feature,
-        `<code>${apiName}()</code> constructor`,
-        logger,
-      );
-    } else if (featureName.endsWith('_event')) {
-      checkDescription(
-        'event',
-        `${apiName}.${featureName}`,
-        feature,
-        `<code>${featureName.replace('_event', '')}</code> event`,
-        logger,
-      );
-    } else if (featureName.endsWith('_permission')) {
-      checkDescription(
-        'permission',
-        `${apiName}.${featureName}`,
-        feature,
-        `<code>${featureName.replace('_permission', '')}</code> permission`,
-        logger,
-      );
-    } else if (featureName == 'secure_context_required') {
-      checkDescription(
-        'secure context required',
-        `${apiName}()`,
-        feature,
-        'Secure context required',
-        logger,
-      );
-    } else if (featureName == 'worker_support') {
-      checkDescription(
-        'worker',
-        `${apiName}()`,
-        feature,
-        'Available in workers',
-        logger,
-      );
-    }
+function processApiData(data, path, logger) {
+  const pathParts = path.split('.');
+  const apiName = pathParts[1];
+  const featureName = pathParts[2];
+
+  if (pathParts.length !== 3) {
+    // Ignore anything that isn't an interface subfeature
+    return;
+  }
+
+  if (featureName == apiName) {
+    checkDescription(
+      'constructor',
+      `${apiName}()`,
+      data,
+      `<code>${apiName}()</code> constructor`,
+      logger,
+    );
+  } else if (featureName.endsWith('_event')) {
+    checkDescription(
+      'event',
+      `${apiName}.${featureName}`,
+      data,
+      `<code>${featureName.replace('_event', '')}</code> event`,
+      logger,
+    );
+  } else if (featureName.endsWith('_permission')) {
+    checkDescription(
+      'permission',
+      `${apiName}.${featureName}`,
+      data,
+      `<code>${featureName.replace('_permission', '')}</code> permission`,
+      logger,
+    );
+  } else if (featureName == 'secure_context_required') {
+    checkDescription(
+      'secure context required',
+      `${apiName}()`,
+      data,
+      'Secure context required',
+      logger,
+    );
+  } else if (featureName == 'worker_support') {
+    checkDescription(
+      'worker',
+      `${apiName}()`,
+      data,
+      'Available in workers',
+      logger,
+    );
   }
 }
 
-/**
- * Process data and check for any incorrect descriptions in said data, logging any errors
- *
- * @param {Identifier} data The data to test
- * @param {Logger} logger The logger to output errors to
- * @returns {void}
- */
-function processData(data, logger) {
-  if (data.api) {
-    for (const apiName in data.api) {
-      const apiData = data.api[apiName];
-      processApiData(apiData, apiName, logger);
+export default {
+  name: 'Descriptions',
+  description: 'Test the descriptions of compatibility data',
+  scope: 'feature',
+  check(logger, { data, path: { full, category } }) {
+    if (category === 'api') {
+      processApiData(data, full, logger);
     }
-  }
-}
-
-/**
- * Test all of the descriptions through the data in a given filename.  This test only functions with files with API data; all other files are silently ignored
- *
- * @param {Identifier} data The contents of the file to test
- * @returns {boolean} If the file contains errors
- */
-export default function testDescriptions(data) {
-  const logger = new Logger('Descriptions');
-
-  processData(data, logger);
-
-  logger.emit();
-  return logger.hasErrors();
-}
+  },
+};

--- a/test/linter/test-notes.js
+++ b/test/linter/test-notes.js
@@ -4,7 +4,7 @@
 import chalk from 'chalk-template';
 import HTMLParser from '@desertnet/html-parser';
 
-import { Logger, VALID_ELEMENTS } from '../utils.js';
+import { VALID_ELEMENTS } from '../utils.js';
 
 const parser = new HTMLParser();
 
@@ -116,46 +116,29 @@ const checkNotes = (notes, browser, feature, logger) => {
 /**
  * Process the data for notes errors
  *
- * @param {Identifier} data The data to test
+ * @param {CompatStatement} data The data to test
  * @param {logger} logger The logger to output errors to
  * @param {string} [feature] The identifier of the feature
  * @returns {void}
  */
 const processData = (data, logger, feature) => {
-  for (const prop in data) {
-    if (prop === '__compat' && data[prop].support) {
-      let statement = data[prop].support;
-      for (const browser in statement) {
-        if (Array.isArray(statement[browser])) {
-          for (let s of statement[browser]) {
-            if (s.notes) checkNotes(s.notes, browser, feature, logger);
-          }
-        } else {
-          if (statement[browser].notes)
-            checkNotes(statement[browser].notes, browser, feature, logger);
-        }
+  for (const browser in data.support) {
+    if (Array.isArray(data.support[browser])) {
+      for (let s of data.support[browser]) {
+        if (s.notes) checkNotes(s.notes, browser, feature, logger);
       }
-    }
-    const sub = data[prop];
-    if (typeof sub === 'object') {
-      processData(sub, logger, feature ? `${feature}.${prop}` : `${prop}`);
+    } else {
+      if (data.support[browser].notes)
+        checkNotes(data.support[browser].notes, browser, feature, logger);
     }
   }
 };
 
-/**
- * Test the data for notes errors
- *
- * @param {Identifier} data The contents of the file to test
- * @returns {boolean} If the file contains errors
- */
-const testNotes = (data) => {
-  const logger = new Logger('Notes');
-
-  processData(data, logger);
-
-  logger.emit();
-  return logger.hasErrors();
+export default {
+  name: 'Notes',
+  description: 'Test the notes in each support statement',
+  scope: 'feature',
+  check(logger, { data }) {
+    processData(data, logger);
+  },
 };
-
-export default testNotes;

--- a/test/linter/test-prefix.js
+++ b/test/linter/test-prefix.js
@@ -2,45 +2,11 @@
  * See LICENSE file for more information. */
 
 import chalk from 'chalk-template';
-import { Logger } from '../utils.js';
 
 /**
  * @typedef {import('../../types').Identifier} Identifier
  * @typedef {import('../utils').Logger} Logger
  */
-
-/**
- * Check the prefix of a specific feature
- *
- * @param {Identifier} data The data to test
- * @param {string} category The category the data belongs to
- * @param {string} prefix The browser-based prefix to test
- * @param {Logger} logger The logger to output errors to
- * @param {string} [path] The path to the data
- * @returns {string[]} Any errors found within the data
- */
-function checkPrefix(data, category, prefix, logger, path = '') {
-  for (const key in data) {
-    if (key === 'prefix' && typeof data[key] === 'string') {
-      if (data[key].includes(prefix)) {
-        const rules = [
-          category == 'api' && !data[key].startsWith(prefix),
-          category == 'css' && !data[key].startsWith(`-${prefix}`),
-        ];
-        if (rules.some((x) => x === true)) {
-          logger.error(
-            chalk`{bold ${prefix}} prefix is wrong for key: {bold ${path}}`,
-          );
-        }
-      }
-    } else {
-      if (typeof data[key] === 'object') {
-        const curr_path = path.length > 0 ? `${path}.${key}` : key;
-        checkPrefix(data[key], category, prefix, logger, curr_path);
-      }
-    }
-  }
-}
 
 /**
  * Process the data for prefix errors
@@ -54,29 +20,50 @@ function processData(data, category, logger) {
   let prefixes = [];
 
   if (category === 'api') {
-    prefixes = ['moz', 'Moz', 'webkit', 'WebKit', 'webKit', 'ms', 'MS'];
+    prefixes = [
+      'moz',
+      'Moz',
+      'MOZ_',
+      'webkit',
+      'WebKit',
+      'webKit',
+      'WEBKIT_',
+      'ms',
+      'MS',
+      'o',
+      'O',
+    ];
   }
   if (category === 'css') {
-    prefixes = ['webkit', 'moz', 'ms'];
+    prefixes = ['-webkit-', '-moz-', '-ms-', '-o-', '-khtml-'];
   }
 
-  for (const prefix of prefixes) {
-    checkPrefix(data, category, prefix, logger);
+  if (prefixes.length === 0) {
+    // Prefixes aren't enforced for other categories
+    return;
+  }
+
+  for (const support of Object.values(data.support)) {
+    const supportStatements = Array.isArray(support) ? support : [support];
+
+    for (const statement of supportStatements) {
+      if (
+        statement.prefix &&
+        !prefixes.some((p) => statement.prefix.startsWith(p))
+      ) {
+        logger.error(
+          chalk`Prefix is set to {bold ${statement.prefix}}, which is invalid for ${category}`,
+        );
+      }
+    }
   }
 }
 
-/**
- * Test for issues with feature's prefix
- *
- * @param {Identifier} data The contents of the file to test
- * @param {object} filePath The path info for the file being tested
- * @returns {boolean} If the file contains errors
- */
-export default function testPrefix(data, filePath) {
-  const logger = new Logger('Prefix');
-
-  processData(data, filePath.category, logger);
-
-  logger.emit();
-  return logger.hasErrors();
-}
+export default {
+  name: 'Prefix',
+  description: 'Ensure that prefixes in support statements are valid',
+  scope: 'feature',
+  check(logger, { data, path: { category } }) {
+    processData(data, category, logger);
+  },
+};

--- a/test/linter/test-schema.js
+++ b/test/linter/test-schema.js
@@ -5,7 +5,6 @@ import Ajv from 'ajv';
 import ajvErrors from 'ajv-errors';
 import ajvFormats from 'ajv-formats';
 import betterAjvErrors from 'better-ajv-errors';
-import { Logger } from '../utils.js';
 
 import compatDataSchema from './../../schemas/compat-data.schema.json' assert { type: 'json' };
 import browserDataSchema from './../../schemas/browsers.schema.json' assert { type: 'json' };
@@ -21,27 +20,19 @@ ajvFormats(ajv, { mode: 'fast' });
 // Allow for custom error messages to provide better directions for contributors
 ajvErrors(ajv);
 
-/**
- * Test a file to make sure it follows the defined schema
- *
- * @param {Identifier} data The contents of the file to test
- * @param {object} filePath The path info for the file being tested
- * @returns {boolean} If the file contains errors
- */
-export default function testSchema(data, filePath) {
-  const schema =
-    filePath.category === 'browsers' ? browserDataSchema : compatDataSchema;
-
-  const logger = new Logger('JSON Schema');
-
-  if (!ajv.validate(schema, data)) {
-    // Output messages by one since better-ajv-errors wrongly joins messages
-    // (see https://github.com/atlassian/better-ajv-errors/pull/21)
-    ajv.errors.forEach((e) => {
-      logger.error(betterAjvErrors(schema, data, [e], { indent: 2 }));
-    });
-  }
-
-  logger.emit();
-  return logger.hasErrors();
-}
+export default {
+  name: 'JSON Schema',
+  description: 'Test a file to ensure that it follows the defined schema',
+  scope: 'file',
+  check(logger, { data, path: { category } }) {
+    const schema =
+      category === 'browsers' ? browserDataSchema : compatDataSchema;
+    if (!ajv.validate(schema, data)) {
+      // Output messages by one since better-ajv-errors wrongly joins messages
+      // (see https://github.com/atlassian/better-ajv-errors/pull/21)
+      ajv.errors.forEach((e) => {
+        logger.error(betterAjvErrors(schema, data, [e], { indent: 2 }));
+      });
+    }
+  },
+};

--- a/test/linter/test-status.js
+++ b/test/linter/test-status.js
@@ -2,7 +2,6 @@
  * See LICENSE file for more information. */
 
 import chalk from 'chalk-template';
-import { Logger } from '../utils.js';
 
 /**
  * @typedef {import('../../types').Identifier} Identifier
@@ -13,7 +12,7 @@ import { Logger } from '../utils.js';
  * @param {Logger} logger
  */
 function checkStatus(data, logger, path = []) {
-  const status = data.__compat?.status;
+  const status = data.status;
   if (status && status.experimental && status.deprecated) {
     logger.error(
       chalk`{red Unexpected simultaneous experimental and deprecated status in ${path.join(
@@ -22,25 +21,13 @@ function checkStatus(data, logger, path = []) {
       chalk`Run {bold npm run fix} to fix this issue automatically`,
     );
   }
-  for (const member in data) {
-    if (member === '__compat') {
-      continue;
-    }
-    checkStatus(data[member], logger, [...path, member]);
-  }
 }
 
-/**
- * @param {Identifier} data The contents of the file to test
- * @returns {boolean} If the file contains errors
- */
-function testStatusContradiction(data) {
-  const logger = new Logger('Status');
-
-  checkStatus(data, logger);
-
-  logger.emit();
-  return logger.hasErrors();
-}
-
-export default testStatusContradiction;
+export default {
+  name: 'Status',
+  description: 'Test the status of support statements',
+  scope: 'feature',
+  check(logger, { data }) {
+    checkStatus(data, logger);
+  },
+};

--- a/test/linter/test-style.js
+++ b/test/linter/test-style.js
@@ -4,7 +4,6 @@
 import chalk from 'chalk-template';
 import { IS_WINDOWS, indexToPos, jsonDiff } from '../utils.js';
 import compareFeatures from '../../scripts/lib/compare-features.js';
-import { Logger } from '../utils.js';
 
 /**
  * @typedef {import('../utils').Logger} Logger
@@ -115,17 +114,11 @@ function processData(rawData, logger) {
   }
 }
 
-/**
- * Test the data for any styling errors that cannot be caught by Prettier or the schema
- *
- * @param {string} rawData The raw contents of the file to test
- * @returns {boolean} If the file contains errors
- */
-export default function testStyle(rawData) {
-  const logger = new Logger('Style');
-
-  processData(rawData, logger);
-
-  logger.emit();
-  return logger.hasErrors();
-}
+export default {
+  name: 'Style',
+  description: 'Tests the style and formatting of the JSON file',
+  scope: 'file',
+  check(logger, { rawdata }) {
+    processData(rawdata, logger);
+  },
+};

--- a/test/linter/test-versions.js
+++ b/test/linter/test-versions.js
@@ -3,7 +3,6 @@
 
 import compareVersions from 'compare-versions';
 import chalk from 'chalk-template';
-import { Logger } from '../utils.js';
 
 import bcd from '../../index.js';
 const { browsers } = bcd;
@@ -137,12 +136,11 @@ function addedBeforeRemoved(statement) {
  * Check the data for any errors in provided versions
  *
  * @param {SupportBlock} supportData The data to test
- * @param {string} relPath The path to the data
+ * @param {string} category The category the data
  * @param {Logger} logger The logger to output errors to
  * @returns {void}
  */
-function checkVersions(supportData, relPath, logger) {
-  const category = relPath.split('.')[0];
+function checkVersions(supportData, category, logger) {
   const browsersToCheck = Object.keys(supportData);
 
   for (const browser of browsersToCheck) {
@@ -157,9 +155,7 @@ function checkVersions(supportData, relPath, logger) {
       for (const statement of supportStatements) {
         if (statement === undefined) {
           if (blockList[category].includes(browser)) {
-            logger.error(
-              chalk`{red → {bold ${browser}} must be defined for {bold ${relPath}}}`,
-            );
+            logger.error(chalk`{red → {bold ${browser}} must be defined}`);
           }
 
           continue;
@@ -169,7 +165,7 @@ function checkVersions(supportData, relPath, logger) {
           // If the data is to be mirrored, make sure it is mirrorable
           if (!browsers[browser].upstream) {
             logger.error(
-              chalk`{red → {bold ${relPath}} sets {bold ${browser}} to mirror, however {bold ${browser}} does not have an upstream browser.}`,
+              chalk`{bold ${browser}} is set to mirror, however {bold ${browser}} does not have an upstream browser.`,
             );
           }
           continue;
@@ -185,9 +181,9 @@ function checkVersions(supportData, relPath, logger) {
           }
           if (!isValidVersion(browser, category, version)) {
             logger.error(
-              chalk`{red → {bold ${relPath}} - {bold ${property}: "${version}"} is {bold NOT} a valid version number for {bold ${browser}}\n    Valid {bold ${browser}} versions are: ${validBrowserVersions[
+              chalk`{bold ${property}: "${version}"} is {bold NOT} a valid version number for {bold ${browser}}\n    Valid {bold ${browser}} versions are: ${validBrowserVersions[
                 browser
-              ].join(', ')}}`,
+              ].join(', ')}`,
               browserTips[browser],
             );
           }
@@ -196,7 +192,7 @@ function checkVersions(supportData, relPath, logger) {
         if ('version_added' in statement && 'version_removed' in statement) {
           if (statement.version_added === statement.version_removed) {
             logger.error(
-              chalk`{red → {bold ${relPath}} - {bold version_added: "${statement.version_added}"} must not be the same as {bold version_removed} for {bold ${browser}}}`,
+              chalk`{bold version_added: "${statement.version_added}"} must not be the same as {bold version_removed} for {bold ${browser}}`,
             );
           }
           if (
@@ -205,7 +201,7 @@ function checkVersions(supportData, relPath, logger) {
             addedBeforeRemoved(statement) === false
           ) {
             logger.error(
-              chalk`{bold ${relPath}} - {bold version_removed: "${statement.version_removed}"} must be greater than {bold version_added: "${statement.version_added}"}`,
+              chalk`{bold version_removed: "${statement.version_removed}"} must be greater than {bold version_added: "${statement.version_added}"}`,
             );
           }
         }
@@ -213,7 +209,7 @@ function checkVersions(supportData, relPath, logger) {
         if ('flags' in statement) {
           if (browsers[browser].accepts_flags === false) {
             logger.error(
-              chalk`{bold ${relPath}} - This browser ({bold ${browser}}) does not support flags, so support cannot be behind a flag for this feature.`,
+              chalk`This browser ({bold ${browser}}) does not support flags, so support cannot be behind a flag for this feature.`,
             );
           }
         }
@@ -221,7 +217,7 @@ function checkVersions(supportData, relPath, logger) {
         if (hasVersionAddedOnly(statement)) {
           if (sawVersionAddedOnly) {
             logger.error(
-              chalk`{red → '{bold ${relPath}}' - {bold ${browser}} has multiple support statements with only {bold version_added}.}`,
+              chalk`{bold ${browser}} has multiple support statements with only {bold version_added}.`,
             );
             break;
           } else {
@@ -236,7 +232,7 @@ function checkVersions(supportData, relPath, logger) {
             )
           ) {
             logger.error(
-              chalk`{red → {bold ${relPath}} - The data for ({bold ${browser}}) says no support, but contains additional properties that suggest support.}`,
+              chalk`The data for ({bold ${browser}}) says no support, but contains additional properties that suggest support.`,
             );
           }
         }
@@ -248,7 +244,7 @@ function checkVersions(supportData, relPath, logger) {
           statementKeys[0] == 'version_added'
         ) {
           logger.error(
-            chalk`{red → '{bold ${relPath}}' - {bold ${browser}} cannot have a {bold version_added: false} only in an array of statements.}`,
+            chalk`{bold ${browser}} cannot have a {bold version_added: false} only in an array of statements.`,
           );
         }
       }
@@ -256,37 +252,11 @@ function checkVersions(supportData, relPath, logger) {
   }
 }
 
-/**
- * Process the data for version errors
- *
- * @param {Identifier} data The data to test
- * @param {Logger} logger The logger to output errors to
- * @param {string} relPath The path of the data
- * @returns {void}
- */
-function findSupport(data, logger, relPath) {
-  for (const prop in data) {
-    if (prop === '__compat' && data[prop].support) {
-      checkVersions(data[prop].support, relPath, logger);
-    }
-    const sub = data[prop];
-    if (typeof sub === 'object') {
-      findSupport(sub, logger, relPath ? `${relPath}.${prop}` : `${prop}`);
-    }
-  }
-}
-
-/**
- * Test for version errors
- *
- * @param {Identifier} data The contents of the file to test
- * @returns {boolean} If the file contains errors
- */
-export default function testVersions(data) {
-  const logger = new Logger('Versions');
-
-  findSupport(data, logger);
-
-  logger.emit();
-  return logger.hasErrors();
-}
+export default {
+  name: 'Versions',
+  description: 'Test the version numbers of support statements',
+  scope: 'feature',
+  check(logger, { data, path: { category } }) {
+    checkVersions(data.support, category, logger);
+  },
+};

--- a/test/utils.js
+++ b/test/utils.js
@@ -129,36 +129,79 @@ export function jsonDiff(actual, expected) {
 }
 
 export class Logger {
-  /** @param {string} title */
-  constructor(title) {
+  constructor(title, path) {
     this.title = title;
-    this.errors = [];
+    this.path = path;
+    this.messages = [];
   }
 
   /**
    * @param {string} message
-   * @param {string} tip
+   * @param {object} options
    */
-  error(message, tip) {
-    this.errors.push({ message: message, tip: tip });
+  error(message, options) {
+    this.messages.push({
+      level: 'error',
+      title: this.title,
+      path: this.path,
+      message,
+      ...options,
+    });
   }
 
-  emit() {
-    const errorCount = this.errors.length;
+  /**
+   * @param {string} message
+   * @param {object} options
+   */
+  warning(message, options) {
+    this.messages.push({
+      level: 'warning',
+      title: this.title,
+      path: this.path,
+      message,
+      ...options,
+    });
+  }
+}
 
-    if (errorCount) {
-      console.error(
-        chalk`{red   → ${this.title} – ${pluralize('error', errorCount)}:}`,
-      );
+export class Linters {
+  /** @param {Array.<Linter>} linters */
+  constructor(linters) {
+    this.linters = linters;
+    this.messages = {};
 
-      for (const error of this.errors) {
-        console.error(chalk`    {red → ${error.message}}`);
-        if (error.tip) console.error(chalk`      {blue → Tip: ${error.tip}}`);
+    for (const linter of this.linters) {
+      if (!this.validateScope(linter.scope)) {
+        throw new Error(
+          `Tried to initialize "${linter.name}" linter, but found invalid scope (${linter.scope}.`,
+        );
       }
+      this.messages[linter.name] = [];
     }
   }
 
-  hasErrors() {
-    return !!this.errors.length;
+  /** @param {string} scope */
+  validateScope(scope) {
+    return ['file', 'feature', 'browser', 'tree'].includes(scope);
+  }
+
+  /**
+   * @param {string} scope
+   * @param {any} data
+   */
+  runScope(scope, data) {
+    if (!this.validateScope(scope)) {
+      throw new Error(
+        `Tried to run tests for "${scope}" which is not a valid scope.`,
+      );
+    }
+
+    for (const linter of this.linters.filter(
+      (linter) => linter.scope === scope,
+    )) {
+      const logger = new Logger(linter.title, data.path.full);
+      linter.check(logger, data);
+      this.messages[linter.name].push(...logger.messages);
+    }
   }
 }


### PR DESCRIPTION
This PR implements the framework for the next-generation linter system as described in https://github.com/openwebdocs/project/issues/79.  Some modifications have been made to the linters to accommodate for the new linter input.

Note that this will fail at the moment as the new setup has revealed some consistency errors between the mixin files and the main files.  Also depends on #16435.
