### PR TITLE
Linter: fix linter exception logging

### DIFF
--- a/test/lint.ts
+++ b/test/lint.ts
@@ -187,12 +187,15 @@ const main = async (
   // Find all unnecessary linting exceptions
   for (const linter of linters.linters) {
     if (linter.exceptions) {
-      const actual = new Set(linters.expectedFailures[linter.name]);
-      for (const exception of linter.exceptions)
-        if (!actual.has(exception))
+      const missingExceptions = linters.missingExpectedFailures[linter.name];
+      for (const exception in missingExceptions) {
+        if (missingExceptions[exception]) {
+          hasErrors = true;
           console.error(
             chalk`{red  ✖ ${linter.name} - Unnecessary exception → ${exception}}`,
           );
+        }
+      }
     }
   }
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
#16740 added a message about linter exceptions, but contained a bug described in #16785. This PR:
 - fixes said bug
 - makes existence of known unnecessary exceptions into a lint error (previously it was just a log statement)

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
Ran `npm run lint` and `npm run lint api/AbortController.json` and observed expected output. Then added an unneeded exception `api.AbortController` and ran these commands again and observed expected lint failure.
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #16785.
<!-- ✅ After submitting, review the results of the "Checks" tab! -->
