### PR TITLE
Use it.skip() to disable build match test rather than comments

### DIFF
--- a/scripts/release/build.test.ts
+++ b/scripts/release/build.test.ts
@@ -13,16 +13,14 @@ import {
 
 describe('build', () => {
   // Disabled due to long build times
-  // it('build data matches', async () => {
-  //   this.skip();
+  it.skip('build data matches', async () => {
+    const devBcd = {
+      ...applyMirroring(bcd),
+      __meta: generateMeta(),
+    };
 
-  //   const devBcd = {
-  //     ...applyMirroring(bcd),
-  //     __meta: generateMeta(),
-  //   };
-
-  //   assert.deepEqual(await createDataBundle(), devBcd);
-  // }).timeout(30000);
+    assert.deepEqual(await createDataBundle(), devBcd);
+  }).timeout(30000);
 
   it('package.json', () => {
     const manifest = createManifest();


### PR DESCRIPTION
This PR replaces the commented-out unittest with `it.skip()` to mitigate the unused variables warnings.
