### PR TITLE
Remove unreachable code from diff script

### DIFF
--- a/scripts/diff.ts
+++ b/scripts/diff.ts
@@ -83,7 +83,6 @@ function describeByKind(
         doesMirror && ` - ${doesMirror}`
       }`;
   }
-  throw new Error(`Unexpected kind ${(diffItem as any).kind}.`);
 }
 
 /**


### PR DESCRIPTION
ts-node refuses to run this script with the line present:

> TSError: ⨯ Unable to compile TypeScript:
> scripts/diff.ts:86:3 - error TS7027: Unreachable code detected.
