### PR TITLE
Add recent major Oculus Browser versions up to 22.0.

### DIFF
--- a/browsers/oculus.json
+++ b/browsers/oculus.json
@@ -113,6 +113,75 @@
         },
         "16.2": {
           "engine": "Blink",
+          "engine_version": "91",
+          "release_date": "2021-07-06",
+          "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes#oculus-browser-162",
+          "status": "retired"
+        },
+        "16.3": {
+          "engine": "Blink",
+          "engine_version": "91",
+          "release_date": "2021-07-19",
+          "status": "retired"
+        },
+        "16.4": {
+          "engine": "Blink",
+          "engine_version": "91",
+          "release_date": "2021-08-02",
+          "status": "retired"
+        },
+        "16.5": {
+          "engine": "Blink",
+          "engine_version": "91",
+          "release_date": "2021-08-16",
+          "status": "retired"
+        },
+        "16.6": {
+          "engine": "Blink",
+          "engine_version": "91",
+          "release_date": "2021-08-30",
+          "status": "retired"
+        },
+        "17.0": {
+          "engine": "Blink",
+          "engine_version": "93",
+          "release_date": "2021-09-13",
+          "status": "retired"
+        },
+        "17.0": {
+          "engine": "Blink",
+          "engine_version": "93",
+          "release_date": "2021-09-13",
+          "status": "retired"
+        },
+        "18.0": {
+          "engine": "Blink",
+          "engine_version": "95",
+          "release_date": "2021-11-30",
+          "status": "retired"
+        },
+        "19.0": {
+          "engine": "Blink",
+          "engine_version": "96",
+          "release_date": "2022-01-31",
+          "status": "retired"
+        },
+        "20.0": {
+          "engine": "Blink",
+          "engine_version": "98",
+          "release_date": "2022-03-14",
+          "status": "retired"
+        },
+        "21.0": {
+          "engine": "Blink",
+          "engine_version": "100",
+          "release_date": "2022-04-25",
+          "status": "retired"
+        },
+        "22.0": {
+          "engine": "Blink",
+          "engine_version": "102",
+          "release_date": "2022-06-06",
           "status": "current"
         }
       }

--- a/browsers/oculus.json
+++ b/browsers/oculus.json
@@ -148,12 +148,6 @@
           "release_date": "2021-09-13",
           "status": "retired"
         },
-        "17.0": {
-          "engine": "Blink",
-          "engine_version": "93",
-          "release_date": "2021-09-13",
-          "status": "retired"
-        },
         "18.0": {
           "engine": "Blink",
           "engine_version": "95",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Adds all of the Oculus Browser 16.x releases, and the major versions through to the present, 22.0. Note that 16.2 was the last version with release notes.

#### Test results and supporting details
`npm run lint` has no new failures.

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
