### PR TITLE
TaskSignal: prioritychange_event url fix

### DIFF
--- a/api/TaskSignal.json
+++ b/api/TaskSignal.json
@@ -124,7 +124,7 @@
       "prioritychange_event": {
         "__compat": {
           "description": "<code>prioritychange</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/prioritychange_event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TaskSignal/prioritychange_event",
           "spec_url": [
             "https://wicg.github.io/scheduling-apis/#ref-for-eventdef-tasksignal-prioritychange",
             "https://wicg.github.io/scheduling-apis/#dom-tasksignal-onprioritychange"


### PR DESCRIPTION
The prioritychange_event is fired on TaskSignal, but the URL assumed it was global. This fixes the URL for the docs to match where they will actually be.