### PR TITLE
Remove svg color rendering

### DIFF
--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -305,38 +305,6 @@
             }
           }
         },
-        "color-rendering": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/color-rendering",
-            "support": {
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": null
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": null
-              },
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
-          }
-        },
         "cursor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/cursor",

--- a/test/linter/test-obsolete.ts
+++ b/test/linter/test-obsolete.ts
@@ -108,7 +108,6 @@ export default {
     'http.headers.Feature-Policy.oversized-images',
     'http.headers.Feature-Policy.unoptimized-images',
     'http.headers.Feature-Policy.unsized-media',
-    'svg.attributes.presentation.color-rendering',
     'svg.elements.view.zoomAndPan',
   ],
 } as Linter;


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Remove SVG attribute `color-rendering`.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
This attribute was removed from the spec and it actually has never been implemented properly, according to the following source. Only Chrome parses it (but does not interpret it in any way). WPT were removed.
https://github.com/w3c/svgwg/issues/647
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Content issue: https://github.com/mdn/content/pull/17462 - merged.
<!-- ✅ After submitting, review the results of the "Checks" tab! -->
