### PR TITLE
Fix TypeScript import

### DIFF
--- a/scripts/release/build.js
+++ b/scripts/release/build.js
@@ -61,6 +61,20 @@ export default bcd;
   await fs.writeFile(dest, content);
 }
 
+async function writeTypeScriptIndex() {
+  const dest = path.resolve(directory, 'index.ts');
+  const content = `/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+import "./types";
+
+import bcd from "./data.json";
+
+export default bcd as CompatData;
+export * from "./types";`;
+  await fs.writeFile(dest, content);
+}
+
 // Returns an array of promises for copying of all files that don't need transformation
 async function copyFiles() {
   for (const file of verbatimFiles) {
@@ -77,7 +91,7 @@ async function createManifest() {
       '.': './data.json',
       './forLegacyNode': './legacynode.mjs',
     },
-    types: 'types.d.ts',
+    types: 'index.ts',
   };
 
   const minimalKeys = [
@@ -126,6 +140,7 @@ async function main() {
   await writeManifest();
   await writeData();
   await writeWrapper();
+  await writeTypeScriptIndex();
   await copyFiles();
 
   console.log('Data bundle is ready');


### PR DESCRIPTION
This PR fixes the TypeScript import for BCD to ensure that TypeScript users may properly import the package and its types.
