### PR TITLE
Update Firefox versions for api.GamepadButton.touched

### DIFF
--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -128,7 +128,7 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "56"
+              "version_added": "55"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `touched` member of the `GamepadButton` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.8).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/GamepadButton/touched

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
