### PR TITLE
Make accepts_flags/webextensions required properties

### DIFF
--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -66,7 +66,7 @@
         },
         "accepts_flags": {
           "type": "boolean",
-          "description": "Whether the browser supports flags to enable or disablle features."
+          "description": "Whether the browser supports user-toggleable flags that enable or disable features."
         },
         "accepts_webextensions": {
           "type": "boolean",
@@ -87,7 +87,13 @@
           "tsType": "{ [version: string]: ReleaseStatement };"
         }
       },
-      "required": ["name", "type", "releases"],
+      "required": [
+        "name",
+        "type",
+        "releases",
+        "accepts_flags",
+        "accepts_webextensions"
+      ],
       "additionalProperties": false
     },
 


### PR DESCRIPTION
This PR makes the `accepts_flags` and `accepts_webextensions` properties in the browser schema required to ensure that there will be no confusion about whether a lack of the variable implies `true` or `false`.  Additionally, this PR fixes a typo in the description for `accepts_flags`, plus adds better wording to clarify its meaning.
