### PR TITLE
Reflect referrerPolicy property capitalization mishap

### DIFF
--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -281,9 +281,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/referrerPolicy",
           "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#dom-a-referrerpolicy",
           "support": {
-            "chrome": {
-              "version_added": "53"
-            },
+            "chrome": [
+              {
+                "version_added": "52"
+              },
+              {
+                "alternative_name": "referrerpolicy",
+                "version_added": "51",
+                "version_removed": "52"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -300,9 +307,7 @@
               "version_added": "14"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "7.2"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -239,9 +239,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/referrerPolicy",
           "spec_url": "https://html.spec.whatwg.org/multipage/image-maps.html#dom-area-referrerpolicy",
           "support": {
-            "chrome": {
-              "version_added": "53"
-            },
+            "chrome": [
+              {
+                "version_added": "52"
+              },
+              {
+                "alternative_name": "referrerpolicy",
+                "version_added": "51",
+                "version_removed": "52"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -258,9 +265,7 @@
               "version_added": "14.1"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "7.2"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -755,9 +755,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/referrerPolicy",
           "spec_url": "https://html.spec.whatwg.org/multipage/iframe-embed-object.html#dom-iframe-referrerpolicy",
           "support": {
-            "chrome": {
-              "version_added": "53"
-            },
+            "chrome": [
+              {
+                "version_added": "52"
+              },
+              {
+                "alternative_name": "referrerpolicy",
+                "version_added": "51",
+                "version_removed": "52"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -768,9 +775,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "38"
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": "14"

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -808,9 +808,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLImageElement/referrerPolicy",
           "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-referrerpolicy",
           "support": {
-            "chrome": {
-              "version_added": "53"
-            },
+            "chrome": [
+              {
+                "version_added": "52"
+              },
+              {
+                "alternative_name": "referrerpolicy",
+                "version_added": "51",
+                "version_removed": "52"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
Initial support for the attributes and all-lowercase properties in M51:
https://storage.googleapis.com/chromium-find-releases-static/b5b.html#b5b0ec361f1cc8603d0d772e5cbb7490a0badad8

The capitalization was fixed and backported to M52:
https://storage.googleapis.com/chromium-find-releases-static/3c3.html#3c3b9e79b591bdf2fdea29c1f44f455f124f2539
