### PR TITLE
Update Safari/iOS support for preventScroll option

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1335,8 +1335,7 @@
                 "notes": "See <a href='https://webkit.org/b/178583'>bug 178583</a>."
               },
               "safari_ios": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/178583'>bug 178583</a>."
+                "version_added": "15.5"
               },
               "samsunginternet_android": {
                 "version_added": "9.0"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Safari/iOS supports `https://webkit.org/blog/12669/new-webkit-features-in-safari-15-5/` from 15.5.

- https://webkit.org/blog/12669/new-webkit-features-in-safari-15-5/
- https://bugs.webkit.org/show_bug.cgi?id=236584

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details
I verified this on iOS 15.5 like https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus.