### PR TITLE
Catch file read errors

### DIFF
--- a/test/lint.ts
+++ b/test/lint.ts
@@ -63,8 +63,12 @@ const loadAndCheckFiles = async (...files: string[]): Promise<DataType> => {
 
         extend(data, fileData);
       } catch (e) {
-        console.error(`Couldn't load ${filePath.full}!`);
-        console.error(e);
+        linters.messages['File'].push({
+          level: 'error',
+          title: 'File Read Error',
+          path: filePath.full,
+          message: e as string,
+        });
       }
     }
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -216,7 +216,9 @@ export class Linters {
 
   constructor(linters: Array<Linter>) {
     this.linters = linters;
-    this.messages = {};
+    this.messages = {
+      File: [],
+    };
     this.missingExpectedFailures = {};
 
     for (const linter of this.linters) {


### PR DESCRIPTION
This PR updates the linter script to catch JSON syntax errors and report them as a failure.
