### PR TITLE
Remove PaymentAddress's languageCode property

### DIFF
--- a/api/PaymentAddress.json
+++ b/api/PaymentAddress.json
@@ -204,49 +204,6 @@
           }
         }
       },
-      "languageCode": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/languageCode",
-          "support": {
-            "chrome": {
-              "version_added": "60"
-            },
-            "chrome_android": {
-              "version_added": "56"
-            },
-            "edge": {
-              "version_added": "15"
-            },
-            "firefox": {
-              "version_added": "56",
-              "version_removed": "63"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": {
-              "version_added": "44"
-            },
-            "safari": {
-              "version_added": "11.1",
-              "version_removed": "12.1"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "organization": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/organization",


### PR DESCRIPTION
This was removed in Chromium M74:
https://storage.googleapis.com/chromium-find-releases-static/dd7.html#dd76bcf7a89662980115900ad7c9acc97caaec33
