### PR TITLE
id in history.onTitleChanged

### DIFF
--- a/webextensions/api/history.json
+++ b/webextensions/api/history.json
@@ -298,6 +298,34 @@
               },
               "safari_ios": "mirror"
             }
+          },
+          "id": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/history/onTitleChanged",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": {
+                  "version_added": false
+                },
+                 "firefox": {
+                  "version_added": "86"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                }
+              }
+            }
           }
         },
         "onVisitRemoved": {

--- a/webextensions/api/history.json
+++ b/webextensions/api/history.json
@@ -309,7 +309,7 @@
                 "edge": {
                   "version_added": false
                 },
-                 "firefox": {
+                "firefox": {
                   "version_added": "86"
                 },
                 "firefox_android": {


### PR DESCRIPTION
#### Summary
Adds the `id` parameter to the `history.onTitleChanged` event. Provides the BCD data requested in [Bug 1756663](https://bugzilla.mozilla.org/show_bug.cgi?id=1756663).

#### Test results and supporting details
Test not yet completed, see https://github.com/mdn/browser-compat-data/issues/16716