### PR TITLE
FF102 Readable/Writable/Transform Streams transferable

### DIFF
--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -469,6 +469,73 @@
             "deprecated": false
           }
         }
+      },
+      "transferable": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Glossary/Transferable_objects",
+          "spec_url": "https://streams.spec.whatwg.org/#rs-transfer",
+          "support": {
+            "chrome": {
+              "version_added": "87"
+            },
+            "chrome_android": {
+              "version_added": "87"
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "87"
+            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "102",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.transferable.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "73"
+            },
+            "opera_android": {
+              "version_added": "62"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "14.0"
+            },
+            "webview_android": {
+              "version_added": "87"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/TransformStream.json
+++ b/api/TransformStream.json
@@ -208,6 +208,73 @@
           }
         }
       },
+      "transferable": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Glossary/Transferable_objects",
+          "spec_url": "https://streams.spec.whatwg.org/#ts-transfer",
+          "support": {
+            "chrome": {
+              "version_added": "87"
+            },
+            "chrome_android": {
+              "version_added": "87"
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "87"
+            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "102",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.transferable.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "73"
+            },
+            "opera_android": {
+              "version_added": "62"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "14.0"
+            },
+            "webview_android": {
+              "version_added": "87"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "writable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TransformStream/writable",

--- a/api/WritableStream.json
+++ b/api/WritableStream.json
@@ -410,6 +410,73 @@
             "deprecated": false
           }
         }
+      },
+      "transferable": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Glossary/Transferable_objects",
+          "spec_url": "https://streams.spec.whatwg.org/#ws-transfer",
+          "support": {
+            "chrome": {
+              "version_added": "87"
+            },
+            "chrome_android": {
+              "version_added": "87"
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "87"
+            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "102",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.streams.transferable.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "73"
+            },
+            "opera_android": {
+              "version_added": "62"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "14.0"
+            },
+            "webview_android": {
+              "version_added": "87"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
FF102 makes `ReadableStream`, `TransformStream`, and `WritableStream` transferrable on nightly behind a pref in  https://bugzilla.mozilla.org/show_bug.cgi?id=1659025

Copying the model from [RTCDataChannel](https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel#browser_compatibility) this adds a transferable property for these methods. 

Chrome and friends support this from version 87 according to https://chromestatus.com/feature/5298733486964736

This puts supports as FALSE for safari, node and deno because I can't confirm versions. 
- Node docs show it is supported in at least 16 LTS https://nodejs.org/docs/latest-v16.x/api/webstreams.html#transferring-with-postmessage
- Can't find any deno info
- Safari gave positive signal but no obvious follow on.

I tried browserstack using  https://wpt.live/streams/transferable/ but results unhelpful. I.e. they show fail, but then even on versions that work locally I still see some cases fail on browserstack.

To me false is fine, but if you are able to find better info?

This is part of https://github.com/mdn/content/issues/16930

