### PR TITLE
Add spec_url to TypeScript typedef

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -290,6 +290,11 @@ export interface CompatStatement {
   mdn_url?: string;
 
   /**
+   * An optional URL or array of URLs, each of which is for a specific part of a specification in which this feature is defined. Each URL must contain a fragment identifier.
+   */
+  spec_url?: string | string[];
+
+  /**
    * Each `__compat` object contains support information.
    *
    * For each browser identifier, it contains a `support_statement` object with


### PR DESCRIPTION
This PR adds the `spec_url` property to the TypeScript definition file.  Caught missing during the work towards #16494.
