### PR TITLE
Update Samsung Internet versions for AuthenticatorAssertionResponse API

### DIFF
--- a/api/AuthenticatorAssertionResponse.json
+++ b/api/AuthenticatorAssertionResponse.json
@@ -40,9 +40,7 @@
             "version_added": "13"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": {
-            "version_added": false
-          },
+          "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false
           }
@@ -93,9 +91,7 @@
               "version_added": "13"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
             }
@@ -147,9 +143,7 @@
               "version_added": "13"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
             }
@@ -201,9 +195,7 @@
               "version_added": "13"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
             }


### PR DESCRIPTION
This PR updates and corrects the real values for Samsung Internet for the `AuthenticatorAssertionResponse` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.7).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AuthenticatorAssertionResponse

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
