### PR TITLE
Update Opera Android release data

### DIFF
--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -380,9 +380,15 @@
         "68": {
           "release_date": "2022-03-30",
           "release_notes": "https://blogs.opera.com/mobile/2022/03/opera-for-android-version-68/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "99"
+        },
+        "69": {
+          "release_date": "2022-05-09",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "100"
         }
       }
     }


### PR DESCRIPTION
This PR updates the release data for Opera Android.  The release date comes from UpToDown (https://opera-browser.en.uptodown.com/android/versions), and the engine version from the user agent string.
