### PR TITLE
Mirror Opera support for Object.fromEntries() and .hasOwn()

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -662,9 +662,7 @@
               "opera": {
                 "version_added": "60"
               },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "12.1"
               },
@@ -1010,9 +1008,7 @@
               "opera": {
                 "version_added": "79"
               },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "15.4"
               },

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -659,9 +659,7 @@
               "nodejs": {
                 "version_added": "12.0.0"
               },
-              "opera": {
-                "version_added": "60"
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": "12.1"
@@ -1005,9 +1003,7 @@
               "nodejs": {
                 "version_added": "16.9.0"
               },
-              "opera": {
-                "version_added": "79"
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": "15.4"


### PR DESCRIPTION
There are lots of entries like this where data hasn't been mirrored, but
this fixes two that came up when looking at the data.
