### PR TITLE
Move html.elements.menu.type.type_menu up a level

### DIFF
--- a/html/elements/menu.json
+++ b/html/elements/menu.json
@@ -137,58 +137,56 @@
             }
           }
         },
-        "type": {
-          "type_menu": {
-            "__compat": {
-              "description": "<code>type=\"menu\"</code>",
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": "mirror",
-                "edge": {
-                  "version_added": "≤18",
-                  "version_removed": "79"
-                },
-                "firefox": [
-                  {
-                    "version_added": "85",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "dom.menuitem.enabled",
-                        "value_to_set": "true"
-                      }
-                    ]
-                  },
-                  {
-                    "version_added": "8",
-                    "version_removed": "85"
-                  }
-                ],
-                "firefox_android": {
-                  "version_added": "8",
-                  "version_removed": "85",
-                  "notes": "Nested menus are not supported."
-                },
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+        "type_menu": {
+          "__compat": {
+            "description": "<code>type=\"menu\"</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
               },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
-              }
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "≤18",
+                "version_removed": "79"
+              },
+              "firefox": [
+                {
+                  "version_added": "85",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.menuitem.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "8",
+                  "version_removed": "85"
+                }
+              ],
+              "firefox_android": {
+                "version_added": "8",
+                "version_removed": "85",
+                "notes": "Nested menus are not supported."
+              },
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
           }
         }


### PR DESCRIPTION
This PR moves `html.elements.menu.type.type_menu` up a level, removing the redundant `type` parent.
