### PR TITLE
Update Chromium versions for fetchPriority members

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -399,10 +399,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLImageElement/fetchPriority",
           "spec_url": "https://wicg.github.io/priority-hints/#img",
           "support": {
-            "chrome": {
-              "version_added": "101",
-              "alternative_name": "fetchpriority"
-            },
+            "chrome": [
+              {
+                "version_added": "102"
+              },
+              {
+                "version_added": "101",
+                "alternative_name": "fetchpriority"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -413,19 +418,13 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -405,6 +405,7 @@
               },
               {
                 "version_added": "101",
+                "version_removed": "102",
                 "alternative_name": "fetchpriority"
               }
             ],

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -206,10 +206,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/fetchPriority",
           "spec_url": "https://wicg.github.io/priority-hints/#link",
           "support": {
-            "chrome": {
-              "version_added": "101",
-              "alternative_name": "fetchpriority"
-            },
+            "chrome": [
+              {
+                "version_added": "102"
+              },
+              {
+                "version_added": "101",
+                "alternative_name": "fetchpriority"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -220,19 +225,13 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -212,6 +212,7 @@
               },
               {
                 "version_added": "101",
+                "version_removed": "102",
                 "alternative_name": "fetchpriority"
               }
             ],

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -247,6 +247,7 @@
               },
               {
                 "version_added": "101",
+                "version_removed": "102",
                 "alternative_name": "fetchpriority"
               }
             ],

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -241,10 +241,15 @@
         "__compat": {
           "spec_url": "https://wicg.github.io/priority-hints/#script",
           "support": {
-            "chrome": {
-              "version_added": "101",
-              "alternative_name": "fetchpriority"
-            },
+            "chrome": [
+              {
+                "version_added": "102"
+              },
+              {
+                "version_added": "101",
+                "alternative_name": "fetchpriority"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -255,19 +260,13 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `fetchPriority` member of the `HTMLImageElement`, `HTMLLinkElement` and `HTMLScriptElement APIs, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.8).

Tests Used:
https://mdn-bcd-collector.appspot.com/tests/api/HTMLImageElement/fetchPriority
https://mdn-bcd-collector.appspot.com/tests/api/HTMLLinkElement/fetchPriority
https://mdn-bcd-collector.appspot.com/tests/api/HTMLScriptElement/fetchPriority

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
