### PR TITLE
Update CSS video-dynamic-range spec URL

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1463,7 +1463,7 @@
           "__compat": {
             "description": "<code>video-dynamic-range</code> media feature",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/video-dynamic-range",
-            "spec_url": "https://www.w3.org/TR/mediaqueries-5/#video-dynamic-range",
+            "spec_url": "https://drafts.csswg.org/mediaqueries-5/#video-dynamic-range",
             "support": {
               "chrome": {
                 "version_added": "98"


### PR DESCRIPTION
As with #16746, this should be using the drafts.csswg.org spec URL rather than a www.w3.org/TR URL.