### PR TITLE
Allow for traversing for mirrored data

### DIFF
--- a/scripts/traverse.js
+++ b/scripts/traverse.js
@@ -44,6 +44,10 @@ function* iterateFeatures(obj, browsers, values, depth, identifier) {
               if (browserData[range] === undefined) {
                 if (values.length == 0 || values.includes('null'))
                   yield `${identifier}${i}`;
+              } else if (browserData[range] === 'mirror') {
+                if (values.includes('mirror')) {
+                  yield `${identifier}${i}`;
+                }
               } else if (
                 values.length == 0 ||
                 values.includes(String(browserData[range].version_added)) ||
@@ -172,6 +176,10 @@ if (esMain(import.meta)) {
         .example(
           'npm run traverse -- -b firefox -f 10',
           'Find all features marked as supported since Firefox 10',
+        )
+        .example(
+          'npm run traverse -- -b samsunginternet_android -f mirror',
+          'Find all features in Samsung Internet that mirror data from Chrome Android',
         );
     },
   );


### PR DESCRIPTION
This PR adds the ability for `mirror` to be specified as a value in the traverse script.
