### PR TITLE
Remove duplicated notes in CustomElementRegistry API

### DIFF
--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -33,7 +33,7 @@
           "deprecated": false
         }
       },
-      "builtin": {
+      "builtin_element_support": {
         "__compat": {
           "description": "Customized built-in element support",
           "support": {
@@ -72,16 +72,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomElementRegistry/define",
           "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-define-dev",
           "support": {
-            "chrome": [
-              {
-                "version_added": "67",
-                "notes": "Support for 'Customized built-in elements' as well."
-              },
-              {
-                "version_added": "54",
-                "notes": "Support for 'Autonomous custom elements' only."
-              }
-            ],
+            "chrome": {
+              "version_added": "54"
+            },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -95,8 +88,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "10.1",
-              "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
+              "version_added": "10.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -114,16 +106,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomElementRegistry/get",
           "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-get-dev",
           "support": {
-            "chrome": [
-              {
-                "version_added": "67",
-                "notes": "Support for 'Customized built-in elements' as well."
-              },
-              {
-                "version_added": "54",
-                "notes": "Support for 'Autonomous custom elements' only."
-              }
-            ],
+            "chrome": {
+              "version_added": "54"
+            },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -137,8 +122,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "10.1",
-              "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
+              "version_added": "10.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -190,16 +174,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomElementRegistry/whenDefined",
           "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-whendefined-dev",
           "support": {
-            "chrome": [
-              {
-                "version_added": "67",
-                "notes": "Support for 'Customized built-in elements' as well."
-              },
-              {
-                "version_added": "54",
-                "notes": "Support for 'Autonomous custom elements' only."
-              }
-            ],
+            "chrome": {
+              "version_added": "54"
+            },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -213,8 +190,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "10.1",
-              "notes": "Supports 'Autonomous custom elements' but not 'Customized built-in elements'"
+              "version_added": "10.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR removes the redundant notes throughout the CustomElementRegistry API.  The notes are simply a repeat of the `builtin_element_support` subfeature.

Additionally, this PR renames `builtin` to `builtin_element_support` to follow our naming conventions.
