### PR TITLE
Ensure mirroring output cannot be "null"

### DIFF
--- a/scripts/release/mirror.test.ts
+++ b/scripts/release/mirror.test.ts
@@ -133,5 +133,21 @@ describe('mirror', () => {
         }
       });
     }
+
+    it('mirror target must have upstream browser', () => {
+      assert.throws(
+        () => mirrorSupport('chrome' as BrowserName, {}),
+        Error,
+        'Upstream is not defined for chrome, cannot mirror!',
+      );
+    });
+
+    it('throw error if upstream data is not defined', () => {
+      assert.throws(
+        () => mirrorSupport('chrome_android' as BrowserName, {}),
+        Error,
+        'The data for chrome is not defined for mirroring to chrome_android, cannot mirror!',
+      );
+    });
   });
 });

--- a/scripts/release/mirror.ts
+++ b/scripts/release/mirror.ts
@@ -405,7 +405,7 @@ export const bumpSupport = (
 const mirrorSupport = (
   destination: BrowserName,
   data: InternalSupportBlock,
-): SupportStatement | null => {
+): SupportStatement => {
   const upstream: BrowserName | undefined = browsers[destination].upstream;
   if (!upstream) {
     throw new Error(
@@ -426,7 +426,12 @@ const mirrorSupport = (
     upstreamData = mirrorSupport(upstream, data);
   }
 
-  return bumpSupport(upstreamData, destination);
+  const result = bumpSupport(upstreamData, destination);
+  if (!result) {
+    throw new Error(`Could not mirror support!`);
+  }
+
+  return result;
 };
 
 export default mirrorSupport;

--- a/scripts/release/mirror.ts
+++ b/scripts/release/mirror.ts
@@ -357,14 +357,10 @@ const bumpWebView = (
  * @param {BrowserName} destination
  */
 export const bumpSupport = (
-  sourceData: SupportStatement | null,
+  sourceData: SupportStatement,
   destination: BrowserName,
 ): SupportStatement | null => {
   let newData: SupportStatement | null = null;
-
-  if (sourceData == null) {
-    return null;
-  }
 
   if (Array.isArray(sourceData)) {
     const newStatements = sourceData
@@ -428,7 +424,7 @@ const mirrorSupport = (
 
   const result = bumpSupport(upstreamData, destination);
   if (!result) {
-    throw new Error(`Could not mirror support!`);
+    throw new Error(`Result is null, cannot mirror!`);
   }
 
   return result;


### PR DESCRIPTION
This PR ensures that the mirroring output cannot be "null", throwing an error if any such cases are identified.
