### PR TITLE
Mark PresentationRequest's startWithDevice deprecated

### DIFF
--- a/api/PresentationRequest.json
+++ b/api/PresentationRequest.json
@@ -298,7 +298,6 @@
       },
       "startWithDevice": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PresentationRequest/startWithDevice",
           "support": {
             "chrome": {
               "version_added": false
@@ -330,9 +329,9 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
It's been removed from Firefox. The MDN page doesn't exist.
