### PR TITLE
Add Chrome/Safari version for AbortSignal.abort() reason parameter

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -88,7 +88,7 @@
             "spec_url": "https://dom.spec.whatwg.org/#abortsignal-abort-reason",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "98"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -109,14 +109,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
Implemented in Chromium M98:
https://storage.googleapis.com/chromium-find-releases-static/155.html#155b2353a12c9e0173b8d33b32b115a2406a8131

Implemented in WebKit trunk version 613.1.8:
https://github.com/WebKit/WebKit/commit/d354a8d80fbd702d13ea293d1462b19e2652ef66
https://github.com/WebKit/WebKit/blob/d354a8d80fbd702d13ea293d1462b19e2652ef66/Source/WebCore/Configurations/Version.xcconfig

The data now fully matches api.AbortSignal.reason (the property).
