### PR TITLE
WebAssembly.Global - Add implementation note about v128

### DIFF
--- a/javascript/builtins/webassembly/Global.json
+++ b/javascript/builtins/webassembly/Global.json
@@ -51,11 +51,13 @@
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-global-global",
               "support": {
                 "chrome": {
-                  "version_added": "69"
+                  "version_added": "69",
+                  "notes": "Constructing a Global with a value of \"v128\" produces a TypeError."
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": "1.0"
+                  "version_added": "1.0",
+                  "notes": "Constructing a Global with a value of \"v128\" produces a TypeError."
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -66,7 +68,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "11.0.0"
+                  "version_added": "11.0.0",
+                  "notes": "Constructing a Global with a value of \"v128\" produces a TypeError."
                 },
                 "opera": {
                   "version_added": false

--- a/javascript/builtins/webassembly/Global.json
+++ b/javascript/builtins/webassembly/Global.json
@@ -52,12 +52,12 @@
               "support": {
                 "chrome": {
                   "version_added": "69",
-                  "notes": "Constructing a <code>Global</code> with a value of <code>v128</code> produces a TypeError."
+                  "notes": "Constructing a <code>Global</code> with a value of <code>v128</code> produces a <code>TypeError</code>."
                 },
                 "chrome_android": "mirror",
                 "deno": {
                   "version_added": "1.0",
-                  "notes": "Constructing a Global with a value of \"v128\" produces a TypeError."
+                  "notes": "Constructing a <code>Global</code> with a value of <code>v128</code> produces a <code>TypeError</code>."
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -69,7 +69,7 @@
                 },
                 "nodejs": {
                   "version_added": "11.0.0",
-                  "notes": "Constructing a Global with a value of \"v128\" produces a TypeError."
+                  "notes": "Constructing a <code>Global</code> with a value of <code>v128</code> produces a <code>TypeError</code>."
                 },
                 "opera": {
                   "version_added": false

--- a/javascript/builtins/webassembly/Global.json
+++ b/javascript/builtins/webassembly/Global.json
@@ -52,7 +52,7 @@
               "support": {
                 "chrome": {
                   "version_added": "69",
-                  "notes": "Constructing a Global with a value of \"v128\" produces a TypeError."
+                  "notes": "Constructing a <code>Global</code> with a value of <code>v128</code> produces a TypeError."
                 },
                 "chrome_android": "mirror",
                 "deno": {


### PR DESCRIPTION
#### Summary
Moves a note from mdn/content to BCD about the V8 engine not supporting `WebAssembly.Global` with the data type `v128`.

#### Test results and supporting details
This is already claimed by MDN's documentation, but I tested construction of a `Global` object in Chrome, to confirm that it still holds true.

#### Related issues
Fixes #16873
