### PR TITLE
Support for StorageArea.onChanged and Session

### DIFF
--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -114,6 +114,34 @@
               }
             }
           },
+          "onChanged": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/StorageArea/onChanged",
+              "support": {
+                "chrome": {
+                  "version_added": "73"
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": "101"
+                },
+                "firefox_android": {
+                  "version_added": "101"
+                },
+                "opera": {
+                  "version_added": true
+                },
+                "safari": {
+                  "version_added": true
+                },
+                "safari_ios": {
+                  "version_added": true
+                }
+              }
+            }
+          },
           "remove": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/remove",
@@ -286,6 +314,34 @@
               },
               "safari_ios": {
                 "version_added": "15"
+              }
+            }
+          }
+        },
+        "session": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/session",
+            "support": {
+              "chrome": {
+                "version_added": "102"
+              },
+              "edge": {
+                "version_added": "102"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "88"
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": {
+                "version_added": null
               }
             }
           }


### PR DESCRIPTION
#### Summary
Adds:
- `StorageArea.onChanged` – documentation of the change made in [Bug 1758475](https://bugzilla.mozilla.org/show_bug.cgi?id=1758475) Support StorageArea.onChanged (onChanged on storage.local/sync/managed).
- `Session` – addition made in Chrome version 102. (https://developer.chrome.com/docs/extensions/reference/storage/#property-session)

#### Test results and supporting details
Ran and passed `npm test`.