### PR TITLE
Update Safari versions for api.CanvasRenderingContext2D.drawFocusIfNeeded.path_parameter

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -718,7 +718,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "9"
+                "version_added": "8"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `drawFocusIfNeeded.path_parameter` member of the `CanvasRenderingContext2D` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.8).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CanvasRenderingContext2D/drawFocusIfNeeded.path_parameter

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
