### PR TITLE
Remove wrong mdn_url for AudioProcessingEvent

### DIFF
--- a/api/AudioProcessingEvent.json
+++ b/api/AudioProcessingEvent.json
@@ -36,7 +36,6 @@
       "AudioProcessingEvent": {
         "__compat": {
           "description": "<code>AudioProcessingEvent()</code> constructor",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioProcessingEvent/AudioProcessingEvent",
           "support": {
             "chrome": {
               "version_added": "57"
@@ -68,7 +67,6 @@
       },
       "inputBuffer": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioProcessingEvent/inputBuffer",
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audioprocessingevent-inputbuffer",
           "support": {
             "chrome": {
@@ -103,7 +101,6 @@
       },
       "outputBuffer": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioProcessingEvent/outputBuffer",
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audioprocessingevent-outputbuffer",
           "support": {
             "chrome": {
@@ -138,7 +135,6 @@
       },
       "playbackTime": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioProcessingEvent/playbackTime",
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audioprocessingevent-playbacktime",
           "support": {
             "chrome": {


### PR DESCRIPTION
`AudioProcessingEvent` is deprecated. Constructors and properties will never be documented on MDN. (The interface page doesn't treat them as _red links_ anymore).

Let's remove URLs that will stay forever broken.