### PR TITLE
Update Safari support for CryptoKey

### DIFF
--- a/api/CryptoKey.json
+++ b/api/CryptoKey.json
@@ -29,9 +29,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "7"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "7"
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -113,9 +115,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "7"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "7"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -162,9 +166,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "7"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "7"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -204,9 +210,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "7"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "7"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -246,9 +254,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "7"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "7"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
This matches the data for crypto.subtle.generateKey() and importKey(),
the APIs that create CryptoKey instances.

Note that this is probably wrong, but done for consistency.

The initial implementations of importKey() and generateKey() were in
WebKit trunk version 538.5:
https://github.com/WebKit/WebKit/commit/a834b36c558ddbefad9fad00a77d2732a47932ea
https://github.com/WebKit/WebKit/blob/a834b36c558ddbefad9fad00a77d2732a47932ea/Source/WebCore/Configurations/Version.xcconfig
https://github.com/WebKit/WebKit/commit/f656051c47f9c9cbab013808f690b75241897709
https://github.com/WebKit/WebKit/blob/f656051c47f9c9cbab013808f690b75241897709/Source/WebCore/Configurations/Version.xcconfig

That would be Safari/iOS 8.

There's a collector test for this as well:
https://mdn-bcd-collector.appspot.com/tests/api/CryptoKey?exposure=Window

Support is in Safari 7.1 and iOS 8, but not iOS 7. That also suggests
Safari/iOS 8/8 would be more correct. This is a possible follow-up.
