### PR TITLE
Update LargestContentfulPaint spec URLs

### DIFF
--- a/api/LargestContentfulPaint.json
+++ b/api/LargestContentfulPaint.json
@@ -3,7 +3,7 @@
     "LargestContentfulPaint": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint",
-        "spec_url": "https://www.w3.org/TR/largest-contentful-paint//#sec-largest-contentful-paint-interface",
+        "spec_url": "https://w3c.github.io/largest-contentful-paint/#sec-largest-contentful-paint-interface",
         "support": {
           "chrome": {
             "version_added": "77"
@@ -35,7 +35,7 @@
       "element": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/element",
-          "spec_url": "https://www.w3.org/TR/largest-contentful-paint//#dom-largestcontentfulpaint-element",
+          "spec_url": "https://w3c.github.io/largest-contentful-paint/#dom-largestcontentfulpaint-element",
           "support": {
             "chrome": {
               "version_added": "77"
@@ -68,7 +68,7 @@
       "id": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/id",
-          "spec_url": "https://www.w3.org/TR/largest-contentful-paint//#dom-largestcontentfulpaint-id",
+          "spec_url": "https://w3c.github.io/largest-contentful-paint/#dom-largestcontentfulpaint-id",
           "support": {
             "chrome": {
               "version_added": "77"
@@ -101,7 +101,7 @@
       "loadTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/loadTime",
-          "spec_url": "https://www.w3.org/TR/largest-contentful-paint//#dom-largestcontentfulpaint-loadtime",
+          "spec_url": "https://w3c.github.io/largest-contentful-paint/#dom-largestcontentfulpaint-loadtime",
           "support": {
             "chrome": {
               "version_added": "77"
@@ -134,7 +134,7 @@
       "renderTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/renderTime",
-          "spec_url": "https://www.w3.org/TR/largest-contentful-paint//#dom-largestcontentfulpaint-rendertime",
+          "spec_url": "https://w3c.github.io/largest-contentful-paint/#dom-largestcontentfulpaint-rendertime",
           "support": {
             "chrome": {
               "version_added": "77"
@@ -167,7 +167,7 @@
       "size": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/size",
-          "spec_url": "https://www.w3.org/TR/largest-contentful-paint//#dom-largestcontentfulpaint-size",
+          "spec_url": "https://w3c.github.io/largest-contentful-paint/#dom-largestcontentfulpaint-size",
           "support": {
             "chrome": {
               "version_added": "77"
@@ -200,7 +200,7 @@
       "toJSON": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/toJSON",
-          "spec_url": "https://www.w3.org/TR/largest-contentful-paint//#dom-largestcontentfulpaint-tojson",
+          "spec_url": "https://w3c.github.io/largest-contentful-paint/#dom-largestcontentfulpaint-tojson",
           "support": {
             "chrome": {
               "version_added": "77"
@@ -233,7 +233,7 @@
       "url": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/url",
-          "spec_url": "https://www.w3.org/TR/largest-contentful-paint//#dom-largestcontentfulpaint-url",
+          "spec_url": "https://w3c.github.io/largest-contentful-paint/#dom-largestcontentfulpaint-url",
           "support": {
             "chrome": {
               "version_added": "77"

--- a/test/linter/test-spec-urls.ts
+++ b/test/linter/test-spec-urls.ts
@@ -44,6 +44,11 @@ const specsExceptions = [
 
   // Remove if https://github.com/w3c/mathml/issues/216 is resolved
   'https://w3c.github.io/mathml/',
+
+  // Remove once https://www.w3.org/TR/largest-contentful-paint/ updates,
+  // and browser-specs picks up the update; see discussion at
+  // https://github.com/mdn/browser-compat-data/pull/16527#issuecomment-1145773922
+  'https://w3c.github.io/largest-contentful-paint/',
 ];
 
 const allowedSpecURLs = [


### PR DESCRIPTION
These should be using https://w3c.github.io/largest-contentful-paint URLs rather than https://www.w3.org/TR/largest-contentful-paint URLs.