### PR TITLE
Account for "preview" version in mirroring script

### DIFF
--- a/scripts/release/mirror.ts
+++ b/scripts/release/mirror.ts
@@ -36,6 +36,10 @@ export const getMatchingBrowserVersion = (
   const releaseKeys = Object.keys(browserData.releases);
   releaseKeys.sort(compareVersions);
 
+  if (sourceVersion == 'preview') {
+    return 'preview';
+  }
+
   const range = sourceVersion.includes('≤');
   const sourceRelease =
     browsers[browserData.upstream].releases[sourceVersion.replace('≤', '')];


### PR DESCRIPTION
This PR fixes the mirroring script to handle mirroring when the upstream browser is set to `preview`.  This PR will unblock #16840.  (I'm surprised that this hasn't happened yet.)
