### PR TITLE
Deno 1.24 supports the beforeunload event

### DIFF
--- a/api/BeforeUnloadEvent.json
+++ b/api/BeforeUnloadEvent.json
@@ -9,6 +9,9 @@
             "version_added": "30"
           },
           "chrome_android": "mirror",
+          "deno": {
+            "version_added": "1.24"
+          },
           "edge": {
             "version_added": "12"
           },
@@ -47,6 +50,9 @@
               "version_added": "30"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
@@ -86,6 +92,9 @@
               "version_added": "60"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "18"
             },

--- a/api/Window.json
+++ b/api/Window.json
@@ -360,6 +360,9 @@
                 "version_added": "30"
               },
               "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
               "edge": {
                 "version_added": "12"
               },
@@ -397,6 +400,9 @@
                 "version_added": false
               },
               "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
               "edge": {
                 "version_added": "12",
                 "version_removed": "79"
@@ -435,6 +441,9 @@
                 "version_added": "1"
               },
               "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
               "edge": {
                 "version_added": "12"
               },
@@ -478,6 +487,9 @@
               "version_added": "1"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.24"
+            },
             "edge": {
               "version_added": "12"
             },


### PR DESCRIPTION
#### Summary
The upcoming Deno 1.24 release adds support for the `beforeunload` event.

#### Test results and supporting details
PR that adds the feature to Deno, including tests: https://github.com/denoland/deno/pull/14830

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

cc: @lucacasonato 

Note: CI will fail until 1.24 is released.