### PR TITLE
Update “alternative stylesheet” spec URLs

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -777,9 +777,9 @@
               "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Alternative_style_sheets",
               "spec_url": [
                 "https://html.spec.whatwg.org/multipage/links.html#rel-alternate",
-                "https://html.spec.whatwg.org/multipage/#the-link-is-an-alternative-stylesheet",
-                "https://html.spec.whatwg.org/multipage/#attr-style-title",
-                "https://html.spec.whatwg.org/multipage/#attr-meta-http-equiv-default-style",
+                "https://html.spec.whatwg.org/multipage/links.html#the-link-is-an-alternative-stylesheet",
+                "https://html.spec.whatwg.org/multipage/semantics.html#attr-style-title",
+                "https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-default-style",
                 "https://drafts.csswg.org/cssom/#css-style-sheet-collections"
               ],
               "support": {


### PR DESCRIPTION
For URLs from the HTML spec, the spec URL should include the filename, not just the fragment part.