### PR TITLE
Correct support data for gamepad(dis)connected_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -2019,7 +2019,7 @@
                 "version_added": "29",
                 "version_removed": "89",
                 "partial_implementation": true,
-                "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://bugzil.la/1697093'>bug 1697093</a>."
+                "notes": "The <code>ongamepadconnected</code> event handler property is not supported. See <a href='https://bugzil.la/1697093'>bug 1697093</a>."
               }
             ],
             "firefox_android": [
@@ -2030,7 +2030,7 @@
                 "version_added": "32",
                 "version_removed": "89",
                 "partial_implementation": true,
-                "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://bugzil.la/1697093'>bug 1697093</a>."
+                "notes": "The <code>ongamepadconnected</code> event handler property is not supported. See <a href='https://bugzil.la/1697093'>bug 1697093</a>."
               }
             ],
             "ie": {
@@ -2042,7 +2042,7 @@
             "safari": {
               "version_added": "10.1",
               "partial_implementation": true,
-              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://webkit.org/b/223860'>bug 223860</a>."
+              "notes": "The <code>ongamepadconnected</code> event handler property is not supported. See <a href='https://webkit.org/b/223860'>bug 223860</a>."
             },
             "safari_ios": {
               "version_added": false
@@ -2086,7 +2086,7 @@
                 "version_added": "29",
                 "version_removed": "89",
                 "partial_implementation": true,
-                "notes": "The event handler property (<code>ongamepaddisconnected</code>) is not supported; see <a href='https://bugzil.la/1697093'>bug 1697093</a>."
+                "notes": "The <code>ongamepaddisconnected</code> event handler property is not supported. See <a href='https://bugzil.la/1697093'>bug 1697093</a>."
               }
             ],
             "firefox_android": [
@@ -2097,7 +2097,7 @@
                 "version_added": "32",
                 "version_removed": "89",
                 "partial_implementation": true,
-                "notes": "The event handler property (<code>ongamepaddisconnected</code>) is not supported; see <a href='https://bugzil.la/1697093'>bug 1697093</a>."
+                "notes": "The <code>ongamepaddisconnected</code> event handler property is not supported. See <a href='https://bugzil.la/1697093'>bug 1697093</a>."
               }
             ],
             "ie": {
@@ -2109,7 +2109,7 @@
             "safari": {
               "version_added": "10.1",
               "partial_implementation": true,
-              "notes": "The event handler property (<code>ongamepaddisconnected</code>) is not supported; see <a href='https://webkit.org/b/223860'>bug 223860</a>."
+              "notes": "The <code>ongamepaddisconnected</code> event handler property is not supported. See <a href='https://webkit.org/b/223860'>bug 223860</a>."
             },
             "safari_ios": {
               "version_added": false

--- a/api/Window.json
+++ b/api/Window.json
@@ -2017,6 +2017,7 @@
               },
               {
                 "version_added": "29",
+                "version_removed": "89",
                 "partial_implementation": true,
                 "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://bugzil.la/1697093'>bug 1697093</a>."
               }
@@ -2027,6 +2028,7 @@
               },
               {
                 "version_added": "32",
+                "version_removed": "89",
                 "partial_implementation": true,
                 "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://bugzil.la/1697093'>bug 1697093</a>."
               }
@@ -2082,6 +2084,7 @@
               },
               {
                 "version_added": "29",
+                "version_removed": "89",
                 "partial_implementation": true,
                 "notes": "The event handler property (<code>ongamepaddisconnected</code>) is not supported; see <a href='https://bugzil.la/1697093'>bug 1697093</a>."
               }
@@ -2092,6 +2095,7 @@
               },
               {
                 "version_added": "32",
+                "version_removed": "89",
                 "partial_implementation": true,
                 "notes": "The event handler property (<code>ongamepaddisconnected</code>) is not supported; see <a href='https://bugzil.la/1697093'>bug 1697093</a>."
               }

--- a/api/Window.json
+++ b/api/Window.json
@@ -2011,12 +2011,26 @@
               "partial_implementation": true,
               "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
-            "firefox": {
-              "version_added": "29"
-            },
-            "firefox_android": {
-              "version_added": "32"
-            },
+            "firefox": [
+              {
+                "version_added": "89"
+              },
+              {
+                "version_added": "29",
+                "partial_implementation": true,
+                "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://bugzil.la/1697093'>bug 1697093</a>."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "89"
+              },
+              {
+                "version_added": "32",
+                "partial_implementation": true,
+                "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://bugzil.la/1697093'>bug 1697093</a>."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -2024,7 +2038,9 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10.1",
+              "partial_implementation": true,
+              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://webkit.org/b/223860'>bug 223860</a>."
             },
             "safari_ios": {
               "version_added": false
@@ -2060,12 +2076,26 @@
               "partial_implementation": true,
               "notes": "The event handler property (<code>ongamepaddisconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
-            "firefox": {
-              "version_added": "29"
-            },
-            "firefox_android": {
-              "version_added": "32"
-            },
+            "firefox": [
+              {
+                "version_added": "89"
+              },
+              {
+                "version_added": "29",
+                "partial_implementation": true,
+                "notes": "The event handler property (<code>ongamepaddisconnected</code>) is not supported; see <a href='https://bugzil.la/1697093'>bug 1697093</a>."
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "89"
+              },
+              {
+                "version_added": "32",
+                "partial_implementation": true,
+                "notes": "The event handler property (<code>ongamepaddisconnected</code>) is not supported; see <a href='https://bugzil.la/1697093'>bug 1697093</a>."
+              }
+            ],
             "ie": {
               "version_added": false
             },
@@ -2073,7 +2103,9 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10.1",
+              "partial_implementation": true,
+              "notes": "The event handler property (<code>ongamepaddisconnected</code>) is not supported; see <a href='https://webkit.org/b/223860'>bug 223860</a>."
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Correct support data for gamepad(dis)connected_event

Mark Safari support as partial due to it missing the window attributes.

Change Firefox support until version 89 to be partial for the same reason.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://bugs.webkit.org/show_bug.cgi?id=223860 - shows the window attributes have only just been implemented in WebKit so can't be in a Safari release.

https://bugzilla.mozilla.org/show_bug.cgi?id=1697093 - shows the window attributes were implemented in Firefox 89.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
