### PR TITLE
Updates opera browser to version 89

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -676,19 +676,26 @@
         "88": {
           "release_date": "2022-06-08",
           "release_notes": "https://blogs.opera.com/desktop/2022/06/opera-88-stable/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "102"
         },
         "89": {
-          "status": "beta",
+          "release_date": "2022-07-07",
+          "release_notes": "https://blogs.opera.com/desktop/2022/07/opera-89-stable/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "103"
         },
         "90": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "104"
+        },
+        "91": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "105"
         }
       }
     }


### PR DESCRIPTION
Hello!

According to this [release note](https://blogs.opera.com/desktop/2022/07/opera-89-stable/) opera browser has updated to version 89.

😉