### PR TITLE
Bump all IndexedDB Safari versions to 8 (was 7)

### DIFF
--- a/api/IDBCursor.json
+++ b/api/IDBCursor.json
@@ -56,7 +56,7 @@
             }
           ],
           "safari": {
-            "version_added": "7"
+            "version_added": "8"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -135,7 +135,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -172,7 +172,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -244,7 +244,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -281,7 +281,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -318,7 +318,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -389,7 +389,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -461,7 +461,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -498,7 +498,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/IDBCursorWithValue.json
+++ b/api/IDBCursorWithValue.json
@@ -42,7 +42,7 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": "7"
+            "version_added": "8"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -121,7 +121,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/IDBDatabase.json
+++ b/api/IDBDatabase.json
@@ -42,7 +42,7 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": "7"
+            "version_added": "8"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -121,7 +121,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -197,7 +197,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -234,7 +234,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -271,7 +271,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -308,7 +308,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -345,7 +345,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -382,7 +382,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -423,7 +423,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/IDBFactory.json
+++ b/api/IDBFactory.json
@@ -42,7 +42,7 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": "7"
+            "version_added": "8"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -121,7 +121,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -192,7 +192,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -229,7 +229,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -42,7 +42,7 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": "7"
+            "version_added": "8"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -121,7 +121,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -158,7 +158,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -267,7 +267,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -336,7 +336,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -405,7 +405,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -442,7 +442,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -513,7 +513,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -550,7 +550,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -587,7 +587,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -624,7 +624,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/IDBKeyRange.json
+++ b/api/IDBKeyRange.json
@@ -47,7 +47,7 @@
             }
           ],
           "safari": {
-            "version_added": "7"
+            "version_added": "8"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -126,7 +126,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -196,7 +196,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -233,7 +233,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -270,7 +270,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -307,7 +307,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -344,7 +344,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -381,7 +381,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -418,7 +418,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -42,7 +42,7 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": "7"
+            "version_added": "8"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -121,7 +121,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -156,7 +156,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -193,7 +193,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -230,7 +230,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -267,7 +267,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -304,7 +304,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -341,7 +341,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -378,7 +378,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -524,7 +524,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -561,7 +561,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -598,7 +598,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -635,7 +635,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -706,7 +706,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -747,7 +747,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -784,7 +784,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -821,7 +821,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/IDBOpenDBRequest.json
+++ b/api/IDBOpenDBRequest.json
@@ -42,7 +42,7 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": "7"
+            "version_added": "8"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -125,7 +125,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -166,7 +166,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/IDBRequest.json
+++ b/api/IDBRequest.json
@@ -51,7 +51,7 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": "7"
+            "version_added": "8"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -130,7 +130,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -205,7 +205,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -242,7 +242,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -279,7 +279,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -316,7 +316,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -357,7 +357,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -394,7 +394,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -42,7 +42,7 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": "7"
+            "version_added": "8"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -121,7 +121,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -163,7 +163,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -239,7 +239,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -276,7 +276,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -350,7 +350,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -426,7 +426,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -463,7 +463,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -500,7 +500,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/IDBVersionChangeEvent.json
+++ b/api/IDBVersionChangeEvent.json
@@ -37,7 +37,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "7"
+            "version_added": "8"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -149,7 +149,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -186,7 +186,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/_globals/indexedDB.json
+++ b/api/_globals/indexedDB.json
@@ -33,7 +33,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "7"
+            "version_added": "8"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",


### PR DESCRIPTION
For iOS, this can be confirmed by testing 7 and 8 on BrowserStack:
https://mdn-bcd-collector.appspot.com/tests/api/indexedDB

For desktop, support can be confirmed using the same test in Safari
7.1.8 on OS X 10.9.5. BrowserStack doesn't have Safari 7 for OS X, so
that can't be tested.

This tweet also supports the notion that it was in 7.1:
https://twitter.com/daleharvey/status/456759068053356544

This is also what https://caniuse.com/indexeddb says.

Since BCD doesn't have Safari 7.1, instead use 8, which is the closest
release in terms of date. This avoid the probably-false claim that it
was supported in Safari 7.
