### PR TITLE
Update SVGAnimatedNumber support in IE/Edge

### DIFF
--- a/api/SVGAnimatedNumber.json
+++ b/api/SVGAnimatedNumber.json
@@ -51,13 +51,15 @@
               "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
               "version_added": "1.5"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
             "oculus": "mirror",
             "opera": {
@@ -92,13 +94,15 @@
               "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": {
               "version_added": "1.5"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": false
+              "version_added": "9"
             },
             "oculus": "mirror",
             "opera": {


### PR DESCRIPTION
Part of https://github.com/mdn/browser-compat-data/pull/6526.

Confirmed in IE9 by evaluating this JS:

> document.createElementNS('http://www.w3.org/2000/svg', 'stop').offset
