### PR TITLE
Remove api.CloseEvent.initCloseEvent from BCD

### DIFF
--- a/api/CloseEvent.json
+++ b/api/CloseEvent.json
@@ -135,46 +135,6 @@
           }
         }
       },
-      "initCloseEvent": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CloseEvent/initCloseEvent",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "deno": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": "12",
-              "version_removed": "79"
-            },
-            "firefox": {
-              "version_added": "8",
-              "version_removed": "41"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "reason": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CloseEvent/reason",


### PR DESCRIPTION
This PR removes the irrelevant `initCloseEvent` member of the `CloseEvent` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features). The lack of current support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.8), even if the current BCD suggests support.
