### PR TITLE
Drop the sourcemaps.info exception from test/spec-urls.test.js

### DIFF
--- a/test/spec-urls.test.js
+++ b/test/spec-urls.test.js
@@ -39,9 +39,6 @@ describe('spec_url data', () => {
       'https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers-05',
       'https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-expect-ct-08',
 
-      // Remove if supported in browser-specs https://github.com/w3c/browser-specs/issues/618
-      'https://sourcemaps.info/spec.html',
-
       // Remove if supported in browser-specs https://github.com/w3c/browser-specs/issues/622
       'https://www.w3.org/TR/WOFF/',
 


### PR DESCRIPTION
https://github.com/w3c/browser-specs/issues/618 has been merged, so we no longer need to maintain this exception.