### PR TITLE
Bump Safari support for background-repeat round and space keywords

### DIFF
--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -109,7 +109,7 @@
               ],
               "opera_android": "mirror",
               "safari": {
-                "version_added": "7"
+                "version_added": "8"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
The original 7 was based on commit dates:
https://github.com/mdn/browser-compat-data/pull/4337

The commits in question were in WebKit trunk version 538.1:
https://github.com/WebKit/WebKit/commit/35a4cb02118dcf9b59d24eea302be5a3aeaa46f2
https://github.com/WebKit/WebKit/blob/35a4cb02118dcf9b59d24eea302be5a3aeaa46f2/Source/WebCore/Configurations/Version.xcconfig
https://github.com/WebKit/WebKit/commit/611d1979098926c1ac674a0a6a08e592bb2127e5
https://github.com/WebKit/WebKit/blob/611d1979098926c1ac674a0a6a08e592bb2127e5/Source/WebCore/Configurations/Version.xcconfig

That maps to Safari 8.
