### PR TITLE
Update Samsung Internet release data

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -212,13 +212,13 @@
         },
         "16.0": {
           "release_date": "2021-11-25",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "92"
         },
         "17.0": {
-          "release_date": "2022-03-26",
-          "status": "beta",
+          "release_date": "2022-05-04",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "96"
         }


### PR DESCRIPTION
This PR updates the release data for Samsung Internet.  The release date comes from UpToDown (https://internet.en.uptodown.com/android/versions).
