### PR TITLE
Assume "false" for accepts_flags if not specified

### DIFF
--- a/test/linter/test-versions.ts
+++ b/test/linter/test-versions.ts
@@ -225,12 +225,10 @@ function checkVersions(
           }
         }
 
-        if ('flags' in statement) {
-          if (browsers[browser].accepts_flags === false) {
-            logger.error(
-              chalk`This browser ({bold ${browser}}) does not support flags, so support cannot be behind a flag for this feature.`,
-            );
-          }
+        if ('flags' in statement && !browsers[browser].accepts_flags) {
+          logger.error(
+            chalk`This browser ({bold ${browser}}) does not support flags, so support cannot be behind a flag for this feature.`,
+          );
         }
 
         if (hasVersionAddedOnly(statement)) {


### PR DESCRIPTION
This PR updates the flag-preventing linter to assume that `accepts_flags` is `false` if not specified.  This retains consistency with how we treat `accepts_webextensions`.  This PR closes #16882 since the other PR will change our scripts to do the opposite.
