### PR TITLE
Remove volumechange event from GlobalEventHandlers

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -3649,57 +3649,6 @@
           }
         }
       },
-      "onvolumechange": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onvolumechange",
-          "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onvolumechange",
-          "support": {
-            "chrome": {
-              "version_added": "32"
-            },
-            "chrome_android": "mirror",
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "9"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": "9"
-            },
-            "opera": [
-              {
-                "version_added": "19"
-              },
-              {
-                "version_added": "≤12.1",
-                "version_removed": "15"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "19"
-              },
-              {
-                "version_added": "≤12.1",
-                "version_removed": "14"
-              }
-            ],
-            "safari": {
-              "version_added": "9"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "onwaiting": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onwaiting",


### PR DESCRIPTION
This PR demixes the `volumechange` event from the GlobalEventHandlers mixin.  Since this is a media event and the event is already on `HTMLMediaElement`, no event features have been added.
