### PR TITLE
Compile types.d.ts directly to build folder in build

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "lint": "node test/lint",
     "fix": "npm run format:fix && node scripts/fix/index.js",
     "stats": "node scripts/statistics",
-    "build": "npm run gentypes && node scripts/release/build",
+    "build": "node scripts/release/build",
     "gentypes": "node scripts/generate-types",
     "release-pulls": "node scripts/release/pulls",
     "release-notes": "node scripts/release/notes",

--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -66,7 +66,9 @@ const transformTS = (browserTS, compatTS) => {
   return ts;
 };
 
-const compile = async () => {
+const compile = async (
+  destination = new URL('../types.d.ts', import.meta.url),
+) => {
   const browserTS = await compileFromFile('schemas/browsers.schema.json', opts);
   const compatTS = await compileFromFile(
     'schemas/compat-data.schema.json',
@@ -80,9 +82,11 @@ const compile = async () => {
     transformTS(browserTS, compatTS),
     generateCompatDataTypes(),
   ].join('\n\n');
-  await fs.writeFile(new URL('../types.d.ts', import.meta.url), ts);
+  await fs.writeFile(destination, ts);
 };
 
 if (esMain(import.meta)) {
   await compile();
 }
+
+export default compile;

--- a/scripts/release/build.js
+++ b/scripts/release/build.js
@@ -8,6 +8,7 @@ import esMain from 'es-main';
 import stringify from 'fast-json-stable-stringify';
 
 import bumpData from './mirror.js';
+import compileTS from '../generate-types.js';
 import { walk } from '../../utils/index.js';
 
 const packageJson = JSON.parse(
@@ -16,7 +17,7 @@ const packageJson = JSON.parse(
 
 const directory = './build/';
 
-const verbatimFiles = ['LICENSE', 'README.md', 'types.d.ts'];
+const verbatimFiles = ['LICENSE', 'README.md'];
 
 // Returns a string representing data ready for writing to JSON file
 async function createDataBundle() {
@@ -61,7 +62,7 @@ export default bcd;
   await fs.writeFile(dest, content);
 }
 
-async function writeTypeScriptIndex() {
+async function writeTypeScript() {
   const dest = path.resolve(directory, 'index.ts');
   const content = `/* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
@@ -73,6 +74,8 @@ import bcd from "./data.json";
 export default bcd as CompatData;
 export * from "./types";`;
   await fs.writeFile(dest, content);
+
+  await compileTS(path.resolve(directory, 'types.d.ts'));
 }
 
 // Returns an array of promises for copying of all files that don't need transformation
@@ -140,7 +143,7 @@ async function main() {
   await writeManifest();
   await writeData();
   await writeWrapper();
-  await writeTypeScriptIndex();
+  await writeTypeScript();
   await copyFiles();
 
   console.log('Data bundle is ready');


### PR DESCRIPTION
This PR runs the compilation step for the TypeScript definitions straight in the build script, setting the output to the build folder.
