### PR TITLE
Use my patched version of ts-node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "open-cli": "~7.0.1",
         "ora": "~6.1.0",
         "prettier": "~2.7.0",
-        "ts-node": "~10.8.0",
+        "ts-node": "github:queengooborg/ts-node#patch-1-built",
         "tslib": "~2.4.0",
         "typescript": "~4.7.2",
         "yargs": "~17.5.0"
@@ -5833,9 +5833,9 @@
     },
     "node_modules/ts-node": {
       "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.1.tgz",
-      "integrity": "sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==",
+      "resolved": "git+ssh://git@github.com/queengooborg/ts-node.git#978ff1f01074e4eececfacf60da254da9028426e",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10446,10 +10446,9 @@
       "dev": true
     },
     "ts-node": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.1.tgz",
-      "integrity": "sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==",
+      "version": "git+ssh://git@github.com/queengooborg/ts-node.git#978ff1f01074e4eececfacf60da254da9028426e",
       "dev": true,
+      "from": "ts-node@git+https://github.com/queengooborg/ts-node.git#patch-1-built",
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "open-cli": "~7.0.1",
     "ora": "~6.1.0",
     "prettier": "~2.7.0",
-    "ts-node": "~10.8.0",
+    "ts-node": "github:queengooborg/ts-node#patch-1-built",
     "tslib": "~2.4.0",
     "typescript": "~4.7.2",
     "yargs": "~17.5.0"


### PR DESCRIPTION
This PR uses my built version of ts-node while awaiting the merge of https://github.com/TypeStrong/ts-node/pull/1792.
