### PR TITLE
Use NodeJS v16 for testing

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 18
+          node-version: 16
       - run: npm ci
       - run: npm test
         env:


### PR DESCRIPTION
This PR downgrades the CI to use NodeJS v16, which is what we require for other MDN projects and recommend for this one.  This mitigates an incompatibility between `ts-node` and NodeJS v18.6.0 as well, which is causing CI failures.