### PR TITLE
Mirror Samsung Internet support for a few features

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -319,9 +319,7 @@
             "safari_ios": {
               "version_added": "15.4"
             },
-            "samsunginternet_android": {
-              "version_added": false
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "98"
             }

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -557,9 +557,7 @@
             "safari_ios": {
               "version_added": "15"
             },
-            "samsunginternet_android": {
-              "version_added": false
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "99"
             }

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1042,9 +1042,7 @@
             "safari_ios": {
               "version_added": "15.4"
             },
-            "samsunginternet_android": {
-              "version_added": false
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "83"
             }

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -640,9 +640,7 @@
               "safari_ios": {
                 "version_added": "13.4"
               },
-              "samsunginternet_android": {
-                "version_added": false
-              },
+              "samsunginternet_android": "mirror",
               "webview_android": {
                 "version_added": "98"
               }
@@ -1889,9 +1887,7 @@
               "safari_ios": {
                 "version_added": "13.4"
               },
-              "samsunginternet_android": {
-                "version_added": false
-              },
+              "samsunginternet_android": "mirror",
               "webview_android": {
                 "version_added": "98"
               }


### PR DESCRIPTION
These are features that are supported "everywhere" except Samsung
Internet. Some will still mirror to false, but mirroring will
automtically update the data when there's a new release of Samsung
Internet.
