### PR TITLE
TSConfig: noFallthroughCasesInSwitch, allowUnreachableCode

### DIFF
--- a/test/utils.ts
+++ b/test/utils.ts
@@ -90,16 +90,13 @@ export function indexToPosRaw(
     return [null, null];
   }
 
-  let prevChar = '';
   for (let i = 0; i < index; i++) {
     const char = str[i];
     switch (char) {
-      case '\n':
-        if (prevChar === '\r') break;
-      // fall through
       case '\r':
         line++;
         col = 1;
+        if (i + 1 < index && str[i + 1] === '\r') i++;
         break;
       case '\t':
         // Use JSON `tab_size` value from `.editorconfig`
@@ -109,7 +106,6 @@ export function indexToPosRaw(
         col++;
         break;
     }
-    prevChar = char;
   }
 
   return [line, col];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
+    "allowUnreachableCode": false,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "ES2020",
     "module": "ESNext",
     "moduleResolution": "node",
+    "noFallthroughCasesInSwitch": true,
     "noImplicitAny": false,
     "esModuleInterop": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Enable [`noFallthroughCasesInSwitch`](https://www.typescriptlang.org/tsconfig#noFallthroughCasesInSwitch). I find it easier to just use this rule than insert a `break;` or a comment `// fall through` in every `case`. Also, this particular case of fall-through just happens to be easier to read without a fall-through. Also, note that it's possible to disable this rule on a line-per-line basis via a special comment.

Set [`allowUnreachableCode`](https://www.typescriptlang.org/tsconfig#allowUnreachableCode) to `false` to make TS compiler error out on dead code.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
N/A
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A
<!-- ✅ After submitting, review the results of the "Checks" tab! -->
