### PR TITLE
Add Samsung Internet versions for AuthenticatorResponse API

### DIFF
--- a/api/AuthenticatorResponse.json
+++ b/api/AuthenticatorResponse.json
@@ -40,9 +40,7 @@
             "version_added": "13"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": {
-            "version_added": false
-          },
+          "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false
           }
@@ -93,9 +91,7 @@
               "version_added": "13"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
             }


### PR DESCRIPTION
This PR adds real values for Samsung Internet for the `AuthenticatorResponse` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.7).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AuthenticatorResponse

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
