### PR TITLE
Don't alter data when performing upstream mirroring

### DIFF
--- a/scripts/release/mirror.js
+++ b/scripts/release/mirror.js
@@ -366,12 +366,20 @@ const mirrorSupport = (destination, data) => {
     );
   }
 
-  if (data[upstream] == 'mirror') {
-    // Perform mirroring upstream if needed
-    data[upstream] = mirrorSupport(upstream, data);
+  let upstreamData = data[upstream];
+
+  if (!upstreamData) {
+    throw new Error(
+      `The data for ${upstream} is not defined for mirroring to ${destination}, cannot mirror!`,
+    );
   }
 
-  return bumpSupport(data[upstream], destination);
+  if (upstreamData === 'mirror') {
+    // Perform mirroring upstream if needed
+    upstreamData = mirrorSupport(upstream, data);
+  }
+
+  return bumpSupport(upstreamData, destination);
 };
 
 export default mirrorSupport;


### PR DESCRIPTION
This PR fixes #16471 by creating a separate variable to hold the upstream data, which mirroring is then performed on if needed, rather than using and altering the initial data.  Additionally, this includes a check to ensure that upstream data is defined for the compatibility data.
