### PR TITLE
Fix linter Obsolete test

### DIFF
--- a/test/linter/test-obsolete.test.ts
+++ b/test/linter/test-obsolete.test.ts
@@ -3,7 +3,26 @@
 
 import assert from 'node:assert/strict';
 
-import { neverImplemented } from './test-obsolete.js';
+import {
+  neverImplemented,
+  implementedAndRemoved,
+  processData,
+} from './test-obsolete.js';
+import bcd from '../../index.js';
+import { Logger } from '../utils.js';
+const { browsers } = bcd;
+
+const errorTime = new Date(),
+  warningTime = new Date();
+errorTime.setFullYear(errorTime.getFullYear() - 2.5);
+warningTime.setFullYear(warningTime.getFullYear() - 2);
+const release = Object.entries(browsers.chrome.releases).find(
+  ([_, statement]) => {
+    if (statement.release_date === undefined) return;
+    const date = new Date(statement.release_date);
+    return errorTime < date && date < warningTime;
+  },
+);
 
 describe('neverImplemented', function () {
   it('returns false for features which were implemented', () => {
@@ -43,5 +62,159 @@ describe('neverImplemented', function () {
       }),
       true,
     );
+  });
+});
+
+describe('implementedAndRemoved', function () {
+  it('returns false for features which were implemented and never removed', () => {
+    assert.equal(
+      implementedAndRemoved({
+        chrome: { version_added: '1' },
+      }),
+      false,
+    );
+    assert.equal(
+      implementedAndRemoved({
+        chrome: [
+          {
+            version_added: '2',
+          },
+          {
+            version_added: '1',
+            version_removed: '2',
+            flags: [
+              {
+                type: 'preference',
+                name: 'flag',
+              },
+            ],
+          },
+        ],
+      }),
+      false,
+    );
+  });
+
+  it('returns false for features which were implemented and removed recently', () => {
+    assert.equal(
+      implementedAndRemoved({
+        chrome: {
+          version_added: '1',
+          version_removed: Object.keys(browsers.chrome.releases)[-1],
+        },
+      }),
+      false,
+    );
+    assert.equal(
+      implementedAndRemoved({
+        chrome: [
+          {
+            version_added: '2',
+            version_removed: Object.keys(browsers.chrome.releases)[-1],
+          },
+          {
+            version_added: '1',
+            version_removed: '2',
+            flags: [
+              {
+                type: 'preference',
+                name: 'flag',
+              },
+            ],
+          },
+        ],
+      }),
+      false,
+    );
+  });
+
+  it('rule 2 warning: returns "warning" for features which were implemented and removed some time ago', () => {
+    // Make sure there is a suitable release
+    assert.ok(release);
+    const version_removed = release[0];
+    assert.equal(
+      implementedAndRemoved({
+        chrome: {
+          version_added: '1',
+          version_removed,
+        },
+      }),
+      'warning',
+    );
+    assert.equal(
+      implementedAndRemoved({
+        chrome: [
+          {
+            version_added: '2',
+            version_removed,
+          },
+          {
+            version_added: '1',
+            version_removed: '2',
+            flags: [
+              {
+                type: 'preference',
+                name: 'flag',
+              },
+            ],
+          },
+        ],
+      }),
+      'warning',
+    );
+  });
+});
+
+describe('processData', function () {
+  it('logs nothing for features which are still on standards track', () => {
+    const logger = new Logger('', '');
+    processData(logger, {
+      support: {
+        chrome: {
+          version_added: '1',
+        },
+      },
+      status: {
+        experimental: true,
+        standard_track: true,
+        deprecated: false,
+      },
+    });
+    assert.equal(logger.messages.length, 0);
+  });
+
+  it('logs "error" for feature according to rule 1', () => {
+    const logger = new Logger('', '');
+    processData(logger, {
+      support: {
+        chrome: {
+          version_added: false,
+        },
+      },
+      status: {
+        deprecated: true,
+        experimental: false,
+        standard_track: false,
+      },
+    });
+    assert.equal(logger.messages.length, 1);
+    assert.equal(logger.messages[0].level, 'error');
+  });
+
+  it('logs "warning" for feature according to rule 2', () => {
+    const logger = new Logger('', '');
+    // Make sure there is a suitable release
+    assert.ok(release);
+    const version_removed = release[0];
+    processData(logger, {
+      support: {
+        chrome: {
+          version_added: '1',
+          version_removed,
+        },
+      },
+    });
+    assert.equal(logger.messages.length, 1);
+    assert.equal(logger.messages[0].level, 'warning');
   });
 });

--- a/test/linter/test-obsolete.ts
+++ b/test/linter/test-obsolete.ts
@@ -35,7 +35,7 @@ warningTime.setFullYear(warningTime.getFullYear() - 2);
  * @param {SupportBlock} support
  * @returns LinterMessageLevel | false
  */
-function implementedAndRemoved(
+export function implementedAndRemoved(
   support: SupportBlock,
 ): LinterMessageLevel | false {
   let result: LinterMessageLevel = 'error';
@@ -69,7 +69,7 @@ function implementedAndRemoved(
  * @param {CompatStatement} data The data to test
  * @returns {void}
  */
-function processData(logger: Logger, data: CompatStatement): void {
+export function processData(logger: Logger, data: CompatStatement): void {
   if (data && data.support) {
     const { support, status } = data;
 

--- a/test/linter/test-obsolete.ts
+++ b/test/linter/test-obsolete.ts
@@ -6,6 +6,7 @@ import {
   BrowserName,
   CompatStatement,
   SupportBlock,
+  SupportStatement,
 } from '../../types/types.js';
 
 import chalk from 'chalk-template';
@@ -38,18 +39,27 @@ function implementedAndRemoved(
   support: SupportBlock,
 ): LinterMessageLevel | false {
   let result: LinterMessageLevel = 'error';
-  for (const [browser, data] of Object.entries(support) as [BrowserName, any]) {
-    // Feature is still supported
-    if (!data.version_removed) return false;
-    const releaseDate = new Date(
-      (browsers[browser as BrowserName] as any).releases[
-        data.version_removed
-      ].release_date,
-    );
-    // Feature was recently supported, no need to show warning
-    if (warningTime < releaseDate) return false;
-    // Feature was supported sufficiently recently to not show an error
-    if (errorTime < releaseDate) result = 'warning';
+  for (const [browser, data] of Object.entries(support) as [
+    BrowserName,
+    SupportStatement,
+  ][]) {
+    for (const d of Array.isArray(data) ? data : [data]) {
+      // Feature is still supported or it is not known when feature was dropped
+      if (!d.version_removed || typeof d.version_removed === 'boolean')
+        return false;
+
+      const releaseDateData =
+        browsers[browser].releases[d.version_removed].release_date;
+
+      // No browser release date
+      if (!releaseDateData) return false;
+
+      const releaseDate = new Date(releaseDateData);
+      // Feature was recently supported, no need to show warning
+      if (warningTime < releaseDate) return false;
+      // Feature was supported sufficiently recently to not show an error
+      if (errorTime < releaseDate) result = 'warning';
+    }
   }
   return result;
 }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
This PR fixes a bug introduced in commit 7351737ae97c9f481013a0228a4da15ab8daf758 from #16614 by restoring the original test #16429.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
This is a linter. Also, I added new tests for this linter.
<!--
I wondered why TS did not catch this issue in the first place so here is what I found:
The bug is in the incorrect type casting in `for` loop:
```
Object.entries(support) as [BrowserName, any]
```
Since `support` is `SupportBlock = Partial<Record<BrowserName, SupportStatement>>` then `Object.entries(support)` is `[string, SupportStatement][]`. But why is `[string, SupportStatement][]` compatible with `[BrowserName, any]`?
-->
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
#16614 #16429
I found this while working on removing `any` in #16699.
<!-- ✅ After submitting, review the results of the "Checks" tab! -->
