### PR TITLE
Ensure that enumeration only includes browser or __compat statements

### DIFF
--- a/scripts/enumerate-features.js
+++ b/scripts/enumerate-features.js
@@ -24,8 +24,10 @@ function enumerateFeatures(dataFrom) {
       )
     : lowLevelWalk();
 
-  for (const { path } of walker) {
-    feats.push(path);
+  for (const feat of walker) {
+    if (feat.compat || feat.browser) {
+      feats.push(feat.path);
+    }
   }
 
   return feats;


### PR DESCRIPTION
This PR updates the feature enumeration script to ensure that parent features without compatibility data are not included in the enumeration list.  That is, if `foo.bar.baz` has a `__compat` statement, but `foo.bar` does not, feature enumeration will include `foo.bar.baz` but not `foo.bar`.
