### PR TITLE
Update Safari version for TextTrackList's getTrackById()

### DIFF
--- a/api/TextTrackList.json
+++ b/api/TextTrackList.json
@@ -150,7 +150,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
It was implemented here:
https://github.com/WebKit/WebKit/commit/b195c162a9805acacbb7d32328ba6fbbc1df4453
https://github.com/WebKit/WebKit/blob/b195c162a9805acacbb7d32328ba6fbbc1df4453/Source/WebCore/Configurations/Version.xcconfig

WebKit trunk version 538.8.0 maps to Safari 8 on both macOS and iOS.

Confirmed with tested in iOS 7 and 8:
https://github.com/mdn/browser-compat-data/pull/16594#issuecomment-1178868912

This was last updated based on the collector here:
https://github.com/mdn/browser-compat-data/pull/7929

But that was based on results from Safari 7.1:
https://github.com/foolip/mdn-bcd-results/commit/5067a4ddaffa8a0e4fde6efaf312d1bbd30a69e2
