### PR TITLE
Array.groupBy/ .groupByToMap renamed to group/groupToMap

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -969,9 +969,9 @@
             }
           }
         },
-        "groupBy": {
+        "group": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/groupBy",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/group",
             "spec_url": "https://tc39.es/proposal-array-grouping/#sec-array.prototype.groupby",
             "support": {
               "chrome": {
@@ -1024,9 +1024,9 @@
             }
           }
         },
-        "groupByToMap": {
+        "groupToMap": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/groupByToMap",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/groupToMap",
             "spec_url": "https://tc39.es/proposal-array-grouping/#sec-array.prototype.groupbymap",
             "support": {
               "chrome": {


### PR DESCRIPTION
The spec changed the name of the Array group() and groupByToMap() methods to remove the "By" in the name. This is an attempt to see if the name will stick, so might still change: https://bugzilla.mozilla.org/show_bug.cgi?id=1773471#c3

This is currently only implemented in FF and only in nightly.  Confusing for anyone testing, so I am going to update. No point adding anything of the old names since this is still in stage 3 of the spec.

Note, the spec URLs did not change.