### PR TITLE
serviceWorkers and indexedDB delete by hostname

### DIFF
--- a/webextensions/api/browsingData.json
+++ b/webextensions/api/browsingData.json
@@ -321,7 +321,11 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "56"
+                  "version_added": "56",
+                  "notes": [
+                    "From Firefox 56 supports the specification of hostnames for the deletion of cookies and local storage items.",
+                    "From Firefox 77 also supports the specification of hostnames for the deletion of service worker and indexedDB items."
+                  ]
                 },
                 "firefox_android": {
                   "version_added": "85"


### PR DESCRIPTION
#### Summary
Adds details about the deletion of serviceWorkers and indexedDB by hostname in browsingData. Provides the BCD for:

- [Bug 1632990](https://bugzilla.mozilla.org/show_bug.cgi?id=1632990) Allow WebExtensions to clear ServiceWorkers by hostname
- [Bug 1551301](https://bugzilla.mozilla.org/show_bug.cgi?id=1551301) Allow WebExtensions to clear IndexedDB by hostname

Related content changes provided in https://github.com/mdn/content/pull/17865
