### PR TITLE
Deno supports Navigator.userAgent

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4356,6 +4356,9 @@
               "version_added": "1"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.22"
+            },
             "edge": {
               "version_added": "12"
             },


### PR DESCRIPTION
This PR adds a version number for Deno for `api.Navigator.userAgent`.  Fixes #16795.
