### PR TITLE
Fix typo in typedef

### DIFF
--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -181,7 +181,7 @@
       "additionalProperties": {
         "$ref": "#/definitions/support_statement"
       },
-      "tsType": "Partial<Record<BrowserNames, SupportStatement>>"
+      "tsType": "Partial<Record<BrowserName, SupportStatement>>"
     },
 
     "spec_url_value": {


### PR DESCRIPTION
This PR fixes #16590 (partially) by fixing a typo in the TypeScript definitions.
