### PR TITLE
FF103 requires secure context for caches

### DIFF
--- a/api/_globals/caches.json
+++ b/api/_globals/caches.json
@@ -38,6 +38,39 @@
           "deprecated": false
         }
       },
+      "secure_context_required": {
+        "__compat": {
+          "description": "Secure context required",
+          "support": {
+            "chrome": {
+              "version_added": "65"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "103"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "11.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "worker_support": {
         "__compat": {
           "description": "Available in workers",


### PR DESCRIPTION
FF103 requires a secure context in order to access the caches global object - https://bugzilla.mozilla.org/show_bug.cgi?id=1112134#c57

Note, there was already a secure context restriction on `CacheStorage` in FF but nothing to stop you getting using `caches` to get this  object- so it was all a bit "unexpected". What I've done is copied this across from CacheStorage to `caches` and updated the version to 103. I tested Chrome and that is indeed also restricting catches from v65. Everything else mirrors. We might add a note to explain why FF103 restricts caches and FF40 restricts CacheStorage if you think it is needed.

Other docs work for this can be tracked in https://github.com/mdn/content/issues/17475 