### PR TITLE
Add oklab() and oklch()

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -790,6 +790,106 @@
             }
           }
         },
+        "oklab": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/oklab",
+            "spec_url": "https://drafts.csswg.org/css-color/#ok-lab",
+            "description": "<code>oklab()</code> (Oklab color model)",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": {
+                "version_added": "15.4"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "oklch": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/oklch",
+            "spec_url": "https://drafts.csswg.org/css-color/#ok-lab",
+            "description": "<code>oklch()</code> (OKLCH color model)",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": {
+                "version_added": "15.4"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "rgb": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/rgb",
@@ -1225,106 +1325,6 @@
                 "standard_track": true,
                 "deprecated": false
               }
-            }
-          }
-        },
-        "oklab": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/oklab",
-            "spec_url": "https://drafts.csswg.org/css-color/#ok-lab",
-            "description": "<code>oklab()</code> (Oklab color model)",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": "15.4"
-              },
-              "safari_ios": {
-                "version_added": "15.4"
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "oklch": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/oklch",
-            "spec_url": "https://drafts.csswg.org/css-color/#ok-lab",
-            "description": "<code>oklch()</code> (OKLCH color model)",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": {
-                "version_added": false
-              },
-              "ie": {
-                "version_added": false
-              },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": "15.4"
-              },
-              "safari_ios": {
-                "version_added": "15.4"
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
             }
           }
         },

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -1228,6 +1228,106 @@
             }
           }
         },
+        "oklab": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/oklab",
+            "spec_url": "https://drafts.csswg.org/css-color/#ok-lab",
+            "description": "<code>oklab()</code> (Oklab color model)",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": {
+                "version_added": "15.4"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "oklch": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/oklch",
+            "spec_url": "https://drafts.csswg.org/css-color/#ok-lab",
+            "description": "<code>oklch()</code> (OKLCH color model)",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": {
+                "version_added": "15.4"
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "transparent": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value#transparent",


### PR DESCRIPTION
#### Summary

I added `oklch()` and `oklab()` from [CSS Colors 4](https://drafts.csswg.org/css-color/#ok-lab) to color types.

[MDN Pages](https://github.com/mdn/content/pull/15033) was recently merged.

#### Test results and supporting details

People reports that Safari 15.4 supports [`oklch()`](https://github.com/Fyrd/caniuse/issues/6124#issuecomment-1105506581).

I found mention only in Safari TP [release notes](https://developer.apple.com/safari/technology-preview/release-notes/).
