### PR TITLE
Fix Opera "fromEntries" compatibility

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -659,7 +659,9 @@
               "nodejs": {
                 "version_added": "12.0.0"
               },
-              "opera": "mirror",
+              "opera": {
+                "version_added": "60"
+              },
               "opera_android": "mirror",
               "safari": {
                 "version_added": "12.1"


### PR DESCRIPTION
#### Summary
Compatibility for fromEntries in Opera seems to be missing.

#### Test results and supporting details
This was tested using [this Pen](https://codepen.io/barzik/pen/OqdVqW). Most recent opera version to fail via Browserstrack was 58, earliest version to pass was 60.

<img width="1069" alt="Screenshot 2022-06-09 at 13 43 31" src="https://user-images.githubusercontent.com/2141225/172839993-796aa4a3-7297-42db-9c75-5c37cb0b3f71.png">
<img width="1030" alt="Screenshot 2022-06-09 at 13 42 26" src="https://user-images.githubusercontent.com/2141225/172840019-6891cafd-8d71-4794-b192-3950e49261c1.png">

