### PR TITLE
Update support of break-before/after/inside properties in Opera

### DIFF
--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -165,8 +165,24 @@
                   "version_added": false
                 },
                 "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
+                "opera": [
+                  {
+                    "version_added": "88"
+                  },
+                  {
+                    "version_added": "11.1",
+                    "version_removed": "12.1"
+                  }
+                ],
+                "opera_android": [
+                  {
+                    "version_added": "70"
+                  },
+                  {
+                    "version_added": "11.1",
+                    "version_removed": "12.1"
+                  }
+                ],
                 "safari": {
                   "version_added": false
                 },
@@ -206,8 +222,24 @@
                   "version_added": "10"
                 },
                 "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
+                "opera": [
+                  {
+                    "version_added": "88"
+                  },
+                  {
+                    "version_added": "11.1",
+                    "version_removed": "12.1"
+                  }
+                ],
+                "opera_android": [
+                  {
+                    "version_added": "70"
+                  },
+                  {
+                    "version_added": "11.1",
+                    "version_removed": "12.1"
+                  }
+                ],
                 "safari": {
                   "version_added": false
                 },

--- a/css/properties/break-before.json
+++ b/css/properties/break-before.json
@@ -165,8 +165,24 @@
                   "version_added": false
                 },
                 "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
+                "opera": [
+                  {
+                    "version_added": "88"
+                  },
+                  {
+                    "version_added": "11.1",
+                    "version_removed": "12.1"
+                  }
+                ],
+                "opera_android": [
+                  {
+                    "version_added": "70"
+                  },
+                  {
+                    "version_added": "11.1",
+                    "version_removed": "12.1"
+                  }
+                ],
                 "safari": {
                   "version_added": false
                 },
@@ -206,8 +222,24 @@
                   "version_added": "10"
                 },
                 "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
+                "opera": [
+                  {
+                    "version_added": "88"
+                  },
+                  {
+                    "version_added": "11.1",
+                    "version_removed": "12.1"
+                  }
+                ],
+                "opera_android": [
+                  {
+                    "version_added": "70"
+                  },
+                  {
+                    "version_added": "11.1",
+                    "version_removed": "12.1"
+                  }
+                ],
                 "safari": {
                   "version_added": false
                 },

--- a/css/properties/break-inside.json
+++ b/css/properties/break-inside.json
@@ -130,8 +130,24 @@
                   "version_added": "10"
                 },
                 "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
+                "opera": [
+                  {
+                    "version_added": "37"
+                  },
+                  {
+                    "version_added": "11.1",
+                    "version_removed": "12.1"
+                  }
+                ],
+                "opera_android": [
+                  {
+                    "version_added": "37"
+                  },
+                  {
+                    "version_added": "11.1",
+                    "version_removed": "12.1"
+                  }
+                ],
                 "safari": {
                   "version_added": "10"
                 },


### PR DESCRIPTION
This is according to the implementer of this:
https://github.com/mdn/browser-compat-data/pull/16628#issuecomment-1153568563
