### PR TITLE
Update "Secure context required" for Web Crypto API

### DIFF
--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -217,9 +217,7 @@
               "firefox": {
                 "version_added": "75"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -228,13 +226,13 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": "47"
-              },
+              "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "15"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/api/CryptoKey.json
+++ b/api/CryptoKey.json
@@ -41,49 +41,6 @@
           "deprecated": false
         }
       },
-      "secure_context_required": {
-        "__compat": {
-          "description": "Secure context required",
-          "support": {
-            "chrome": {
-              "version_added": "60"
-            },
-            "chrome_android": "mirror",
-            "deno": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "75"
-            },
-            "firefox_android": {
-              "version_added": false
-            },
-            "ie": {
-              "version_added": false
-            },
-            "nodejs": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": "47"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "algorithm": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CryptoKey",

--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -85,13 +85,13 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": "47"
-            },
+            "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "15"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
The main update is this change in WebKit main version 612.1.24:
https://github.com/WebKit/WebKit/commit/1ee37646d48f3b7a829a328b37d1af411d287869
https://github.com/WebKit/WebKit/blob/1ee37646d48f3b7a829a328b37d1af411d287869/Source/WebCore/Configurations/Version.xcconfig

That maps to Safari/iOS 15.

Remove the entry on CryptoKey as redundant.

Also use "mirror" in some places where differences are implausible.
