### PR TITLE
Add spec_url and mdn_url for more form-control attributes

### DIFF
--- a/html/elements/input/attributes.json
+++ b/html/elements/input/attributes.json
@@ -690,7 +690,7 @@
           "max": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/max",
-              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#attr-input-max",
+              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#the-min-and-max-attributes",
               "support": {
                 "chrome": {
                   "version_added": "4"
@@ -739,7 +739,7 @@
           "maxlength": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/maxlength",
-              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#attr-input-maxlength",
+              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#the-maxlength-and-minlength-attributes",
               "support": {
                 "chrome": {
                   "version_added": "1"
@@ -788,7 +788,7 @@
           "min": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/min",
-              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#attr-input-min",
+              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#the-min-and-max-attributes",
               "support": {
                 "chrome": {
                   "version_added": "4"
@@ -837,7 +837,7 @@
           "minlength": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/minlength",
-              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#attr-input-minlength",
+              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#the-maxlength-and-minlength-attributes",
               "support": {
                 "chrome": {
                   "version_added": "40"
@@ -1082,7 +1082,7 @@
           "readonly": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/readonly",
-              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#attr-input-readonly",
+              "spec_url": "https://html.spec.whatwg.org/multipage/input.html#the-readonly-attribute",
               "support": {
                 "chrome": {
                   "version_added": "1"

--- a/html/elements/meter.json
+++ b/html/elements/meter.json
@@ -192,6 +192,8 @@
         },
         "max": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/max",
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-meter-max",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -239,6 +241,8 @@
         },
         "min": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/min",
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-meter-max",
             "support": {
               "chrome": {
                 "version_added": "6"

--- a/html/elements/progress.json
+++ b/html/elements/progress.json
@@ -60,6 +60,8 @@
         },
         "max": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/max",
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#attr-progress-max",
             "support": {
               "chrome": {
                 "version_added": "6"

--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -301,6 +301,8 @@
         },
         "maxlength": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/maxlength",
+            "spec_url": "https://html.spec.whatwg.org/multipage/input.html#the-maxlength-and-minlength-attributes",
             "support": {
               "chrome": {
                 "version_added": "4"
@@ -348,6 +350,8 @@
         },
         "minlength": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/minlength",
+            "spec_url": "https://html.spec.whatwg.org/multipage/input.html#the-maxlength-and-minlength-attributes",
             "support": {
               "chrome": {
                 "version_added": "40"
@@ -537,6 +541,8 @@
         },
         "readonly": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/readonly",
+            "spec_url": "https://html.spec.whatwg.org/multipage/input.html#the-readonly-attribute",
             "support": {
               "chrome": {
                 "version_added": "1"


### PR DESCRIPTION
This adds (or updates) `spec_url` and `mdn_url` values for more HTML content attributes that are allowed both for the `input` element and other elements (mostly `textarea,` but also the `progress` and `meter` elements).