### PR TITLE
Updates versions/statuses for applicationCache in shared workers

### DIFF
--- a/api/SharedWorkerGlobalScope.json
+++ b/api/SharedWorkerGlobalScope.json
@@ -71,10 +71,12 @@
               "version_added": false
             },
             "opera": {
-              "version_added": "10.6"
+              "version_added": "10.6",
+              "version_removed": "71"
             },
             "opera_android": {
-              "version_added": "11"
+              "version_added": "11",
+              "version_removed": "60"
             },
             "safari": {
               "version_added": false
@@ -82,7 +84,8 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": "≤37",
+              "version_removed": "85"
             }
           },
           "status": {
@@ -119,8 +122,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+              "standard_track": false,
+              "deprecated": true
             }
           }
         }


### PR DESCRIPTION
The version_removed versions were missing for a few browsers, and the
statuses of the secure_context_required subfeature didn't match the
parent feature.
