### PR TITLE
Updates opera browser to version 88

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -667,19 +667,26 @@
         "87": {
           "release_date": "2022-05-17",
           "release_notes": "https://blogs.opera.com/desktop/2022/05/opera-87-stable/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "101"
         },
         "88": {
-          "status": "beta",
+          "release_date": "2022-06-08",
+          "release_notes": "https://blogs.opera.com/desktop/2022/06/opera-88-stable/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "102"
         },
         "89": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "103"
+        },
+        "90": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "104"
         }
       }
     }


### PR DESCRIPTION
Hello!

According to this [release note](https://blogs.opera.com/desktop/2022/06/opera-88-stable/) opera browser has updated to version 88.

😉👋