### PR TITLE
Fix formatting for caches.json

### DIFF
--- a/api/_globals/caches.json
+++ b/api/_globals/caches.json
@@ -46,10 +46,10 @@
               "version_added": "65"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
             "deno": {
               "version_added": false
             },
+            "edge": "mirror",
             "firefox": {
               "version_added": "103"
             },

--- a/api/_globals/caches.json
+++ b/api/_globals/caches.json
@@ -48,7 +48,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "deno": {
-              "version_added": false,
+              "version_added": false
             },
             "firefox": {
               "version_added": "103"


### PR DESCRIPTION
This PR fixes the formatting for the `caches.json` file.  (I'm surprised this didn't fail the linter.)
