### PR TITLE
Update Firefox versions for ApplicationCache API

### DIFF
--- a/api/ApplicationCache.json
+++ b/api/ApplicationCache.json
@@ -13,7 +13,8 @@
             "version_removed": "86"
           },
           "firefox": {
-            "version_added": "3"
+            "version_added": "3",
+            "version_removed": "47"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -97,7 +98,8 @@
               "version_removed": "86"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "47"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -138,7 +140,8 @@
               "version_removed": "86"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "47"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -179,7 +182,8 @@
               "version_removed": "86"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "47"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -220,7 +224,8 @@
               "version_removed": "86"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "47"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -261,7 +266,8 @@
               "version_removed": "86"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "47"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -302,7 +308,8 @@
               "version_removed": "86"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "3.5",
+              "version_removed": "47"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -343,7 +350,8 @@
               "version_removed": "86"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "47"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -383,7 +391,8 @@
               "version_removed": "86"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "47"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -429,7 +438,8 @@
               "version_removed": "86"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "47"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -475,7 +485,8 @@
               "version_removed": "86"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "47"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -522,7 +533,8 @@
               "version_removed": "86"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "47"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `ApplicationCache` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.7).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ApplicationCache

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
