### PR TITLE
Bump support of element.matches() from Safari 7 to 8

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -3553,7 +3553,7 @@
             ],
             "safari": [
               {
-                "version_added": "7"
+                "version_added": "8"
               },
               {
                 "version_added": "5",


### PR DESCRIPTION
Implemented in WebKit trunk version 538.31:
https://github.com/WebKit/WebKit/commit/75277039772bf5f7151950351058b3fb7ec6637f
https://github.com/WebKit/WebKit/blob/75277039772bf5f7151950351058b3fb7ec6637f/Source/WebCore/Configurations/Version.xcconfig

This maps to Safari/iOS 8.

Support in iOS 8 (but not 7) was confirmed with this test:
http://mdn-bcd-collector.appspot.com/tests/api/Element/matches

It's also supported in Safari 7.1 on OS X 10.9.5, which we map to Safari
8 per the backported releases guidline:
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#backported-releases
