### PR TITLE
Update Safari + Safari iOS/iPadOS release data

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -206,9 +206,11 @@
           "engine_version": "613.1.17"
         },
         "15.5": {
+          "release_date": "2022-05-16",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15_5-release-notes",
-          "status": "beta",
-          "engine": "WebKit"
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "613.2.7"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -178,9 +178,11 @@
           "engine_version": "613.1.17"
         },
         "15.5": {
+          "release_date": "2022-05-16",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15_5-release-notes",
-          "status": "beta",
-          "engine": "WebKit"
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "613.2.7"
         }
       }
     }


### PR DESCRIPTION
This PR updates the Safari Desktop and Mobile release data.  The release date comes from the iOS/iPadOS 15.5 release date, and the engine version from the About pane in Safari.
