### PR TITLE
Update Firefox versions for Gamepad API

### DIFF
--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -291,7 +291,7 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "56"
+              "version_added": "55"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -328,7 +328,7 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "56"
+              "version_added": "55"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -479,7 +479,7 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "56"
+              "version_added": "55"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `Gamepad` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.8).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Gamepad

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
