### PR TITLE
updated spec: @import

### DIFF
--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>@import</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@import",
-          "spec_url": "https://drafts.csswg.org/css-cascade/#at-import",
+          "spec_url": "https://www.w3.org/TR/css-cascade-5/#at-import",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
The spec was pointing to version 3. We are at parts of v5 being implemented. 
Cascade layers is in v5
https://www.w3.org/TR/css-cascade-5/#at-import