### PR TITLE
Simplify statements for api.BaseAudioContext.createPeriodicWave

### DIFF
--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -640,24 +640,11 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/createPeriodicWave",
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createperiodicwave",
           "support": {
-            "chrome": [
-              {
-                "version_added": "59",
-                "notes": "Default values supported"
-              },
-              {
-                "version_added": "30"
-              }
-            ],
-            "chrome_android": [
-              {
-                "version_added": "59",
-                "notes": "Default values supported"
-              },
-              {
-                "version_added": "30"
-              }
-            ],
+            "chrome": {
+              "version_added": "30",
+              "notes": "Before Chrome 59, all arguments must be specified."
+            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
@@ -669,34 +656,14 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "17"
-            },
-            "opera_android": {
-              "version_added": "18"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "8"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": [
-              {
-                "version_added": "7.0",
-                "notes": "Default values supported"
-              },
-              {
-                "version_added": "2.0"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "59",
-                "notes": "Default values supported"
-              },
-              {
-                "version_added": "≤37"
-              }
-            ]
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR simplifies the Chromium support statements for `api.BaseAudioContext.createPeriodicWave`.  There is no need to use two separate support statements, as a single note and a single statement is sufficient.
