### PR TITLE
Move Content-Security-Policy header up a level

### DIFF
--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -1,67 +1,1112 @@
 {
   "http": {
     "headers": {
-      "csp": {
-        "Content-Security-Policy": {
+      "Content-Security-Policy": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy",
+          "spec_url": "https://w3c.github.io/webappsec-csp/#csp-header",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "25"
+              },
+              {
+                "version_added": "14",
+                "alternative_name": "X-Webkit-CSP"
+              }
+            ],
+            "chrome_android": {
+              "version_added": true
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": [
+              {
+                "version_added": "23"
+              },
+              {
+                "version_added": "4",
+                "alternative_name": "X-Content-Security-Policy"
+              }
+            ],
+            "firefox_android": {
+              "version_added": "23"
+            },
+            "ie": {
+              "version_added": "10",
+              "notes": "Only supporting 'sandbox' directive.",
+              "alternative_name": "X-Content-Security-Policy"
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": "mirror",
+            "safari": [
+              {
+                "version_added": "7"
+              },
+              {
+                "version_added": "6",
+                "alternative_name": "X-Webkit-CSP"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "7"
+              },
+              {
+                "version_added": "6",
+                "notes": "X-Webkit-CSP"
+              }
+            ],
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "worker_support": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy",
-            "spec_url": "https://w3c.github.io/webappsec-csp/#csp-header",
+            "description": "Worker support",
             "support": {
-              "chrome": [
-                {
-                  "version_added": "25"
-                },
-                {
-                  "version_added": "14",
-                  "alternative_name": "X-Webkit-CSP"
-                }
-              ],
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "≤79"
+              },
+              "firefox": {
+                "version_added": "50"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": {
+                "version_added": null
+              },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "base-uri": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/base-uri",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-base-uri",
+            "support": {
+              "chrome": {
+                "version_added": "40"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "35"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": "9.3"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "block-all-mixed-content": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/block-all-mixed-content",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "≤79"
+              },
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": null
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "child-src": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/child-src",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-child-src",
+            "support": {
+              "chrome": {
+                "version_added": "40"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": "9.3"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "connect-src": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-connect-src",
+            "support": {
+              "chrome": {
+                "version_added": "25"
+              },
               "chrome_android": {
                 "version_added": true
               },
               "edge": {
                 "version_added": "14"
               },
-              "firefox": [
-                {
-                  "version_added": "23"
-                },
-                {
-                  "version_added": "4",
-                  "alternative_name": "X-Content-Security-Policy"
-                }
-              ],
+              "firefox": {
+                "version_added": "23",
+                "notes": "Before Firefox 50, ping attributes of &lt;a&gt; elements weren't covered by connect-src."
+              },
               "firefox_android": {
                 "version_added": "23"
               },
               "ie": {
-                "version_added": "10",
-                "notes": "Only supporting 'sandbox' directive.",
-                "alternative_name": "X-Content-Security-Policy"
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "default-src": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/default-src",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-default-src",
+            "support": {
+              "chrome": {
+                "version_added": "25"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "23"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "font-src": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/font-src",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-font-src",
+            "support": {
+              "chrome": {
+                "version_added": "25"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "23"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "form-action": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/form-action",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-form-action",
+            "support": {
+              "chrome": {
+                "version_added": "40"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "version_added": "36"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": "9.3"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "frame-ancestors": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-frame-ancestors",
+            "support": {
+              "chrome": {
+                "version_added": "40"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "15"
+              },
+              "firefox": {
+                "version_added": "33",
+                "notes": "Before Firefox 58, <code>frame-ancestors</code> is ignored in <code>Content-Security-Policy-Report-Only</code>."
+              },
+              "firefox_android": {
+                "version_added": "33",
+                "notes": "Before Firefox for Android 58, <code>frame-ancestors</code> is ignored in <code>Content-Security-Policy-Report-Only</code>."
+              },
+              "ie": {
+                "version_added": false
               },
               "oculus": "mirror",
               "opera": {
-                "version_added": "15"
+                "version_added": "26"
               },
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": "9.3"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": null
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "frame-src": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/frame-src",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-frame-src",
+            "support": {
+              "chrome": {
+                "version_added": "25"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "23"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "img-src": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/img-src",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-img-src",
+            "support": {
+              "chrome": {
+                "version_added": "25"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "23"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "manifest-src": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/manifest-src",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-manifest-src",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "41"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "media-src": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/media-src",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-media-src",
+            "support": {
+              "chrome": {
+                "version_added": "25"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "23"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "meta-element-support": {
+          "__compat": {
+            "description": "<code>&lt;meta&gt;</code> element support",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "≤18"
+              },
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
               "opera_android": "mirror",
-              "safari": [
-                {
-                  "version_added": "7"
-                },
-                {
-                  "version_added": "6",
-                  "alternative_name": "X-Webkit-CSP"
-                }
-              ],
-              "safari_ios": [
-                {
-                  "version_added": "7"
-                },
-                {
-                  "version_added": "6",
-                  "notes": "X-Webkit-CSP"
-                }
-              ],
+              "safari": {
+                "version_added": true
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "navigate-to": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/navigate-to",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-navigate-to",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "object-src": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/object-src",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-object-src",
+            "support": {
+              "chrome": {
+                "version_added": "25"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "23"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "plugin-types": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/plugin-types",
+            "support": {
+              "chrome": {
+                "version_added": "40",
+                "version_removed": "90"
+              },
+              "chrome_android": {
+                "version_added": true,
+                "version_removed": "90"
+              },
+              "edge": {
+                "version_added": "15",
+                "version_removed": "90"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": {
+                "version_added": "9.3"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "prefetch-src": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/prefetch-src",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-prefetch-src",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "notes": "See <a href='https://crbug.com/801561'>bug 801561</a>."
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1457204'>bug 1457204</a>."
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/185070'>bug 185070</a>."
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "referrer": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/referrer",
+            "support": {
+              "chrome": {
+                "version_added": "33",
+                "version_removed": "56"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "37",
+                "version_removed": "62"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": {
+                "version_added": true,
+                "version_removed": "43"
+              },
+              "opera_android": {
+                "version_added": true,
+                "version_removed": "43"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "report-sample": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "59"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "≤79"
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": null
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "report-to": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/report-to",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-report-to",
+            "support": {
+              "chrome": {
+                "version_added": "70"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "report-uri": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-report-uri",
+            "support": {
+              "chrome": {
+                "version_added": "25"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "23"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "require-sri-for": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/require-sri-for",
+            "support": {
+              "chrome": {
+                "version_added": "54"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "require-trusted-types-for": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for",
+            "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#require-trusted-types-for-csp-directive",
+            "support": {
+              "chrome": {
+                "version_added": "83"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "sandbox": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-sandbox",
+            "support": {
+              "chrome": {
+                "version_added": "25"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "50"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "10"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "script-src": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/script-src",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-script-src",
+            "support": {
+              "chrome": {
+                "version_added": "25"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "23"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -71,790 +1116,9 @@
               "deprecated": false
             }
           },
-          "worker_support": {
+          "external_scripts": {
             "__compat": {
-              "description": "Worker support",
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": "mirror",
-                "edge": {
-                  "version_added": "≤79"
-                },
-                "firefox": {
-                  "version_added": "50"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "10"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "base-uri": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/base-uri",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-base-uri",
-              "support": {
-                "chrome": {
-                  "version_added": "40"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "35"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "10"
-                },
-                "safari_ios": {
-                  "version_added": "9.3"
-                },
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "block-all-mixed-content": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/block-all-mixed-content",
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": "mirror",
-                "edge": {
-                  "version_added": "≤79"
-                },
-                "firefox": {
-                  "version_added": "48"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": null
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": true
-              }
-            }
-          },
-          "child-src": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/child-src",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-child-src",
-              "support": {
-                "chrome": {
-                  "version_added": "40"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "15"
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "10"
-                },
-                "safari_ios": {
-                  "version_added": "9.3"
-                },
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "connect-src": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-connect-src",
-              "support": {
-                "chrome": {
-                  "version_added": "25"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "14"
-                },
-                "firefox": {
-                  "version_added": "23",
-                  "notes": "Before Firefox 50, ping attributes of &lt;a&gt; elements weren't covered by connect-src."
-                },
-                "firefox_android": {
-                  "version_added": "23"
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "7"
-                },
-                "safari_ios": {
-                  "version_added": "7"
-                },
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "default-src": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/default-src",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-default-src",
-              "support": {
-                "chrome": {
-                  "version_added": "25"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "14"
-                },
-                "firefox": {
-                  "version_added": "23"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "7"
-                },
-                "safari_ios": {
-                  "version_added": "7"
-                },
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "font-src": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/font-src",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-font-src",
-              "support": {
-                "chrome": {
-                  "version_added": "25"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "14"
-                },
-                "firefox": {
-                  "version_added": "23"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "7"
-                },
-                "safari_ios": {
-                  "version_added": "7"
-                },
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "form-action": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/form-action",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-form-action",
-              "support": {
-                "chrome": {
-                  "version_added": "40"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "15"
-                },
-                "firefox": {
-                  "version_added": "36"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "10"
-                },
-                "safari_ios": {
-                  "version_added": "9.3"
-                },
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "frame-ancestors": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-frame-ancestors",
-              "support": {
-                "chrome": {
-                  "version_added": "40"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "15"
-                },
-                "firefox": {
-                  "version_added": "33",
-                  "notes": "Before Firefox 58, <code>frame-ancestors</code> is ignored in <code>Content-Security-Policy-Report-Only</code>."
-                },
-                "firefox_android": {
-                  "version_added": "33",
-                  "notes": "Before Firefox for Android 58, <code>frame-ancestors</code> is ignored in <code>Content-Security-Policy-Report-Only</code>."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": {
-                  "version_added": "26"
-                },
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "10"
-                },
-                "safari_ios": {
-                  "version_added": "9.3"
-                },
-                "samsunginternet_android": "mirror",
-                "webview_android": {
-                  "version_added": null
-                }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "frame-src": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/frame-src",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-frame-src",
-              "support": {
-                "chrome": {
-                  "version_added": "25"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "14"
-                },
-                "firefox": {
-                  "version_added": "23"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "7"
-                },
-                "safari_ios": {
-                  "version_added": "7"
-                },
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "img-src": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/img-src",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-img-src",
-              "support": {
-                "chrome": {
-                  "version_added": "25"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "14"
-                },
-                "firefox": {
-                  "version_added": "23"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "7"
-                },
-                "safari_ios": {
-                  "version_added": "7"
-                },
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "manifest-src": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/manifest-src",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-manifest-src",
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": "mirror",
-                "edge": {
-                  "version_added": "79"
-                },
-                "firefox": {
-                  "version_added": "41"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "media-src": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/media-src",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-media-src",
-              "support": {
-                "chrome": {
-                  "version_added": "25"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "14"
-                },
-                "firefox": {
-                  "version_added": "23"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "7"
-                },
-                "safari_ios": {
-                  "version_added": "7"
-                },
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "meta-element-support": {
-            "__compat": {
-              "description": "<code>&lt;meta&gt;</code> element support",
-              "support": {
-                "chrome": {
-                  "version_added": true
-                },
-                "chrome_android": "mirror",
-                "edge": {
-                  "version_added": "≤18"
-                },
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": true
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "navigate-to": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/navigate-to",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-navigate-to",
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "object-src": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/object-src",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-object-src",
-              "support": {
-                "chrome": {
-                  "version_added": "25"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "14"
-                },
-                "firefox": {
-                  "version_added": "23"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "7"
-                },
-                "safari_ios": {
-                  "version_added": "7"
-                },
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "plugin-types": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/plugin-types",
-              "support": {
-                "chrome": {
-                  "version_added": "40",
-                  "version_removed": "90"
-                },
-                "chrome_android": {
-                  "version_added": true,
-                  "version_removed": "90"
-                },
-                "edge": {
-                  "version_added": "15",
-                  "version_removed": "90"
-                },
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "10"
-                },
-                "safari_ios": {
-                  "version_added": "9.3"
-                },
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
-              }
-            }
-          },
-          "prefetch-src": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/prefetch-src",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-prefetch-src",
-              "support": {
-                "chrome": {
-                  "version_added": false,
-                  "notes": "See <a href='https://crbug.com/801561'>bug 801561</a>."
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/1457204'>bug 1457204</a>."
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false,
-                  "notes": "See <a href='https://webkit.org/b/185070'>bug 185070</a>."
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": {
-                  "version_added": false
-                },
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "referrer": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/referrer",
-              "support": {
-                "chrome": {
-                  "version_added": "33",
-                  "version_removed": "56"
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "37",
-                  "version_removed": "62"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": {
-                  "version_added": true,
-                  "version_removed": "43"
-                },
-                "opera_android": {
-                  "version_added": true,
-                  "version_removed": "43"
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
-              }
-            }
-          },
-          "report-sample": {
-            "__compat": {
+              "description": "With external scripts",
               "support": {
                 "chrome": {
                   "version_added": "59"
@@ -868,51 +1132,17 @@
                 },
                 "firefox_android": "mirror",
                 "ie": {
-                  "version_added": null
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "15.4"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "report-to": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/report-to",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-report-to",
-              "support": {
-                "chrome": {
-                  "version_added": "70"
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "ie": {
                   "version_added": false
                 },
                 "oculus": "mirror",
                 "opera": {
-                  "version_added": false
+                  "version_added": null
                 },
                 "opera_android": {
-                  "version_added": false
+                  "version_added": null
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": null
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -924,634 +1154,402 @@
                 "deprecated": false
               }
             }
-          },
-          "report-uri": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-report-uri",
-              "support": {
-                "chrome": {
-                  "version_added": "25"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "14"
-                },
-                "firefox": {
-                  "version_added": "23"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "7"
-                },
-                "safari_ios": {
-                  "version_added": "7"
-                },
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+          }
+        },
+        "script-src-attr": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/script-src-attr",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-script-src-attr",
+            "support": {
+              "chrome": {
+                "version_added": "75"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": true
-              }
-            }
-          },
-          "require-sri-for": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/require-sri-for",
-              "support": {
-                "chrome": {
-                  "version_added": "54"
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1529337'>bug 1529337</a>."
               },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
-              }
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "require-trusted-types-for": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for",
-              "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#require-trusted-types-for-csp-directive",
-              "support": {
-                "chrome": {
+          }
+        },
+        "script-src-elem": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/script-src-elem",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-script-src-elem",
+            "support": {
+              "chrome": {
+                "version_added": "75"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1529337'>bug 1529337</a>."
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "strict-dynamic": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic",
+            "support": {
+              "chrome": {
+                "version_added": "52"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "style-src": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/style-src",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-style-src",
+            "support": {
+              "chrome": {
+                "version_added": "25"
+              },
+              "chrome_android": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "14"
+              },
+              "firefox": {
+                "version_added": "23"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": {
+                "version_added": "7"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "style-src-attr": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/style-src-attr",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-style-src-attr",
+            "support": {
+              "chrome": {
+                "version_added": "75"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1529338'>bug 1529338</a>."
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "style-src-elem": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/style-src-elem",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-style-src-elem",
+            "support": {
+              "chrome": {
+                "version_added": "75"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1529338'>bug 1529338</a>."
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": null
+              },
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "trusted-types": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types",
+            "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#trusted-types-csp-directive",
+            "support": {
+              "chrome": [
+                {
                   "version_added": "83"
                 },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "sandbox": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-sandbox",
-              "support": {
-                "chrome": {
-                  "version_added": "25"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "14"
-                },
-                "firefox": {
-                  "version_added": "50"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": "10"
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "7"
-                },
-                "safari_ios": {
-                  "version_added": "7"
-                },
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "script-src": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/script-src",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-script-src",
-              "support": {
-                "chrome": {
-                  "version_added": "25"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "14"
-                },
-                "firefox": {
-                  "version_added": "23"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "7"
-                },
-                "safari_ios": {
-                  "version_added": "7"
-                },
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            },
-            "external_scripts": {
-              "__compat": {
-                "description": "With external scripts",
-                "support": {
-                  "chrome": {
-                    "version_added": "59"
-                  },
-                  "chrome_android": "mirror",
-                  "edge": {
-                    "version_added": "≤79"
-                  },
-                  "firefox": {
-                    "version_added": null
-                  },
-                  "firefox_android": "mirror",
-                  "ie": {
-                    "version_added": false
-                  },
-                  "oculus": "mirror",
-                  "opera": {
-                    "version_added": null
-                  },
-                  "opera_android": {
-                    "version_added": null
-                  },
-                  "safari": {
-                    "version_added": null
-                  },
-                  "safari_ios": "mirror",
-                  "samsunginternet_android": "mirror",
-                  "webview_android": "mirror"
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": true,
-                  "deprecated": false
+                {
+                  "version_added": "73",
+                  "version_removed": "76",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-productivity-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
                 }
-              }
-            }
-          },
-          "script-src-attr": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/script-src-attr",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-script-src-attr",
-              "support": {
-                "chrome": {
-                  "version_added": "75"
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/1529337'>bug 1529337</a>."
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "preview"
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+              ],
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "script-src-elem": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/script-src-elem",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-script-src-elem",
-              "support": {
-                "chrome": {
-                  "version_added": "75"
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/1529337'>bug 1529337</a>."
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "preview"
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "strict-dynamic": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic",
-              "support": {
-                "chrome": {
-                  "version_added": "52"
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "52"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "15.4"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "style-src": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/style-src",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-style-src",
-              "support": {
-                "chrome": {
-                  "version_added": "25"
-                },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": "14"
-                },
-                "firefox": {
-                  "version_added": "23"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "7"
-                },
-                "safari_ios": {
-                  "version_added": "7"
-                },
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+              "safari": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "style-src-attr": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/style-src-attr",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-style-src-attr",
-              "support": {
-                "chrome": {
-                  "version_added": "75"
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/1529338'>bug 1529338</a>."
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "preview"
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+          }
+        },
+        "unsafe-hashes": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe-hashes",
+            "support": {
+              "chrome": {
+                "version_added": "69"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1343950'>bug 1343950</a>."
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "style-src-elem": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/style-src-elem",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-style-src-elem",
-              "support": {
-                "chrome": {
-                  "version_added": "75"
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/1529338'>bug 1529338</a>."
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
-                "safari": {
-                  "version_added": "preview"
-                },
-                "safari_ios": {
-                  "version_added": false
-                },
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+          }
+        },
+        "upgrade-insecure-requests": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/upgrade-insecure-requests",
+            "spec_url": "https://w3c.github.io/webappsec-upgrade-insecure-requests/#delivery",
+            "support": {
+              "chrome": {
+                "version_added": "43"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "17"
+              },
+              "firefox": {
+                "version_added": "42"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "10.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
-          },
-          "trusted-types": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types",
-              "spec_url": "https://w3c.github.io/webappsec-trusted-types/dist/spec/#trusted-types-csp-directive",
-              "support": {
-                "chrome": [
-                  {
-                    "version_added": "83"
-                  },
-                  {
-                    "version_added": "73",
-                    "version_removed": "76",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "#enable-experimental-productivity-features",
-                        "value_to_set": "Enabled"
-                      }
-                    ]
-                  }
-                ],
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": {
-                  "version_added": false
-                },
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+          }
+        },
+        "worker-src": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/worker-src",
+            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-worker-src",
+            "support": {
+              "chrome": {
+                "version_added": "59",
+                "notes": "Chrome 59 and higher skips the deprecated <code>child-src</code> directive."
               },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "unsafe-hashes": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe-hashes",
-              "support": {
-                "chrome": {
-                  "version_added": "69"
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/1343950'>bug 1343950</a>."
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "15.4"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "79"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "upgrade-insecure-requests": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/upgrade-insecure-requests",
-              "spec_url": "https://w3c.github.io/webappsec-upgrade-insecure-requests/#delivery",
-              "support": {
-                "chrome": {
-                  "version_added": "43"
-                },
-                "chrome_android": "mirror",
-                "edge": {
-                  "version_added": "17"
-                },
-                "firefox": {
-                  "version_added": "42"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "10.1"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+              "firefox": {
+                "version_added": "58"
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "worker-src": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/worker-src",
-              "spec_url": "https://w3c.github.io/webappsec-csp/#directive-worker-src",
-              "support": {
-                "chrome": {
-                  "version_added": "59",
-                  "notes": "Chrome 59 and higher skips the deprecated <code>child-src</code> directive."
-                },
-                "chrome_android": "mirror",
-                "edge": {
-                  "version_added": "79"
-                },
-                "firefox": {
-                  "version_added": "58"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": {
-                  "version_added": "48"
-                },
-                "opera_android": {
-                  "version_added": "45"
-                },
-                "safari": {
-                  "version_added": "15.5"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": {
-                  "version_added": "7.0"
-                },
-                "webview_android": "mirror"
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
+              "oculus": "mirror",
+              "opera": {
+                "version_added": "48"
+              },
+              "opera_android": {
+                "version_added": "45"
+              },
+              "safari": {
+                "version_added": "15.5"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": {
+                "version_added": "7.0"
+              },
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }


### PR DESCRIPTION
This PR moves the `Content-Security-Policy` header up a level to conform to our structure.  Originally, it was nested under a `csp` category, which only had this header as a subfeature.
