### PR TITLE
FF103 transferrable streams

### DIFF
--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -378,9 +378,7 @@
                 ]
               }
             ],
-            "firefox_android": {
-              "version_added": "mirror"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -365,7 +365,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "103"
               },
               {
                 "version_added": "102",
@@ -379,7 +379,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "mirror"
             },
             "ie": {
               "version_added": false

--- a/api/TransformStream.json
+++ b/api/TransformStream.json
@@ -175,7 +175,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "103"
               },
               {
                 "version_added": "102",
@@ -189,7 +189,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "mirror"
             },
             "ie": {
               "version_added": false

--- a/api/TransformStream.json
+++ b/api/TransformStream.json
@@ -188,9 +188,7 @@
                 ]
               }
             ],
-            "firefox_android": {
-              "version_added": "mirror"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/WritableStream.json
+++ b/api/WritableStream.json
@@ -373,9 +373,7 @@
                 ]
               }
             ],
-            "firefox_android": {
-              "version_added": "mirror"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/WritableStream.json
+++ b/api/WritableStream.json
@@ -360,7 +360,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "103"
               },
               {
                 "version_added": "102",
@@ -374,7 +374,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": false
+              "version_added": "mirror"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
FF103 makes some stream types transferrable by default which were previously behind a pref and on nightly. This just changes nightly to FF103.

The associated bug is https://bugzilla.mozilla.org/show_bug.cgi?id=1770627

Other docs work can be tracked in https://github.com/mdn/content/issues/17472