### PR TITLE
FF102 readable stream releaseLock() rejects pending read requests

### DIFF
--- a/api/ReadableStreamBYOBReader.json
+++ b/api/ReadableStreamBYOBReader.json
@@ -320,6 +320,45 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "reject_pending_read_request": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "notes": "<code>releaseLock()</code> throws if there are pending read requests (rather than pending read requests being rejected)."
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "102"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/api/ReadableStreamDefaultReader.json
+++ b/api/ReadableStreamDefaultReader.json
@@ -250,6 +250,45 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "reject_pending_read_request": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "notes": "<code>releaseLock()</code> throws if there are pending read requests (rather than pending read requests being rejected)."
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "102"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This originates from a review comment from @MattiasBuelens (readable byte stream spec author) in https://github.com/mdn/content/pull/16818#discussion_r914227736<

> As of https://github.com/whatwg/streams/pull/1168, this is no longer a requirement. When calling `releaseLock()`, any outstanding read requests will now be immediately rejected, and a new reader can be acquired later on to read the remaining chunks.
> Note that, at the time of writing, only Firefox has implemented this spec change. Other browsers still throw when calling `releaseLock()` while there are pending reads.

So in essence, from FF102 firefox obeys the spec and rejects pending read requests if releaseLock is called on a reader while there are pending requests. Other browsers will throw in `releaseLock()`.

What I have tried to do here is capture that in a `releaseLock()` subfeature `reject_pending_read_request` adding a note for chrome about the old behaviour. It might be better as a subfeature one level up `releaseLock_reject_pending_read_request` - appreciate your guidance @queengooborg . 