### PR TITLE
Add more spec URLs for the “alternative stylesheet” feature

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -770,7 +770,13 @@
             "__compat": {
               "description": "Alternative stylesheets.",
               "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Alternative_style_sheets",
-              "spec_url": "https://html.spec.whatwg.org/multipage/links.html#rel-alternate",
+              "spec_url": [
+                "https://html.spec.whatwg.org/multipage/links.html#rel-alternate",
+                "https://html.spec.whatwg.org/multipage/#the-link-is-an-alternative-stylesheet",
+                "https://html.spec.whatwg.org/multipage/#attr-style-title",
+                "https://html.spec.whatwg.org/multipage/#attr-meta-http-equiv-default-style",
+                "https://drafts.csswg.org/cssom/#css-style-sheet-collections"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "1",


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/#rel-alternate alone as a spec URL does not adequately capture the scope of the “alternative stylesheets” feature.

https://developer.mozilla.org/docs/Web/CSS/Alternative_style_sheets#specifications has five spec citations in total — which we’re currently using the `spec-urls` YAML frontmatter metadata key to record.

But it would be better to have those spec URLs in BCD itself — then we can switch the MDN article to just using the `browser-compat` key, so that the spec URLs get pulled in from BCD too.
