### PR TITLE
Fix Identifier type

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,6 +1,6 @@
 {
   "all": true,
-  "include": ["**/scripts/**", "**/test/**", "**/utils/**"],
+  "include": ["index.ts", "**/scripts/**", "**/test/**", "**/utils/**"],
   "exclude": [
     "**/.nyc_output/**",
     "**/coverage/**",

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,0 +1,18 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+import { CompatStatement } from './types/types.js';
+
+import assert from 'node:assert/strict';
+
+import bcd from './index.js';
+
+describe('Using BCD', () => {
+  it('subscript notation', () => {
+    const data: CompatStatement = bcd['api']['AbortController']['__compat'];
+  });
+
+  it('dot notation', () => {
+    const data: CompatStatement = bcd.api.AbortController.__compat;
+  });
+});

--- a/index.test.ts
+++ b/index.test.ts
@@ -3,14 +3,19 @@
 
 import { CompatStatement } from './types/types.js';
 
+import assert from 'node:assert/strict';
+
 import bcd from './index.js';
 
 describe('Using BCD', () => {
   it('subscript notation', () => {
-    const data: CompatStatement = bcd['api']['AbortController']['__compat'];
+    const data: CompatStatement | undefined =
+      bcd['api']['AbortController']['__compat'];
+    assert.ok(data);
   });
 
   it('dot notation', () => {
-    const data: CompatStatement = bcd.api.AbortController.__compat;
+    const data: CompatStatement | undefined = bcd.api.AbortController.__compat;
+    assert.ok(data);
   });
 });

--- a/index.test.ts
+++ b/index.test.ts
@@ -3,8 +3,6 @@
 
 import { CompatStatement } from './types/types.js';
 
-import assert from 'node:assert/strict';
-
 import bcd from './index.js';
 
 describe('Using BCD', () => {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "prepare": "npm run gentypes",
     "confluence": "node ./node_modules/mdn-confluence/main/generate.es6.js --output-dir=. --bcd-module=./index.js",
     "diff": "ts-node scripts/diff.ts",
-    "unittest": "c8 mocha --recursive \"{,!(node_modules)/**}/*.test.ts\"",
+    "unittest": "c8 mocha index.test.ts --recursive \"{,!(node_modules)/**}/*.test.ts\"",
     "coverage": "c8 report -r lcov && open-cli coverage/lcov-report/index.html",
     "format": "npx eslint \"**/*.ts\" && npx prettier --check \"**/*.md\" \"**/*.json\"",
     "format:fix": "npx eslint --fix \"**/*.ts\" && npx prettier --write \"**/*.md\" \"**/*.json\"",

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -262,7 +262,7 @@
       "errorMessage": {
         "additionalProperties": "Feature names can only contain alphanumerical characters or the following symbols: _-$@"
       },
-      "tsType": "{[key: string]: Identifier} & {__compat?: CompatStatement}"
+      "tsType": "Record<string, Identifier> & {__compat?: CompatStatement};"
     },
 
     "webextensions_identifier": {


### PR DESCRIPTION
This PR fixes the `Identifier` type to ensure the BCD data can be converted to the TypeScript types.
