### PR TITLE
Ensure that status is required for browser release statement

### DIFF
--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -119,6 +119,7 @@
           "tsType": "BrowserStatus"
         }
       },
+      "required": ["status"],
       "additionalProperties": false
     }
   },


### PR DESCRIPTION
This PR makes the `status` option a required property for browser releases.
