### PR TITLE
Run scripts/migrations/009-mirror to migrate Safari data

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -70,9 +70,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/AudioBufferSourceNode.json
+++ b/api/AudioBufferSourceNode.json
@@ -334,9 +334,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "4.4.3"

--- a/api/AudioScheduledSourceNode.json
+++ b/api/AudioScheduledSourceNode.json
@@ -103,9 +103,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"
@@ -143,9 +141,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -181,9 +177,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/AudioTrack.json
+++ b/api/AudioTrack.json
@@ -52,9 +52,7 @@
           "safari": {
             "version_added": "7"
           },
-          "safari_ios": {
-            "version_added": "7"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -116,9 +114,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -181,9 +177,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -246,9 +240,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -311,9 +303,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -376,9 +366,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/AudioTrackList.json
+++ b/api/AudioTrackList.json
@@ -52,9 +52,7 @@
           "safari": {
             "version_added": "7"
           },
-          "safari_ios": {
-            "version_added": "7"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -120,9 +118,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -189,9 +185,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -254,9 +248,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -319,9 +311,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -388,9 +378,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -649,15 +649,7 @@
                 "version_added": "30"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "59",
-                "notes": "Default values supported"
-              },
-              {
-                "version_added": "30"
-              }
-            ],
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
@@ -679,15 +671,7 @@
               "version_added": "8"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": [
-              {
-                "version_added": "7.0",
-                "notes": "Default values supported"
-              },
-              {
-                "version_added": "2.0"
-              }
-            ],
+            "samsunginternet_android": "mirror",
             "webview_android": [
               {
                 "version_added": "59",

--- a/api/BeforeUnloadEvent.json
+++ b/api/BeforeUnloadEvent.json
@@ -25,9 +25,7 @@
           "safari": {
             "version_added": "7"
           },
-          "safari_ios": {
-            "version_added": "7"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": {
             "version_added": "3.0"
           },
@@ -65,9 +63,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -244,16 +244,7 @@
                 "prefix": "webkit"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "7"
-              },
-              {
-                "version_added": "6",
-                "version_removed": "7",
-                "prefix": "webkit"
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/CSSPrimitiveValue.json
+++ b/api/CSSPrimitiveValue.json
@@ -256,9 +256,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/CSSValue.json
+++ b/api/CSSValue.json
@@ -58,9 +58,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -94,9 +92,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -346,9 +346,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -446,9 +444,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1007,9 +1003,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1249,9 +1243,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1330,9 +1322,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1612,9 +1602,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1649,9 +1637,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1683,9 +1669,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1768,9 +1752,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2406,9 +2388,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2717,9 +2697,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/api/CharacterData.json
+++ b/api/CharacterData.json
@@ -412,9 +412,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/Clients.json
+++ b/api/Clients.json
@@ -238,23 +238,7 @@
                 "version_added": "40"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "51",
-                "notes": "URLs may open inside an existing browsing context provided by a standalone web app"
-              },
-              {
-                "version_added": "43",
-                "notes": "Can open any URL. "
-              },
-              {
-                "version_added": "42",
-                "notes": "Can only open URLs on the same origin."
-              },
-              {
-                "version_added": "40"
-              }
-            ],
+            "chrome_android": "mirror",
             "edge": [
               {
                 "version_added": "79",
@@ -294,23 +278,7 @@
                 "version_added": "4.0"
               }
             ],
-            "webview_android": [
-              {
-                "version_added": "51",
-                "notes": "URLs may open inside an existing browsing context provided by a standalone web app"
-              },
-              {
-                "version_added": "43",
-                "notes": "Can open any URL. "
-              },
-              {
-                "version_added": "42",
-                "notes": "Can only open URLs on the same origin."
-              },
-              {
-                "version_added": "40"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/api/Comment.json
+++ b/api/Comment.json
@@ -67,9 +67,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/CompositionEvent.json
+++ b/api/CompositionEvent.json
@@ -63,9 +63,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/Console.json
+++ b/api/Console.json
@@ -84,9 +84,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -187,9 +185,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1202,9 +1198,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -183,16 +183,7 @@
                 "prefix": "webkit"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "11"
-              },
-              {
-                "version_added": "7",
-                "version_removed": "11.3",
-                "prefix": "webkit"
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -82,26 +82,8 @@
                 "notes": "Support for 'Autonomous custom elements' only."
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "67",
-                "notes": "Support for 'Customized built-in elements' as well."
-              },
-              {
-                "version_added": "54",
-                "notes": "Support for 'Autonomous custom elements' only."
-              }
-            ],
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "Support for 'Customized built-in elements' as well."
-              },
-              {
-                "version_added": "79",
-                "notes": "Support for 'Autonomous custom elements' only."
-              }
-            ],
+            "chrome_android": "mirror",
+            "edge": "mirror",
             "firefox": {
               "version_added": "63"
             },
@@ -110,51 +92,15 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": [
-              {
-                "version_added": "54",
-                "notes": "Support for 'Customized built-in elements' as well."
-              },
-              {
-                "version_added": "41",
-                "notes": "Support for 'Autonomous custom elements' only."
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "48",
-                "notes": "Support for 'Customized built-in elements' as well."
-              },
-              {
-                "version_added": "41",
-                "notes": "Support for 'Autonomous custom elements' only."
-              }
-            ],
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "10.1",
               "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": [
-              {
-                "version_added": "9.0",
-                "notes": "Support for 'Customized built-in elements' as well."
-              },
-              {
-                "version_added": "6.0",
-                "notes": "Support for 'Autonomous custom elements' only."
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "67",
-                "notes": "Support for 'Customized built-in elements' as well."
-              },
-              {
-                "version_added": "54",
-                "notes": "Support for 'Autonomous custom elements' only."
-              }
-            ]
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -178,26 +124,8 @@
                 "notes": "Support for 'Autonomous custom elements' only."
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "67",
-                "notes": "Support for 'Customized built-in elements' as well."
-              },
-              {
-                "version_added": "54",
-                "notes": "Support for 'Autonomous custom elements' only."
-              }
-            ],
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "Support for 'Customized built-in elements' as well."
-              },
-              {
-                "version_added": "79",
-                "notes": "Support for 'Autonomous custom elements' only."
-              }
-            ],
+            "chrome_android": "mirror",
+            "edge": "mirror",
             "firefox": {
               "version_added": "63"
             },
@@ -206,51 +134,15 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": [
-              {
-                "version_added": "54",
-                "notes": "Support for 'Customized built-in elements' as well."
-              },
-              {
-                "version_added": "41",
-                "notes": "Support for 'Autonomous custom elements' only."
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "48",
-                "notes": "Support for 'Customized built-in elements' as well."
-              },
-              {
-                "version_added": "41",
-                "notes": "Support for 'Autonomous custom elements' only."
-              }
-            ],
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "10.1",
               "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": [
-              {
-                "version_added": "9.0",
-                "notes": "Support for 'Customized built-in elements' as well."
-              },
-              {
-                "version_added": "6.0",
-                "notes": "Support for 'Autonomous custom elements' only."
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "67",
-                "notes": "Support for 'Customized built-in elements' as well."
-              },
-              {
-                "version_added": "54",
-                "notes": "Support for 'Autonomous custom elements' only."
-              }
-            ]
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -308,26 +200,8 @@
                 "notes": "Support for 'Autonomous custom elements' only."
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "67",
-                "notes": "Support for 'Customized built-in elements' as well."
-              },
-              {
-                "version_added": "54",
-                "notes": "Support for 'Autonomous custom elements' only."
-              }
-            ],
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "Support for 'Customized built-in elements' as well."
-              },
-              {
-                "version_added": "79",
-                "notes": "Support for 'Autonomous custom elements' only."
-              }
-            ],
+            "chrome_android": "mirror",
+            "edge": "mirror",
             "firefox": {
               "version_added": "63"
             },
@@ -336,51 +210,15 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": [
-              {
-                "version_added": "54",
-                "notes": "Support for 'Customized built-in elements' as well."
-              },
-              {
-                "version_added": "41",
-                "notes": "Support for 'Autonomous custom elements' only."
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "48",
-                "notes": "Support for 'Customized built-in elements' as well."
-              },
-              {
-                "version_added": "41",
-                "notes": "Support for 'Autonomous custom elements' only."
-              }
-            ],
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "10.1",
               "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": [
-              {
-                "version_added": "9.0",
-                "notes": "Support for 'Customized built-in elements' as well."
-              },
-              {
-                "version_added": "6.0",
-                "notes": "Support for 'Autonomous custom elements' only."
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "67",
-                "notes": "Support for 'Customized built-in elements' as well."
-              },
-              {
-                "version_added": "54",
-                "notes": "Support for 'Autonomous custom elements' only."
-              }
-            ]
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/api/DOMRectReadOnly.json
+++ b/api/DOMRectReadOnly.json
@@ -41,21 +41,7 @@
               "version_removed": "27"
             }
           ],
-          "firefox_android": [
-            {
-              "version_added": "31"
-            },
-            {
-              "alternative_name": "DOMRect",
-              "version_added": "27",
-              "version_removed": "31"
-            },
-            {
-              "alternative_name": "ClientRect",
-              "version_added": "4",
-              "version_removed": "27"
-            }
-          ],
+          "firefox_android": "mirror",
           "ie": {
             "alternative_name": "ClientRect",
             "version_added": "4"

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -110,9 +110,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -428,9 +426,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -652,9 +648,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/api/Document.json
+++ b/api/Document.json
@@ -803,20 +803,7 @@
                 "version_added": "1"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "18"
-              },
-              {
-                "alternative_name": "charset",
-                "version_added": "18",
-                "notes": "<code>charset</code> alias was made read-only in Chrome 45."
-              },
-              {
-                "alternative_name": "inputEncoding",
-                "version_added": "18"
-              }
-            ],
+            "chrome_android": "mirror",
             "edge": [
               {
                 "version_added": "12"
@@ -843,19 +830,7 @@
                 "version_added": "1.5"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "4"
-              },
-              {
-                "alternative_name": "charset",
-                "version_added": "44"
-              },
-              {
-                "alternative_name": "inputEncoding",
-                "version_added": "4"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": [
               {
                 "version_added": "9"
@@ -924,20 +899,7 @@
                 "version_added": "1"
               }
             ],
-            "samsunginternet_android": [
-              {
-                "version_added": "1.0"
-              },
-              {
-                "alternative_name": "charset",
-                "version_added": "1.0",
-                "notes": "<code>charset</code> alias was made read-only in Samsung Internet 5.0."
-              },
-              {
-                "alternative_name": "inputEncoding",
-                "version_added": "1.0"
-              }
-            ],
+            "samsunginternet_android": "mirror",
             "webview_android": [
               {
                 "version_added": "1"
@@ -4300,9 +4262,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": [
               {
@@ -4906,10 +4866,7 @@
               "version_added": "7",
               "version_removed": "14"
             },
-            "safari_ios": {
-              "version_added": "7",
-              "version_removed": "14"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -6268,30 +6225,7 @@
                 ]
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "14",
-                "partial_implementation": true,
-                "notes": "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>."
-              },
-              {
-                "version_added": "10.3",
-                "partial_implementation": true,
-                "notes": [
-                  "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>.",
-                  "Before Safari 14, the event does not bubble, so <code>document.addEventListener('visibilitychange', ...)</code> works, but <code>window.addEventListener('visibilitychange', ...)</code> does not."
-                ]
-              },
-              {
-                "version_added": "7",
-                "partial_implementation": true,
-                "notes": [
-                  "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>.",
-                  "Before Safari 14, the event does not bubble, so <code>document.addEventListener('visibilitychange', ...)</code> works, but <code>window.addEventListener('visibilitychange', ...)</code> does not.",
-                  "The <code>onvisibilitychange</code> event handler property is not supported."
-                ]
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": [
               {
@@ -6379,9 +6313,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": [
               {
@@ -6430,10 +6362,7 @@
                 "version_added": "7",
                 "version_removed": "14.1"
               },
-              "safari_ios": {
-                "version_added": "7",
-                "version_removed": "14.5"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
                 "version_added": "≤37",

--- a/api/DocumentType.json
+++ b/api/DocumentType.json
@@ -380,9 +380,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/EXT_texture_filter_anisotropic.json
+++ b/api/EXT_texture_filter_anisotropic.json
@@ -37,9 +37,7 @@
           "safari": {
             "version_added": "7"
           },
-          "safari_ios": {
-            "version_added": "7"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": [
             {
               "version_added": "3.0"

--- a/api/Element.json
+++ b/api/Element.json
@@ -1351,17 +1351,7 @@
                 "partial_implementation": true
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "7"
-              },
-              {
-                "version_added": "6",
-                "version_removed": "7",
-                "notes": "Not supported for SVG elements.",
-                "partial_implementation": true
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": [
               {
@@ -3914,9 +3904,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"
@@ -3958,9 +3946,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"
@@ -5120,9 +5106,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/EventSource.json
+++ b/api/EventSource.json
@@ -120,9 +120,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": {
                 "version_added": "2.0"
               },

--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -430,9 +430,7 @@
                 "safari": {
                   "version_added": "15"
                 },
-                "safari_ios": {
-                  "version_added": "15"
-                },
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror"
               },

--- a/api/File.json
+++ b/api/File.json
@@ -169,10 +169,7 @@
               "version_added": "7",
               "version_removed": "10"
             },
-            "safari_ios": {
-              "version_added": "7",
-              "version_removed": "10"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"
@@ -217,9 +214,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"
@@ -264,9 +259,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"

--- a/api/FocusEvent.json
+++ b/api/FocusEvent.json
@@ -25,9 +25,7 @@
           "safari": {
             "version_added": "7"
           },
-          "safari_ios": {
-            "version_added": "7"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -63,9 +61,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -101,9 +97,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/FormDataEvent.json
+++ b/api/FormDataEvent.json
@@ -23,9 +23,7 @@
           "safari": {
             "version_added": "15"
           },
-          "safari_ios": {
-            "version_added": "15"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -59,9 +57,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -95,9 +91,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -465,9 +465,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/api/HTMLFieldSetElement.json
+++ b/api/HTMLFieldSetElement.json
@@ -153,9 +153,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "1.0"
             },

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -357,9 +357,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -839,9 +839,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1862,9 +1860,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2870,9 +2866,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/HTMLMetaElement.json
+++ b/api/HTMLMetaElement.json
@@ -139,9 +139,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/HTMLOutputElement.json
+++ b/api/HTMLOutputElement.json
@@ -66,9 +66,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/HTMLSourceElement.json
+++ b/api/HTMLSourceElement.json
@@ -63,9 +63,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -298,9 +296,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -1024,9 +1024,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/IDBCursor.json
+++ b/api/IDBCursor.json
@@ -435,9 +435,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -199,9 +199,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -314,9 +312,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/ImageBitmap.json
+++ b/api/ImageBitmap.json
@@ -23,9 +23,7 @@
           "safari": {
             "version_added": "15"
           },
-          "safari_ios": {
-            "version_added": "15"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -62,9 +60,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -98,9 +94,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -134,9 +128,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/ImageBitmapRenderingContext.json
+++ b/api/ImageBitmapRenderingContext.json
@@ -23,9 +23,7 @@
           "safari": {
             "version_added": "15"
           },
-          "safari_ios": {
-            "version_added": "15"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -57,9 +55,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -100,9 +96,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -67,9 +67,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -104,9 +102,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -67,9 +67,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/MediaError.json
+++ b/api/MediaError.json
@@ -113,9 +113,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -39,9 +39,7 @@
           "safari": {
             "version_added": "15"
           },
-          "safari_ios": {
-            "version_added": "15"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false
@@ -89,9 +87,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
@@ -139,9 +135,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
@@ -189,9 +183,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
@@ -239,9 +231,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
@@ -289,9 +279,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false

--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -41,9 +41,7 @@
           "safari": {
             "version_added": "15"
           },
-          "safari_ios": {
-            "version_added": "15"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false
@@ -96,9 +94,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
@@ -152,9 +148,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
@@ -209,9 +203,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
@@ -336,9 +328,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -69,9 +69,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/MutationObserver.json
+++ b/api/MutationObserver.json
@@ -41,15 +41,7 @@
               "prefix": "WebKit"
             }
           ],
-          "safari_ios": [
-            {
-              "version_added": "7"
-            },
-            {
-              "version_added": "6",
-              "prefix": "WebKit"
-            }
-          ],
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": [
             {
@@ -109,15 +101,7 @@
                 "prefix": "WebKit"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "7"
-              },
-              {
-                "version_added": "6",
-                "prefix": "WebKit"
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": [
               {

--- a/api/MutationRecord.json
+++ b/api/MutationRecord.json
@@ -25,9 +25,7 @@
           "safari": {
             "version_added": "7"
           },
-          "safari_ios": {
-            "version_added": "7"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -62,9 +60,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -100,9 +96,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -138,9 +132,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -176,9 +168,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -214,9 +204,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -252,9 +240,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -290,9 +276,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -328,9 +312,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -366,9 +348,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -393,15 +393,7 @@
                 "version_added": "2"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "64",
-                "notes": "Returns a fixed timestamp as a privacy measure - <code>20181001000000</code>."
-              },
-              {
-                "version_added": "4"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -503,9 +495,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": {
                 "version_added": "11.0"
               },
@@ -549,9 +539,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": {
                 "version_added": "11.0"
               },
@@ -1861,9 +1849,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
@@ -4125,9 +4111,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": {
                 "version_added": "11.0"
               },
@@ -4177,9 +4161,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": {
                 "version_added": "11.0"
               },

--- a/api/Node.json
+++ b/api/Node.json
@@ -400,10 +400,7 @@
               "version_added": "1",
               "version_removed": "7"
             },
-            "safari_ios": {
-              "version_added": "1",
-              "version_removed": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -560,10 +560,7 @@
                 "version_added": "11",
                 "version_removed": "15"
               },
-              "safari_ios": {
-                "version_added": "11",
-                "version_removed": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": {
                 "version_added": "1.5"
               },
@@ -895,9 +892,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -251,9 +251,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -703,9 +703,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -300,15 +300,7 @@
                 "version_added": "46"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "64",
-                "notes": "Changes to parameters that should update live now do so starting in Firefox 64."
-              },
-              {
-                "version_added": "46"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/RadioNodeList.json
+++ b/api/RadioNodeList.json
@@ -25,9 +25,7 @@
           "safari": {
             "version_added": "7"
           },
-          "safari_ios": {
-            "version_added": "7"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -62,9 +60,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/Response.json
+++ b/api/Response.json
@@ -295,9 +295,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "40"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/api/SVGFEGaussianBlurElement.json
+++ b/api/SVGFEGaussianBlurElement.json
@@ -61,9 +61,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/SVGRadialGradientElement.json
+++ b/api/SVGRadialGradientElement.json
@@ -151,9 +151,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -725,10 +725,7 @@
               "version_added": "7",
               "notes": "See <a href='https://webkit.org/b/226721'>bug 226721</a>."
             },
-            "safari_ios": {
-              "version_added": "7",
-              "notes": "See <a href='https://webkit.org/b/226721'>bug 226721</a>."
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/SecurityPolicyViolationEvent.json
+++ b/api/SecurityPolicyViolationEvent.json
@@ -202,9 +202,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -418,9 +416,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -56,9 +56,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/SpeechSynthesis.json
+++ b/api/SpeechSynthesis.json
@@ -31,9 +31,7 @@
           "safari": {
             "version_added": "7"
           },
-          "safari_ios": {
-            "version_added": "7"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": {
             "version_added": "3.0"
           },
@@ -79,9 +77,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -127,9 +123,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -179,9 +173,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0",
               "notes": "In Android, <code>pause()</code> ends the current utterance. <code>pause()</code> behaves the same as <code>cancel()</code>."
@@ -228,9 +220,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -276,9 +266,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -324,9 +312,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -372,9 +358,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -420,9 +404,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },

--- a/api/SpeechSynthesisErrorEvent.json
+++ b/api/SpeechSynthesisErrorEvent.json
@@ -31,9 +31,7 @@
           "safari": {
             "version_added": "7"
           },
-          "safari_ios": {
-            "version_added": "7"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": {
             "version_added": "3.0"
           },
@@ -119,9 +117,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },

--- a/api/SpeechSynthesisEvent.json
+++ b/api/SpeechSynthesisEvent.json
@@ -31,9 +31,7 @@
           "safari": {
             "version_added": "7"
           },
-          "safari_ios": {
-            "version_added": "7"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": {
             "version_added": "3.0"
           },
@@ -121,9 +119,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -210,9 +206,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -260,10 +254,7 @@
                 "version_added": "7",
                 "version_removed": "14.1"
               },
-              "safari_ios": {
-                "version_added": "7",
-                "version_removed": "14.5"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": {
                 "version_added": "3.0"
               },
@@ -310,9 +301,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -358,9 +347,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },

--- a/api/SpeechSynthesisUtterance.json
+++ b/api/SpeechSynthesisUtterance.json
@@ -31,9 +31,7 @@
           "safari": {
             "version_added": "7"
           },
-          "safari_ios": {
-            "version_added": "7"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": {
             "version_added": "3.0"
           },
@@ -80,9 +78,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -136,9 +132,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -188,9 +182,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -240,9 +232,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -288,9 +278,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -340,9 +328,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -392,9 +378,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -440,9 +424,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -488,9 +470,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -540,9 +520,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -592,9 +570,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -640,9 +616,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -688,9 +662,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -736,9 +708,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },

--- a/api/SpeechSynthesisVoice.json
+++ b/api/SpeechSynthesisVoice.json
@@ -31,9 +31,7 @@
           "safari": {
             "version_added": "7"
           },
-          "safari_ios": {
-            "version_added": "7"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": {
             "version_added": "3.0"
           },
@@ -79,9 +77,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -127,9 +123,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -175,9 +169,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -223,9 +215,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },
@@ -271,9 +261,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "3.0"
             },

--- a/api/SubmitEvent.json
+++ b/api/SubmitEvent.json
@@ -23,9 +23,7 @@
           "safari": {
             "version_added": "15"
           },
-          "safari_ios": {
-            "version_added": "15"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -59,9 +57,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -102,16 +98,7 @@
                 "notes": "Property is not set for <code>&lt;button&gt;</code> elements. See <a href='https://webkit.org/b/229660'>bug 229660</a>."
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "15.4"
-              },
-              {
-                "version_added": "15",
-                "partial_implementation": true,
-                "notes": "Property is not set for <code>&lt;button&gt;</code> elements. See <a href='https://webkit.org/b/229660'>bug 229660</a>."
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -38,16 +38,7 @@
               "prefix": "WebKit"
             }
           ],
-          "safari_ios": [
-            {
-              "version_added": "11"
-            },
-            {
-              "version_added": "7",
-              "version_removed": "11.3",
-              "prefix": "WebKit"
-            }
-          ],
+          "safari_ios": "mirror",
           "samsunginternet_android": {
             "version_added": "6.0"
           },
@@ -198,9 +189,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -267,9 +256,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -328,9 +315,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -384,9 +369,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -454,9 +437,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -531,9 +512,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -604,9 +583,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -684,9 +661,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -741,9 +716,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -801,9 +774,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -866,9 +837,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "6.0"
             },
@@ -922,9 +891,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "6.0"
             },

--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -247,9 +247,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -287,9 +285,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/TextTrackList.json
+++ b/api/TextTrackList.json
@@ -116,9 +116,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "4.4"
@@ -254,9 +252,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "4.4"

--- a/api/UIEvent.json
+++ b/api/UIEvent.json
@@ -67,9 +67,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "1.0"
             },

--- a/api/URL.json
+++ b/api/URL.json
@@ -50,15 +50,7 @@
               "prefix": "webkit"
             }
           ],
-          "safari_ios": [
-            {
-              "version_added": "7"
-            },
-            {
-              "version_added": "6",
-              "prefix": "webkit"
-            }
-          ],
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": [
             {
@@ -256,9 +248,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -300,9 +290,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -832,9 +820,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "6.0"
             },

--- a/api/VTTRegion.json
+++ b/api/VTTRegion.json
@@ -23,9 +23,7 @@
           "safari": {
             "version_added": "7"
           },
-          "safari_ios": {
-            "version_added": "7"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -59,9 +57,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -95,9 +91,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -165,9 +159,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -201,9 +193,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -237,9 +227,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -273,9 +261,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -309,9 +295,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -345,9 +329,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/ValidityState.json
+++ b/api/ValidityState.json
@@ -70,9 +70,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/VideoTrack.json
+++ b/api/VideoTrack.json
@@ -52,9 +52,7 @@
           "safari": {
             "version_added": "7"
           },
-          "safari_ios": {
-            "version_added": "7"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -116,9 +114,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -181,9 +177,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -246,9 +240,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -311,9 +303,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -376,9 +366,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/VideoTrackList.json
+++ b/api/VideoTrackList.json
@@ -52,9 +52,7 @@
           "safari": {
             "version_added": "7"
           },
-          "safari_ios": {
-            "version_added": "7"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -120,9 +118,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -189,9 +185,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -254,9 +248,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -319,9 +311,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -388,9 +378,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -453,9 +441,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -25,9 +25,7 @@
           "safari": {
             "version_added": "15"
           },
-          "safari_ios": {
-            "version_added": "15"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -62,9 +60,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -100,9 +96,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -138,9 +132,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -176,9 +168,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -214,9 +204,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -252,9 +240,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -290,9 +276,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -328,9 +312,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -365,9 +347,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -436,9 +416,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -474,9 +452,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -545,9 +521,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -616,9 +590,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -687,9 +659,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -725,9 +695,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -796,9 +764,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -834,9 +800,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -872,9 +836,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -910,9 +872,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -948,9 +908,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -986,9 +944,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1024,9 +980,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1062,9 +1016,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1100,9 +1052,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1138,9 +1088,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1176,9 +1124,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1214,9 +1160,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1252,9 +1196,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1290,9 +1232,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1328,9 +1268,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1366,9 +1304,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1404,9 +1340,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1442,9 +1376,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1480,9 +1412,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1518,9 +1448,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1556,9 +1484,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1594,9 +1520,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1632,9 +1556,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1670,9 +1592,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1741,9 +1661,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1779,9 +1697,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1817,9 +1733,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1855,9 +1769,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1893,9 +1805,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1931,9 +1841,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1969,9 +1877,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2007,9 +1913,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2045,9 +1949,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2083,9 +1985,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2121,9 +2021,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2159,9 +2057,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2197,9 +2093,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2235,9 +2129,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2273,9 +2165,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2311,9 +2201,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2349,9 +2237,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2387,9 +2273,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2425,9 +2309,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2463,9 +2345,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2501,9 +2381,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2539,9 +2417,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2577,9 +2453,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2615,9 +2489,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2686,9 +2558,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2724,9 +2594,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2762,9 +2630,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2833,9 +2699,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2871,9 +2735,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2909,9 +2771,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2947,9 +2807,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -2985,9 +2843,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -3023,9 +2879,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -3061,9 +2915,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -3099,9 +2951,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -3137,9 +2987,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -3175,9 +3023,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -3213,9 +3059,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -3251,9 +3095,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -3289,9 +3131,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -3327,9 +3167,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -3365,9 +3203,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -3403,9 +3239,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -3441,9 +3275,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -3479,9 +3311,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -3517,9 +3347,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -3588,9 +3416,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -3659,9 +3485,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -3730,9 +3554,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -3801,9 +3623,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -3872,9 +3692,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -3943,9 +3761,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -4014,9 +3830,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -4085,9 +3899,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -4156,9 +3968,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -4194,9 +4004,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -4232,9 +4040,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -4303,9 +4109,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -4341,9 +4145,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -4412,9 +4214,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -4450,9 +4250,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/WebGLTransformFeedback.json
+++ b/api/WebGLTransformFeedback.json
@@ -25,9 +25,7 @@
           "safari": {
             "version_added": "15"
           },
-          "safari_ios": {
-            "version_added": "15"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },

--- a/api/WebGLVertexArrayObject.json
+++ b/api/WebGLVertexArrayObject.json
@@ -25,9 +25,7 @@
           "safari": {
             "version_added": "15"
           },
-          "safari_ios": {
-            "version_added": "15"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },

--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -665,27 +665,7 @@
                 "notes": "Only parameter of type <code>String</code> supported. Returns <code>boolean</code>."
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "18",
-                "notes": "See <a href='https://bugzil.la/775368'>bug 775368</a>."
-              },
-              {
-                "version_added": "14",
-                "version_removed": "18",
-                "notes": "Only parameter of type <code>ArrayBuffer</code> and <code>String</code> supported."
-              },
-              {
-                "version_added": "8",
-                "version_removed": "14",
-                "notes": "Only parameter of type <code>String</code> supported."
-              },
-              {
-                "version_added": "7",
-                "version_removed": "8",
-                "notes": "Only parameter of type <code>String</code> supported. Returns <code>boolean</code>."
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "10"
             },

--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -65,9 +65,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "1.0"
             },
@@ -105,9 +103,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "1.0"
             },

--- a/api/Window.json
+++ b/api/Window.json
@@ -600,16 +600,7 @@
                 "prefix": "webkit"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "7"
-              },
-              {
-                "version_added": "6",
-                "version_removed": "7",
-                "prefix": "webkit"
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -3909,21 +3900,7 @@
                 "notes": "The <code>message</code> parameter must be a string."
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "8",
-                "notes": "Supports sending <code>File</code> and <code>FileList</code> objects between windows. This is only allowed if the recipient's principal is contained within the sender's principal for security reasons."
-              },
-              {
-                "version_added": "6",
-                "notes": "The <code>message</code> parameter is serialized using the <a href='https://developer.mozilla.org/docs/Web/API/Web_Workers_API/Structured_clone_algorithm'>structured clone algorithm</a>. This means you can pass a broad variety of data objects safely to the destination window without having to serialize them yourself."
-              },
-              {
-                "version_added": "4",
-                "version_removed": "6",
-                "notes": "The <code>message</code> parameter must be a string."
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": [
               {
                 "version_added": "10",
@@ -4235,15 +4212,7 @@
                 "prefix": "webkit"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "7"
-              },
-              {
-                "version_added": "6",
-                "prefix": "webkit"
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": [
               {
@@ -5907,9 +5876,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -180,9 +180,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -117,9 +117,7 @@
               "version_added": "5"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "4.4"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -290,9 +288,7 @@
               "version_added": "5"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "4.4"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -335,9 +331,7 @@
               "version_added": "5"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "4.4"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -497,9 +491,7 @@
               "version_added": "5"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "4.4"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1027,9 +1027,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1080,9 +1078,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1285,9 +1281,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1413,17 +1407,7 @@
                   "notes": "Doesn't send the correct <code>Content-Type</code> header by default. See <a href='https://webkit.org/b/227477'>bug 227477</a>."
                 }
               ],
-              "safari_ios": [
-                {
-                  "version_added": "15"
-                },
-                {
-                  "version_added": "10.3",
-                  "version_removed": "15",
-                  "partial_implementation": true,
-                  "notes": "Doesn't send the correct <code>Content-Type</code> header by default. See <a href='https://webkit.org/b/227477'>bug 227477</a>."
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1598,9 +1582,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1640,9 +1622,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "1.0"
             },

--- a/api/XMLHttpRequestUpload.json
+++ b/api/XMLHttpRequestUpload.json
@@ -356,9 +356,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "1.0"
             },

--- a/api/_globals/atob.json
+++ b/api/_globals/atob.json
@@ -24,15 +24,7 @@
               "version_added": "1"
             }
           ],
-          "firefox_android": [
-            {
-              "version_added": "27",
-              "notes": "<code>atob()</code> ignores all space characters in the argument to comply with the latest HTML5 spec (see <a href='https://bugzil.la/711180'>bug 711180</a>)."
-            },
-            {
-              "version_added": "4"
-            }
-          ],
+          "firefox_android": "mirror",
           "ie": {
             "version_added": "10"
           },

--- a/api/_globals/createImageBitmap.json
+++ b/api/_globals/createImageBitmap.json
@@ -27,10 +27,7 @@
             "version_added": "15",
             "notes": "See <a href='https://webkit.org/b/182424'>bug 182424</a>."
           },
-          "safari_ios": {
-            "version_added": "15",
-            "notes": "See <a href='https://webkit.org/b/182424'>bug 182424</a>."
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },

--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -33,19 +33,7 @@
                 "version_added": "5"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "49",
-                "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "5"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "10"
             },

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -913,9 +913,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/-webkit-mask-attachment.json
+++ b/css/properties/-webkit-mask-attachment.json
@@ -25,10 +25,7 @@
               "version_added": "4",
               "version_removed": "7"
             },
-            "safari_ios": {
-              "version_added": "3.2",
-              "version_removed": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "2",

--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -59,15 +59,7 @@
                   "version_added": "7"
                 }
               ],
-              "safari_ios": [
-                {
-                  "version_added": "9"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": [
                 {

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -66,15 +66,7 @@
                   "version_added": "7"
                 }
               ],
-              "safari_ios": [
-                {
-                  "version_added": "9"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": [
                 {
                   "version_added": "6.0"
@@ -138,9 +130,7 @@
                 "safari": {
                   "version_added": "7"
                 },
-                "safari_ios": {
-                  "version_added": "7"
-                },
+                "safari_ios": "mirror",
                 "samsunginternet_android": {
                   "version_added": "7.0"
                 },

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -65,15 +65,7 @@
                   "version_added": "7"
                 }
               ],
-              "safari_ios": [
-                {
-                  "version_added": "9"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": [
                 {
                   "version_added": "3.0"
@@ -137,9 +129,7 @@
                 "safari": {
                   "version_added": "7"
                 },
-                "safari_ios": {
-                  "version_added": "7"
-                },
+                "safari_ios": "mirror",
                 "samsunginternet_android": {
                   "version_added": "7.0"
                 },

--- a/css/properties/animation-direction.json
+++ b/css/properties/animation-direction.json
@@ -38,19 +38,7 @@
                 "version_added": "5"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "16"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "49"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "5"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "10"
             },

--- a/css/properties/animation-duration.json
+++ b/css/properties/animation-duration.json
@@ -38,19 +38,7 @@
                 "version_added": "5"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "16"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "49"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "5"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "10",
               "partial_implementation": true,

--- a/css/properties/animation-fill-mode.json
+++ b/css/properties/animation-fill-mode.json
@@ -38,19 +38,7 @@
                 "version_added": "5"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "16"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "49"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "5"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "10"
             },

--- a/css/properties/animation-iteration-count.json
+++ b/css/properties/animation-iteration-count.json
@@ -38,19 +38,7 @@
                 "version_added": "5"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "16"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "49"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "5"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "10"
             },

--- a/css/properties/animation-name.json
+++ b/css/properties/animation-name.json
@@ -38,19 +38,7 @@
                 "version_added": "5"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "49",
-                "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "5"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "10"
             },

--- a/css/properties/animation-play-state.json
+++ b/css/properties/animation-play-state.json
@@ -38,19 +38,7 @@
                 "version_added": "5"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "49",
-                "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "5"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "10"
             },

--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -38,19 +38,7 @@
                 "version_added": "5"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "49",
-                "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "5"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "10"
             },

--- a/css/properties/animation.json
+++ b/css/properties/animation.json
@@ -38,19 +38,7 @@
                 "version_added": "5"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "49",
-                "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "5"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "10"
             },

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -38,19 +38,7 @@
                 "prefix": "-moz-"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "80"
-              },
-              {
-                "version_added": "64",
-                "prefix": "-webkit-"
-              },
-              {
-                "version_added": "4",
-                "prefix": "-moz-"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -62,9 +62,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/backface-visibility.json
+++ b/css/properties/backface-visibility.json
@@ -38,19 +38,7 @@
                 "version_added": "10"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "49",
-                "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "10"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "10"
             },

--- a/css/properties/background-position.json
+++ b/css/properties/background-position.json
@@ -105,9 +105,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/border-end-end-radius.json
+++ b/css/properties/border-end-end-radius.json
@@ -26,9 +26,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/border-end-start-radius.json
+++ b/css/properties/border-end-start-radius.json
@@ -26,9 +26,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/border-start-end-radius.json
+++ b/css/properties/border-start-end-radius.json
@@ -26,9 +26,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/border-start-start-radius.json
+++ b/css/properties/border-start-start-radius.json
@@ -26,9 +26,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/box-align.json
+++ b/css/properties/box-align.json
@@ -24,16 +24,7 @@
                 "prefix": "-moz-"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "49",
-                "prefix": "-webkit-"
-              },
-              {
-                "version_added": "4",
-                "prefix": "-moz-"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -57,11 +57,7 @@
               "prefix": "-webkit-",
               "notes": "This property is only supported for inline elements."
             },
-            "safari_ios": {
-              "version_added": "7",
-              "prefix": "-webkit-",
-              "notes": "This property is only supported for inline elements."
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "prefix": "-webkit-",

--- a/css/properties/box-direction.json
+++ b/css/properties/box-direction.json
@@ -24,16 +24,7 @@
                 "version_added": "1"
               }
             ],
-            "firefox_android": [
-              {
-                "prefix": "-webkit-",
-                "version_added": "49"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "4"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/css/properties/box-flex.json
+++ b/css/properties/box-flex.json
@@ -24,16 +24,7 @@
                 "version_added": "1"
               }
             ],
-            "firefox_android": [
-              {
-                "prefix": "-webkit-",
-                "version_added": "49"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "4"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/css/properties/box-ordinal-group.json
+++ b/css/properties/box-ordinal-group.json
@@ -24,16 +24,7 @@
                 "version_added": "1"
               }
             ],
-            "firefox_android": [
-              {
-                "prefix": "-webkit-",
-                "version_added": "49"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "4"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/css/properties/box-orient.json
+++ b/css/properties/box-orient.json
@@ -24,16 +24,7 @@
                 "version_added": "1"
               }
             ],
-            "firefox_android": [
-              {
-                "prefix": "-webkit-",
-                "version_added": "49"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "4"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/css/properties/box-pack.json
+++ b/css/properties/box-pack.json
@@ -24,16 +24,7 @@
                 "version_added": "1"
               }
             ],
-            "firefox_android": [
-              {
-                "prefix": "-webkit-",
-                "version_added": "49"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "4"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/css/properties/box-sizing.json
+++ b/css/properties/box-sizing.json
@@ -40,20 +40,7 @@
                 "notes": "Before Firefox 23, <code>box-sizing</code> is not respected when the height is calculated from <a href='https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle'><code>window.getComputedStyle()</code></a>."
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "29"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "49"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "4",
-                "notes": "Before Firefox 23, <code>box-sizing</code> is not respected when the height is calculated from <a href='https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle'><code>window.getComputedStyle()</code></a>."
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "8",
               "notes": "<code>box-sizing</code> is not respected when the height is calculated from <a href='https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle'><code>window.getComputedStyle()</code></a>."

--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -43,15 +43,7 @@
                 "version_added": "7"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "9.3"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "7"
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -116,9 +108,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -185,9 +175,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -273,9 +261,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -218,15 +218,7 @@
                   "version_added": "7"
                 }
               ],
-              "safari_ios": [
-                {
-                  "version_added": "9"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": [
                 {
@@ -410,15 +402,7 @@
                   "version_added": "7"
                 }
               ],
-              "safari_ios": [
-                {
-                  "version_added": "9"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": [
                 {
@@ -618,9 +602,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -68,15 +68,7 @@
                 "version_added": "7"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "9"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "7"
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": [
               {
@@ -128,15 +120,7 @@
                   "version_added": "7"
                 }
               ],
-              "safari_ios": [
-                {
-                  "version_added": "9"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -80,15 +80,7 @@
                 "version_added": "7"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "9"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "7"
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": [
               {

--- a/css/properties/flex-flow.json
+++ b/css/properties/flex-flow.json
@@ -60,15 +60,7 @@
                 "version_added": "7"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "9"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "7"
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": [
               {

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -67,15 +67,7 @@
                 "version_added": "7"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "9"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "7"
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": [
               {

--- a/css/properties/flex-wrap.json
+++ b/css/properties/flex-wrap.json
@@ -46,15 +46,7 @@
                 "version_added": "7"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "9"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "7"
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": [
               {

--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -86,15 +86,7 @@
                 "version_added": "7"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "9"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "7"
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": [
               {

--- a/css/properties/font-size.json
+++ b/css/properties/font-size.json
@@ -78,9 +78,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
                 "version_added": "4"

--- a/css/properties/font-variant-ligatures.json
+++ b/css/properties/font-variant-ligatures.json
@@ -54,15 +54,7 @@
                 "version_added": "7"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "9.3"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "7"
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": [
               {

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -233,23 +233,7 @@
                   "partial_implementation": true
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "79"
-                },
-                {
-                  "version_added": "57",
-                  "version_removed": "79",
-                  "notes": "<code>repeat(auto-fill, ...)</code> and <code>repeat(auto-fit, ...)</code> only support one repeated column (see <a href='https://bugzil.la/1341507'>bug 1341507</a>).",
-                  "partial_implementation": true
-                },
-                {
-                  "version_added": "52",
-                  "version_removed": "57",
-                  "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>).",
-                  "partial_implementation": true
-                }
-              ],
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -234,23 +234,7 @@
                   "partial_implementation": true
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "79"
-                },
-                {
-                  "version_added": "57",
-                  "version_removed": "79",
-                  "notes": "<code>repeat(auto-fill, ...)</code> and <code>repeat(auto-fit, ...)</code> only support one repeated column (see <a href='https://bugzil.la/1341507'>bug 1341507</a>).",
-                  "partial_implementation": true
-                },
-                {
-                  "version_added": "52",
-                  "version_removed": "57",
-                  "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>).",
-                  "partial_implementation": true
-                }
-              ],
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/css/properties/image-rendering.json
+++ b/css/properties/image-rendering.json
@@ -70,15 +70,7 @@
                   "version_added": "6"
                 }
               ],
-              "safari_ios": [
-                {
-                  "version_added": "7"
-                },
-                {
-                  "alternative_name": "-webkit-optimize-contrast",
-                  "version_added": "6"
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
                 "alternative_name": "-webkit-optimize-contrast",
@@ -115,9 +107,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -151,9 +141,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -65,15 +65,7 @@
                   "version_added": "7"
                 }
               ],
-              "safari_ios": [
-                {
-                  "version_added": "9"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": [
                 {
                   "version_added": "6.0"

--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -755,9 +755,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -790,9 +788,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1490,9 +1486,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1851,9 +1845,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1892,9 +1884,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -2071,9 +2061,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -2106,9 +2094,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -2141,9 +2127,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -2779,9 +2763,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -2820,9 +2802,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -3325,9 +3305,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -3366,9 +3344,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/mask-type.json
+++ b/css/properties/mask-type.json
@@ -24,9 +24,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "37"

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -89,19 +89,7 @@
                   "version_added": "2"
                 }
               ],
-              "safari_ios": [
-                {
-                  "version_added": "11"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                },
-                {
-                  "alternative_name": "intrinsic",
-                  "version_added": "1"
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -87,19 +87,7 @@
                   "version_added": "2"
                 }
               ],
-              "safari_ios": [
-                {
-                  "version_added": "11"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                },
-                {
-                  "alternative_name": "intrinsic",
-                  "version_added": "1"
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": [
                 {
@@ -207,19 +195,7 @@
                   "version_added": "2"
                 }
               ],
-              "safari_ios": [
-                {
-                  "version_added": "11"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                },
-                {
-                  "alternative_name": "intrinsic",
-                  "version_added": "1"
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": [
                 {
@@ -288,19 +264,7 @@
                   "version_added": "2"
                 }
               ],
-              "safari_ios": [
-                {
-                  "version_added": "11"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                },
-                {
-                  "alternative_name": "intrinsic",
-                  "version_added": "1"
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -67,9 +67,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
                 "version_added": "37"
@@ -128,19 +126,7 @@
                   "version_added": "2"
                 }
               ],
-              "safari_ios": [
-                {
-                  "version_added": "11"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                },
-                {
-                  "alternative_name": "intrinsic",
-                  "version_added": "1"
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": [
                 {

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -78,9 +78,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
                 "version_added": "37",
@@ -132,15 +130,7 @@
                   "version_added": "7"
                 }
               ],
-              "safari_ios": [
-                {
-                  "version_added": "11"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": {
                 "alternative_name": "-webkit-fill-available",
                 "version_added": "5.0"

--- a/css/properties/offset-rotate.json
+++ b/css/properties/offset-rotate.json
@@ -19,32 +19,8 @@
                 "version_added": "46"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "56"
-              },
-              {
-                "alternative_name": "offset-rotation",
-                "version_added": "55"
-              },
-              {
-                "alternative_name": "motion-rotation",
-                "version_added": "46"
-              }
-            ],
-            "edge": [
-              {
-                "version_added": "79"
-              },
-              {
-                "alternative_name": "offset-rotation",
-                "version_added": "79"
-              },
-              {
-                "alternative_name": "motion-rotation",
-                "version_added": "79"
-              }
-            ],
+            "chrome_android": "mirror",
+            "edge": "mirror",
             "firefox": [
               {
                 "version_added": "72"
@@ -68,62 +44,14 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": [
-              {
-                "version_added": "43"
-              },
-              {
-                "alternative_name": "offset-rotation",
-                "version_added": "42"
-              },
-              {
-                "alternative_name": "motion-rotation",
-                "version_added": "33"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "alternative_name": "offset-rotation",
-                "version_added": "42"
-              },
-              {
-                "alternative_name": "motion-rotation",
-                "version_added": "33"
-              }
-            ],
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": [
-              {
-                "version_added": "6.0"
-              },
-              {
-                "alternative_name": "offset-rotation",
-                "version_added": "6.0"
-              },
-              {
-                "alternative_name": "motion-rotation",
-                "version_added": "5.0"
-              }
-            ],
-            "webview_android": [
-              {
-                "version_added": "56"
-              },
-              {
-                "alternative_name": "offset-rotation",
-                "version_added": "55"
-              },
-              {
-                "alternative_name": "motion-rotation",
-                "version_added": "46"
-              }
-            ]
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/order.json
+++ b/css/properties/order.json
@@ -61,15 +61,7 @@
                 "version_added": "7"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "9"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "7"
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": [
               {

--- a/css/properties/overflow-wrap.json
+++ b/css/properties/overflow-wrap.json
@@ -67,15 +67,7 @@
                 "version_added": "1"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "7"
-              },
-              {
-                "alternative_name": "word-wrap",
-                "version_added": "1"
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": [
               {

--- a/css/properties/perspective-origin.json
+++ b/css/properties/perspective-origin.json
@@ -38,19 +38,7 @@
                 "version_added": "10"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "49",
-                "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "10"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "10"
             },

--- a/css/properties/perspective.json
+++ b/css/properties/perspective.json
@@ -38,19 +38,7 @@
                 "version_added": "10"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "49",
-                "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "10"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "10"
             },

--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -186,15 +186,7 @@
                   "version_added": "7"
                 }
               ],
-              "safari_ios": [
-                {
-                  "version_added": "13"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/ruby-position.json
+++ b/css/properties/ruby-position.json
@@ -47,11 +47,7 @@
               "prefix": "-webkit-",
               "notes": "Implemented as a non-standard, prefixed, version of <code>ruby-position</code>, <code>-webkit-ruby-position</code>: it has two properties: <code>before</code> and <code>after</code> (both equivalent, for ltr and rtl scripts to the standard <code>over</code> value used with <code>ruby-align: start</code>)."
             },
-            "safari_ios": {
-              "version_added": "7",
-              "prefix": "-webkit-",
-              "notes": "Implemented as a non-standard, prefixed, version of <code>ruby-position</code>, <code>-webkit-ruby-position</code>: it has two properties: <code>before</code> and <code>after</code> (both equivalent, for ltr and rtl scripts to the standard <code>over</code> value used with <code>ruby-align: start</code>)."
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "14.0"
             },

--- a/css/properties/scroll-padding-block-end.json
+++ b/css/properties/scroll-padding-block-end.json
@@ -24,9 +24,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/scroll-padding-block-start.json
+++ b/css/properties/scroll-padding-block-start.json
@@ -24,9 +24,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/scroll-padding-block.json
+++ b/css/properties/scroll-padding-block.json
@@ -24,9 +24,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/scroll-padding-inline-end.json
+++ b/css/properties/scroll-padding-inline-end.json
@@ -24,9 +24,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/scroll-padding-inline-start.json
+++ b/css/properties/scroll-padding-inline-start.json
@@ -24,9 +24,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/scroll-padding-inline.json
+++ b/css/properties/scroll-padding-inline.json
@@ -24,9 +24,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/scroll-snap-stop.json
+++ b/css/properties/scroll-snap-stop.json
@@ -25,9 +25,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/tab-size.json
+++ b/css/properties/tab-size.json
@@ -50,9 +50,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "4.4"

--- a/css/properties/text-align.json
+++ b/css/properties/text-align.json
@@ -76,16 +76,7 @@
                   "version_added": "1"
                 }
               ],
-              "safari_ios": [
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "1"
-                },
-                {
-                  "prefix": "-khtml-",
-                  "version_added": "1"
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
                 "prefix": "-webkit-",

--- a/css/properties/text-decoration-skip.json
+++ b/css/properties/text-decoration-skip.json
@@ -42,17 +42,7 @@
                 "notes": "Supports only <code>none</code>, <code>auto</code>, and <code>objects</code> values."
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "12.2",
-                "notes": "Supports only <code>none</code>, <code>auto</code>, and <code>objects</code> values."
-              },
-              {
-                "version_added": "7",
-                "prefix": "-webkit-",
-                "notes": "Supports only <code>none</code>, <code>auto</code>, and <code>objects</code> values."
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/text-emphasis-color.json
+++ b/css/properties/text-emphasis-color.json
@@ -42,15 +42,7 @@
                 "version_added": "7"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "7"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "7"
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "prefix": "-webkit-",

--- a/css/properties/text-emphasis-position.json
+++ b/css/properties/text-emphasis-position.json
@@ -42,15 +42,7 @@
                 "version_added": "7"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "7"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "7"
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "prefix": "-webkit-",

--- a/css/properties/text-emphasis-style.json
+++ b/css/properties/text-emphasis-style.json
@@ -42,15 +42,7 @@
                 "version_added": "7"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "7"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "7"
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "prefix": "-webkit-",

--- a/css/properties/text-emphasis.json
+++ b/css/properties/text-emphasis.json
@@ -42,15 +42,7 @@
                 "version_added": "7"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "7"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "7"
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "prefix": "-webkit-",

--- a/css/properties/text-orientation.json
+++ b/css/properties/text-orientation.json
@@ -85,9 +85,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -38,19 +38,7 @@
                 "version_added": "3.5"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "16"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "49"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "4"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": [
               {
                 "version_added": "10"

--- a/css/properties/transform-style.json
+++ b/css/properties/transform-style.json
@@ -38,19 +38,7 @@
                 "version_added": "10"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "16"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "49"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "10"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/css/properties/transition-delay.json
+++ b/css/properties/transition-delay.json
@@ -38,19 +38,7 @@
                 "version_added": "4"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "49",
-                "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "4"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": [
               {
                 "version_added": "10"

--- a/css/properties/transition-duration.json
+++ b/css/properties/transition-duration.json
@@ -38,19 +38,7 @@
                 "version_added": "4"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "49",
-                "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "4"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": [
               {
                 "version_added": "10"

--- a/css/properties/transition-property.json
+++ b/css/properties/transition-property.json
@@ -38,19 +38,7 @@
                 "version_added": "4"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "49",
-                "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "4"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": [
               {
                 "version_added": "10"

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -38,19 +38,7 @@
                 "version_added": "4"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "16"
-              },
-              {
-                "version_added": "49",
-                "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "4"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": [
               {
                 "version_added": "10"

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -43,24 +43,7 @@
                 "version_added": "4"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "16",
-                "notes": [
-                  "Before Firefox 57, transitions do not work when transitioning from a <a href='https://developer.mozilla.org/docs/Web/CSS/text-shadow'><code>text-shadow</code></a> with a color specified to a <code>text-shadow</code> without a color specified (see <a href='https://bugzil.la/726550'>bug 726550</a>).",
-                  "Before Firefox 57, cancelling a filling animation (for example, with <code>animation-fill-mode: forwards</code> set) can trigger a transition set on the same element, although only once (see <a href='https://bugzil.la/1192592'>bug 1192592</a> and <a href='https://bug1192592.bmoattachments.org/attachment.cgi?id=8843824'>these test cases</a> for more information).",
-                  "Before Firefox 57, the <a href='https://developer.mozilla.org/docs/Web/CSS/background-position'><code>background-position</code></a> property can't be transitioned between two values containing different numbers of <a href='https://developer.mozilla.org/docs/Web/CSS/position_value'><code>&lt;position&gt;</code></a> values, for example <code>background-position: 10px 10px;</code> and <code>background-position: 20px 20px, 30px 30px;</code> (see <a href='https://bugzil.la/1390446'>bug 1390446</a>)."
-                ]
-              },
-              {
-                "version_added": "49",
-                "prefix": "-webkit-"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "4"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": [
               {
                 "version_added": "10"

--- a/css/properties/unicode-bidi.json
+++ b/css/properties/unicode-bidi.json
@@ -155,15 +155,7 @@
                   "version_added": "7"
                 }
               ],
-              "safari_ios": [
-                {
-                  "version_added": "11"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -43,19 +43,7 @@
                 "version_added": "1"
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "79"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "49"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "4"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "prefix": "-ms-",
               "version_added": "10"

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -64,9 +64,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -160,19 +158,7 @@
                   "version_added": "2"
                 }
               ],
-              "safari_ios": [
-                {
-                  "version_added": "11"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                },
-                {
-                  "alternative_name": "intrinsic",
-                  "version_added": "1"
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -358,10 +344,7 @@
                 "alternative_name": "-webkit-fill-available",
                 "version_added": "7"
               },
-              "safari_ios": {
-                "alternative_name": "-webkit-fill-available",
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": {
                 "version_added": "5.0",
                 "alternative_name": "-webkit-fill-available"

--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -60,9 +60,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/selectors/-webkit-meter-inner-element.json
+++ b/css/selectors/-webkit-meter-inner-element.json
@@ -24,9 +24,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/selectors/-webkit-progress-bar.json
+++ b/css/selectors/-webkit-progress-bar.json
@@ -24,9 +24,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/selectors/-webkit-progress-inner-element.json
+++ b/css/selectors/-webkit-progress-inner-element.json
@@ -24,9 +24,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/selectors/-webkit-progress-value.json
+++ b/css/selectors/-webkit-progress-value.json
@@ -24,9 +24,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/selectors/cue.json
+++ b/css/selectors/cue.json
@@ -28,9 +28,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -62,9 +60,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/selectors/descendant.json
+++ b/css/selectors/descendant.json
@@ -16,15 +16,7 @@
                 "version_added": "1"
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "61",
-                "notes": "<code>&gt;&gt;&gt;</code> is aliased to this selector <a href='https://developers.google.com/web/updates/2017/06/chrome-60-deprecations#make_shadow-piercing_descendant_combinator_behave_like_descendent_combinator'>since its use as the 'shadow-piercing descendant combinator' was deprecated</a>."
-              },
-              {
-                "version_added": "18"
-              }
-            ],
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
@@ -46,15 +38,7 @@
               "version_added": "1"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": [
-              {
-                "version_added": "8.0",
-                "notes": "<code>&gt;&gt;&gt;</code> is aliased to this selector <a href='https://developers.google.com/web/updates/2017/06/chrome-60-deprecations#make_shadow-piercing_descendant_combinator_behave_like_descendent_combinator'>since its use as the 'shadow-piercing descendant combinator' was deprecated</a>."
-              },
-              {
-                "version_added": "1.0"
-              }
-            ],
+            "samsunginternet_android": "mirror",
             "webview_android": [
               {
                 "version_added": "61",

--- a/css/selectors/future.json
+++ b/css/selectors/future.json
@@ -25,9 +25,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/selectors/past.json
+++ b/css/selectors/past.json
@@ -25,9 +25,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/selectors/scope.json
+++ b/css/selectors/scope.json
@@ -26,9 +26,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -60,9 +58,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -217,23 +217,7 @@
                   "notes": "With the preference enabled, the <code>d</code> SVG presentation attribute, <code>clip-path</code> CSS property, and <code>offset-path</code> CSS property support <code>path()</code>."
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "97",
-                  "partial_implementation": true,
-                  "notes": "Only supported on the <code>d</code> SVG presentation attribute and the <code>clip-path</code> and <code>offset-path</code> CSS properties. Not supported on the <code>shape-outside</code> CSS property."
-                },
-                {
-                  "version_added": "79",
-                  "partial_implementation": true,
-                  "notes": "Only supported on the <code>clip-path</code> and <code>offset-path</code> properties."
-                },
-                {
-                  "version_added": "63",
-                  "partial_implementation": true,
-                  "notes": "Only supported on the <code>offset-path</code> property."
-                }
-              ],
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/css/types/calc.json
+++ b/css/types/calc.json
@@ -57,15 +57,7 @@
                 "version_added": "6"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "7"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "6"
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": [
               {

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -73,17 +73,7 @@
                   "notes": "Only supports <code>display-p3</code> and <code>srgb</code> predefined color profiles."
                 }
               ],
-              "safari_ios": [
-                {
-                  "version_added": "15"
-                },
-                {
-                  "version_added": "10.3",
-                  "version_removed": "15",
-                  "partial_implementation": true,
-                  "notes": "Only supports <code>display-p3</code> and <code>srgb</code> predefined color profiles."
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -205,15 +195,7 @@
                   }
                 ]
               },
-              "safari_ios": {
-                "version_added": "15",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "CSS color-contrast()"
-                  }
-                ]
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -261,15 +243,7 @@
                   }
                 ]
               },
-              "safari_ios": {
-                "version_added": "15",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "CSS color-mix()"
-                  }
-                ]
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -532,9 +506,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -569,9 +541,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -606,9 +576,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -242,15 +242,7 @@
                   "version_added": "5.1"
                 }
               ],
-              "safari_ios": [
-                {
-                  "version_added": "7"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "6"
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": [
                 {
@@ -384,24 +376,7 @@
                     ]
                   }
                 ],
-                "firefox_android": [
-                  {
-                    "version_added": "16",
-                    "notes": "Before Firefox 36, gradients weren't applied on the pre-multiplied color space, leading to shades of grey unexpectedly appearing when used with transparency."
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "49"
-                  },
-                  {
-                    "prefix": "-moz-",
-                    "version_added": "4",
-                    "notes": [
-                      "Since Firefox 42, the prefixed version of gradients can be disabled by setting <code>layout.css.prefixes.gradients</code> to <code>false</code>.",
-                      "Considers <code>&lt;angle&gt;</code> to start to the right, instead of the top. I.e. it considered an angle of <code>0deg</code> as a direction indicator pointing to the right."
-                    ]
-                  }
-                ],
+                "firefox_android": "mirror",
                 "ie": {
                   "version_added": "10",
                   "notes": "Internet Explorer 5.5 through 9.0 supported gradients via a proprietary filter: <code><a href='https://developer.mozilla.org/docs/Web/CSS/-ms-filter#Gradient'>-ms-filter: progid:DXImageTransform.Microsoft.Gradient()</a></code>."
@@ -452,19 +427,7 @@
                     ]
                   }
                 ],
-                "safari_ios": [
-                  {
-                    "version_added": "7"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "6",
-                    "notes": [
-                      "Safari 4 was supporting an experimental <code><a href='https://developer.apple.com/library/archive/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(linear,…)</a></code> function. It is more limited than the later standard version: you cannot specify both a position and an angle like in <code>linear-gradient()</code>. This old outdated syntax is still supported for compatibility purposes.",
-                      "Considers <code>&lt;angle&gt;</code> to start to the right, instead of the top. I.e. it considered an angle of <code>0deg</code> as a direction indicator pointing to the right."
-                    ]
-                  }
-                ],
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": [
                   {
@@ -537,9 +500,7 @@
                   "safari": {
                     "version_added": "7"
                   },
-                  "safari_ios": {
-                    "version_added": "7"
-                  },
+                  "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
                   "webview_android": "mirror"
                 },
@@ -576,9 +537,7 @@
                   "safari": {
                     "version_added": "7"
                   },
-                  "safari_ios": {
-                    "version_added": "7"
-                  },
+                  "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
                   "webview_android": "mirror"
                 },
@@ -622,9 +581,7 @@
                   "safari": {
                     "version_added": "7"
                   },
-                  "safari_ios": {
-                    "version_added": "7"
-                  },
+                  "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
                   "webview_android": "mirror"
                 },
@@ -670,21 +627,7 @@
                     "notes": "Since Firefox 42, the prefixed version of gradients can be disabled by setting <code>layout.css.prefixes.gradients</code> to <code>false</code>."
                   }
                 ],
-                "firefox_android": [
-                  {
-                    "version_added": "16",
-                    "notes": "Before Firefox 36, gradients weren't applied on the pre-multiplied color space, leading to shades of grey unexpectedly appearing when used with transparency."
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "49"
-                  },
-                  {
-                    "prefix": "-moz-",
-                    "version_added": "4",
-                    "notes": "Since Firefox 42, the prefixed version of gradients can be disabled by setting <code>layout.css.prefixes.gradients</code> to <code>false</code>."
-                  }
-                ],
+                "firefox_android": "mirror",
                 "ie": {
                   "version_added": "10",
                   "notes": "Internet Explorer 5.5 through 9.0 supported gradients via a proprietary filter: <code><a href='https://developer.mozilla.org/docs/Web/CSS/-ms-filter#Gradient'>-ms-filter: progid:DXImageTransform.Microsoft.Gradient()</a></code>."
@@ -728,16 +671,7 @@
                     "notes": "Safari 4 was supporting an experimental <code><a href='https://developer.apple.com/library/archive/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(radial,…)</a></code> function. This old outdated syntax is still supported for compatibility purposes."
                   }
                 ],
-                "safari_ios": [
-                  {
-                    "version_added": "7"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "6",
-                    "notes": "Safari 4 was supporting an experimental <code><a href='https://developer.apple.com/library/archive/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(radial,…)</a></code> function. This old outdated syntax is still supported for compatibility purposes."
-                  }
-                ],
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": [
                   {
@@ -883,9 +817,7 @@
                   "safari": {
                     "version_added": "7"
                   },
-                  "safari_ios": {
-                    "version_added": "7"
-                  },
+                  "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
                   "webview_android": "mirror"
                 },
@@ -980,24 +912,7 @@
                     ]
                   }
                 ],
-                "firefox_android": [
-                  {
-                    "version_added": "16",
-                    "notes": "Before Firefox 36, gradients weren't applied on the pre-multiplied color space, leading to shades of grey unexpectedly appearing when used with transparency."
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "49"
-                  },
-                  {
-                    "prefix": "-moz-",
-                    "version_added": "4",
-                    "notes": [
-                      "Since Firefox 42, the prefixed version of gradients can be disabled by setting <code>layout.css.prefixes.gradients</code> to <code>false</code>.",
-                      "Considers <code>&lt;angle&gt;</code> to start to the right, instead of the top. I.e. it considered an angle of <code>0deg</code> as a direction indicator pointing to the right."
-                    ]
-                  }
-                ],
+                "firefox_android": "mirror",
                 "ie": {
                   "version_added": "10",
                   "notes": "Internet Explorer 5.5 through 9.0 supported gradients via a proprietary filter: <code><a href='https://developer.mozilla.org/docs/Web/CSS/-ms-filter#Gradient'>-ms-filter: progid:DXImageTransform.Microsoft.Gradient()</a></code>."
@@ -1048,19 +963,7 @@
                     ]
                   }
                 ],
-                "safari_ios": [
-                  {
-                    "version_added": "7"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "6",
-                    "notes": [
-                      "Safari 4 was supporting an experimental <code><a href='https://developer.apple.com/library/archive/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(linear,…)</a></code> function. It is more limited than the later standard version: you cannot specify both a position and an angle like in <code>repeating-linear-gradient()</code>. This old outdated syntax is still supported for compatibility purposes.",
-                      "Considers <code>&lt;angle&gt;</code> to start to the right, instead of the top. I.e. it considered an angle of <code>0deg</code> as a direction indicator pointing to the right."
-                    ]
-                  }
-                ],
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": [
                   {
@@ -1133,9 +1036,7 @@
                   "safari": {
                     "version_added": "7"
                   },
-                  "safari_ios": {
-                    "version_added": "7"
-                  },
+                  "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
                   "webview_android": "mirror"
                 },
@@ -1172,9 +1073,7 @@
                   "safari": {
                     "version_added": "7"
                   },
-                  "safari_ios": {
-                    "version_added": "7"
-                  },
+                  "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
                   "webview_android": "mirror"
                 },
@@ -1218,9 +1117,7 @@
                   "safari": {
                     "version_added": "7"
                   },
-                  "safari_ios": {
-                    "version_added": "7"
-                  },
+                  "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
                   "webview_android": "mirror"
                 },
@@ -1323,16 +1220,7 @@
                     "notes": "Safari 4 was supporting an experimental <code><a href='https://developer.apple.com/library/archive/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(radial,…)</a></code> function. This old outdated syntax is still supported for compatibility purposes."
                   }
                 ],
-                "safari_ios": [
-                  {
-                    "version_added": "7"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "6",
-                    "notes": "Safari 4 was supporting an experimental <code><a href='https://developer.apple.com/library/archive/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(radial,…)</a></code> function. This old outdated syntax is still supported for compatibility purposes."
-                  }
-                ],
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": [
                   {
@@ -1376,21 +1264,7 @@
                       "notes": "Since Firefox 42, the prefixed version of gradients can be disabled by setting <code>layout.css.prefixes.gradients</code> to <code>false</code>."
                     }
                   ],
-                  "firefox_android": [
-                    {
-                      "version_added": "16",
-                      "notes": "Before Firefox 36, gradients weren't applied on the pre-multiplied color space, leading to shades of grey unexpectedly appearing when used with transparency."
-                    },
-                    {
-                      "prefix": "-webkit-",
-                      "version_added": "49"
-                    },
-                    {
-                      "prefix": "-moz-",
-                      "version_added": "10",
-                      "notes": "Since Firefox 42, the prefixed version of gradients can be disabled by setting <code>layout.css.prefixes.gradients</code> to <code>false</code>."
-                    }
-                  ],
+                  "firefox_android": "mirror",
                   "ie": {
                     "version_added": "10"
                   },
@@ -1486,9 +1360,7 @@
                   "safari": {
                     "version_added": "7"
                   },
-                  "safari_ios": {
-                    "version_added": "7"
-                  },
+                  "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
                   "webview_android": "mirror"
                 },

--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -139,9 +139,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -541,9 +539,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
                 "version_added": "1.5"
@@ -593,9 +589,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -139,9 +139,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -592,9 +590,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
                 "version_added": "1.5"
@@ -644,9 +640,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/types/position.json
+++ b/css/types/position.json
@@ -67,9 +67,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/html/elements/dir.json
+++ b/html/elements/dir.json
@@ -30,9 +30,7 @@
             "safari": {
               "version_added": "≤4"
             },
-            "safari_ios": {
-              "version_added": "≤3"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -69,9 +67,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/html/elements/embed.json
+++ b/html/elements/embed.json
@@ -61,9 +61,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -147,9 +145,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -187,9 +183,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -227,9 +221,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -265,9 +257,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -305,9 +295,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/html/elements/hr.json
+++ b/html/elements/hr.json
@@ -69,9 +69,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -143,9 +141,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -183,9 +179,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -223,9 +217,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -184,15 +184,7 @@
                   "version_added": true
                 }
               ],
-              "safari_ios": [
-                {
-                  "version_added": "7"
-                },
-                {
-                  "prefix": "webkit",
-                  "version_added": true
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": [
                 {

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -147,17 +147,7 @@
                   "notes": "Safari doesn't preserve space for images without a valid <code>src</code>, which may disrupt layouts that rely on lazy loading (see <a href='https://webkit.org/b/224197'>bug 224197</a>)."
                 }
               ],
-              "safari_ios": [
-                {
-                  "version_added": "15"
-                },
-                {
-                  "version_added": "14",
-                  "version_removed": "15",
-                  "partial_implementation": true,
-                  "notes": "Safari doesn't preserve space for images without a valid <code>src</code>, which may disrupt layouts that rely on lazy loading (see <a href='https://webkit.org/b/224197'>bug 224197</a>)."
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/html/elements/input/input.json
+++ b/html/elements/input/input.json
@@ -66,9 +66,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -106,9 +104,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/html/elements/legend.json
+++ b/html/elements/legend.json
@@ -69,9 +69,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/html/elements/li.json
+++ b/html/elements/li.json
@@ -69,9 +69,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -109,9 +107,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -67,9 +67,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -152,9 +150,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": {
                 "version_added": "1.0",
                 "notes": "In Chrome and other Blink-based browsers, adding the <code>disabled</code> attribute using JavaScript does not remove the stylesheet from <code>document.styleSheets</code>."
@@ -233,9 +229,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -273,9 +267,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -416,9 +408,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1023,9 +1013,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1096,9 +1084,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1174,9 +1160,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/html/elements/main.json
+++ b/html/elements/main.json
@@ -30,9 +30,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -97,9 +97,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -137,9 +135,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -364,9 +360,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -485,9 +479,7 @@
                 "safari": {
                   "version_added": "≤4"
                 },
-                "safari_ios": {
-                  "version_added": "≤3"
-                },
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror"
               },
@@ -538,9 +530,7 @@
                 "safari": {
                   "version_added": "15"
                 },
-                "safari_ios": {
-                  "version_added": "15"
-                },
+                "safari_ios": "mirror",
                 "samsunginternet_android": {
                   "version_added": "6.2"
                 },

--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -113,9 +113,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -193,9 +191,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -233,9 +229,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -353,9 +347,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -474,9 +466,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -556,9 +546,7 @@
               "safari": {
                 "version_added": "≤4"
               },
-              "safari_ios": {
-                "version_added": "≤3"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -105,22 +105,7 @@
                 ]
               }
             ],
-            "chrome_android": [
-              {
-                "version_added": "66",
-                "notes": [
-                  "Support added for <code>autocomplete</code> on the <code>&lt;textarea&gt;</code> and <code>&lt;select&gt;</code> elements.",
-                  "Chrome does not accept <code>off</code> as a value. See <a href='https://crbug.com/587466'>bug 587466</a>."
-                ]
-              },
-              {
-                "version_added": true,
-                "notes": [
-                  "Originally only supported on the <code>&lt;input&gt;</code> element.",
-                  "Chrome does not accept <code>off</code> as a value. See <a href='https://crbug.com/587466'>bug 587466</a>."
-                ]
-              }
-            ],
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "≤79"
             },
@@ -142,22 +127,7 @@
               "version_added": null
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": [
-              {
-                "version_added": "9.0",
-                "notes": [
-                  "Support added for <code>autocomplete</code> on the <code>&lt;textarea&gt;</code> and <code>&lt;select&gt;</code> elements.",
-                  "Samsung Internet does not accept <code>off</code> as a value. See <a href='https://crbug.com/587466'>bug 587466</a>."
-                ]
-              },
-              {
-                "version_added": true,
-                "notes": [
-                  "Originally only supported on the <code>&lt;input&gt;</code> element.",
-                  "Samsung Internet does not accept <code>off</code> as a value. See <a href='https://crbug.com/587466'>bug 587466</a>."
-                ]
-              }
-            ],
+            "samsunginternet_android": "mirror",
             "webview_android": [
               {
                 "version_added": "66",

--- a/http/headers/content-security-policy-report-only.json
+++ b/http/headers/content-security-policy-report-only.json
@@ -30,9 +30,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "4.4"

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -260,9 +260,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -302,9 +300,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -344,9 +340,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -478,9 +472,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -520,9 +512,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -600,9 +590,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -711,9 +699,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -953,9 +939,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1062,9 +1046,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1104,9 +1086,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1298,9 +1278,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/http/headers/referrer-policy.json
+++ b/http/headers/referrer-policy.json
@@ -60,9 +60,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/http/headers/strict-transport-security.json
+++ b/http/headers/strict-transport-security.json
@@ -32,9 +32,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/http/status.json
+++ b/http/status.json
@@ -422,9 +422,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -1920,9 +1920,7 @@
                 "safari": {
                   "version_added": "7"
                 },
-                "safari_ios": {
-                  "version_added": "7"
-                },
+                "safari_ios": "mirror",
                 "samsunginternet_android": {
                   "version_added": "2.0"
                 },
@@ -1965,9 +1963,7 @@
                 "safari": {
                   "version_added": "7"
                 },
-                "safari_ios": {
-                  "version_added": "7"
-                },
+                "safari_ios": "mirror",
                 "samsunginternet_android": {
                   "version_added": "2.0"
                 },
@@ -2165,23 +2161,7 @@
                   "notes": "A placeholder property named <code>iterator</code> is used."
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "36"
-                },
-                {
-                  "alternative_name": "@@iterator",
-                  "version_added": "27",
-                  "version_removed": "36",
-                  "notes": "A placeholder property named <code>@@iterator</code> is used."
-                },
-                {
-                  "alternative_name": "iterator",
-                  "version_added": "17",
-                  "version_removed": "27",
-                  "notes": "A placeholder property named <code>iterator</code> is used."
-                }
-              ],
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -227,9 +227,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
                 "version_added": "≤37"

--- a/javascript/builtins/BigInt64Array.json
+++ b/javascript/builtins/BigInt64Array.json
@@ -30,9 +30,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -72,9 +70,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/javascript/builtins/BigUint64Array.json
+++ b/javascript/builtins/BigUint64Array.json
@@ -30,9 +30,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -72,9 +70,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -406,9 +406,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -448,9 +446,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -890,9 +886,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -932,9 +926,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2159,9 +2159,7 @@
                 "safari": {
                   "version_added": "7"
                 },
-                "safari_ios": {
-                  "version_added": "7"
-                },
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror"
               },
@@ -2352,9 +2350,7 @@
                 "safari": {
                   "version_added": "7"
                 },
-                "safari_ios": {
-                  "version_added": "7"
-                },
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror"
               },
@@ -2545,9 +2541,7 @@
                 "safari": {
                   "version_added": "7"
                 },
-                "safari_ios": {
-                  "version_added": "7"
-                },
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror"
               },

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -201,9 +201,7 @@
                 "safari": {
                   "version_added": "15"
                 },
-                "safari_ios": {
-                  "version_added": "15"
-                },
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror"
               },
@@ -247,9 +245,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -72,23 +72,7 @@
                   "notes": "A placeholder property named <code>iterator</code> is used."
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "36"
-                },
-                {
-                  "alternative_name": "@@iterator",
-                  "version_added": "27",
-                  "version_removed": "36",
-                  "notes": "A placeholder property named <code>@@iterator</code> is used."
-                },
-                {
-                  "alternative_name": "iterator",
-                  "version_added": "17",
-                  "version_removed": "27",
-                  "notes": "A placeholder property named <code>iterator</code> is used."
-                }
-              ],
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -781,23 +781,7 @@
                   "notes": "A placeholder property named <code>iterator</code> is used."
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "36"
-                },
-                {
-                  "alternative_name": "@@iterator",
-                  "version_added": "27",
-                  "version_removed": "36",
-                  "notes": "A placeholder property named <code>@@iterator</code> is used."
-                },
-                {
-                  "alternative_name": "iterator",
-                  "version_added": "17",
-                  "version_removed": "27",
-                  "notes": "A placeholder property named <code>iterator</code> is used."
-                }
-              ],
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -889,9 +889,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1241,9 +1239,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -396,9 +396,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -722,23 +722,7 @@
                   "notes": "A placeholder property named <code>iterator</code> is used."
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "36"
-                },
-                {
-                  "alternative_name": "@@iterator",
-                  "version_added": "27",
-                  "version_removed": "36",
-                  "notes": "A placeholder property named <code>@@iterator</code> is used."
-                },
-                {
-                  "alternative_name": "iterator",
-                  "version_added": "17",
-                  "version_removed": "27",
-                  "notes": "A placeholder property named <code>iterator</code> is used."
-                }
-              ],
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -2876,23 +2876,7 @@
                   "notes": "A placeholder property named <code>iterator</code> is used."
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "36"
-                },
-                {
-                  "alternative_name": "@@iterator",
-                  "version_added": "27",
-                  "version_removed": "36",
-                  "notes": "A placeholder property named <code>@@iterator</code> is used."
-                },
-                {
-                  "alternative_name": "iterator",
-                  "version_added": "17",
-                  "version_removed": "27",
-                  "notes": "A placeholder property named <code>iterator</code> is used."
-                }
-              ],
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -1988,23 +1988,7 @@
                   "notes": "A placeholder property named <code>iterator</code> is used."
                 }
               ],
-              "firefox_android": [
-                {
-                  "version_added": "36"
-                },
-                {
-                  "alternative_name": "@@iterator",
-                  "version_added": "27",
-                  "version_removed": "36",
-                  "notes": "A placeholder property named <code>@@iterator</code> is used."
-                },
-                {
-                  "alternative_name": "iterator",
-                  "version_added": "17",
-                  "version_removed": "27",
-                  "notes": "A placeholder property named <code>iterator</code> is used."
-                }
-              ],
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/javascript/builtins/webassembly/WebAssembly.json
+++ b/javascript/builtins/webassembly/WebAssembly.json
@@ -119,9 +119,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -208,9 +206,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -277,9 +277,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -320,9 +318,7 @@
             "safari": {
               "version_added": "15"
             },
-            "safari_ios": {
-              "version_added": "15"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/javascript/operators/await.json
+++ b/javascript/operators/await.json
@@ -110,9 +110,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/javascript/operators/class.json
+++ b/javascript/operators/class.json
@@ -43,9 +43,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/javascript/operators/super.json
+++ b/javascript/operators/super.json
@@ -32,9 +32,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -852,9 +852,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -894,9 +892,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -937,9 +933,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1373,9 +1367,7 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": {
-                "version_added": "15"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/mathml/elements/menclose.json
+++ b/mathml/elements/menclose.json
@@ -29,9 +29,7 @@
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "7"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/svg/elements/use.json
+++ b/svg/elements/use.json
@@ -122,9 +122,7 @@
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": "7"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
                 "version_added": "4.4"

--- a/webextensions/api/browserSettings.json
+++ b/webextensions/api/browserSettings.json
@@ -319,9 +319,7 @@
               "chrome": {
                 "version_added": false
               },
-              "edge": {
-                "version_added": false
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "72"
               },
@@ -332,9 +330,7 @@
               "safari": {
                 "version_added": false
               },
-              "safari_ios": {
-                "version_added": false
-              }
+              "safari_ios": "mirror"
             }
           }
         },


### PR DESCRIPTION
After https://github.com/mdn/browser-compat-data/pull/16594 a lot more
Safari data can be mirrored. Note that this just ran the script and also
includes a small amount of non-Safari changes.
