### PR TITLE
Update Chromium versions for Object.is

### DIFF
--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -917,7 +917,7 @@
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.is",
             "support": {
               "chrome": {
-                "version_added": "30"
+                "version_added": "19"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -944,9 +944,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
Chrome 19 confirmed with this test in BrowserStack:
http://mdn-bcd-collector.appspot.com/tests/javascript/builtins/Object/is

Part of https://github.com/mdn/browser-compat-data/pull/6526.
