### PR TITLE
Add Firefox Android versions for api.CanvasRenderingContext2D.setTransform.matrix_parameter

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2472,9 +2472,7 @@
               "firefox": {
                 "version_added": "70"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR adds real values for Firefox Android for the `setTransform.matrix_parameter` member of the `CanvasRenderingContext2D` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.8).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CanvasRenderingContext2D/setTransform.matrix_parameter

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
