### PR TITLE
Fix consistency across APIs with mixins

### DIFF
--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "3"
+            "version_added": "1"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "3"
+            "version_added": "1"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "3"
+            "version_added": "1"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/HTMLStyleElement.json
+++ b/api/HTMLStyleElement.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "3"
+            "version_added": "1"
           },
           "safari_ios": {
             "version_added": "1"

--- a/api/ProcessingInstruction.json
+++ b/api/ProcessingInstruction.json
@@ -30,7 +30,7 @@
             "version_added": "≤12.1"
           },
           "safari": {
-            "version_added": "3"
+            "version_added": "1"
           },
           "safari_ios": {
             "version_added": "1"


### PR DESCRIPTION
This PR is a quick follow-up to #16439 that sets the API versions to the proper version number.  Required to land #16437.
