### PR TITLE
Remove api.SVGImageElement.crossOrigin from BCD

### DIFF
--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -43,40 +43,6 @@
           "deprecated": false
         }
       },
-      "crossOrigin": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLImageElement/crossOrigin",
-          "spec_url": "https://svgwg.org/svg2-draft/embedded.html#__svg__SVGImageElement__crossOrigin",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "decode": {
         "__compat": {
           "description": "<code>decode()</code>",


### PR DESCRIPTION
This PR removes the irrelevant `crossOrigin` member of the `SVGImageElement` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features). The lack of current support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.8), even if the current BCD suggests support.
