### PR TITLE
Add resize event entry for HTMLVideoElement

### DIFF
--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -668,6 +668,50 @@
           }
         }
       },
+      "resize_event": {
+        "__compat": {
+          "description": "<code>resize</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/resize_event",
+          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#event-media-resize",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": "9"
+            },
+            "opera": {
+              "version_added": "10.5"
+            },
+            "opera_android": {
+              "version_added": "11"
+            },
+            "safari": {
+              "version_added": "3.1"
+            },
+            "safari_ios": {
+              "version_added": "3"
+            },
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "videoHeight": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/videoHeight",

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -672,7 +672,10 @@
         "__compat": {
           "description": "<code>resize</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/resize_event",
-          "spec_url": "https://html.spec.whatwg.org/multipage/media.html#event-media-resize",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/media.html#event-media-resize",
+            "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onresize"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
This event is fired when videoWidth or videoHeight changes, so put it on
HTMLVideoElement where those properties are. In the Blink
implementation, firing the event is explicitly conditional on the
element being an HTMLVideoElement, not an HTMLAudioElement.

The same versions as for videoWidth and videoHeight are used without
testing to confirm.
