### PR TITLE
Introduce a "source_file" compat prop

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'node:url';
 import { fdir } from 'fdir';
 
 import extend from './scripts/lib/extend.js';
+import { walk } from './utils/index.js';
 
 const dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -31,8 +32,18 @@ async function load(...dirs: string[]) {
 
     for (const fp of paths) {
       try {
-        const contents = await fs.readFile(fp);
-        extend(result, JSON.parse(contents.toString('utf8')));
+        const rawcontents = await fs.readFile(fp);
+        const contents: CompatData = JSON.parse(rawcontents.toString('utf8'));
+
+        // Add source_file props
+        const walker = walk(undefined, contents);
+        for (const { compat } of walker) {
+          if (!compat) continue;
+
+          compat.source_file = path.relative(dirname, fp);
+        }
+
+        extend(result, contents);
       } catch (e) {
         // Skip invalid JSON. Tests will flag the problem separately.
         continue;

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -225,6 +225,10 @@
           "description": "An optional URL or array of URLs, each of which is for a specific part of a specification in which this feature is defined. Each URL must contain a fragment identifier.",
           "tsType": "string | string[]"
         },
+        "source_file": {
+          "type": "string",
+          "description": "The path to the file that defines this feature in browser-compat-data, relative to the repository root. Useful for guiding potential contributors towards the correct file to edit. This is automatically generated at build time and should never manually be specified."
+        },
         "support": {
           "$ref": "#/definitions/support_block",
           "description": "The data for the support of each browser, containing a `support_statement` object for each browser identifier with information about versions, prefixes, or alternate names, as well as notes.",


### PR DESCRIPTION
This PR introduces a new `source_file` compat prop that contains the relative path to the file that includes the feature.  This is helpful for websites/apps that wish to include a link back to the exact file the feature is introduced in, to make submitting pull requests easier.

CC @Fyrd -- I noticed CanIUse links back to the specific JSON files, so this should help with the transition to BCD's built versions!
