### PR TITLE
Update Edge versions for RTCDtlsTransport API

### DIFF
--- a/api/RTCDtlsTransport.json
+++ b/api/RTCDtlsTransport.json
@@ -130,6 +130,7 @@
               },
               {
                 "version_added": "15",
+                "version_removed": "79",
                 "alternative_name": "transport"
               }
             ],

--- a/api/RTCDtlsTransport.json
+++ b/api/RTCDtlsTransport.json
@@ -215,6 +215,7 @@
               },
               {
                 "version_added": "12",
+                "version_removed": "79",
                 "alternative_name": "dtlsstatechange"
               }
             ],

--- a/api/RTCDtlsTransport.json
+++ b/api/RTCDtlsTransport.json
@@ -124,10 +124,15 @@
               "version_added": "72"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "15",
-              "alternative_name": "transport"
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "15",
+                "alternative_name": "transport"
+              }
+            ],
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
@@ -203,10 +208,15 @@
               "version_added": "72"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "12",
-              "alternative_name": "dtlsstatechange"
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "alternative_name": "dtlsstatechange"
+              }
+            ],
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `RTCDtlsTransport` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.8).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/RTCDtlsTransport

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
