### PR TITLE
Treat accept_flags as optional (default true) in mirroring

### DIFF
--- a/browsers/oculus.json
+++ b/browsers/oculus.json
@@ -1,7 +1,6 @@
 {
   "browsers": {
     "oculus": {
-      "accepts_flags": true,
       "name": "Oculus Browser",
       "type": "xr",
       "upstream": "chrome_android",

--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -66,7 +66,7 @@
         },
         "accepts_flags": {
           "type": "boolean",
-          "description": "Whether the browser supports flags to enable or disablle features."
+          "description": "Whether the browser supports flags to enable or disable features."
         },
         "accepts_webextensions": {
           "type": "boolean",

--- a/scripts/release/mirror.ts
+++ b/scripts/release/mirror.ts
@@ -355,7 +355,7 @@ export const bumpSupport = (
     newData = bumpGeneric(sourceData, destination, notesRepl);
   }
 
-  if (!browsers[destination].accepts_flags && newData.flags) {
+  if (browsers[destination].accepts_flags === false && newData.flags) {
     // Remove flag data if the target browser doesn't accept flags
     return { version_added: false };
   }


### PR DESCRIPTION
This is how the property is used, with oculus.json being the single
outlier of setting accept_flags to true. In test-versions.js,
`browsers[browser].accepts_flags === false` is used as the condition.

This will allow much more data to be mirrored.
