### PR TITLE
Update CSS dynamic-range spec URL

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -482,7 +482,7 @@
           "__compat": {
             "description": "<code>dynamic-range</code> media feature",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/dynamic-range",
-            "spec_url": "https://www.w3.org/TR/mediaqueries-5/#dynamic-range",
+            "spec_url": "https://drafts.csswg.org/mediaqueries-5/#dynamic-range",
             "support": {
               "chrome": {
                 "version_added": "98"


### PR DESCRIPTION
This should be using the drafts.csswg.org spec URL rather than a www.w3.org/TR URL.