### PR TITLE
Remove incorrect computed aspect ratio data

### DIFF
--- a/html/elements/embed.json
+++ b/html/elements/embed.json
@@ -74,52 +74,6 @@
             }
           }
         },
-        "aspect_ratio_computed_from_attributes": {
-          "__compat": {
-            "description": "Aspect ratio computed from <code>width</code> and <code>height</code> attributes",
-            "support": {
-              "chrome": {
-                "version_added": "79"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "71"
-                },
-                {
-                  "version_added": "69",
-                  "version_removed": "71",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.width-and-height-map-to-aspect-ratio.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "14"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "height": {
           "__compat": {
             "support": {

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -245,52 +245,6 @@
             }
           }
         },
-        "aspect_ratio_computed_from_attributes": {
-          "__compat": {
-            "description": "Aspect ratio computed from <code>width</code> and <code>height</code> attributes",
-            "support": {
-              "chrome": {
-                "version_added": "79"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "71"
-                },
-                {
-                  "version_added": "69",
-                  "version_removed": "71",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.width-and-height-map-to-aspect-ratio.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "14"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "external_protocol_urls_blocked": {
           "__compat": {
             "description": "External protocol URLs blocked",

--- a/html/elements/object.json
+++ b/html/elements/object.json
@@ -70,52 +70,6 @@
             }
           }
         },
-        "aspect_ratio_computed_from_attributes": {
-          "__compat": {
-            "description": "Aspect ratio computed from <code>width</code> and <code>height</code> attributes",
-            "support": {
-              "chrome": {
-                "version_added": "79"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "71"
-                },
-                {
-                  "version_added": "69",
-                  "version_removed": "71",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.width-and-height-map-to-aspect-ratio.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "14"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "border": {
           "__compat": {
             "support": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Computed aspect ratio was never spec'd or implemented for these elements.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://github.com/whatwg/html/issues/4961#issuecomment-539225576 - it was decided that this feature would only apply to `img`, `video`, and `<input type="image">`.
