### PR TITLE
Updates firefox to version 101

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -724,23 +724,30 @@
         "100": {
           "release_date": "2022-05-03",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/100",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "100"
         },
         "101": {
           "release_date": "2022-05-31",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/101",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "101"
         },
         "102": {
           "release_date": "2022-06-28",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/102",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "102"
+        },
+        "103": {
+          "release_date": "2022-07-26",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/103",
+          "status": "nightly",
+          "engine": "Gecko",
+          "engine_version": "103"
         }
       }
     }

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -591,23 +591,30 @@
         "100": {
           "release_date": "2022-05-03",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/100",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "100"
         },
         "101": {
           "release_date": "2022-05-31",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/101",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "101"
         },
         "102": {
           "release_date": "2022-06-28",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/102",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "102"
+        },
+        "103": {
+          "release_date": "2022-07-26",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/103",
+          "status": "nightly",
+          "engine": "Gecko",
+          "engine_version": "103"
         }
       }
     }


### PR DESCRIPTION
Hello everyone!

I updated Firefox browser to version 101, according to [this release note](https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/101).

And according to [this release note](https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/103), the release date of firefox 103 is 26/07/22.

 😉