### PR TITLE
Add exception for 103 Early Hints HTTP status

### DIFF
--- a/test/linter/test-spec-urls.js
+++ b/test/linter/test-spec-urls.js
@@ -24,6 +24,9 @@ const specsExceptions = [
   // Exception for April Fools' joke for "418 I'm a teapot"
   'https://www.rfc-editor.org/rfc/rfc2324',
 
+  // Exception for "103 Early Hints" HTTP status code
+  'https://httpwg.org/specs/rfc8297.html',
+
   // Unfortunately this doesn't produce a rendered spec, so it isn't in browser-specs
   // Remove if it is in the main ECMA spec
   'https://github.com/tc39/proposal-regexp-legacy-features/',


### PR DESCRIPTION
This PR adds an exception for the 103 HTTP status code's spec URL, since it apparently isn't in `browser-specs`.
