### PR TITLE
Don't require real values or include statistics by default for IE

### DIFF
--- a/scripts/statistics.ts
+++ b/scripts/statistics.ts
@@ -142,7 +142,6 @@ const getStats = (
         'chrome_android',
         'edge',
         'firefox',
-        'ie',
         'safari',
         'safari_ios',
         'webview_android',

--- a/test/linter/test-versions.ts
+++ b/test/linter/test-versions.ts
@@ -54,7 +54,6 @@ const realValuesTargetBrowsers = [
   'edge',
   'firefox',
   'firefox_android',
-  'ie',
   'opera',
   'opera_android',
   'safari',


### PR DESCRIPTION
This PR removes Internet Explorer from the real values requirement and the default browsers for the statistics script, since Internet Explorer is now dead and there's much less incentive to maintain IE data.
