### PR TITLE
Update Opera versions for structuredClone API

### DIFF
--- a/api/_globals/structuredClone.json
+++ b/api/_globals/structuredClone.json
@@ -37,9 +37,7 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": {
-            "version_added": false
-          },
+          "opera_android": "mirror",
           "safari": {
             "version_added": "15.4"
           },


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `structuredClone` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.8).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/structuredClone

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
