### PR TITLE
Update Chromium versions of ClipboardEvent

### DIFF
--- a/api/ClipboardEvent.json
+++ b/api/ClipboardEvent.json
@@ -6,7 +6,7 @@
         "spec_url": "https://w3c.github.io/clipboard-apis/#clipboard-event-interfaces",
         "support": {
           "chrome": {
-            "version_added": "58"
+            "version_added": "41"
           },
           "chrome_android": "mirror",
           "edge": {
@@ -78,7 +78,7 @@
           "spec_url": "https://w3c.github.io/clipboard-apis/#clipboardevent-clipboarddata",
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": "41"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This interface was introduced here:
https://chromium.googlesource.com/chromium/src/+/23bcb1aea137d5cbb147cf9cebe1c85c3c34df95

Mapping by date using https://www.chromium.org/developers/calendar/
suggests Chromium M41.

Chrome 41 was confirmed with this test on BrowserStack:
http://mdn-bcd-collector.appspot.com/tests/api/ClipboardEvent

Note that while the interface didn't exist before this time, the
clipboardData property did on Event, using custom bindings. This isn't
represented in any way in the data, but could be using
partial_implementation ranges.
