### PR TITLE
Update Firefox Android versions for crossOriginIsolated API

### DIFF
--- a/api/_globals/crossOriginIsolated.json
+++ b/api/_globals/crossOriginIsolated.json
@@ -16,9 +16,7 @@
           "firefox": {
             "version_added": "72"
           },
-          "firefox_android": {
-            "version_added": false
-          },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -60,9 +58,7 @@
             "firefox": {
               "version_added": "72"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox Android for the `crossOriginIsolated` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.8).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/crossOriginIsolated

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
