### PR TITLE
Update Chromium versions for HTMLMediaElement API

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -493,7 +493,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/controller",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "17",
+              "version_removed": "36"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -1498,7 +1499,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mediaGroup",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "17",
+              "version_removed": "36"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `HTMLMediaElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.8).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLMediaElement

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
