### PR TITLE
Update Firefox versions for api.ImageBitmapRenderingContext.transferFromImageBitmap

### DIFF
--- a/api/ImageBitmapRenderingContext.json
+++ b/api/ImageBitmapRenderingContext.json
@@ -82,7 +82,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "52"
+                "version_added": "50"
               },
               {
                 "version_added": "46",


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `transferFromImageBitmap` member of the `ImageBitmapRenderingContext` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.8).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ImageBitmapRenderingContext/transferFromImageBitmap

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
