### PR TITLE
Disable build match test due to long build times

### DIFF
--- a/scripts/release/build.test.ts
+++ b/scripts/release/build.test.ts
@@ -12,14 +12,17 @@ import {
 } from './build.js';
 
 describe('build', () => {
-  it('build data matches', async () => {
-    const devBcd = {
-      ...applyMirroring(bcd),
-      __meta: generateMeta(),
-    };
+  // Disabled due to long build times
+  // it('build data matches', async () => {
+  //   this.skip();
 
-    assert.deepEqual(await createDataBundle(), devBcd);
-  }).timeout(30000);
+  //   const devBcd = {
+  //     ...applyMirroring(bcd),
+  //     __meta: generateMeta(),
+  //   };
+
+  //   assert.deepEqual(await createDataBundle(), devBcd);
+  // }).timeout(30000);
 
   it('package.json', () => {
     const manifest = createManifest();


### PR DESCRIPTION
This PR disables the test to ensure the build output matches the contributor data.
