### PR TITLE
Deprecate nonPersistentCookies from privacy.websites.cookieConfig

### DIFF
--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -421,6 +421,65 @@
                   "version_added": false
                 }
               }
+            },
+            "behavior": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "59"
+                  },
+                  "firefox_android": {
+                    "version_added": "59"
+                  },
+                  "opera": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
+            "nonPersistentCookies": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "59"
+                  },
+                  "firefox_android": {
+                    "version_added": "59"
+                  },
+                  "opera": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "deprecated": true
+                }
+              }
             }
           },
           "firstPartyIsolate": {


### PR DESCRIPTION
#### Summary
Update to address deprecation of `nonPersistentCookies` from `privacy.websites.cookieConfig` API implemented by [Bug 1754924](https://bugzilla.mozilla.org/show_bug.cgi?id=1754924) 

#### Test results and supporting details
 Passed `npm test`