### PR TITLE
Simplify Chromium statements for html.global_attributes.autocomplete

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -89,22 +89,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/autocomplete",
           "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-autocomplete",
           "support": {
-            "chrome": [
-              {
-                "version_added": "66",
-                "notes": [
-                  "Support added for <code>autocomplete</code> on the <code>&lt;textarea&gt;</code> and <code>&lt;select&gt;</code> elements.",
-                  "Chrome does not accept <code>off</code> as a value. See <a href='https://crbug.com/587466'>bug 587466</a>."
-                ]
-              },
-              {
-                "version_added": true,
-                "notes": [
-                  "Originally only supported on the <code>&lt;input&gt;</code> element.",
-                  "Chrome does not accept <code>off</code> as a value. See <a href='https://crbug.com/587466'>bug 587466</a>."
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": true,
+              "notes": [
+                "In Chrome 66, support was added for the <code>&lt;textarea&gt;</code> and <code>&lt;select&gt;</code> elements.",
+                "Originally only supported on the <code>&lt;input&gt;</code> element.",
+                "Chrome does not accept <code>off</code> as a value. See <a href='https://crbug.com/587466'>bug 587466</a>."
+              ]
+            },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "≤79"
@@ -128,22 +120,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "66",
-                "notes": [
-                  "Support added for <code>autocomplete</code> on the <code>&lt;textarea&gt;</code> and <code>&lt;select&gt;</code> elements.",
-                  "WebView does not accept <code>off</code> as a value. See <a href='https://crbug.com/587466'>bug 587466</a>."
-                ]
-              },
-              {
-                "version_added": true,
-                "notes": [
-                  "Originally only supported on the <code>&lt;input&gt;</code> element.",
-                  "WebView does not accept <code>off</code> as a value. See <a href='https://crbug.com/587466'>bug 587466</a>."
-                ]
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR simplifies the Chromium statements for the `autocomplete` HTML attribute.
