### PR TITLE
Note that the video.onresize property was not in IE/EdgeHTML

### DIFF
--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -681,15 +681,25 @@
               "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "The <code>onresize</code> event handler property is not supported."
+              }
+            ],
             "firefox": {
               "version_added": "3.5"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "9"
+              "version_added": "9",
+              "partial_implementation": true,
+              "notes": "The <code>onresize</code> event handler property is not supported."
             },
             "opera": {
               "version_added": "10.5"


### PR DESCRIPTION
Confirmed with this test in IE 11 and Edge 18:
http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=10451

It seems like this was a problem for onresize specifically, probably
a mishap because there was already a window.onresize property.
