### PR TITLE
Update support for break-before/break-after: avoid-column

### DIFF
--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -130,19 +130,24 @@
               "description": "<code>avoid-column</code>",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "102"
                 },
                 "chrome_android": "mirror",
-                "edge": {
-                  "version_added": "12",
-                  "version_removed": "79"
-                },
+                "edge": [
+                  {
+                    "version_added": "102"
+                  },
+                  {
+                    "version_added": "12",
+                    "version_removed": "79"
+                  }
+                ],
                 "firefox": {
                   "version_added": false
                 },
                 "firefox_android": "mirror",
                 "ie": {
-                  "version_added": false
+                  "version_added": "10"
                 },
                 "opera": "mirror",
                 "opera_android": "mirror",

--- a/css/properties/break-before.json
+++ b/css/properties/break-before.json
@@ -130,13 +130,18 @@
               "description": "<code>avoid-column</code>",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "102"
                 },
                 "chrome_android": "mirror",
-                "edge": {
-                  "version_added": "12",
-                  "version_removed": "79"
-                },
+                "edge": [
+                  {
+                    "version_added": "102"
+                  },
+                  {
+                    "version_added": "12",
+                    "version_removed": "79"
+                  }
+                ],
                 "firefox": {
                   "version_added": false
                 },


### PR DESCRIPTION
These are supported since Chromium M102 according to the implementer:
https://github.com/mdn/browser-compat-data/pull/16628#issuecomment-1153568563

The test case in that comment was used to confirm support for
break-before:avoid-column in IE10 and Edge 18.

IE10 support for break-after:avoid-column was not tested, but set
because it appears to have been set to false by accident:
https://github.com/mdn/browser-compat-data/pull/3330

The same split for break-before didn't make the same change:
https://github.com/mdn/browser-compat-data/pull/3374
