### PR TITLE
Mirror Edge support of RTCRtpTransceiver.currentDirection

### DIFF
--- a/api/RTCRtpTransceiver.json
+++ b/api/RTCRtpTransceiver.json
@@ -60,7 +60,7 @@
               "version_added": "69"
             },
             "edge": {
-              "version_added": false
+              "version_added": "79"
             },
             "firefox": {
               "version_added": "59"


### PR DESCRIPTION
Confirmed supported in Edge 80 with this test:
http://mdn-bcd-collector.appspot.com/tests/api/RTCRtpTransceiver/currentDirection

