### PR TITLE
Use "title" prop to define TypeScript interface names

### DIFF
--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -125,10 +125,10 @@
     }
   },
 
+  "title": "BrowserDataFile",
   "type": "object",
   "properties": {
     "browsers": { "$ref": "#/definitions/browsers" }
   },
-  "additionalProperties": false,
-  "tsName": "BrowserDataFile"
+  "additionalProperties": false
 }

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -280,6 +280,7 @@
     }
   },
 
+  "title": "CompatDataFile",
   "type": "object",
   "patternProperties": {
     "^(?!__compat)(?!webextensions)[a-zA-Z_0-9-$@]*$": {
@@ -298,6 +299,5 @@
     "additionalProperties": "Feature names can only contain alphanumerical characters or the following symbols: _-$@"
   },
   "maxProperties": 1,
-  "minProperties": 1,
-  "tsName": "CompatDataFile"
+  "minProperties": 1
 }

--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -93,9 +93,11 @@ const transformTS = (browserTS, compatTS) => {
   let ts = browserTS + '\n\n' + compatTS;
 
   ts = ts
-    .replace('export type Browsers1', 'export type Browsers')
-    .replace('export interface Browsers {\n  browsers?: Browsers1;\n}', '')
-    .replace('export interface CompatData {}', '')
+    .replace(
+      'export interface BrowserDataFile {\n  browsers?: Browsers;\n}',
+      '',
+    )
+    .replace('export interface CompatDataFile {}', '')
     .replace(
       ' */\nexport type WebextensionsIdentifier',
       ' * THIS INTERFACE SHOULD NOT BE USED AND MAY BE REMOVED AT ANY TIME; USE THE "Identifier" INTERFACE INSTEAD.\n */\nexport type WebextensionsIdentifier',


### PR DESCRIPTION
This PR is a small tweak that abandons the proposed `tsName` prop to specify TypeScript names, and instead use the `title` prop.
