### PR TITLE
Fix Safari support for sizes/srcset attributes/properties

### DIFF
--- a/api/HTMLSourceElement.json
+++ b/api/HTMLSourceElement.json
@@ -141,7 +141,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10.1",
+              "notes": "The <a href='https://developer.mozilla.org/docs/Web/HTML/Element/source#attr-sizes'><code>sizes</code> attribute is supported since Safari 9.1."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -219,7 +220,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10.1",
+              "notes": "The <a href='https://developer.mozilla.org/docs/Web/HTML/Element/source#attr-srcset'><code>srcset</code> attribute is supported since Safari 9.1."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/HTMLSourceElement.json
+++ b/api/HTMLSourceElement.json
@@ -142,7 +142,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "10.1",
-              "notes": "The <a href='https://developer.mozilla.org/docs/Web/HTML/Element/source#attr-sizes'><code>sizes</code> attribute is supported since Safari 9.1."
+              "notes": "The <a href='https://developer.mozilla.org/docs/Web/HTML/Element/source#attr-sizes'><code>sizes</code></a> attribute is supported since Safari 9.1."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -221,7 +221,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "10.1",
-              "notes": "The <a href='https://developer.mozilla.org/docs/Web/HTML/Element/source#attr-srcset'><code>srcset</code> attribute is supported since Safari 9.1."
+              "notes": "The <a href='https://developer.mozilla.org/docs/Web/HTML/Element/source#attr-srcset'><code>srcset</code></a> attribute is supported since Safari 9.1."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -100,16 +100,9 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": [
-                {
-                  "version_added": "9"
-                },
-                {
-                  "version_added": "7",
-                  "partial_implementation": true,
-                  "notes": "Supports a subset of the syntax for resolution switching (using the <code>x</code> descriptor), but not the full syntax that can be used with <code>sizes</code> (using the <code>w</code> descriptor)."
-                }
-              ],
+              "safari": {
+                "version_added": "9.1"
+              },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": [
@@ -193,16 +186,9 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": [
-                {
-                  "version_added": "9"
-                },
-                {
-                  "version_added": "7",
-                  "partial_implementation": true,
-                  "notes": "Supports a subset of the syntax for resolution switching (using the <code>x</code> descriptor), but not the full syntax that can be used with <code>sizes</code> (using the <code>w</code> descriptor)."
-                }
-              ],
+              "safari": {
+                "version_added": "9.1"
+              },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": [


### PR DESCRIPTION
The `<picture>` element was in WebKit trunk version 602.1.14:
https://github.com/WebKit/WebKit/commit/ee1f2663e07eb21f6ea8e0b0d01fce127d66e9a7
https://github.com/WebKit/WebKit/blob/ee1f2663e07eb21f6ea8e0b0d01fce127d66e9a7/Source/WebCore/Configurations/Version.xcconfig

The reflected properties were in WebKit trunk version 603.1.6:
https://github.com/WebKit/WebKit/commit/96c370b3601a5427ba1a4dd2ef78657d59729721
https://github.com/WebKit/WebKit/blob/96c370b3601a5427ba1a4dd2ef78657d59729721/Source/WebCore/Configurations/Version.xcconfig

Add notes to reflect the discrepancy, in case we try to merge attributes
and reflected properties in the future.
