### PR TITLE
chore: update pr-rebase-needed workflow

### DIFF
--- a/.github/workflows/pr-rebase-needed.yml
+++ b/.github/workflows/pr-rebase-needed.yml
@@ -7,5 +7,7 @@ on:
 jobs:
   idle:
     uses: mdn/workflows/.github/workflows/pr-rebase-needed.yml@main
+    with:
+      target-repo: "mdn/browser-compat-data"
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add required `target-repo` input and rename workflow name.
Update required as a result of https://github.com/mdn/workflows/pull/55