### PR TITLE
Specify file extension for ts-node commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,17 +74,17 @@
     "coverage": "c8 report -r lcov && open-cli coverage/lcov-report/index.html",
     "format": "npx eslint \"**/*.ts\" && npx prettier --check \"**/*.md\" \"**/*.json\"",
     "format:fix": "npx eslint --fix \"**/*.ts\" && npx prettier --write \"**/*.md\" \"**/*.json\"",
-    "lint": "ts-node test/lint",
-    "fix": "npm run format:fix && ts-node scripts/fix/index",
-    "stats": "ts-node scripts/statistics",
-    "build": "ts-node scripts/release/build",
-    "gentypes": "ts-node scripts/generate-types",
-    "release-pulls": "ts-node scripts/release/pulls",
-    "release-notes": "ts-node scripts/release/notes",
-    "release-stats": "ts-node scripts/release/stats",
-    "remove-redundant-flags": "ts-node scripts/remove-redundant-flags",
+    "lint": "ts-node test/lint.ts",
+    "fix": "npm run format:fix && ts-node scripts/fix/index.ts",
+    "stats": "ts-node scripts/statistics.ts",
+    "build": "ts-node scripts/release/build.ts",
+    "gentypes": "ts-node scripts/generate-types.ts",
+    "release-pulls": "ts-node scripts/release/pulls.ts",
+    "release-notes": "ts-node scripts/release/notes.ts",
+    "release-stats": "ts-node scripts/release/stats.ts",
+    "remove-redundant-flags": "ts-node scripts/remove-redundant-flags.ts",
     "show-errors": "npm test 1> /dev/null",
     "test": "npm run format && npm run lint && npm run unittest",
-    "traverse": "ts-node scripts/traverse"
+    "traverse": "ts-node scripts/traverse.ts"
   }
 }


### PR DESCRIPTION
This PR adds the file extensions to the `ts-node` commands, which fixes an issue around NodeJS v18.6.0.
