### PR TITLE
Update Firefox Android versions for MimeType API

### DIFF
--- a/api/MimeType.json
+++ b/api/MimeType.json
@@ -15,9 +15,7 @@
           "firefox": {
             "version_added": "1"
           },
-          "firefox_android": {
-            "version_added": false
-          },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": "11"
           },
@@ -59,9 +57,7 @@
             "firefox": {
               "version_added": "1"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "11"
             },
@@ -104,9 +100,7 @@
             "firefox": {
               "version_added": "1"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "11"
             },
@@ -149,9 +143,7 @@
             "firefox": {
               "version_added": "1"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "11"
             },
@@ -194,9 +186,7 @@
             "firefox": {
               "version_added": "1"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "11"
             },


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox Android for the `MimeType` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.8).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MimeType

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
