### PR TITLE
Add Opera versions for api.HTMLObjectElement.contentWindow

### DIFF
--- a/api/HTMLObjectElement.json
+++ b/api/HTMLObjectElement.json
@@ -399,12 +399,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "13"
             },


### PR DESCRIPTION
This PR adds real values for Opera and Opera Android for the `contentWindow` member of the `HTMLObjectElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.8).  The collector obtains results based upon Opera Desktop 12.16 and 15, as well as the latest version of Opera Desktop and Opera Android.  Version numbers are then copied for Blink-based Opera versions from Chrome Desktop and Android respectively.

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLObjectElement/contentWindow

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
