### PR TITLE
Add data for MathML global attributes

### DIFF
--- a/mathml/global_attributes.json
+++ b/mathml/global_attributes.json
@@ -1,6 +1,53 @@
 {
   "mathml": {
     "global_attributes": {
+      "dir": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/dir",
+          "spec_url": "https://w3c.github.io/mathml-core/#dfn-dir",
+          "support": {
+            "chrome": {
+              "version_added": "80",
+              "impl_url": "https://crrev.com/c/1908533",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "70",
+              "impl_url": "https://hg.mozilla.org/mozilla-central/rev/3b30c8db537c",
+              "notes": "Prior to Firefox 70, the attribute was only accepted on a few elements, as specified in MathML 3."
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "8",
+              "impl_url": "https://trac.webkit.org/changeset/159504"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "displaystyle": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/displaystyle",
@@ -34,7 +81,7 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": true,
+              "version_added": "14",
               "impl_url": "https://trac.webkit.org/changeset/267578"
             },
             "safari_ios": "mirror",
@@ -72,7 +119,7 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": true,
+              "version_added": "10",
               "impl_url": "https://trac.webkit.org/changeset/203104"
             },
             "safari_ios": "mirror",
@@ -119,10 +166,13 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": true,
+              "version_added": "5",
               "impl_url": "https://trac.webkit.org/changeset/62968"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "4",
+              "impl_url": "https://trac.webkit.org/changeset/62968"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -166,10 +216,13 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": true,
+              "version_added": "5",
               "impl_url": "https://trac.webkit.org/changeset/62968"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "4",
+              "impl_url": "https://trac.webkit.org/changeset/62968"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -213,10 +266,13 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": true,
+              "version_added": "5",
               "impl_url": "https://trac.webkit.org/changeset/63079"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "4",
+              "impl_url": "https://trac.webkit.org/changeset/63079"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -262,7 +318,7 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": true,
+              "version_added": "10",
               "impl_url": "https://trac.webkit.org/changeset/203679",
               "partial_implementation": true,
               "notes": "Safari only accepts the attribute on a few elements, as specified in MathML 3."

--- a/mathml/global_attributes.json
+++ b/mathml/global_attributes.json
@@ -20,7 +20,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": true
+              "version_added": "83",
+              "impl_url": "https://hg.mozilla.org/mozilla-central/rev/60a72a6c7c1d",
+              "notes": "Prior to Firefox 83, the attribute was only accepted on a few elements, as specified in MathML 3."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -32,11 +34,10 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": true,
+              "impl_url": "https://trac.webkit.org/changeset/267578"
             },
-            "safari_ios": {
-              "version_added": true
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -58,7 +59,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": true
+              "version_added": "7",
+              "impl_url": "https://hg.mozilla.org/mozilla-central/rev/12294b20e4d9"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -70,11 +72,10 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": true,
+              "impl_url": "https://trac.webkit.org/changeset/203104"
             },
-            "safari_ios": {
-              "version_added": true
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -104,7 +105,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": true
+              "version_added": "70",
+              "impl_url": "https://hg.mozilla.org/mozilla-central/rev/3b30c8db537c",
+              "notes": "Prior to Firefox 70, the attribute was only accepted on a few elements, as specified in MathML 3."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -116,11 +119,10 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": true,
+              "impl_url": "https://trac.webkit.org/changeset/62968"
             },
-            "safari_ios": {
-              "version_added": true
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -150,7 +152,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": true
+              "version_added": "70",
+              "impl_url": "https://hg.mozilla.org/mozilla-central/rev/3b30c8db537c",
+              "notes": "Prior to Firefox 70, the attribute was only accepted on a few elements, as specified in MathML 3."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -162,11 +166,10 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": true,
+              "impl_url": "https://trac.webkit.org/changeset/62968"
             },
-            "safari_ios": {
-              "version_added": true
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -196,7 +199,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": true
+              "version_added": "70",
+              "impl_url": "https://hg.mozilla.org/mozilla-central/rev/3b30c8db537c",
+              "notes": "Prior to Firefox 70, the attribute was only accepted on a few elements, as specified in MathML 3."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -208,11 +213,10 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": true,
+              "impl_url": "https://trac.webkit.org/changeset/63079"
             },
-            "safari_ios": {
-              "version_added": true
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -244,7 +248,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": true
+              "version_added": "70",
+              "impl_url": "https://hg.mozilla.org/mozilla-central/rev/3b30c8db537c",
+              "notes": "Prior to Firefox 70, the attribute was only accepted on a few elements, as specified in MathML 3."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -256,11 +262,12 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": true,
+              "impl_url": "https://trac.webkit.org/changeset/203679",
+              "partial_implementation": true,
+              "notes": "Safari only accepts the attribute on a few elements, as specified in MathML 3."
             },
-            "safari_ios": {
-              "version_added": true
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -290,7 +297,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": true
+              "version_added": "70",
+              "impl_url": "https://hg.mozilla.org/mozilla-central/rev/3b30c8db537c",
+              "notes": "Prior to Firefox 70, the attribute was only accepted on a few elements, as specified in MathML 3."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -302,12 +311,9 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
-              "impl_url": "https://webkit.org/b/202303"
+              "version_added": false
             },
-            "safari_ios": {
-              "version_added": true
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/mathml/global_attributes.json
+++ b/mathml/global_attributes.json
@@ -1,0 +1,323 @@
+{
+  "mathml": {
+    "global_attributes": {
+      "displaystyle": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/displaystyle",
+          "spec_url": "https://w3c.github.io/mathml-core/#dfn-displaystyle",
+          "support": {
+            "chrome": {
+              "version_added": "83",
+              "impl_url": "https://crrev.com/c/2105317",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "href": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/href",
+          "spec_url": "https://w3c.github.io/mathml/#fund_globatt",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mathbackground": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/mathbackground",
+          "spec_url": "https://w3c.github.io/mathml-core/#dfn-mathbackground",
+          "support": {
+            "chrome": {
+              "version_added": "80",
+              "impl_url": "https://crrev.com/c/1908533",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "mathcolor": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/mathcolor",
+          "spec_url": "https://w3c.github.io/mathml-core/#dfn-mathcolor",
+          "support": {
+            "chrome": {
+              "version_added": "80",
+              "impl_url": "https://crrev.com/c/1908533",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "mathsize": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/mathsize",
+          "spec_url": "https://w3c.github.io/mathml-core/#dfn-mathsize",
+          "support": {
+            "chrome": {
+              "version_added": "80",
+              "impl_url": "https://crrev.com/c/1908533",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "mathvariant": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/mathvariant",
+          "spec_url": "https://w3c.github.io/mathml-core/#dfn-mathvariant",
+          "support": {
+            "chrome": {
+              "version_added": "84",
+              "partial_implementation": true,
+              "notes": "The only value supported is 'normal'.",
+              "impl_url": "https://crrev.com/c/2161013",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": true
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "scriptlevel": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/scriptlevel",
+          "spec_url": "https://w3c.github.io/mathml-core/#dfn-scriptlevel",
+          "support": {
+            "chrome": {
+              "version_added": "88",
+              "impl_url": "https://crrev.com/c/2474780",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": true
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/202303"
+            },
+            "safari_ios": {
+              "version_added": true
+            },
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### Summary

This is adding data for MDN articles describing MathML global attributes.

#### Test results and supporting details

This was done by checking the source code of browsers, bug entries as well as the commits.

Note: `npm test` fails with "version_added: 'true' is NOT a valid version number" but that seems to be what other files do to.

#### Related issues

https://github.com/mdn/content/pull/17812
