### PR TITLE
Bump ts-node to 10.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "open-cli": "~7.0.1",
         "ora": "~6.1.0",
         "prettier": "~2.7.0",
-        "ts-node": "github:queengooborg/ts-node#patch-1-built",
+        "ts-node": "~10.8.2",
         "tslib": "~2.4.0",
         "typescript": "~4.7.2",
         "yargs": "~17.5.0"
@@ -5832,10 +5832,10 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "10.8.1",
-      "resolved": "git+ssh://git@github.com/queengooborg/ts-node.git#978ff1f01074e4eececfacf60da254da9028426e",
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.2.tgz",
+      "integrity": "sha512-LYdGnoGddf1D6v8REPtIH+5iq/gTDuZqv2/UJUU7tKjuEU8xVZorBM+buCGNjj+pGEud+sOoM4CX3/YzINpENA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10446,9 +10446,10 @@
       "dev": true
     },
     "ts-node": {
-      "version": "git+ssh://git@github.com/queengooborg/ts-node.git#978ff1f01074e4eececfacf60da254da9028426e",
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.2.tgz",
+      "integrity": "sha512-LYdGnoGddf1D6v8REPtIH+5iq/gTDuZqv2/UJUU7tKjuEU8xVZorBM+buCGNjj+pGEud+sOoM4CX3/YzINpENA==",
       "dev": true,
-      "from": "ts-node@github:queengooborg/ts-node#patch-1-built",
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "open-cli": "~7.0.1",
     "ora": "~6.1.0",
     "prettier": "~2.7.0",
-    "ts-node": "github:queengooborg/ts-node#patch-1-built",
+    "ts-node": "~10.8.2",
     "tslib": "~2.4.0",
     "typescript": "~4.7.2",
     "yargs": "~17.5.0"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
This is a follow-up to #16669. That PR switched BCD to a custom fork of `ts-node` which integrated [a specific patch](https://github.com/mdn/browser-compat-data/pull/16669) for a bug fix in NodeJS 16.15. Now, ts-node 10.8.2 was released and it integrates this fix upstream, so BCD can switch back.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
I produced this patch by:
 1. editing `package.json` to replace `"ts-node": "github:queengooborg/ts-node#patch-1-built",` with `"ts-node": "~10.8.2",`
 2. running `npm i ts-node@~10.8.2` to update `package-lock.json`
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

@queengooborg It might be easier for you to follow the above steps and to produce this patch by yourself in the first place than to verify correctness of `"integrity"` fields. In that case, please do what is easiest to verify and e.g., close this PR and open a different one.

Test: The CI passed when I ran it on NodeJS 16 here: https://github.com/bershanskiy/browser-compat-data/runs/7271084934

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
#16669
#16668
<!-- ✅ After submitting, review the results of the "Checks" tab! -->

