### PR TITLE
Update MediaRecorderErrorEvent flags

### DIFF
--- a/api/MediaRecorderErrorEvent.json
+++ b/api/MediaRecorderErrorEvent.json
@@ -28,8 +28,8 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
-          "deprecated": false
+          "standard_track": false,
+          "deprecated": true
         }
       },
       "MediaRecorderErrorEvent": {


### PR DESCRIPTION
This is a follow-up to https://github.com/mdn/browser-compat-data/pull/16747

In that PR, I changed the flags for the subfeatures forgot to change the flags for the `MediaRecorderErrorEvent` feature itself...