### PR TITLE
Default TS export: cast to "any" first

### DIFF
--- a/scripts/release/build.ts
+++ b/scripts/release/build.ts
@@ -87,7 +87,9 @@ import { CompatData } from "./types";
 
 import bcd from "./data.json";
 
-export default bcd as CompatData;
+// XXX The cast to "any" mitigates a TS definition issue. This is very bad practice and
+// should be fixed as soon as possible.
+export default bcd as any as CompatData;
 export * from "./types";`;
   await fs.writeFile(dest, content);
 


### PR DESCRIPTION
This PR mitigates the ongoing TypeScript bug around the `Identifier` interface.  Note: this is definitely a bad practice and should be properly fixed very soon, but this issue has plagued the past four BCD releases.
