### PR TITLE
Media features - range syntax and update

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1626,11 +1626,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Media_Queries/Using_media_queries#syntax_improvements_in_level_4",
             "support": {
               "chrome": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/1034465'>bug 1034465</a>."
+                "version_added": "104"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": "104"
               },
               "edge": {
                 "version_added": false
@@ -1660,7 +1659,7 @@
                 "version_added": false
               },
               "webview_android": {
-                "version_added": false
+                "version_added": "104"
               }
             },
             "status": {
@@ -1800,6 +1799,55 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "update": {
+          "__compat": {
+            "description": "<code>update</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/update-frequency",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "102"
+              },
+              "firefox_android": {
+                "version_added": "102"
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
A couple of changes to media features:

- Add the [update media feature](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/update-frequency) which looks to be[ in Firefox 102](https://bugzilla.mozilla.org/show_bug.cgi?id=1422312).
- Update range syntax for Chromium, [shipping in 104](https://bugs.chromium.org/p/chromium/issues/detail?id=1034465).