### PR TITLE
Update WebView versions for api.AbortSignal.timeout

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -316,9 +316,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "98"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR updates and corrects the real values for WebView Android for the `timeout` member of the `AbortSignal` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.7).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AbortSignal/timeout

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
