### PR TITLE
Add Samsung Internet versions for AuthenticatorAttestationResponse API

### DIFF
--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -40,9 +40,7 @@
             "version_added": "13"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": {
-            "version_added": false
-          },
+          "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false
           }
@@ -93,9 +91,7 @@
               "version_added": "13"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
             }
@@ -129,9 +125,7 @@
               "version_added": "16"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
             }
@@ -165,9 +159,7 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
             }
@@ -201,9 +193,7 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
             }
@@ -238,9 +228,7 @@
               "version_added": "16"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
             }


### PR DESCRIPTION
This PR adds real values for Samsung Internet for the `AuthenticatorAttestationResponse` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.7).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AuthenticatorAttestationResponse

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
