### PR TITLE
Remove BrowserDataFile from TypeScript definitions

### DIFF
--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -57,10 +57,7 @@ const transformTS = (browserTS, compatTS) => {
 
   ts = ts
     .replace('export type Browsers1', 'export type Browsers')
-    .replace(
-      'export interface Browsers {\n  browsers?: Browsers1;\n}',
-      'export interface BrowserDataFile {\n  browsers?: Browsers;\n}',
-    )
+    .replace('export interface Browsers {\n  browsers?: Browsers1;\n}', '')
     .replace('export interface CompatData {}', '');
 
   return ts;


### PR DESCRIPTION
This PR removes the `BrowserDataFile` interface from the TypeScript definitions.  This does not need to be exposed and is schema-only.
