### PR TITLE
Explicitly set flags/webextensions support for all browsers

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -5,6 +5,7 @@
       "type": "desktop",
       "preview_name": "Canary",
       "pref_url": "chrome://flags",
+      "accepts_flags": true,
       "accepts_webextensions": true,
       "releases": {
         "1": {

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -5,6 +5,8 @@
       "type": "mobile",
       "upstream": "chrome",
       "pref_url": "chrome://flags",
+      "accepts_flags": true,
+      "accepts_webextensions": false,
       "releases": {
         "18": {
           "release_date": "2012-06-27",

--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -3,6 +3,8 @@
     "deno": {
       "name": "Deno",
       "type": "server",
+      "accepts_flags": true,
+      "accepts_webextensions": false,
       "releases": {
         "1.0": {
           "release_date": "2020-05-13",

--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -5,6 +5,7 @@
       "type": "desktop",
       "upstream": "chrome",
       "pref_url": "about:flags",
+      "accepts_flags": true,
       "accepts_webextensions": true,
       "releases": {
         "12": {

--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -5,6 +5,7 @@
       "type": "desktop",
       "preview_name": "Nightly",
       "pref_url": "about:config",
+      "accepts_flags": true,
       "accepts_webextensions": true,
       "releases": {
         "1": {

--- a/browsers/ie.json
+++ b/browsers/ie.json
@@ -3,6 +3,8 @@
     "ie": {
       "name": "Internet Explorer",
       "type": "desktop",
+      "accepts_flags": false,
+      "accepts_webextensions": false,
       "releases": {
         "1": {
           "release_date": "1995-08-16",

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -3,6 +3,8 @@
     "nodejs": {
       "name": "Node.js",
       "type": "server",
+      "accepts_flags": true,
+      "accepts_webextensions": false,
       "releases": {
         "0.10.0": {
           "release_date": "2013-03-11",

--- a/browsers/oculus.json
+++ b/browsers/oculus.json
@@ -1,11 +1,12 @@
 {
   "browsers": {
     "oculus": {
-      "accepts_flags": true,
       "name": "Oculus Browser",
       "type": "xr",
       "upstream": "chrome_android",
       "pref_url": "chrome://flags",
+      "accepts_flags": true,
+      "accepts_webextensions": false,
       "releases": {
         "5.0": {
           "engine": "Blink",

--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -4,6 +4,8 @@
       "name": "Opera",
       "type": "desktop",
       "upstream": "chrome",
+      "pref_url": "opera://flags",
+      "accepts_flags": true,
       "accepts_webextensions": true,
       "releases": {
         "2": {

--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -5,6 +5,7 @@
       "type": "mobile",
       "upstream": "chrome_android",
       "accepts_flags": false,
+      "accepts_webextensions": false,
       "releases": {
         "10.1": {
           "release_date": "2010-11-09",

--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -4,6 +4,7 @@
       "name": "Safari",
       "type": "desktop",
       "preview_name": "TP",
+      "accepts_flags": true,
       "accepts_webextensions": true,
       "releases": {
         "1": {

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -4,6 +4,7 @@
       "name": "Safari on iOS",
       "type": "mobile",
       "upstream": "safari",
+      "accepts_flags": true,
       "accepts_webextensions": true,
       "releases": {
         "1": {

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -5,6 +5,7 @@
       "type": "mobile",
       "upstream": "chrome_android",
       "accepts_flags": false,
+      "accepts_webextensions": false,
       "releases": {
         "1.0": {
           "release_date": "2013-04-27",

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -5,6 +5,7 @@
       "type": "mobile",
       "upstream": "chrome_android",
       "accepts_flags": false,
+      "accepts_webextensions": false,
       "releases": {
         "1": {
           "release_date": "2008-09-23",


### PR DESCRIPTION
This PR explicitly sets whether browsers support flags and/or webextensions, rather than leaving the value blank and allowing the script to assume one or the other.  Mitigates issues such as the one addressed in #16882.