### PR TITLE
Simplify Chromium statements for css.selectors.descendant

### DIFF
--- a/css/selectors/descendant.json
+++ b/css/selectors/descendant.json
@@ -7,15 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Descendant_combinator",
           "spec_url": "https://drafts.csswg.org/selectors/#descendant-combinators",
           "support": {
-            "chrome": [
-              {
-                "version_added": "61",
-                "notes": "<code>&gt;&gt;&gt;</code> is aliased to this selector <a href='https://developers.google.com/web/updates/2017/06/chrome-60-deprecations#make_shadow-piercing_descendant_combinator_behave_like_descendent_combinator'>since its use as the 'shadow-piercing descendant combinator' was deprecated</a>."
-              },
-              {
-                "version_added": "1"
-              }
-            ],
+            "chrome": {
+              "version_added": "1",
+              "notes": "Since Chrome 61, <code>&gt;&gt;&gt;</code> is aliased to this selector <a href='https://developers.google.com/web/updates/2017/06/chrome-60-deprecations#make_shadow-piercing_descendant_combinator_behave_like_descendent_combinator'>since its use as the 'shadow-piercing descendant combinator' was deprecated</a>."
+            },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
@@ -39,15 +34,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "61",
-                "notes": "<code>&gt;&gt;&gt;</code> is aliased to this selector <a href='https://developers.google.com/web/updates/2017/06/chrome-60-deprecations#make_shadow-piercing_descendant_combinator_behave_like_descendent_combinator'>since its use as the 'shadow-piercing descendant combinator' was deprecated</a>."
-              },
-              {
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR simplifies the Chromium statements for the `descendants` CSS selector.  The behavioral change is not a spec change or otherwise spec-related, so it does not constitute a subfeature or `partial_implementation` and should not be separated into multiple statements.
