### PR TITLE
Update Chrome/Safari versions for api.Document.securitypolicyviolation_event

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -5895,7 +5895,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onsecuritypolicyviolation",
           "support": {
             "chrome": {
-              "version_added": "97"
+              "version_added": "76"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -5908,15 +5908,11 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "15.5"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
This PR updates and corrects the real values for Chrome and Safari for the `securitypolicyviolation_event` member of the `Document` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.8).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Document/securitypolicyviolation_event

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._

This is a partial fix for #16992.