### PR TITLE
TLS min/max in browserSettings

### DIFF
--- a/webextensions/api/browserSettings.json
+++ b/webextensions/api/browserSettings.json
@@ -312,6 +312,32 @@
             }
           }
         },
+        "tlsVersionRestrictionConfig": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/tlsVersionRestrictionConfig",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge":  {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": "72"
+              },
+              "firefox_android":  {
+                "version_added": false
+              },
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios":  {
+                "version_added": false
+              }
+            }
+          }
+        },
         "useDocumentFonts": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings/useDocumentFonts",


### PR DESCRIPTION
#### Summary
Adds the `tlsVersionRestrictionConfig` property to the `browserSettings` API . Provides the BCD data requested in [Bug1593635](https://bugzilla.mozilla.org/show_bug.cgi?id=1593635).

#### Test results and supporting details
Unable to test locally.