### PR TITLE
Update Opera versions for api.AbortSignal.throwIfAborted

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -269,9 +269,7 @@
               "version_added": false
             },
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "15.4"
             },


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `throwIfAborted` member of the `AbortSignal` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.7).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AbortSignal/throwIfAborted

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
