### PR TITLE
Add data for attributes of the HTML input element

### DIFF
--- a/html/elements/input/attributes.json
+++ b/html/elements/input/attributes.json
@@ -1,0 +1,1280 @@
+{
+  "html": {
+    "elements": {
+      "input": {
+        "attributes": {
+          "accept": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/accept",
+              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#attr-input-accept",
+              "support": {
+                "chrome": {
+                  "version_added": "1"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "1"
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": "6"
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "1"
+                },
+                "safari_ios": {
+                  "version_added": "1"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "1"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "align": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "1"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "1"
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": "5.5"
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "1"
+                },
+                "safari_ios": {
+                  "version_added": "1"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "1"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": true
+              }
+            }
+          },
+          "alt": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input#alt",
+              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#attr-input-alt",
+              "support": {
+                "chrome": {
+                  "version_added": "1"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "1"
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": "5.5"
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "1"
+                },
+                "safari_ios": {
+                  "version_added": "1"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "1"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "capture": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/capture",
+              "spec_url": "https://w3c.github.io/html-media-capture/#the-capture-attribute",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": {
+                  "version_added": "25"
+                },
+                "edge": {
+                  "version_added": false
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": "79"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": "14"
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": "10"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.5"
+                },
+                "webview_android": {
+                  "version_added": "4.4"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "checked": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input#checked",
+              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#attr-input-checked",
+              "support": {
+                "chrome": {
+                  "version_added": "1"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "1"
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": "5.5"
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "1"
+                },
+                "safari_ios": {
+                  "version_added": "1"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "1"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "dirname": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input#dirname",
+              "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-dirname",
+              "support": {
+                "chrome": {
+                  "version_added": "17"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "6"
+                },
+                "safari_ios": {
+                  "version_added": "6"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "4.4"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "disabled": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/disabled",
+              "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-disabled",
+              "support": {
+                "chrome": {
+                  "version_added": "1"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "1"
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": "5.5"
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "1"
+                },
+                "safari_ios": {
+                  "version_added": "1"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "1"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "form": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input#form",
+              "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fae-form",
+              "support": {
+                "chrome": {
+                  "version_added": "1"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "1"
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": "5.5"
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "1"
+                },
+                "safari_ios": {
+                  "version_added": "1"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "1"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "formaction": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input#formaction",
+              "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-formaction",
+              "support": {
+                "chrome": {
+                  "version_added": "9"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "4"
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "5"
+                },
+                "safari_ios": {
+                  "version_added": "4.2"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "3"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "formenctype": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input#formenctype",
+              "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-formenctype",
+              "support": {
+                "chrome": {
+                  "version_added": "9"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "4"
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "5"
+                },
+                "safari_ios": {
+                  "version_added": "4.2"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "3"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "formmethod": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input#formmethod",
+              "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-formmethod",
+              "support": {
+                "chrome": {
+                  "version_added": "9"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "4"
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "5"
+                },
+                "safari_ios": {
+                  "version_added": "4.2"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "3"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "formnovalidate": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input#formnovalidate",
+              "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-formnovalidate",
+              "support": {
+                "chrome": {
+                  "version_added": "4"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "4"
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "5"
+                },
+                "safari_ios": {
+                  "version_added": "4"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "formtarget": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input#formtarget",
+              "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-formtarget",
+              "support": {
+                "chrome": {
+                  "version_added": "9"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "4"
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "5"
+                },
+                "safari_ios": {
+                  "version_added": "4.2"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "3"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "list": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input#list",
+              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#attr-input-list",
+              "support": {
+                "chrome": {
+                  "version_added": "20"
+                },
+                "chrome_android": {
+                  "version_added": "25"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "4"
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "12.1"
+                },
+                "safari_ios": {
+                  "version_added": "12.2"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.5"
+                },
+                "webview_android": {
+                  "version_added": "4.4.3"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "max": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/max",
+              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#attr-input-max",
+              "support": {
+                "chrome": {
+                  "version_added": "4"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "16"
+                },
+                "firefox_android": {
+                  "version_added": "16"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "5"
+                },
+                "safari_ios": {
+                  "version_added": "4"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "maxlength": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/maxlength",
+              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#attr-input-maxlength",
+              "support": {
+                "chrome": {
+                  "version_added": "1"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "1"
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": "5.5"
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "1"
+                },
+                "safari_ios": {
+                  "version_added": "1"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "1"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "min": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/min",
+              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#attr-input-min",
+              "support": {
+                "chrome": {
+                  "version_added": "4"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "16"
+                },
+                "firefox_android": {
+                  "version_added": "16"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "5"
+                },
+                "safari_ios": {
+                  "version_added": "4"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "minlength": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/minlength",
+              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#attr-input-minlength",
+              "support": {
+                "chrome": {
+                  "version_added": "40"
+                },
+                "chrome_android": {
+                  "version_added": "40"
+                },
+                "edge": {
+                  "version_added": "17"
+                },
+                "firefox": {
+                  "version_added": "51"
+                },
+                "firefox_android": {
+                  "version_added": "51"
+                },
+                "ie": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": "27"
+                },
+                "opera_android": {
+                  "version_added": "27"
+                },
+                "safari": {
+                  "version_added": "10.1"
+                },
+                "safari_ios": {
+                  "version_added": "10.3"
+                },
+                "samsunginternet_android": {
+                  "version_added": "4.0"
+                },
+                "webview_android": {
+                  "version_added": "40"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "multiple": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/multiple",
+              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#attr-input-multiple",
+              "support": {
+                "chrome": {
+                  "version_added": "2"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "3.6"
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "4"
+                },
+                "safari_ios": {
+                  "version_added": "3.2"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "name": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input#name",
+              "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-name",
+              "support": {
+                "chrome": {
+                  "version_added": "1"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "1"
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": "5.5"
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "1"
+                },
+                "safari_ios": {
+                  "version_added": "1"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "1"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "pattern": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/pattern",
+              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#attr-input-pattern",
+              "support": {
+                "chrome": {
+                  "version_added": "4"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "4"
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "5"
+                },
+                "safari_ios": {
+                  "version_added": "4"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "placeholder": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input#placeholder",
+              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#attr-input-placeholder",
+              "support": {
+                "chrome": {
+                  "version_added": "3"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "4"
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "4"
+                },
+                "safari_ios": {
+                  "version_added": "3.2"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "readonly": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/readonly",
+              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#attr-input-readonly",
+              "support": {
+                "chrome": {
+                  "version_added": "1"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "1"
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": "5.5"
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "1"
+                },
+                "safari_ios": {
+                  "version_added": "1"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "1"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "src": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input#src",
+              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#attr-input-src",
+              "support": {
+                "chrome": {
+                  "version_added": "1"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "1"
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": "5.5"
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "1"
+                },
+                "safari_ios": {
+                  "version_added": "1"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "1"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "step": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/step",
+              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#attr-input-step",
+              "support": {
+                "chrome": {
+                  "version_added": "5"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "16"
+                },
+                "firefox_android": {
+                  "version_added": "16"
+                },
+                "ie": {
+                  "version_added": "10"
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "5"
+                },
+                "safari_ios": {
+                  "version_added": "4"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "≤37"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "usemap": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "1"
+                },
+                "chrome_android": {
+                  "version_added": "18"
+                },
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "1"
+                },
+                "firefox_android": {
+                  "version_added": "4"
+                },
+                "ie": {
+                  "version_added": "6"
+                },
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
+                "safari": {
+                  "version_added": "1"
+                },
+                "safari_ios": {
+                  "version_added": "1"
+                },
+                "samsunginternet_android": {
+                  "version_added": "1.0"
+                },
+                "webview_android": {
+                  "version_added": "1"
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": true
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/mdn/browser-compat-data/issues/3157

This change adds data for content attributes of the HTML `input` element (in contrast to `HTMLInputElement` IDL attributes, which we already have data for).

Otherwise, without this change, among the problems we have is that we a number of MDN articles have broken BCD tables; for example:

- https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept#browser_compatibility
- https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/capture#browser_compatibility
- https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled#browser_compatibility
- https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/max#browser_compatibility
- https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/maxlength#browser_compatibility
- https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/min#browser_compatibility
- https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/minlength#browser_compatibility
- https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/pattern#browser_compatibility
- https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly#browser_compatibility

Also, this change allows us to store the spec URL for these features in BCD; otherwise we need to use the `spec-url` frontmatter metadata key in MDN to store the spec URLs. Storing them in BCD is preferable, because that gives all consumers of BCD data access to the URLs.