### PR TITLE
Update WebView versions for api.NetworkInformation.typechange_event

### DIFF
--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -437,7 +437,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "50"
             }
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for WebView Android for the `typechange_event` member of the `NetworkInformation` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.8).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/NetworkInformation/typechange_event

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
