### PR TITLE
NumberFormat/PluralRules updates

### DIFF
--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -654,7 +654,7 @@
                 "deprecated": false
               }
             },
-            "number_param_string_is_decimal": {
+            "number_parameter.string_decimal": {
               "__compat": {
                 "description": "<code>number</code> param string value is decimal (not <code>Number</code>)",
                 "support": {

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -908,6 +908,44 @@
                 "standard_track": true,
                 "deprecated": false
               }
+            },
+            "result_useGrouping_property": {
+              "__compat": {
+                "description": "The result <code>useGrouping</code> parameter may contain <code>'always'</code>, ode>'auto'</code>, <code>'min2'</code>, <code>true</code> and <code>false</code> (previous versions may only ntain <code>true</code> and <code>false</code>)",
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "preview"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": false
+                  },
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
             }
           },
           "supportedLocalesOf": {

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -859,44 +859,6 @@
                 "experimental": false,
                 "standard_track": true,
                 "deprecated": false
-              },
-              "result_useGrouping_property": {
-                "__compat": {
-                  "description": "The result property <code>useGrouping</code> may contain <code>'always'</code>, <code>'auto'</code>, <code>'min2'</code>, <code>true</code> and <code>false</code> (previous versions may only contain <code>true</code> and <code>false</code>)",
-                  "support": {
-                    "chrome": {
-                      "version_added": false
-                    },
-                    "chrome_android": "mirror",
-                    "deno": {
-                      "version_added": false
-                    },
-                    "edge": "mirror",
-                    "firefox": {
-                      "version_added": "preview"
-                    },
-                    "firefox_android": "mirror",
-                    "ie": {
-                      "version_added": false
-                    },
-                    "nodejs": {
-                      "version_added": false
-                    },
-                    "opera": "mirror",
-                    "opera_android": "mirror",
-                    "safari": {
-                      "version_added": false
-                    },
-                    "safari_ios": "mirror",
-                    "samsunginternet_android": "mirror",
-                    "webview_android": "mirror"
-                  },
-                  "status": {
-                    "experimental": true,
-                    "standard_track": true,
-                    "deprecated": false
-                  }
-                }
               }
             }
           },

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -653,6 +653,43 @@
                 "standard_track": true,
                 "deprecated": false
               }
+            },
+            "number_param_string_is_decimal": {
+              "__compat": {
+                "description": "<code>number</code> param string value is decimal (not <code>Number</code>)",
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": "mirror",
+                  "deno": "mirror",
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "preview"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": false
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
             }
           },
           "formatRange": {

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -859,6 +859,44 @@
                 "experimental": false,
                 "standard_track": true,
                 "deprecated": false
+              },
+              "result_useGrouping_property": {
+                "__compat": {
+                  "description": "The result <code>useGrouping</code> parameter may contain <code>'always'</code>, <code>'auto'</code>, <code>'min2'</code>, <code>true</code> and <code>false</code> (previous versions may only contain <code>true</code> and <code>false</code>)",
+                  "support": {
+                    "chrome": {
+                      "version_added": false
+                    },
+                    "chrome_android": "mirror",
+                    "deno": {
+                      "version_added": false
+                    },
+                    "edge": "mirror",
+                    "firefox": {
+                      "version_added": "preview"
+                    },
+                    "firefox_android": "mirror",
+                    "ie": {
+                      "version_added": false
+                    },
+                    "nodejs": {
+                      "version_added": false
+                    },
+                    "opera": "mirror",
+                    "opera_android": "mirror",
+                    "safari": {
+                      "version_added": false
+                    },
+                    "safari_ios": "mirror",
+                    "samsunginternet_android": "mirror",
+                    "webview_android": "mirror"
+                  },
+                  "status": {
+                    "experimental": true,
+                    "standard_track": true,
+                    "deprecated": false
+                  }
+                }
               }
             }
           },

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -862,7 +862,7 @@
               },
               "result_useGrouping_property": {
                 "__compat": {
-                  "description": "The result <code>useGrouping</code> parameter may contain <code>'always'</code>, <code>'auto'</code>, <code>'min2'</code>, <code>true</code> and <code>false</code> (previous versions may only contain <code>true</code> and <code>false</code>)",
+                  "description": "The result property <code>useGrouping</code> may contain <code>'always'</code>, <code>'auto'</code>, <code>'min2'</code>, <code>true</code> and <code>false</code> (previous versions may only contain <code>true</code> and <code>false</code>)",
                   "support": {
                     "chrome": {
                       "version_added": false

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -571,6 +571,7 @@
             },
             "options_useGrouping_parameter": {
               "__compat": {
+                "description": "<code>options.useGrouping</code> parameter",
                 "support": {
                   "chrome": {
                     "version_added": "24"

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -616,7 +616,7 @@
                   "deprecated": false
                 }
               },
-              "options_useGrouping_parameter.string_values": {
+              "options_useGrouping_parameter-string_values": {
                 "__compat": {
                   "description": "<code>options.useGrouping</code> parameter accepts: <code>'always'</code>, <code>'auto'</code>, <code>'min2'</code> (in addition to: <code>true</code> and <code>false</code>)",
                   "support": {
@@ -702,7 +702,7 @@
                 "deprecated": false
               }
             },
-            "number_parameter.string_decimal": {
+            "number_parameter-string_decimal": {
               "__compat": {
                 "description": "<code>number</code> param string value is decimal (not <code>Number</code>)",
                 "support": {

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -571,7 +571,7 @@
             },
             "options_useGrouping_parameter": {
               "__compat": {
-                "description": "<code>options.useGrouping</code> parameter",
+                "description": "<code>options.useGrouping</code> parameter accepts: <code>'always'</code>, <code>'auto'</code>, <code>'min2'</code> (as well as <code>true</code> and <code>false</code>)",
                 "support": {
                   "chrome": {
                     "version_added": false
@@ -662,7 +662,9 @@
                     "version_added": false
                   },
                   "chrome_android": "mirror",
-                  "deno": "mirror",
+                  "deno": {
+                    "version_added": false
+                  },
                   "edge": "mirror",
                   "firefox": {
                     "version_added": "preview"

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -571,39 +571,87 @@
             },
             "options_useGrouping_parameter": {
               "__compat": {
-                "description": "<code>options.useGrouping</code> parameter accepts: <code>'always'</code>, <code>'auto'</code>, <code>'min2'</code> (as well as <code>true</code> and <code>false</code>)",
                 "support": {
                   "chrome": {
-                    "version_added": false
+                    "version_added": "24"
                   },
                   "chrome_android": "mirror",
                   "deno": {
-                    "version_added": false
+                    "version_added": "1.8"
                   },
-                  "edge": "mirror",
+                  "edge": {
+                    "version_added": "12"
+                  },
                   "firefox": {
-                    "version_added": "preview"
+                    "version_added": "29"
                   },
-                  "firefox_android": "mirror",
+                  "firefox_android": {
+                    "version_added": "56"
+                  },
                   "ie": {
-                    "version_added": false
+                    "version_added": "11"
                   },
-                  "nodejs": {
-                    "version_added": false
-                  },
+                  "nodejs": [
+                    {
+                      "version_added": "13.0.0"
+                    },
+                    {
+                      "version_added": "0.12.0",
+                      "partial_implementation": true,
+                      "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>NumberFormat</code> instance silently falls back to <code>en-US</code>. To make full ICU (locale) data available before version 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
+                    }
+                  ],
                   "opera": "mirror",
                   "opera_android": "mirror",
                   "safari": {
-                    "version_added": false
+                    "version_added": "10"
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
                   "webview_android": "mirror"
                 },
                 "status": {
-                  "experimental": true,
+                  "experimental": false,
                   "standard_track": true,
                   "deprecated": false
+                }
+              },
+              "options_useGrouping_parameter.string_values": {
+                "__compat": {
+                  "description": "<code>options.useGrouping</code> parameter accepts: <code>'always'</code>, <code>'auto'</code>, <code>'min2'</code> (in addition to: <code>true</code> and <code>false</code>)",
+                  "support": {
+                    "chrome": {
+                      "version_added": false
+                    },
+                    "chrome_android": "mirror",
+                    "deno": {
+                      "version_added": false
+                    },
+                    "edge": "mirror",
+                    "firefox": {
+                      "version_added": "preview"
+                    },
+                    "firefox_android": "mirror",
+                    "ie": {
+                      "version_added": false
+                    },
+                    "nodejs": {
+                      "version_added": false
+                    },
+                    "opera": "mirror",
+                    "opera_android": "mirror",
+                    "safari": {
+                      "version_added": false
+                    },
+                    "safari_ios": "mirror",
+                    "samsunginternet_android": "mirror",
+                    "webview_android": "mirror"
+                  },
+                  "status": {
+                    "experimental": true,
+                    "standard_track": true,
+                    "deprecated": false
+                  }
                 }
               }
             }

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -669,7 +669,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "preview"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -709,7 +709,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "preview"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/intl/NumberFormat.json
+++ b/javascript/builtins/intl/NumberFormat.json
@@ -616,7 +616,7 @@
                   "deprecated": false
                 }
               },
-              "options_useGrouping_parameter-string_values": {
+              "string_values": {
                 "__compat": {
                   "description": "<code>options.useGrouping</code> parameter accepts: <code>'always'</code>, <code>'auto'</code>, <code>'min2'</code> (in addition to: <code>true</code> and <code>false</code>)",
                   "support": {

--- a/javascript/builtins/intl/PluralRules.json
+++ b/javascript/builtins/intl/PluralRules.json
@@ -194,7 +194,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "preview"
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
FF supports a number of `Intl.NumberFormat` items in nightly from https://bugzilla.mozilla.org/show_bug.cgi?id=1648137

This includes:
- `Intl.NumberFormat.format()` - subfeature `number_param_string_is_decimal` to reflect spec update that strings are treated as  Decimal rather than Number - see https://github.com/tc39/proposal-intl-numberformat-v3#interpret-strings-as-decimals-ecma-402-334
- `Intl.NumberFormat.formatRange()`
- `Intl.NumberFormat.formatRangeToParts()`
- `Intl.PluralRules.selectRange()` 
