### PR TITLE
Allow for multiple beta browser releases in browser data

### DIFF
--- a/test/linter/test-browsers-data.js
+++ b/test/linter/test-browsers-data.js
@@ -18,7 +18,7 @@ const { browsers } = bcd;
  * @returns {void}
  */
 function processData(browser, data, logger) {
-  for (const status of ['current', 'beta', 'nightly']) {
+  for (const status of ['current', 'nightly']) {
     const releasesForStatus = Object.entries(data.releases)
       .filter(([, data]) => data.status == status)
       .map(([version]) => version);


### PR DESCRIPTION
This PR allows a browser to define multiple beta browser versions, such as in the case of Safari 15.6 and 16.  CC @gsnedders
