### PR TITLE
Update Safari versions for api.FontFace.variant

### DIFF
--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -550,7 +550,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "10",
+              "version_removed": "13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `variant` member of the `FontFace` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.8).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/FontFace/variant

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
