### PR TITLE
Cover TypeScript definitions in semantic versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ For the purposes of [semantic versioning](https://semver.org/) (SemVer), the pub
 
 - The high-level namespace objects documented in [_Package contents_](#Package-contents)
 - The schema definitions for browser and support data structures
+- The TypeScript definitions
 
 The details of browser compatibility change frequently, as browsers ship new features, standards organizations revise specifications, and Web developers discover new bugs. We routinely publish updates to the package to reflect these changes.
 


### PR DESCRIPTION
TypeScript definitions are a critical part of BCD to certain consumers, but is not covered by the semantic versioning policy.  To ensure that we do not break anything for TypeScript users, this PR marks TypeScript definitions as covered by the semantic versioning policy.
