### PR TITLE
Updates firefox to version 102

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -731,23 +731,30 @@
         "101": {
           "release_date": "2022-05-31",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/101",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "101"
         },
         "102": {
           "release_date": "2022-06-28",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/102",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "102"
         },
         "103": {
           "release_date": "2022-07-26",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/103",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "103"
+        },
+        "104": {
+          "release_date": "2022-08-23",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/104",
+          "status": "nightly",
+          "engine": "Gecko",
+          "engine_version": "104"
         }
       }
     }

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -599,23 +599,30 @@
         "101": {
           "release_date": "2022-05-31",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/101",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "101"
         },
         "102": {
           "release_date": "2022-06-28",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/102",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "102"
         },
         "103": {
           "release_date": "2022-07-26",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/103",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "103"
+        },
+        "104": {
+          "release_date": "2022-08-23",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/104",
+          "status": "nightly",
+          "engine": "Gecko",
+          "engine_version": "104"
         }
       }
     }


### PR DESCRIPTION
Hello everyone!

I updated Firefox browser to version 102 according to [this release note](https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/102).

And according to [this release note](https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/104), the release date of firefox 104 is 23/08/22.

 🙂