### PR TITLE
Remove unused types in mirroring migration script

### DIFF
--- a/scripts/migrations/009-mirror.ts
+++ b/scripts/migrations/009-mirror.ts
@@ -1,13 +1,7 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import {
-  CompatData,
-  BrowserName,
-  Identifier,
-  ReleaseStatement,
-  SimpleSupportStatement,
-} from '../../types/types.js';
+import { CompatData, BrowserName } from '../../types/types.js';
 import {
   InternalSupportStatement,
   InternalSupportBlock,


### PR DESCRIPTION
This PR removes unused imports in the migration mirroring script.
