### PR TITLE
Support for muted in tabs.create

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1828,6 +1828,33 @@
                 }
               }
             },
+            "muted": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": {
+                    "version_added": false
+                  },
+                  "firefox": {
+                    "version_added": "100"
+                  },
+                  "firefox_android": {
+                    "version_added": "100"
+                  },
+                  "opera": {
+                    "version_added": false
+                  },
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": {
+                    "version_added": false
+                  }
+                }
+              }
+            },
             "openInReaderMode": {
               "__compat": {
                 "support": {


### PR DESCRIPTION
#### Summary
Update to add `muted` to `createProperties` in the `tabs.create` API as implemented by [Bug 1372100](https://bugzilla.mozilla.org/show_bug.cgi?id=1372100) 

#### Test results and supporting details
 Passed `npm test`
