### PR TITLE
Update Samsung Internet versions for PublicKeyCredential API

### DIFF
--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -39,9 +39,7 @@
             "version_added": "13"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": {
-            "version_added": false
-          },
+          "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false
           }
@@ -91,9 +89,7 @@
               "version_added": "13"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
             }
@@ -144,9 +140,7 @@
               "version_added": "13"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
             }
@@ -197,9 +191,7 @@
               "version_added": "13"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
             }
@@ -250,9 +242,7 @@
               "version_added": "13"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
             }


### PR DESCRIPTION
This PR updates and corrects the real values for Samsung Internet for the `PublicKeyCredential` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.8).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PublicKeyCredential

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
