### PR TITLE
Handle linter code exceptions

### DIFF
--- a/test/utils.ts
+++ b/test/utils.ts
@@ -237,12 +237,21 @@ export class Linters {
     const linters = this.linters.filter((linter) => linter.scope === scope);
     for (const linter of linters) {
       const logger = new Logger(linter.name, data.path.full);
-      const shouldFail = linter.exceptions?.includes(data.path.full);
-      linter.check(logger, data);
-      if (!shouldFail) {
-        this.messages[linter.name].push(...logger.messages);
-      } else {
-        this.expectedFailures[linter.name].push(data.path.full);
+      try {
+        const shouldFail = linter.exceptions?.includes(data.path.full);
+        linter.check(logger, data);
+        if (!shouldFail) {
+          this.messages[linter.name].push(...logger.messages);
+        } else {
+          this.expectedFailures[linter.name].push(data.path.full);
+        }
+      } catch (e: any) {
+        this.messages[linter.name].push({
+          level: 'error',
+          title: linter.name,
+          path: e.traceback,
+          message: 'Linter failure! ' + e,
+        });
       }
     }
   }


### PR DESCRIPTION
This PR updates the linter code to handle any code exceptions that occur while running linter tests.

Note: this does not use the `logger.error()` call and hook into the existing message handling because a code failure should _never_ be considered as an exception.
