### PR TITLE
Update the CSS color-contrast spec URL

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -179,7 +179,7 @@
           "__compat": {
             "description": "<code>color-contrast()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/color-contrast",
-            "spec_url": "https://drafts.csswg.org/css-color-5/#colorcontrast",
+            "spec_url": "https://drafts.csswg.org/css-color-6/#colorcontrast",
             "support": {
               "chrome": {
                 "version_added": false

--- a/test/linter/test-spec-urls.ts
+++ b/test/linter/test-spec-urls.ts
@@ -44,6 +44,9 @@ const specsExceptions = [
 
   // Remove if https://github.com/w3c/mathml/issues/216 is resolved
   'https://w3c.github.io/mathml/',
+
+  // Remove when we get a browser-specs update
+  'https://drafts.csswg.org/css-color-6/',
 ];
 
 const allowedSpecURLs = [


### PR DESCRIPTION
https://drafts.csswg.org/css-color-5/#changes-20220428 notes that `color-contrast()` moved to the Level 6 spec