### PR TITLE
FF102 User-defined byte-streams enabled

### DIFF
--- a/api/ReadableByteStreamController.json
+++ b/api/ReadableByteStreamController.json
@@ -74,7 +74,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -141,7 +141,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -209,7 +209,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -277,7 +277,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -345,7 +345,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -413,7 +413,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/ReadableByteStreamController.json
+++ b/api/ReadableByteStreamController.json
@@ -25,18 +25,24 @@
           "edge": {
             "version_added": "89"
           },
-          "firefox": {
-            "version_added": "99",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.streams.byte_streams.enabled",
-                "value_to_set": "true"
-              }
-            ]
-          },
+          "firefox": [
+            {
+              "version_added": "102"
+            },
+            {
+              "version_added": "99",
+              "version_removed": "102",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.byte_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
-            "version_added": false
+            "version_added": "102"
           },
           "ie": {
             "version_added": false
@@ -90,18 +96,24 @@
             "edge": {
               "version_added": "89"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.byte_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "102"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "102",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.byte_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "102"
             },
             "ie": {
               "version_added": false
@@ -152,18 +164,24 @@
             "edge": {
               "version_added": "89"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.byte_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "102"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "102",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.byte_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "102"
             },
             "ie": {
               "version_added": false
@@ -214,18 +232,24 @@
             "edge": {
               "version_added": "89"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.byte_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "102"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "102",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.byte_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "102"
             },
             "ie": {
               "version_added": false
@@ -276,18 +300,24 @@
             "edge": {
               "version_added": "89"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.byte_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "102"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "102",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.byte_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "102"
             },
             "ie": {
               "version_added": false
@@ -338,18 +368,24 @@
             "edge": {
               "version_added": "89"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.byte_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "102"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "102",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.byte_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "102"
             },
             "ie": {
               "version_added": false

--- a/api/ReadableStreamBYOBReader.json
+++ b/api/ReadableStreamBYOBReader.json
@@ -134,7 +134,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -202,7 +202,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -270,7 +270,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -338,7 +338,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/ReadableStreamBYOBReader.json
+++ b/api/ReadableStreamBYOBReader.json
@@ -361,12 +361,24 @@
             "edge": {
               "version_added": "89"
             },
-            "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1604037'>bug 1604037</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "102"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "102",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.byte_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "102"
             },
             "ie": {
               "version_added": false

--- a/api/ReadableStreamBYOBReader.json
+++ b/api/ReadableStreamBYOBReader.json
@@ -17,18 +17,24 @@
           "edge": {
             "version_added": "89"
           },
-          "firefox": {
-            "version_added": "99",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.streams.byte_streams.enabled",
-                "value_to_set": "true"
-              }
-            ]
-          },
+          "firefox": [
+            {
+              "version_added": "102"
+            },
+            {
+              "version_added": "99",
+              "version_removed": "102",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.byte_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
-            "version_added": false
+            "version_added": "102"
           },
           "ie": {
             "version_added": false
@@ -83,18 +89,24 @@
             "edge": {
               "version_added": "89"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.byte_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "102"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "102",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.byte_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "102"
             },
             "ie": {
               "version_added": false
@@ -145,18 +157,24 @@
             "edge": {
               "version_added": "89"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.byte_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "102"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "102",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.byte_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "102"
             },
             "ie": {
               "version_added": false
@@ -207,18 +225,24 @@
             "edge": {
               "version_added": "89"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.byte_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "102"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "102",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.byte_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "102"
             },
             "ie": {
               "version_added": false
@@ -269,18 +293,24 @@
             "edge": {
               "version_added": "89"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.byte_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "102"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "102",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.byte_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "102"
             },
             "ie": {
               "version_added": false

--- a/api/ReadableStreamBYOBReader.json
+++ b/api/ReadableStreamBYOBReader.json
@@ -66,7 +66,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -394,7 +394,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/ReadableStreamBYOBRequest.json
+++ b/api/ReadableStreamBYOBRequest.json
@@ -17,18 +17,24 @@
           "edge": {
             "version_added": "89"
           },
-          "firefox": {
-            "version_added": "99",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.streams.byte_streams.enabled",
-                "value_to_set": "true"
-              }
-            ]
-          },
+          "firefox": [
+            {
+              "version_added": "102"
+            },
+            {
+              "version_added": "99",
+              "version_removed": "102",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.streams.byte_streams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": {
-            "version_added": false
+            "version_added": "102"
           },
           "ie": {
             "version_added": false
@@ -82,18 +88,24 @@
             "edge": {
               "version_added": "89"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.byte_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "102"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "102",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.byte_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "102"
             },
             "ie": {
               "version_added": false
@@ -144,18 +156,24 @@
             "edge": {
               "version_added": "89"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.byte_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "102"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "102",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.byte_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "102"
             },
             "ie": {
               "version_added": false
@@ -206,18 +224,24 @@
             "edge": {
               "version_added": "89"
             },
-            "firefox": {
-              "version_added": "99",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.streams.byte_streams.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "102"
+              },
+              {
+                "version_added": "99",
+                "version_removed": "102",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.byte_streams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "102"
             },
             "ie": {
               "version_added": false

--- a/api/ReadableStreamBYOBRequest.json
+++ b/api/ReadableStreamBYOBRequest.json
@@ -66,7 +66,7 @@
           }
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -133,7 +133,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -201,7 +201,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -269,7 +269,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
FF102 enables the pref `dom.streams.byte_streams.enabled` in https://bugzilla.mozilla.org/show_bug.cgi?id=1767342.
This PR adds `version_added` support for FF102 in desktop and android, and `version_removed` for the preferenced version. 

Note, as these are supported in multiple platforms, I have changed them to no longer be marked as experimental

Related docs work can be tracked in https://github.com/mdn/content/issues/16816