### PR TITLE
Add Firefox Android versions for api.DOMRectReadOnly.fromRect

### DIFF
--- a/api/DOMRectReadOnly.json
+++ b/api/DOMRectReadOnly.json
@@ -236,9 +236,7 @@
             "firefox": {
               "version_added": "69"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR adds real values for Firefox Android for the `fromRect` member of the `DOMRectReadOnly` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.8).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/DOMRectReadOnly/fromRect

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
