### PR TITLE
Ensure that browser key is passed into path for browser linters

### DIFF
--- a/test/lint.js
+++ b/test/lint.js
@@ -102,6 +102,7 @@ const main = (
       path: {
         full: `browsers.${browser}`,
         category: 'browsers',
+        browser,
       },
     });
   }


### PR DESCRIPTION
This PR fixes a bug where the browser name isn't passed into browser tests for linters.
