### PR TITLE
Mirroring: throw error if source release couldn't be found

### DIFF
--- a/scripts/release/mirror.ts
+++ b/scripts/release/mirror.ts
@@ -38,9 +38,13 @@ export const getMatchingBrowserVersion = (
 
   const range = sourceVersion.includes('≤');
   const sourceRelease =
-    browsers[browserData.upstream as BrowserName].releases[
-      sourceVersion.replace('≤', '')
-    ];
+    browsers[browserData.upstream].releases[sourceVersion.replace('≤', '')];
+
+  if (!sourceRelease) {
+    throw new Error(
+      `Could not find source release "${browserData.upstream} ${sourceVersion}"!`,
+    );
+  }
 
   for (const r of releaseKeys) {
     const release = browserData.releases[r];


### PR DESCRIPTION
This PR adds an error in the event that the source release could not be found.  This error should never be thrown within BCD, but may be thrown during the `update-bcd` command of the collector project.
