### PR TITLE
Refactor: normalize source_file property

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,7 @@ import { fileURLToPath } from 'node:url';
 import { fdir } from 'fdir';
 
 import extend from './scripts/lib/extend.js';
-import { walk } from './utils/index.js';
+import { normalizePath, walk } from './utils/index.js';
 
 const dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -40,7 +40,7 @@ async function load(...dirs: string[]) {
         for (const { compat } of walker) {
           if (!compat) continue;
 
-          compat.source_file = path.relative(dirname, fp);
+          compat.source_file = normalizePath(path.relative(dirname, fp));
         }
 
         extend(result, contents);

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -4,5 +4,6 @@
 import iterSupport from './iter-support.js';
 import query from './query.js';
 import walk from './walk.js';
+import normalizePath from './normalize-path.js';
 
-export { iterSupport, query, walk };
+export { iterSupport, normalizePath, query, walk };

--- a/utils/normalize-path.test.ts
+++ b/utils/normalize-path.test.ts
@@ -1,0 +1,28 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+import assert from 'node:assert/strict';
+
+import { normalizePathInternal } from './normalize-path.js';
+
+describe('normalizePath()', function () {
+  const pathWindows = {
+    sep: '\\',
+  };
+
+  const pathPOSIX = {
+    sep: '/',
+  };
+
+  describe('On Windows should replace "\\" with "/"', function () {
+    assert.equal(normalizePathInternal('\\', pathWindows), '/');
+    assert.equal(normalizePathInternal('\\a\\b', pathWindows), '/a/b');
+    assert.equal(normalizePathInternal('a\\b', pathWindows), 'a/b');
+  });
+
+  describe('should do nothing with anything else', function () {
+    assert.equal(normalizePathInternal('/', pathPOSIX), '/');
+    assert.equal(normalizePathInternal('/a-b', pathPOSIX), '/a-b');
+    assert.equal(normalizePathInternal('ab', pathPOSIX), 'ab');
+  });
+});

--- a/utils/normalize-path.ts
+++ b/utils/normalize-path.ts
@@ -1,0 +1,13 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+import path from 'node:path';
+
+export function normalizePathInternal(p: string, testPath: any = path): string {
+  if (testPath.sep === '/') return p;
+  return p.replace(/\\/gi, '/');
+}
+
+export default function normalizePath(p: string): string {
+  return normalizePathInternal(p, path);
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
On Windows, paths have a separator `\` instead of `/` used on the web and literally everywhere else. This can be confusing and results in differences between published packages built on Windows. For reference, the latest BCD release, 5.0.1, uses `/`.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
Please see docs on [`path.sep`](https://nodejs.org/api/path.html#pathsep).
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
`source_file` property was introduced in #16675.
<!-- ✅ After submitting, review the results of the "Checks" tab! -->
