### PR TITLE
Remove description for HTMLElement.click()

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -763,7 +763,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/click",
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-click-dev",
-          "description": "click()",
           "support": {
             "chrome": {
               "version_added": "9",


### PR DESCRIPTION
We don't add a description for methods (only for constructors and events).