### PR TITLE
Add entries for break-before/break-after: avoid (in multicol)

### DIFF
--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -123,6 +123,40 @@
               }
             }
           },
+          "avoid": {
+            "__compat": {
+              "description": "<code>avoid</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "102"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "avoid-column": {
             "__compat": {
               "description": "<code>avoid-column</code>",

--- a/css/properties/break-before.json
+++ b/css/properties/break-before.json
@@ -123,6 +123,40 @@
               }
             }
           },
+          "avoid": {
+            "__compat": {
+              "description": "<code>avoid</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "102"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "avoid-column": {
             "__compat": {
               "description": "<code>avoid-column</code>",


### PR DESCRIPTION
This is supported with LayoutNGBlockFragmentation, enabled in M102:
https://storage.googleapis.com/chromium-find-releases-static/1bb.html#1bb5f043274b0c27199c7ddb25e1f906167b5ddd

No entries are added for pages media, since that isn't supported yet.
