### PR TITLE
Consistency test: mirror statements before comparing values (part 2)

### DIFF
--- a/test/linter/test-consistency.js
+++ b/test/linter/test-consistency.js
@@ -424,7 +424,10 @@ export class ConsistencyChecker {
    */
   extractBrowsers(compatData, callback) {
     return Object.keys(compatData.support).filter((browser) => {
-      const browserData = compatData.support[browser];
+      let browserData = compatData.support[browser];
+      if (browserData === 'mirror') {
+        browserData = mirrorSupport(browser, compatData.support);
+      }
 
       if (Array.isArray(browserData)) {
         return browserData.every(callback);


### PR DESCRIPTION
This PR is a follow-up to #16644 that ensures the `extractBrowsers()` function also performs mirroring.
