### PR TITLE
Update Chromium versions for api.SVGImageElement.decode

### DIFF
--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -84,7 +84,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-decode-dev",
           "support": {
             "chrome": {
-              "version_added": "65"
+              "version_added": "64"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `decode` member of the `SVGImageElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.8).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGImageElement/decode

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
