### PR TITLE
Remove irrelevant notes about Firefox "chrome code" for URL

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -31,18 +31,9 @@
           },
           "firefox": {
             "version_added": "19",
-            "notes": [
-              "Before version 57, Firefox had a bug whereby single quotes contained in URLs are escaped when accessed via URL APIs (see <a href='https://bugzil.la/1386683'>bug 1386683</a>).",
-              "To use it from chrome code, JSM and Bootstrap scope, you have to import it with <code>Cu.importGlobalProperties(['URL']);</code>."
-            ]
+            "notes": "Before version 57, Firefox had a bug whereby single quotes contained in URLs are escaped when accessed via URL APIs (see <a href='https://bugzil.la/1386683'>bug 1386683</a>)."
           },
-          "firefox_android": {
-            "version_added": "19",
-            "notes": [
-              "Before version 57, Firefox had a bug whereby single quotes contained in URLs are escaped when accessed via URL APIs (see <a href='https://bugzil.la/1386683'>bug 1386683</a>).",
-              "To use it from chrome code, JSM and Bootstrap scope, you have to import it with <code>Cu.importGlobalProperties(['URL']);</code>."
-            ]
-          },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": "10"
           },


### PR DESCRIPTION
This isn't relevant to web developers.
