### PR TITLE
Update preventScroll option support for Android's Web Browsers due to unsupported

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1016,7 +1016,8 @@
                 "version_added": "64"
               },
               "chrome_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/953169'>bug 953169</a>."
               },
               "edge": {
                 "version_added": "17"
@@ -1025,7 +1026,8 @@
                 "version_added": "68"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1544660'>bug 1544660</a>."
               },
               "ie": {
                 "version_added": false

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1015,14 +1015,18 @@
               "chrome": {
                 "version_added": "64"
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "edge": {
                 "version_added": "17"
               },
               "firefox": {
                 "version_added": "68"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
#### Summary
`preventScroll` option of `element.focus()` doesn't support all Android browsers (Blink and Gecko) yet.

- https://bugzilla.mozilla.org/show_bug.cgi?id=1544660
- https://bugs.chromium.org/p/chromium/issues/detail?id=953169

#### Test results and supporting details
I tested Firefox latest, Chrome latest and Samsung Internet latest etc.