### PR TITLE
Use "fire" as the verb for events in notes (not "emit")

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2142,7 +2142,7 @@ December 7, 2021
   - Internet Explorer
   - Safari
   - Safari for iOS
-  - Webview Android
+  - WebView Android
 
 - All entries using Safari 6.1, a backport release of Safari 7, have been changed to avoid unexplained discontinuities in support. Since it's no longer used in any support statements, the data for the Safari 6.1 release has been removed. See [the guideline for historic Safari backport releases](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#backported-releases) for more information on this change. ([#11156](https://github.com/mdn/browser-compat-data/pull/11156))
 

--- a/api/Window.json
+++ b/api/Window.json
@@ -3966,7 +3966,7 @@
             },
             "firefox": {
               "version_added": "4",
-              "notes": "Firefox emits a <code>popstate</code> event on page load."
+              "notes": "Firefox fires a <code>popstate</code> event on page load."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4450,16 +4450,16 @@
           "support": {
             "chrome": {
               "version_added": "1",
-              "notes": "Chrome does not emit a <code>resize</code> event on page load."
+              "notes": "Chrome does not fire a <code>resize</code> event on page load."
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12",
-              "notes": "Before Edge 79, Edge emitted a <code>resize</code> event on page load. This is no longer the case."
+              "notes": "Before Edge 79, Edge fired a <code>resize</code> event on page load. This is no longer the case."
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Before Firefox 68, Firefox emitted a <code>resize</code> event on page load. This is no longer the case."
+              "notes": "Before Firefox 68, Firefox fired a <code>resize</code> event on page load. This is no longer the case."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4467,11 +4467,11 @@
             },
             "opera": {
               "version_added": "7",
-              "notes": "Opera does not emit a <code>resize</code> event on page load."
+              "notes": "Opera does not fire a <code>resize</code> event on page load."
             },
             "opera_android": {
               "version_added": "10.1",
-              "notes": "Opera does not emit a <code>resize</code> event on page load."
+              "notes": "Opera does not fire a <code>resize</code> event on page load."
             },
             "safari": {
               "version_added": "1.1"
@@ -4480,7 +4480,7 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "1",
-              "notes": "Webview does not emit a <code>resize</code> event on page load."
+              "notes": "WebView does not fire a <code>resize</code> event on page load."
             }
           },
           "status": {

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -126,7 +126,7 @@ The currently accepted browser identifiers should be declared in alphabetical or
 - `safari`, Safari on macOS
 - `safari_ios`, Safari on iOS, based on the iOS version
 - `samsunginternet_android`, the Samsung Internet browser (Android version)
-- `webview_android`, Webview, the built-in browser for Android
+- `webview_android`, WebView, the built-in browser for Android
 
 Desktop browser identifiers are mandatory, with the `version_added` property set to `null` if support is unknown.
 

--- a/webextensions/api/management.json
+++ b/webextensions/api/management.json
@@ -325,7 +325,7 @@
                 "version_added": "55",
                 "notes": [
                   "Before version 56, only extensions whose <code>type</code> is <code>'theme'</code> are supported.",
-                  "This event is not emitted when the extension is in the \"pending uninstall\" state. The event is emitted as expected once the extension is completely removed (for example, when the <code>about:addons</code> tab is closed)."
+                  "This event is not fired when the extension is in the \"pending uninstall\" state. The event is fired as expected once the extension is completely removed (for example, when the <code>about:addons</code> tab is closed)."
                 ]
               },
               "firefox_android": "mirror",


### PR DESCRIPTION
This is wording in spec and MDN:
https://dom.spec.whatwg.org/#firing-events
https://developer.mozilla.org/en-US/docs/Web/Events

Also fix WebView capitalization, which was wrong in one of the affected
notes.
