### PR TITLE
Fix typedef declarations

### DIFF
--- a/scripts/release/build.js
+++ b/scripts/release/build.js
@@ -66,11 +66,11 @@ async function writeTypeScriptIndex() {
   const content = `/* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import "./types";
+import { CompatData } from "./types";
 
 import bcd from "./data.json";
 
-export default bcd as CompatData;
+export default (bcd as unknown) as CompatData;
 export * from "./types";`;
   await fs.writeFile(dest, content);
 }

--- a/scripts/release/build.js
+++ b/scripts/release/build.js
@@ -70,7 +70,7 @@ import { CompatData } from "./types";
 
 import bcd from "./data.json";
 
-export default (bcd as unknown) as CompatData;
+export default bcd as CompatData;
 export * from "./types";`;
   await fs.writeFile(dest, content);
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -255,7 +255,7 @@ export interface SimpleSupportStatement {
 export type Identifier = PrimaryIdentifier & IdentifierMeta;
 
 export interface PrimaryIdentifier
-  extends Record<Exclude<string, '__compat'>, Identifier> {}
+  extends Record<Omit<string, '__compat'>, Identifier> {}
 
 interface IdentifierMeta {
   /**
@@ -352,7 +352,7 @@ interface CompatDataBrowsers {
 }
 
 interface CompatDataIdentifiers
-  extends Record<Exclude<string, 'browsers'>, PrimaryIdentifier> {
+  extends Record<Omit<string, 'browsers'>, PrimaryIdentifier> {
   /**
    * Contains data for each [Web API](https://developer.mozilla.org/docs/Web/API)
    * interface.

--- a/types.d.ts
+++ b/types.d.ts
@@ -80,7 +80,7 @@ export interface BrowserStatement {
    * The preview browser's name, for example:
    * `"Nightly"`, `"Canary"`, `"TP"`, etc.
    */
-  preview_name: string;
+  preview_name?: string;
 
   /**
    * The known versions of this browser.


### PR DESCRIPTION
This PR fixes the typedef declarations exported from BCD.  Apparently, TypeScript does not like attempting to convert the JSON data directly to `CompatData`, so a cast to `unknown` first is needed.
