### PR TITLE
Update initial support for Payment Request in Chrome Android

### DIFF
--- a/api/PaymentAddress.json
+++ b/api/PaymentAddress.json
@@ -48,7 +48,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
@@ -89,7 +89,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
@@ -130,7 +130,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
@@ -171,7 +171,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
@@ -255,7 +255,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
@@ -296,7 +296,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
@@ -337,7 +337,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
@@ -378,7 +378,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
@@ -419,7 +419,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
@@ -460,7 +460,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
@@ -502,7 +502,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "55"
             },
             "edge": {
               "version_added": "15"

--- a/api/PaymentAddress.json
+++ b/api/PaymentAddress.json
@@ -8,7 +8,7 @@
             "version_added": "60"
           },
           "chrome_android": {
-            "version_added": "56"
+            "version_added": "53"
           },
           "edge": {
             "version_added": "15"

--- a/api/PaymentRequestUpdateEvent.json
+++ b/api/PaymentRequestUpdateEvent.json
@@ -109,7 +109,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"

--- a/api/PaymentRequestUpdateEvent.json
+++ b/api/PaymentRequestUpdateEvent.json
@@ -9,7 +9,7 @@
             "version_added": "60"
           },
           "chrome_android": {
-            "version_added": "56"
+            "version_added": "53"
           },
           "edge": {
             "version_added": "15"
@@ -61,7 +61,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"

--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -9,7 +9,7 @@
             "version_added": "60"
           },
           "chrome_android": {
-            "version_added": "56"
+            "version_added": "53"
           },
           "edge": {
             "version_added": "15"

--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -61,7 +61,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
@@ -113,7 +113,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
@@ -165,7 +165,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
@@ -268,7 +268,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
@@ -319,7 +319,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "58"
+              "version_added": "56"
             },
             "edge": {
               "version_added": "15"
@@ -370,7 +370,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
@@ -529,7 +529,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
@@ -580,7 +580,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "53"
             },
             "edge": {
               "version_added": "15"
@@ -631,7 +631,7 @@
               "version_added": "60"
             },
             "chrome_android": {
-              "version_added": "56"
+              "version_added": "55"
             },
             "edge": {
               "version_added": "15"


### PR DESCRIPTION
This is based on https://github.com/mdn/browser-compat-data/pull/6526.

api.PaymentResponse.payerName remains "56" but is correct:
https://storage.googleapis.com/chromium-find-releases-static/04d.html#04dad8e7c11b7d2e44ca5d36bf6167278ed3e2b2

api.PaymentAddress.languageCode should be removed:
https://github.com/mdn/browser-compat-data/pull/16985