### PR TITLE
Add spec URL for Selection.prototype.modify

### DIFF
--- a/api/Selection.json
+++ b/api/Selection.json
@@ -760,6 +760,7 @@
       "modify": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Selection/modify",
+          "spec_url": "https://w3c.github.io/selection-api/#dom-selection-modify",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -785,7 +786,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
This was just spec'd in https://github.com/w3c/selection-api/pull/157.
