### PR TITLE
Update Firefox support for FileSystemEntry's getParent()

### DIFF
--- a/api/FileSystemEntry.json
+++ b/api/FileSystemEntry.json
@@ -208,7 +208,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "52"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
Update Firefox support for FileSystemEntry's getParent()

Confirmed by testing in Firefox 51 and 52:
https://mdn-bcd-collector.appspot.com/tests/api/FileSystemEntry/getParent

Also supported by the tracking bug:
https://bugzilla.mozilla.org/show_bug.cgi?id=1284987

Part of https://github.com/mdn/browser-compat-data/pull/6526.