### PR TITLE
Linter: enforce reverse-chronological order for multiple support blocks

### DIFF
--- a/scripts/fix/browser-order.js
+++ b/scripts/fix/browser-order.js
@@ -20,7 +20,7 @@ import { IS_WINDOWS } from '../../test/utils.js';
  * @param {Identifier} value The value of the key
  * @returns {Identifier} Value with sorting applied
  */
-const orderSupportBlock = (key, value) => {
+export const orderSupportBlock = (key, value) => {
   if (key === '__compat') {
     value.support = Object.keys(value.support)
       .sort()

--- a/scripts/fix/feature-order.js
+++ b/scripts/fix/feature-order.js
@@ -21,7 +21,7 @@ import { IS_WINDOWS } from '../../test/utils.js';
  * @param {Identifier} value The value of the key
  * @returns {Identifier} The new value
  */
-function orderFeatures(key, value) {
+export function orderFeatures(key, value) {
   if (value instanceof Object && '__compat' in value) {
     value = Object.keys(value)
       .sort(compareFeatures)

--- a/scripts/fix/statement-order.js
+++ b/scripts/fix/statement-order.js
@@ -17,7 +17,7 @@ import compareStatements from '../lib/compare-statements.js';
  *
  * @returns {*} The new value
  */
-function orderStatements(key, value) {
+export function orderStatements(key, value) {
   if (key === '__compat') {
     for (let browser of Object.keys(value.support)) {
       let supportData = value.support[browser];

--- a/test/linter/test-style.js
+++ b/test/linter/test-style.js
@@ -3,60 +3,14 @@
 
 import chalk from 'chalk-template';
 import { IS_WINDOWS, indexToPos, jsonDiff } from '../utils.js';
-import compareFeatures from '../../scripts/lib/compare-features.js';
 import { Logger } from '../utils.js';
+import { orderSupportBlock } from '../../scripts/fix/browser-order.js';
+import { orderFeatures } from '../../scripts/fix/feature-order.js';
+import { orderStatements } from '../../scripts/fix/statement-order.js';
 
 /**
  * @typedef {import('../utils').Logger} Logger
  */
-
-/**
- * Return a new "support_block" object whose first-level properties
- * (browser names) have been ordered according to Array.prototype.sort,
- * and so will be stringified in that order as well. This relies on
- * guaranteed "own" property ordering, which is insertion order for
- * non-integer keys (which is our case).
- *
- * @param {string} key The key in the object
- * @param {*} value The value of the key
- *
- * @returns {*} The new value
- */
-function orderSupportBlock(key, value) {
-  if (key === '__compat') {
-    value.support = Object.keys(value.support)
-      .sort()
-      .reduce((result, key) => {
-        result[key] = value.support[key];
-        return result;
-      }, {});
-  }
-  return value;
-}
-
-/**
- * Return a new feature object whose first-level properties have been
- * ordered according to Array.prototype.sort, and so will be
- * stringified in that order as well. This relies on guaranteed "own"
- * property ordering, which is insertion order for non-integer keys
- * (which is our case).
- *
- * @param {string} key The key in the object
- * @param {*} value The value of the key
- *
- * @returns {*} The new value
- */
-function orderFeatures(key, value) {
-  if (value instanceof Object && '__compat' in value) {
-    value = Object.keys(value)
-      .sort(compareFeatures)
-      .reduce((result, key) => {
-        result[key] = value[key];
-        return result;
-      }, {});
-  }
-  return value;
-}
 
 /**
  * Process the data for any styling errors that cannot be caught by Prettier or the schema
@@ -71,6 +25,7 @@ function processData(rawData, logger) {
   let expected = JSON.stringify(dataObject, null, 2);
   let expectedBrowserSorting = JSON.stringify(dataObject, orderSupportBlock, 2);
   let expectedFeatureSorting = JSON.stringify(dataObject, orderFeatures, 2);
+  let expectedStatementSorting = JSON.stringify(dataObject, orderStatements, 2);
 
   // prevent false positives from git.core.autocrlf on Windows
   if (IS_WINDOWS) {
@@ -78,6 +33,7 @@ function processData(rawData, logger) {
     expected = expected.replace(/\r/g, '');
     expectedBrowserSorting = expectedBrowserSorting.replace(/\r/g, '');
     expectedFeatureSorting = expectedFeatureSorting.replace(/\r/g, '');
+    expectedStatementSorting = expectedStatementSorting.replace(/\r/g, '');
   }
 
   if (actual !== expected) {
@@ -97,6 +53,16 @@ function processData(rawData, logger) {
   if (expected !== expectedFeatureSorting) {
     logger.error(
       chalk`Feature sorting error on ${jsonDiff(
+        actual,
+        expectedFeatureSorting,
+      )}`,
+      chalk`Run {bold npm run fix} to fix sorting automatically`,
+    );
+  }
+
+  if (expected !== expectedStatementSorting) {
+    logger.error(
+      chalk`Statement sorting error on ${jsonDiff(
         actual,
         expectedFeatureSorting,
       )}`,


### PR DESCRIPTION
This PR enforces the rules added in migration 005 in the linter.
