### PR TITLE
Update some spec URLs from CSS Typed OM and Painting API specs

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -51,7 +51,7 @@
       "Hz": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/Hz",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-hz",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-hz",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -100,7 +100,7 @@
       "Q": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/Q",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-q",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-q",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -149,7 +149,7 @@
       "ch": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/ch",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-ch",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-ch",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -198,7 +198,7 @@
       "cm": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/cm",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-cm",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-cm",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -247,7 +247,7 @@
       "deg": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/deg",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-deg",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-deg",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -296,7 +296,7 @@
       "dpcm": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/dpcm",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-dpcm",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-dpcm",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -345,7 +345,7 @@
       "dpi": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/dpi",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-dpi",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-dpi",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -394,7 +394,7 @@
       "dppx": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/dppx",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-dppx",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-dppx",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -443,7 +443,7 @@
       "em": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/em",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-em",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-em",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -541,7 +541,7 @@
       "ex": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/ex",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-ex",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-ex",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -590,7 +590,7 @@
       "fr": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/fr",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-fr",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-fr",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -639,7 +639,7 @@
       "grad": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/grad",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-grad",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-grad",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -688,7 +688,7 @@
       "ic": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/ic",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-ic",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-ic",
           "support": {
             "chrome": {
               "version_added": false,
@@ -741,7 +741,7 @@
       "in": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/in",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-in",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-in",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -790,7 +790,7 @@
       "kHz": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/kHz",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-khz",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-khz",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -839,7 +839,7 @@
       "lh": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/lh",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-lh",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-lh",
           "support": {
             "chrome": {
               "version_added": false,
@@ -890,7 +890,7 @@
       "mm": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/mm",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-mm",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-mm",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -939,7 +939,7 @@
       "ms": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/ms",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-ms",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-ms",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -988,7 +988,7 @@
       "number": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/number",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-number",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-number",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -1086,7 +1086,7 @@
       "pc": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/pc",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-pc",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-pc",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -1135,7 +1135,7 @@
       "percent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/percent",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-percent",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-percent",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -1184,7 +1184,7 @@
       "pt": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/pt",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-pt",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-pt",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -1233,7 +1233,7 @@
       "px": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/px",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-px",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-px",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -1282,7 +1282,7 @@
       "rad": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/rad",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-rad",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-rad",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -1380,7 +1380,7 @@
       "rem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/rem",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-rem",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-rem",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -1429,7 +1429,7 @@
       "rlh": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/rlh",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-rlh",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-rlh",
           "support": {
             "chrome": {
               "version_added": false,
@@ -1480,7 +1480,7 @@
       "s": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/s",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-s",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-s",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -1622,7 +1622,7 @@
       "turn": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/turn",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-turn",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-turn",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -1671,7 +1671,7 @@
       "vb": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/vb",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-vb",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-vb",
           "support": {
             "chrome": {
               "version_added": false,
@@ -1723,7 +1723,7 @@
       "vh": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/vh",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-vh",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-vh",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -1772,7 +1772,7 @@
       "vi": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/vi",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-vi",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-vi",
           "support": {
             "chrome": {
               "version_added": false,
@@ -1824,7 +1824,7 @@
       "vmax": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/vmax",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-vmax",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-vmax",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -1873,7 +1873,7 @@
       "vmin": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/vmin",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-vmin",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-vmin",
           "support": {
             "chrome": {
               "version_added": "66"
@@ -1922,7 +1922,7 @@
       "vw": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/vw",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-vw",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-vw",
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/PaintSize.json
+++ b/api/PaintSize.json
@@ -50,7 +50,7 @@
       "height": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaintSize/height",
-          "spec_url": "https://drafts.css-houdini.org/css-paint-api-1/#dom-paintsize-height",
+          "spec_url": "https://drafts.css-houdini.org/css-paint-api/#dom-paintsize-height",
           "support": {
             "chrome": {
               "version_added": "65"
@@ -99,7 +99,7 @@
       "width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaintSize/width",
-          "spec_url": "https://drafts.css-houdini.org/css-paint-api-1/#dom-paintsize-width",
+          "spec_url": "https://drafts.css-houdini.org/css-paint-api/#dom-paintsize-width",
           "support": {
             "chrome": {
               "version_added": "65"


### PR DESCRIPTION
These should use the unleveled https://drafts.css-houdini.org/css-typed-om spec rather than the leveled spec.