### PR TITLE
Standardise comparing version strings throughout scripts

### DIFF
--- a/scripts/lib/compare-statements.test.ts
+++ b/scripts/lib/compare-statements.test.ts
@@ -124,22 +124,22 @@ const tests: { input: Identifier; output: Identifier }[] = [
       },
     },
   },
-  // {
-  //   input: {
-  //     __compat: {
-  //       support: {
-  //         safari: [{ version_added: '10' }, { version_added: 'preview' }],
-  //       },
-  //     },
-  //   },
-  //   output: {
-  //     __compat: {
-  //       support: {
-  //         safari: [{ version_added: 'preview' }, { version_added: '10' }],
-  //       },
-  //     },
-  //   },
-  // },
+  {
+    input: {
+      __compat: {
+        support: {
+          safari: [{ version_added: '10' }, { version_added: 'preview' }],
+        },
+      },
+    },
+    output: {
+      __compat: {
+        support: {
+          safari: [{ version_added: 'preview' }, { version_added: '10' }],
+        },
+      },
+    },
+  },
 ] as any;
 
 function orderStatements(key: string, value: CompatStatement): CompatStatement {

--- a/scripts/lib/compare-statements.test.ts
+++ b/scripts/lib/compare-statements.test.ts
@@ -98,6 +98,48 @@ const tests: { input: Identifier; output: Identifier }[] = [
       },
     },
   },
+  {
+    input: {
+      __compat: {
+        support: {
+          chrome: [
+            { version_added: '20' },
+            { version_added: '≤30' },
+            { version_added: '≤10' },
+            { version_added: '40' },
+          ],
+        },
+      },
+    },
+    output: {
+      __compat: {
+        support: {
+          chrome: [
+            { version_added: '40' },
+            { version_added: '≤30' },
+            { version_added: '20' },
+            { version_added: '≤10' },
+          ],
+        },
+      },
+    },
+  },
+  // {
+  //   input: {
+  //     __compat: {
+  //       support: {
+  //         safari: [{ version_added: '10' }, { version_added: 'preview' }],
+  //       },
+  //     },
+  //   },
+  //   output: {
+  //     __compat: {
+  //       support: {
+  //         safari: [{ version_added: 'preview' }, { version_added: '10' }],
+  //       },
+  //     },
+  //   },
+  // },
 ] as any;
 
 function orderStatements(key: string, value: CompatStatement): CompatStatement {

--- a/scripts/lib/compare-statements.ts
+++ b/scripts/lib/compare-statements.ts
@@ -3,7 +3,7 @@
 
 import { SimpleSupportStatement } from '../../types/types.js';
 
-import compareVersions from 'compare-versions';
+import compareVersions from './compare-versions.js';
 
 /**
  *
@@ -52,10 +52,7 @@ const compareStatements = (
     typeof a.version_added == 'string' &&
     typeof b.version_added == 'string'
   ) {
-    return compareVersions(
-      b.version_added.replace('≤', ''),
-      a.version_added.replace('≤', ''),
-    );
+    return compareVersions(b.version_added, a.version_added);
   }
 
   return 0;

--- a/scripts/lib/compare-versions.js
+++ b/scripts/lib/compare-versions.js
@@ -1,0 +1,46 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+import _compareVersions from 'compare-versions';
+
+/**
+ * Compare version strings to find greater, equal or lesser.
+ *
+ * @param {string} v1
+ * @param {string} v2
+ * @returns {(1 | 0 | -1)}
+ */
+export default function compareVersions(v1, v2) {
+  if (v1 === 'preview') v1 = '65535';
+  if (v2 === 'preview') v2 = '65535';
+  v1 = v1.replace('≤', '');
+  v2 = v2.replace('≤', '');
+  return _compareVersions(v1, v2);
+}
+
+/**
+ * Validate version strings.
+ *
+ * @param {string} v
+ * @returns {bool}
+ */
+compareVersions.validate = function (v) {
+  v = v.replace('≤', '');
+  return v === 'preview' || _compareVersions.validate(v);
+};
+
+/**
+ * Compare version strings using the specified operator.
+ *
+ * @param {string} v1
+ * @param {string} v2
+ * @param {string} operator
+ * @returns {bool}
+ */
+compareVersions.compare = function (v1, v2, operator) {
+  if (v1 === 'preview') v1 = '65535';
+  if (v2 === 'preview') v2 = '65535';
+  v1 = v1.replace('≤', '');
+  v2 = v2.replace('≤', '');
+  return _compareVersions.compare(v1, v2, operator);
+};

--- a/scripts/lib/compare-versions.test.js
+++ b/scripts/lib/compare-versions.test.js
@@ -1,0 +1,36 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+import assert from 'node:assert/strict';
+
+import compareVersions from './compare-versions.js';
+
+describe('compare-versions script', () => {
+  it('`compareVersions` works correctly', () => {
+    assert.equal(compareVersions('1', '1'), 0);
+    assert.equal(compareVersions('1', '2'), -1);
+    assert.equal(compareVersions('2', '1'), 1);
+    assert.equal(compareVersions('1', '≤2'), -1);
+    assert.equal(compareVersions('≤2', '1'), 1);
+    assert.equal(compareVersions('2', '≤2'), 0);
+    assert.equal(compareVersions('≤2', '2'), 0);
+    assert.equal(compareVersions('≤2', '≤2'), 0);
+    assert.equal(compareVersions('1', 'preview'), -1);
+    assert.equal(compareVersions('preview', '1'), 1);
+    assert.equal(compareVersions('preview', 'preview'), 0);
+  });
+
+  it('`compareVersions.validate` works correctly', () => {
+    assert.equal(compareVersions.validate('1'), true);
+    assert.equal(compareVersions.validate('2'), true);
+    assert.equal(compareVersions.validate('preview'), true);
+    assert.equal(compareVersions.validate('≤2'), true);
+    assert.equal(compareVersions.validate('foo'), false);
+    assert.equal(compareVersions.validate('≤preview'), true);
+  });
+
+  it('`compareVersions.compare` works correctly', () => {
+    assert.equal(compareVersions.compare('1', 'preview', '<'), true);
+    assert.equal(compareVersions.compare('≤2', 'preview', '<'), true);
+  });
+});

--- a/scripts/release/mirror.ts
+++ b/scripts/release/mirror.ts
@@ -10,7 +10,7 @@ import { InternalSupportBlock } from '../../types/index.js';
 
 type Notes = string | string[] | null;
 
-import compareVersions from 'compare-versions';
+import compareVersions from '../lib/compare-versions.js';
 
 import bcd from '../../index.js';
 const { browsers } = bcd;
@@ -213,11 +213,7 @@ const combineStatements = (...data: SupportStatement[]): SupportStatement => {
       } else if (typeof newVA === 'string') {
         if (
           typeof currentVA !== 'string' ||
-          compareVersions.compare(
-            currentVA.replace('≤', ''),
-            newVA.replace('≤', ''),
-            '>',
-          )
+          compareVersions.compare(currentVA, newVA, '>')
         ) {
           currentStatement.version_added = newVA;
         }

--- a/test/linter/test-consistency.test.ts
+++ b/test/linter/test-consistency.test.ts
@@ -76,3 +76,150 @@ describe('ConsistencyChecker.getVersionAdded()', function () {
     );
   });
 });
+
+describe('ConsistencyChecker.isVersionAddedGreater()', function () {
+  it('foo', () => {
+    assert.equal(
+      check.isVersionAddedGreater(
+        { chrome: { version_added: '1' } },
+        { chrome: { version_added: '1' } },
+        'chrome',
+      ),
+      false,
+    );
+    assert.equal(
+      check.isVersionAddedGreater(
+        { chrome: { version_added: '1' } },
+        { chrome: { version_added: '2' } },
+        'chrome',
+      ),
+      true,
+    );
+    assert.equal(
+      check.isVersionAddedGreater(
+        { chrome: { version_added: '2' } },
+        { chrome: { version_added: '1' } },
+        'chrome',
+      ),
+      false,
+    );
+
+    assert.equal(
+      check.isVersionAddedGreater(
+        { chrome: { version_added: '≤1' } },
+        { chrome: { version_added: '1' } },
+        'chrome',
+      ),
+      true,
+    );
+    assert.equal(
+      check.isVersionAddedGreater(
+        { chrome: { version_added: '≤1' } },
+        { chrome: { version_added: '2' } },
+        'chrome',
+      ),
+      true,
+    );
+    assert.equal(
+      check.isVersionAddedGreater(
+        { chrome: { version_added: '≤2' } },
+        { chrome: { version_added: '1' } },
+        'chrome',
+      ),
+      false,
+    );
+
+    assert.equal(
+      check.isVersionAddedGreater(
+        { chrome: { version_added: '1' } },
+        { chrome: { version_added: '≤1' } },
+        'chrome',
+      ),
+      false,
+    );
+    assert.equal(
+      check.isVersionAddedGreater(
+        { chrome: { version_added: '2' } },
+        { chrome: { version_added: '≤1' } },
+        'chrome',
+      ),
+      false,
+    );
+    assert.equal(
+      check.isVersionAddedGreater(
+        { chrome: { version_added: '1' } },
+        { chrome: { version_added: '≤2' } },
+        'chrome',
+      ),
+      false,
+    );
+
+    assert.equal(
+      check.isVersionAddedGreater(
+        { chrome: { version_added: '≤1' } },
+        { chrome: { version_added: '≤1' } },
+        'chrome',
+      ),
+      false,
+    );
+    assert.equal(
+      check.isVersionAddedGreater(
+        { chrome: { version_added: '≤1' } },
+        { chrome: { version_added: '≤2' } },
+        'chrome',
+      ),
+      false,
+    );
+    assert.equal(
+      check.isVersionAddedGreater(
+        { chrome: { version_added: '≤2' } },
+        { chrome: { version_added: '≤1' } },
+        'chrome',
+      ),
+      false,
+    );
+
+    assert.equal(
+      check.isVersionAddedGreater(
+        { chrome: { version_added: '1' } },
+        { chrome: { version_added: 'preview' } },
+        'chrome',
+      ),
+      false,
+    );
+    assert.equal(
+      check.isVersionAddedGreater(
+        { chrome: { version_added: '≤1' } },
+        { chrome: { version_added: 'preview' } },
+        'chrome',
+      ),
+      false,
+    );
+
+    assert.equal(
+      check.isVersionAddedGreater(
+        { chrome: { version_added: 'preview' } },
+        { chrome: { version_added: '1' } },
+        'chrome',
+      ),
+      false,
+    );
+    assert.equal(
+      check.isVersionAddedGreater(
+        { chrome: { version_added: 'preview' } },
+        { chrome: { version_added: '≤1' } },
+        'chrome',
+      ),
+      false,
+    );
+
+    assert.equal(
+      check.isVersionAddedGreater(
+        { chrome: { version_added: 'preview' } },
+        { chrome: { version_added: 'preview' } },
+        'chrome',
+      ),
+      false,
+    );
+  });
+});

--- a/test/linter/test-consistency.test.ts
+++ b/test/linter/test-consistency.test.ts
@@ -110,7 +110,7 @@ describe('ConsistencyChecker.isVersionAddedGreater()', function () {
         { chrome: { version_added: '1' } },
         'chrome',
       ),
-      true,
+      false,
     );
     assert.equal(
       check.isVersionAddedGreater(

--- a/test/linter/test-consistency.ts
+++ b/test/linter/test-consistency.ts
@@ -16,7 +16,7 @@ import {
   InternalSupportStatement,
 } from '../../types/index.js';
 
-import compareVersions from 'compare-versions';
+import compareVersions from '../../scripts/lib/compare-versions.js';
 import chalk from 'chalk-template';
 import { query } from '../../utils/index.js';
 import mirrorSupport from '../../scripts/release/mirror.js';
@@ -392,21 +392,13 @@ export class ConsistencyChecker {
       }
 
       if (selectedValue !== null) {
-        if (
-          typeof resolvedValue === 'string' &&
-          typeof selectedValue === 'string'
-        ) {
-          // Earlier value takes precedence
-          const resolvedIsEarlier = compareVersions.compare(
-            resolvedValue.replace('≤', ''),
-            selectedValue.replace('≤', ''),
-            '<',
-          );
-          if (resolvedIsEarlier) {
-            selectedValue = resolvedValue;
-          }
-        } else if (typeof resolvedValue === 'string') {
-          // If selectedValue is bool/null but resolvedValue is string
+        // Earlier value takes precedence
+        const resolvedIsEarlier = compareVersions.compare(
+          resolvedValue,
+          selectedValue,
+          '<',
+        );
+        if (resolvedIsEarlier) {
           selectedValue = resolvedValue;
         } else {
           // If neither are version numbers, assign to the truthiest value
@@ -442,20 +434,7 @@ export class ConsistencyChecker {
       if (b_version_added.startsWith('≤')) {
         return false;
       }
-      if (a_version_added === 'preview' && b_version_added === 'preview') {
-        return false;
-      }
-      if (b_version_added === 'preview') {
-        return true;
-      }
-      if (a_version_added === 'preview') {
-        return false;
-      }
-      return compareVersions.compare(
-        a_version_added.replace('≤', ''),
-        b_version_added,
-        a_version_added.startsWith('≤') ? '<=' : '<',
-      );
+      return compareVersions.compare(a_version_added, b_version_added, '<');
     }
 
     return false;

--- a/test/linter/test-versions.test.js
+++ b/test/linter/test-versions.test.js
@@ -47,18 +47,18 @@ describe('addedBeforeRemoved', function () {
   it('values include preview', () => {
     assert.equal(
       addedBeforeRemoved({ version_added: '1', version_removed: 'preview' }),
-      null,
+      true,
     );
     assert.equal(
       addedBeforeRemoved({ version_added: 'preview', version_removed: '1' }),
-      null,
+      false,
     );
     assert.equal(
       addedBeforeRemoved({
         version_added: 'preview',
         version_removed: 'preview',
       }),
-      null,
+      false,
     );
   });
 });

--- a/test/linter/test-versions.test.js
+++ b/test/linter/test-versions.test.js
@@ -1,0 +1,64 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+import assert from 'node:assert/strict';
+
+import { addedBeforeRemoved } from './test-versions.js';
+
+describe('addedBeforeRemoved', function () {
+  it('values are simple version numbers', () => {
+    assert.equal(
+      addedBeforeRemoved({ version_added: '1', version_removed: '1' }),
+      false,
+    );
+    assert.equal(
+      addedBeforeRemoved({ version_added: '1', version_removed: '2' }),
+      true,
+    );
+    assert.equal(
+      addedBeforeRemoved({ version_added: '2', version_removed: '1' }),
+      false,
+    );
+  });
+
+  it('values include inequalities', () => {
+    assert.equal(
+      addedBeforeRemoved({ version_added: '1', version_removed: '≤2' }),
+      true,
+    );
+    assert.equal(
+      addedBeforeRemoved({ version_added: '≤2', version_removed: '1' }),
+      false,
+    );
+    assert.equal(
+      addedBeforeRemoved({ version_added: '2', version_removed: '≤2' }),
+      false,
+    );
+    assert.equal(
+      addedBeforeRemoved({ version_added: '≤2', version_removed: '2' }),
+      false,
+    );
+    assert.equal(
+      addedBeforeRemoved({ version_added: '≤2', version_removed: '≤2' }),
+      false,
+    );
+  });
+
+  it('values include preview', () => {
+    assert.equal(
+      addedBeforeRemoved({ version_added: '1', version_removed: 'preview' }),
+      null,
+    );
+    assert.equal(
+      addedBeforeRemoved({ version_added: 'preview', version_removed: '1' }),
+      null,
+    );
+    assert.equal(
+      addedBeforeRemoved({
+        version_added: 'preview',
+        version_removed: 'preview',
+      }),
+      null,
+    );
+  });
+});

--- a/test/linter/test-versions.ts
+++ b/test/linter/test-versions.ts
@@ -13,7 +13,7 @@ import {
   InternalSupportStatement,
 } from '../../types/index';
 
-import compareVersions from 'compare-versions';
+import compareVersions from '../../scripts/lib/compare-versions.js';
 import chalk from 'chalk-template';
 
 import bcd from '../../index.js';
@@ -122,28 +122,20 @@ export function addedBeforeRemoved(
     return false;
   }
 
-  // In order to ensure that the versions could be displayed without the "≤"
-  // markers and still make sense, compare the versions without them. This
-  // means that combinations like version_added: "≤37" + version_removed: "37"
-  // are not allowed, even though this can be technically correct.
-  const added = statement.version_added.replace('≤', '');
-  const removed = statement.version_removed.replace('≤', '');
+  const added = statement.version_added;
+  const removed = statement.version_removed;
 
   if (!compareVersions.validate(added) || !compareVersions.validate(removed)) {
     return null;
   }
 
-  if (added === 'preview' && removed === 'preview') {
-    return false;
-  }
-  if (added === 'preview' && removed !== 'preview') {
-    return false;
-  }
-  if (added !== 'preview' && removed === 'preview') {
-    return true;
-  }
-
-  return compareVersions.compare(added, removed, '<');
+  // Note that this disallows combinations like version_added: "≤37" +
+  // version_removed: "37", even though this can be technically correct.
+  return compareVersions.compare(
+    statement.version_added,
+    statement.version_removed,
+    '<',
+  );
 }
 
 /**

--- a/test/linter/test-versions.ts
+++ b/test/linter/test-versions.ts
@@ -112,7 +112,9 @@ function hasVersionAddedOnly(statement: SimpleSupportStatement): boolean {
  * @param {SimpleSupportStatement} statement
  * @returns {(boolean|null)}
  */
-function addedBeforeRemoved(statement: SimpleSupportStatement): boolean | null {
+export function addedBeforeRemoved(
+  statement: SimpleSupportStatement,
+): boolean | null {
   if (
     typeof statement.version_added !== 'string' ||
     typeof statement.version_removed !== 'string'


### PR DESCRIPTION
Currently we just use `compare-versions` directly everywhere, often having to preprocess our version strings to be semver strings. We should instead unify this, and have a single place which implements the comparison logic.

This partly addresses #16598.