### PR TITLE
Update length BCD table for new viewport-percentage units

### DIFF
--- a/css/types/length.json
+++ b/css/types/length.json
@@ -590,6 +590,150 @@
             }
           }
         },
+        "viewport_percentage_units_dynamic": {
+          "__compat": {
+            "description": "<code>dvb</code>, <code>dvh</code>, <code>dvi</code>, <code>dvmax</code>, <code>dvmin</code>, <code>dvw</code> units",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "101"
+              },
+              "firefox_android": {
+                "version_added": "101"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": {
+                "version_added": "15.4"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "viewport_percentage_units_large": {
+          "__compat": {
+            "description": "<code>lvb</code>, <code>lvh</code>, <code>lvi</code>, <code>lvmax</code>, <code>lvmin</code>, <code>lvw</code> units",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "101"
+              },
+              "firefox_android": {
+                "version_added": "101"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": {
+                "version_added": "15.4"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "viewport_percentage_units_small": {
+          "__compat": {
+            "description": "<code>svb</code>, <code>svh</code>, <code>svi</code>, <code>svmax</code>, <code>svmin</code>, <code>svw</code> units",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "101"
+              },
+              "firefox_android": {
+                "version_added": "101"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": {
+                "version_added": "15.4"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "vmax": {
           "__compat": {
             "description": "<code>vmax</code> unit",
@@ -743,150 +887,6 @@
               },
               "webview_android": {
                 "version_added": "≤37"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "viewport_percentage_units_dynamic": {
-          "__compat": {
-            "description": "<code>dvb</code>, <code>dvh</code>, <code>dvi</code>, <code>dvmax</code>, <code>dvmin</code>, <code>dvw</code> units",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "101"
-              },
-              "firefox_android": {
-                "version_added": "101"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": "15.4"
-              },
-              "safari_ios": {
-                "version_added": "15.4"
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "viewport_percentage_units_large": {
-          "__compat": {
-            "description": "<code>lvb</code>, <code>lvh</code>, <code>lvi</code>, <code>lvmax</code>, <code>lvmin</code>, <code>lvw</code> units",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "101"
-              },
-              "firefox_android": {
-                "version_added": "101"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": "15.4"
-              },
-              "safari_ios": {
-                "version_added": "15.4"
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "viewport_percentage_units_small": {
-          "__compat": {
-            "description": "<code>svb</code>, <code>svh</code>, <code>svi</code>, <code>svmax</code>, <code>svmin</code>, <code>svw</code> units",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": "101"
-              },
-              "firefox_android": {
-                "version_added": "101"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": "15.4"
-              },
-              "safari_ios": {
-                "version_added": "15.4"
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
               }
             },
             "status": {

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -458,11 +458,12 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1287034'>bug 1287034</a>."
+                "version_added": "101",
+                "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "101",
+                "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
               },
               "ie": {
                 "version_added": false
@@ -557,11 +558,12 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1287034'>bug 1287034</a>."
+                "version_added": "101",
+                "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "19",
+                "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
               },
               "ie": {
                 "version_added": false
@@ -745,6 +747,150 @@
               },
               "webview_android": {
                 "version_added": "≤37"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "viewport_percentage_units_dynamic": {
+          "__compat": {
+            "description": "<code>dvb</code>, <code>dvh</code>, <code>dvi</code>, <code>dvmax</code>, <code>dvmin</code>, <code>dvw</code> units",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "101"
+              },
+              "firefox_android": {
+                "version_added": "101"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": {
+                "version_added": "15.4"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "viewport_percentage_units_large": {
+          "__compat": {
+            "description": "<code>lvb</code>, <code>lvh</code>, <code>lvi</code>, <code>lvmax</code>, <code>lvmin</code>, <code>lvw</code> units",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "101"
+              },
+              "firefox_android": {
+                "version_added": "101"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": {
+                "version_added": "15.4"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "viewport_percentage_units_small": {
+          "__compat": {
+            "description": "<code>svb</code>, <code>svh</code>, <code>svi</code>, <code>svmax</code>, <code>svmin</code>, <code>svw</code> units",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "101"
+              },
+              "firefox_android": {
+                "version_added": "101"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": {
+                "version_added": "15.4"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
               }
             },
             "status": {

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -340,8 +340,8 @@
               }
             },
             "status": {
-              "experimental": false,
-              "standard_track": true,
+              "experimental": true,
+              "standard_track": false,
               "deprecated": false
             }
           }
@@ -438,8 +438,8 @@
               }
             },
             "status": {
-              "experimental": false,
-              "standard_track": true,
+              "experimental": true,
+              "standard_track": false,
               "deprecated": false
             }
           }

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -458,12 +458,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "101",
-                "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
+                "version_added": "101"
               },
               "firefox_android": {
-                "version_added": "101",
-                "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
+                "version_added": "101"
               },
               "ie": {
                 "version_added": false
@@ -558,12 +556,10 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": "101",
-                "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
+                "version_added": "101"
               },
               "firefox_android": {
-                "version_added": "19",
-                "notes": "Starting with version 21, viewport-percentage lengths are invalid in <code>@page</code>."
+                "version_added": "101"
               },
               "ie": {
                 "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
- In Firefox release 101, new viewport sizes have been introduced: small (s), large (l), and dynamic (d).
- As a result, the existing viewport-percentage length units (vw, vh, vmin, vmax) can have more variants.
Each can be of the type s, l, d resulting in:
dvb, dvh, dvi, dvmax, dvmin, dvw,
lvb, lvh, lvi, lvmax, lvmin, lvw,
svb, svh, svi, svmax, svmin, svw
- Also, vb and vi units are now also supported by default in FF and were already supported in Safari, so are longer experimental

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://bugzilla.mozilla.org/show_bug.cgi?id=1610815

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Doc issue tracking this work: https://github.com/mdn/content/issues/15465
Comment reference: https://github.com/mdn/content/issues/15465#issuecomment-1139175513

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
