### PR TITLE
Flag removal script: remove cutoff date; remove flags immediately

### DIFF
--- a/scripts/remove-redundant-flags.test.ts
+++ b/scripts/remove-redundant-flags.test.ts
@@ -5,8 +5,6 @@ import assert from 'node:assert/strict';
 
 import { removeRedundantFlags } from './remove-redundant-flags.js';
 
-const cutoffDate = new Date('2019-01-01T00:00Z');
-
 const tests = [
   {
     input: {
@@ -285,22 +283,9 @@ const tests = [
       test6: {
         __compat: {
           support: {
-            chrome: [
-              {
-                version_added: '80',
-              },
-              {
-                version_added: '21',
-                version_removed: '80',
-                flags: [
-                  {
-                    type: 'preference',
-                    name: '#service-worker-payment-apps',
-                    value_to_set: 'Enabled',
-                  },
-                ],
-              },
-            ],
+            chrome: {
+              version_added: '80',
+            },
           },
           status: {
             experimental: true,
@@ -404,21 +389,9 @@ const tests = [
       test8: {
         __compat: {
           support: {
-            chrome: [
-              {
-                version_added: '86',
-              },
-              {
-                version_added: '21',
-                flags: [
-                  {
-                    type: 'preference',
-                    name: '#service-worker-payment-apps',
-                    value_to_set: 'Enabled',
-                  },
-                ],
-              },
-            ],
+            chrome: {
+              version_added: '86',
+            },
           },
           status: {
             experimental: true,
@@ -437,9 +410,7 @@ describe('remove-redundant-flags', () => {
     it(`Test #${i}`, () => {
       const expected = JSON.stringify(test['output'], null, 2);
       const output = JSON.stringify(
-        JSON.parse(JSON.stringify(test['input']), (k, v) =>
-          removeRedundantFlags(k, v, null, cutoffDate),
-        ),
+        JSON.parse(JSON.stringify(test['input']), removeRedundantFlags),
         null,
         2,
       );


### PR DESCRIPTION
This PR updates the redundant flag removal script to remove flags immediately upon `version_removed` or stable release introduction, to match the updated data guidelines: https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-flag-data
