### PR TITLE
Add Firefox versions for api.MouseEvent.region

### DIFF
--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -892,21 +892,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "32"
-              },
-              {
-                "version_added": "30",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "canvas.hitregions.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "32"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -892,16 +892,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "30",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "canvas.hitregions.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "32"
+              },
+              {
+                "version_added": "30",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "canvas.hitregions.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `region` member of the `MouseEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.8).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MouseEvent/region

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
