### PR TITLE
Update css/at-rules/import spec URL

### DIFF
--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>@import</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@import",
-          "spec_url": "https://www.w3.org/TR/css-cascade-5/#at-import",
+          "spec_url": "https://drafts.csswg.org/css-cascade-5/#at-import",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
This should be using the drafts.csswg.org URL rather than the www.w3.org/TR URL.
