### PR TITLE
Update Firefox versions for api.FetchEvent.preloadResponse

### DIFF
--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -208,7 +208,7 @@
               "version_added": "18"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "99"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `preloadResponse` member of the `FetchEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.8).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FetchEvent/preloadResponse

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
