### PR TITLE
Update Deno release data

### DIFF
--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -147,15 +147,23 @@
         "1.20": {
           "release_date": "2022-03-17",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.20.0",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "10.0"
         },
         "1.21": {
           "release_date": "2022-04-21",
-          "status": "nightly",
+          "release_notes": "https://github.com/denoland/deno/releases/tag/v1.21.0",
+          "status": "retired",
           "engine": "V8",
-          "engine_version": "10.1"
+          "engine_version": "10.0"
+        },
+        "1.22": {
+          "release_date": "2022-05-18",
+          "release_notes": "https://github.com/denoland/deno/releases/tag/v1.22.0",
+          "status": "current",
+          "engine": "V8",
+          "engine_version": "10.0"
         }
       }
     }


### PR DESCRIPTION
This PR updates the release data for Deno based upon both GitHub release history (for dates and release notes) and checking `Deno.version.v8` (for the engine versions).
