### PR TITLE
Add partial_implementation to api.CustomElementRegistry.define

### DIFF
--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -74,12 +74,12 @@
           "support": {
             "chrome": [
               {
-                "version_added": "67",
-                "notes": "Support for 'Customized built-in elements' as well."
+                "version_added": "67"
               },
               {
                 "version_added": "54",
-                "notes": "Support for 'Autonomous custom elements' only."
+                "partial_implementation": true,
+                "notes": "Only 'Autonomous custom elements' are supported."
               }
             ],
             "chrome_android": "mirror",
@@ -96,7 +96,8 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "10.1",
-              "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
+              "partial_implementation": true,
+              "notes": "Only 'Autonomous custom elements' are supported."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR adds `partial_implementation: true` to api.CustomElementRegistry.define for Chrome and Safari, since Safari only (and Chrome used to) supports one type of element.
