### PR TITLE
Update IE/Opera/Safari support for <meta http-equiv="refresh">

### DIFF
--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -259,12 +259,16 @@
                 },
                 "firefox_android": "mirror",
                 "ie": {
-                  "version_added": true
+                  "version_added": "≤6"
                 },
-                "opera": "mirror",
-                "opera_android": "mirror",
+                "opera": {
+                  "version_added": "≤12.1"
+                },
+                "opera_android": {
+                  "version_added": "≤12.1"
+                },
                 "safari": {
-                  "version_added": true
+                  "version_added": "1"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
IE support in IE6 (or earlier) confirmed by articles:
https://zoompf.com/blog/2010/03/meta-refresh-nullifies-caching-for-ie6-and-ie7/
https://seclists.org/fulldisclosure/2005/Aug/574

Opera support in 12.16 was confirmed manually.

For Safari, this was in the initial revision of WebKit:
https://github.com/WebKit/WebKit/blob/a063c2b75ddebd1edfe9c54c428d762bdb61f794/WebCore/khtml/html/html_headimpl.cpp#L260
