### PR TITLE
Demix invalid event from GlobalEventHandlers

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -6454,6 +6454,56 @@
           }
         }
       },
+      "invalid_event": {
+        "__compat": {
+          "description": "<code>invalid</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/invalid_event",
+          "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#handler-oninvalid",
+          "support": {
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "9"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "5"
+            },
+            "safari_ios": {
+              "version_added": "4"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "keydown_event": {
         "__compat": {
           "description": "<code>keydown</code> event",

--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -1833,55 +1833,6 @@
           }
         }
       },
-      "oninvalid": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/oninvalid",
-          "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#handler-oninvalid",
-          "support": {
-            "chrome": {
-              "version_added": "4"
-            },
-            "chrome_android": {
-              "version_added": "18"
-            },
-            "edge": {
-              "version_added": "13"
-            },
-            "firefox": {
-              "version_added": "9"
-            },
-            "firefox_android": {
-              "version_added": "9"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "opera": {
-              "version_added": "≤12.1"
-            },
-            "opera_android": {
-              "version_added": "≤12.1"
-            },
-            "safari": {
-              "version_added": "5"
-            },
-            "safari_ios": {
-              "version_added": "4"
-            },
-            "samsunginternet_android": {
-              "version_added": "1.0"
-            },
-            "webview_android": {
-              "version_added": "≤37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "onkeydown": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onkeydown",

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1715,6 +1715,56 @@
           }
         }
       },
+      "invalid_event": {
+        "__compat": {
+          "description": "<code>invalid</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/invalid_event",
+          "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#handler-oninvalid",
+          "support": {
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "9"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "5"
+            },
+            "safari_ios": {
+              "version_added": "4"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "isContentEditable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/isContentEditable",

--- a/api/Window.json
+++ b/api/Window.json
@@ -3176,6 +3176,56 @@
           }
         }
       },
+      "invalid_event": {
+        "__compat": {
+          "description": "<code>invalid</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/invalid_event",
+          "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#handler-oninvalid",
+          "support": {
+            "chrome": {
+              "version_added": "4"
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "edge": {
+              "version_added": "13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "9"
+            },
+            "ie": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "5"
+            },
+            "safari_ios": {
+              "version_added": "4"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0"
+            },
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "languagechange_event": {
         "__compat": {
           "description": "<code>languagechange</code> event",


### PR DESCRIPTION
This PR demixes the `invalid` event from the GlobalEventHandlers mixin.
