### PR TITLE
Update more HTML element API spec URLs to dev targets

### DIFF
--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -455,7 +455,7 @@
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/length",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-length",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-length-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -751,7 +751,7 @@
       "reportValidity": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/reportValidity",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-reportvalidity",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-reportvalidity-dev",
           "support": {
             "chrome": {
               "version_added": "40"
@@ -1094,7 +1094,7 @@
       "validationMessage": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/validationMessage",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validationmessage",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validationmessage-dev",
           "support": {
             "chrome": {
               "version_added": "4"
@@ -1143,7 +1143,7 @@
       "validity": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/validity",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validity",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-constraint-validation-api:dom-cva-validity",
           "support": {
             "chrome": {
               "version_added": "3"
@@ -1192,7 +1192,7 @@
       "value": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/value",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-value",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-value-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -1241,7 +1241,7 @@
       "willValidate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/willValidate",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-willvalidate",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-willvalidate-dev",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -147,7 +147,7 @@
       },
       "checkValidity": {
         "__compat": {
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-checkvalidity",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-checkvalidity-dev",
           "support": {
             "chrome": {
               "version_added": "4"
@@ -387,7 +387,7 @@
       },
       "form": {
         "__compat": {
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fae-form",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fae-form-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -725,7 +725,7 @@
       "reportValidity": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/reportValidity",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-reportvalidity",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-reportvalidity-dev",
           "support": {
             "chrome": {
               "version_added": "40"
@@ -869,7 +869,7 @@
       },
       "select": {
         "__compat": {
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-select",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-select-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -1115,7 +1115,7 @@
       },
       "setCustomValidity": {
         "__compat": {
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-setcustomvalidity",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-setcustomvalidity-dev",
           "support": {
             "chrome": {
               "version_added": "4"
@@ -1163,7 +1163,7 @@
       },
       "setRangeText": {
         "__compat": {
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-setrangetext",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-setrangetext-dev",
           "support": {
             "chrome": {
               "version_added": "24"
@@ -1211,7 +1211,7 @@
       },
       "setSelectionRange": {
         "__compat": {
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-setselectionrange",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-setselectionrange-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -1308,7 +1308,7 @@
       },
       "type": {
         "__compat": {
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-type",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-type-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -1356,7 +1356,7 @@
       },
       "validationMessage": {
         "__compat": {
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validationmessage",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validationmessage-dev",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -1404,7 +1404,7 @@
       },
       "validity": {
         "__compat": {
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validity",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-constraint-validation-api:dom-cva-validity",
           "support": {
             "chrome": {
               "version_added": "3"
@@ -1452,7 +1452,7 @@
       },
       "value": {
         "__compat": {
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-value",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-value-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -1500,7 +1500,7 @@
       },
       "willValidate": {
         "__compat": {
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-willvalidate",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-willvalidate-dev",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/HTMLTitleElement.json
+++ b/api/HTMLTitleElement.json
@@ -51,7 +51,7 @@
       "text": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTitleElement/text",
-          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#dom-title-text",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#dom-title-text-dev",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/HTMLTrackElement.json
+++ b/api/HTMLTrackElement.json
@@ -317,7 +317,7 @@
       "readyState": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTrackElement/readyState",
-          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-track-readystate",
+          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-track-readystate-dev",
           "support": {
             "chrome": {
               "version_added": "23"
@@ -466,7 +466,7 @@
       "track": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTrackElement/track",
-          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-track-track",
+          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-track-track-dev",
           "support": {
             "chrome": {
               "version_added": "23"


### PR DESCRIPTION
This is a follow-up to https://github.com/mdn/browser-compat-data/pull/16234 that updates a few more spec URLs for `HTML*Element` API members to `-dev` targets.