### PR TITLE
Fix TypeScript definition for Identifier interface and Browser.upstream

### DIFF
--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -61,7 +61,8 @@
         },
         "upstream": {
           "type": "string",
-          "description": "The upstream browser this browser derives from (e.g. Firefox Android is derived from Firefox, Edge is derived from Chrome)."
+          "description": "The upstream browser this browser derives from (e.g. Firefox Android is derived from Firefox, Edge is derived from Chrome).",
+          "tsType": "BrowserName"
         },
         "accepts_flags": {
           "type": "boolean",

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -257,7 +257,8 @@
       "additionalProperties": false,
       "errorMessage": {
         "additionalProperties": "Feature names can only contain alphanumerical characters or the following symbols: _-$@"
-      }
+      },
+      "tsType": "{[key: string]: Identifier} & {__compat?: CompatStatement}"
     },
 
     "webextensions_identifier": {

--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -69,12 +69,7 @@ const transformTS = (browserTS, compatTS) => {
   ts = ts
     .replace('export type Browsers1', 'export type Browsers')
     .replace('export interface Browsers {\n  browsers?: Browsers1;\n}', '')
-    .replace('export interface CompatData {}', '')
-    .replace(
-      'export interface Identifier {',
-      "export interface Identifier extends Record<Omit<string, '__compat'>, Identifier> {",
-    )
-    .replace('[k: string]: Identifier;', '');
+    .replace('export interface CompatData {}', '');
 
   return ts;
 };


### PR DESCRIPTION
This PR fixes #16601 by updating the TypeScript definition of the `Identifier` interface with the suggestion in the issue.  Additionally, this ensures that a browser's `upstream` property is a `BrowserName`.
