### PR TITLE
Increase build script test timeout

### DIFF
--- a/scripts/release/build.test.ts
+++ b/scripts/release/build.test.ts
@@ -22,7 +22,7 @@ describe('build', () => {
     };
 
     assert.deepEqual(await createDataBundle(), devBcd);
-  }).timeout(10000);
+  }).timeout(30000);
 
   it('package.json', () => {
     const manifest = createManifest();


### PR DESCRIPTION
This PR increases the timeout for the build test.  (Unfortunately build times are getting longer as we add more mirroring statements.)
