### PR TITLE
Add Intl.NumberFormat V3 features that are experimental

### DIFF
--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -255,6 +255,120 @@
                 }
               }
             },
+            "options_roundingIncrement_parameter": {
+              "__compat": {
+                "description": "<code>options.roundingIncrement</code> parameter",
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "nightly"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": false
+                  },
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "options_roundingMode_parameter": {
+              "__compat": {
+                "description": "<code>options.roundingMode</code> parameter",
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "nightly"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": false
+                  },
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "options_roundingPriority_parameter": {
+              "__compat": {
+                "description": "<code>options.roundingPriority</code> parameter",
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "nightly"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": false
+                  },
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
             "options_signDisplay_parameter": {
               "__compat": {
                 "description": "<code>options.signDisplay</code> parameter",
@@ -331,6 +445,44 @@
                 }
               }
             },
+            "options_trailingZeroDisplay_parameter": {
+              "__compat": {
+                "description": "<code>options.trailingZeroDisplay</code> parameter",
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "nightly"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": false
+                  },
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
             "options_unit_parameter": {
               "__compat": {
                 "description": "<code>options.unit</code> parameter",
@@ -402,6 +554,44 @@
                 },
                 "status": {
                   "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "options_useGrouping_parameter": {
+              "__compat": {
+                "description": "<code>options.useGrouping</code> parameter",
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "nightly"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": false
+                  },
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": true,
                   "standard_track": true,
                   "deprecated": false
                 }


### PR DESCRIPTION
In mdn/content#17883 we marked these features as experimental in the docs: they are in the spec and are implemented in Firefox (in Nightly).

This adds them inside bcd.

This is the last bit to fix mdn/content#17848.