### PR TITLE
Opera Android 70 is released

### DIFF
--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -387,9 +387,15 @@
         },
         "69": {
           "release_date": "2022-05-09",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "100"
+        },
+        "70": {
+          "release_date": "2022-06-29",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "102"
         }
       }
     }


### PR DESCRIPTION
This PR updates the release data for Opera Android.  The release date comes from UpToDown (https://opera-browser.en.uptodown.com/android/download/75193113), and the Chrome version comes from the user agent string from the browser itself.
