### PR TITLE
Updates edge to version 103

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -212,22 +212,29 @@
         },
         "102": {
           "release_date": "2022-05-31",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "102",
           "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1020124530-may-31"
         },
         "103": {
           "release_date": "2022-06-23",
-          "status": "beta",
+          "status": "current",
           "engine": "Blink",
-          "engine_version": "103"
+          "engine_version": "103",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1030126437-june-23"
         },
         "104": {
           "release_date": "2022-08-04",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "104"
+        },
+        "105": {
+          "release_date": "2022-08-04",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "105"
         }
       }
     }


### PR DESCRIPTION
Hello everyone! 😉

I updated Edge browser to version 103, according to [this release note](https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1030126437-june-23).

:)