### PR TITLE
Demix loadend event from GlobalEventHandlers

### DIFF
--- a/api/GlobalEventHandlers.json
+++ b/api/GlobalEventHandlers.json
@@ -877,40 +877,6 @@
           }
         }
       },
-      "onloadend": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onloadend",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "52",
-              "notes": "See <a href='https://bugzil.la/1574487'>bug 1574487</a>."
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "onloadstart": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onloadstart",


### PR DESCRIPTION
This PR demixes the `loadend` event from the GlobalEventHandlers mixin.
