### PR TITLE
Remove windows.mozPaintCount

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3909,56 +3909,6 @@
           }
         }
       },
-      "mozPaintCount": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/mozPaintCount",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": "4",
-              "version_removed": "72"
-            },
-            "firefox_android": {
-              "version_added": "4",
-              "version_removed": "79"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/name",


### PR DESCRIPTION
[Window.mozPaintCount](https://developer.mozilla.org/en-US/docs/Web/API/Window/mozPaintCount) was disabled in FF72. It has now been removed in FF102 by https://bugzilla.mozilla.org/show_bug.cgi?id=1769758

The page has been removed from MDN. This is the corresponding removal of the redundant data in BCD.

Other docs work for this tracked in https://github.com/mdn/content/issues/16625