### PR TITLE
Add Chromium versions for AbortSignal API

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -290,7 +290,7 @@
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-abortsignal-timeout①",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "103"
             },
             "chrome_android": "mirror",
             "deno": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `AbortSignal` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.7).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AbortSignal

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._

Fixes #16793, fixes #16481.