### PR TITLE
Updating the latest Edge releases

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -65,133 +65,133 @@
         },
         "80": {
           "release_date": "2020-02-07",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-80036148-february-7",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-80036148-february-7",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "80"
         },
         "81": {
           "release_date": "2020-04-13",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-81041653-april-13",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-81041653-april-13",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "81"
         },
         "83": {
           "release_date": "2020-05-21",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-83047837-may-21",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-83047837-may-21",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "83"
         },
         "84": {
           "release_date": "2020-07-16",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-84052240-july-16",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-84052240-july-16",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "84"
         },
         "85": {
           "release_date": "2020-08-27",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-85056441-august-27",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-85056441-august-27",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "85"
         },
         "86": {
           "release_date": "2020-10-09",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-86062238-october-9",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-86062238-october-9",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "86"
         },
         "87": {
           "release_date": "2020-11-19",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-87066441-november-19",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-87066441-november-19",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "87"
         },
         "88": {
           "release_date": "2021-01-21",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-88070550-january-21",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-88070550-january-21",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "88"
         },
         "89": {
           "release_date": "2021-03-04",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-89077445-march-4",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-89077445-march-4",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "89"
         },
         "90": {
           "release_date": "2021-04-15",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-90081839-april-15",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-90081839-april-15",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "90"
         },
         "91": {
           "release_date": "2021-05-27",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-91086437-may-27",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-91086437-may-27",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "91"
         },
         "92": {
           "release_date": "2021-07-22",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-92090255-july-22",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-92090255-july-22",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "92"
         },
         "93": {
           "release_date": "2021-09-02",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-93096138-september-02",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-93096138-september-02",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "93"
         },
         "94": {
           "release_date": "2021-09-24",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-94099231-september-24",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-94099231-september-24",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "94"
         },
         "95": {
           "release_date": "2021-10-21",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-950102030-october-21",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-950102030-october-21",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "95"
         },
         "96": {
           "release_date": "2021-11-19",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-960105429-november-19",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-960105429-november-19",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "96"
         },
         "97": {
           "release_date": "2022-01-06",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-970107255-january-6",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-970107255-january-6",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "97"
         },
         "98": {
           "release_date": "2022-02-03",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-980110843-february-3",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-980110843-february-3",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "98"
         },
         "99": {
           "release_date": "2022-03-03",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-990115030-march-3",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-990115030-march-3",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "99"
@@ -204,24 +204,28 @@
           "engine_version": "100"
         },
         "101": {
-          "release_date": "2022-05-05",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1010121039-may-5",
-          "status": "current",
+          "release_date": "2022-04-29",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1010121032-april-28",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "101"
         },
         "102": {
-          "status": "beta",
+          "release_date": "2022-05-31",
+          "status": "current",
           "engine": "Blink",
-          "engine_version": "102"
+          "engine_version": "102",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1020124530-may-31"
         },
         "103": {
-          "status": "nightly",
+          "release_date": "2022-06-23",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "103"
         },
         "104": {
-          "status": "planned",
+          "release_date": "2022-08-04",
+          "status": "nightly",
           "engine": "Blink",
           "engine_version": "104"
         }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
This is an update to the `browsers/edge.json` file.

Edge 102 became stable yesterday, so the file needs to be updated.

Additionally, I'm fixing a bunch of release note URLs, and adding target release dates for 103 and 104.