### PR TITLE
Remove internal types from types.d.ts

### DIFF
--- a/dev.d.ts
+++ b/dev.d.ts
@@ -6,3 +6,5 @@ import { CompatData } from './types';
 import './external';
 
 export default CompatData;
+
+export type InternalSupportStatement = SupportStatement | 'mirror';

--- a/types.d.ts
+++ b/types.d.ts
@@ -146,14 +146,11 @@ export interface ReleaseStatement {
  *
  * It is an array of `simple_support_statement` objects, but if there
  * is only one of them, the array must be omitted.
- *
- * Internally, "mirror" may also be used to represent that the data
- * should be mirrored from its upstream counterpart.
  */
 export type SupportStatement =
   | SimpleSupportStatement
-  | SimpleSupportStatement[]
-  | 'mirror';
+  | SimpleSupportStatement[];
+
 export type VersionValue = string | boolean | null;
 
 /**


### PR DESCRIPTION
This PR ensures that internal types aren't exposed to end users, which may cause issues with TypeScript definitions.
