### PR TITLE
Simplify Chromium statements for api.Clients.openWindow

### DIFF
--- a/api/Clients.json
+++ b/api/Clients.json
@@ -221,33 +221,17 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Clients/openWindow",
           "spec_url": "https://w3c.github.io/ServiceWorker/#clients-openwindow",
           "support": {
-            "chrome": [
-              {
-                "version_added": "51",
-                "notes": "URLs may open inside an existing browsing context provided by a standalone web app"
-              },
-              {
-                "version_added": "43",
-                "notes": "Can open any URL. "
-              },
-              {
-                "version_added": "42",
-                "notes": "Can only open URLs on the same origin."
-              },
-              {
-                "version_added": "40"
-              }
-            ],
+            "chrome": {
+              "version_added": "40",
+              "notes": [
+                "Before Chrome 43, this method could only open URLs on the same origin.",
+                "Since Chrome 51, URLs may open inside an existing browsing context provided by a standalone web app."
+              ]
+            },
             "chrome_android": "mirror",
-            "edge": [
-              {
-                "version_added": "79",
-                "notes": "URLs may open inside an existing browsing context provided by a standalone web app"
-              },
-              {
-                "version_added": "17"
-              }
-            ],
+            "edge": {
+              "version_added": "17"
+            },
             "firefox": {
               "version_added": "45",
               "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
@@ -269,15 +253,7 @@
               "version_added": "11.1"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": [
-              {
-                "version_added": "5.0",
-                "notes": "URLs may open inside an existing browsing context provided by a standalone web app"
-              },
-              {
-                "version_added": "4.0"
-              }
-            ],
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {


### PR DESCRIPTION
This PR simplifies the Chromium statements for `api.Clients.openWindow`.  These differences in behavior do not qualify for subfeatures or `partial_implementation`, and as such should not be separated into multiple support statements.

Note: these notes came from the original wiki migration.
