### PR TITLE
Add a unittest to confirm build output "matches" developer output

### DIFF
--- a/scripts/release/build.test.ts
+++ b/scripts/release/build.test.ts
@@ -1,0 +1,25 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+import { BrowserName } from '../../types/types.js';
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+import bcd from '../../index.js';
+import { applyMirroring, createDataBundle } from './build.js';
+
+const packageJson = JSON.parse(
+  await fs.readFile(new URL('../../package.json', import.meta.url), 'utf-8'),
+);
+
+describe('build', () => {
+  it('build data matches', async () => {
+    const devBcd = {
+      ...applyMirroring(bcd),
+      __meta: { version: packageJson.version },
+    };
+
+    assert.deepEqual(await createDataBundle(), devBcd);
+  });
+});

--- a/scripts/release/build.ts
+++ b/scripts/release/build.ts
@@ -22,11 +22,9 @@ const directory = './build/';
 
 const verbatimFiles = ['LICENSE', 'README.md'];
 
-// Returns a string representing data ready for writing to JSON file
-async function createDataBundle() {
-  const { default: bcd } = await import('../../index.js');
-
-  const walker = walk(undefined, bcd);
+export function applyMirroring(data) {
+  const response = Object.assign({}, data);
+  const walker = walk(undefined, response);
 
   for (const feature of walker) {
     if (!feature.compat) {
@@ -44,18 +42,24 @@ async function createDataBundle() {
     }
   }
 
-  const string = stringify({
-    ...bcd,
+  return response;
+}
+
+// Returns an object containing the prepared BCD data
+export async function createDataBundle() {
+  const { default: bcd } = await import('../../index.js');
+
+  return {
+    ...applyMirroring(bcd),
     __meta: { version: packageJson.version },
-  });
-  return string;
+  };
 }
 
 // Returns a promise for writing the data to JSON file
 async function writeData() {
   const dest = path.resolve(directory, 'data.json');
   const data = await createDataBundle();
-  await fs.writeFile(dest, data);
+  await fs.writeFile(dest, stringify(data));
 }
 
 async function writeWrapper() {


### PR DESCRIPTION
This PR adds a unittest to ensure that the build script's output matches the developer output, after mirroring and the meta object has been applied.
