### PR TITLE
Mirror WorkerGlobalScope for Chrome Android

### DIFF
--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -91,9 +91,7 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": {
-              "version_added": "40"
-            },
+            "chrome_android": "mirror",
             "deno": {
               "version_added": "1.0"
             },
@@ -223,9 +221,7 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": {
-              "version_added": "40"
-            },
+            "chrome_android": "mirror",
             "deno": {
               "version_added": false
             },
@@ -268,9 +264,7 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": {
-              "version_added": "40"
-            },
+            "chrome_android": "mirror",
             "deno": {
               "version_added": "1.7"
             },
@@ -315,9 +309,7 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": {
-              "version_added": "40"
-            },
+            "chrome_android": "mirror",
             "deno": {
               "version_added": "1.8"
             },
@@ -440,9 +432,7 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": {
-              "version_added": "40"
-            },
+            "chrome_android": "mirror",
             "deno": {
               "version_added": "1.0"
             },


### PR DESCRIPTION
The 40 versions are from a wiki migration PR:
https://github.com/mdn/browser-compat-data/pull/982

This data is not plausible, as the data for Worker and
DedicatedWorkerGlobalScope is mirrored from Chrome 4.