### PR TITLE
FF103 Errors are serializable (support structuredClone)

### DIFF
--- a/javascript/builtins/AggregateError.json
+++ b/javascript/builtins/AggregateError.json
@@ -80,6 +80,47 @@
               "deprecated": false
             }
           }
+        },
+        "serializable_object": {
+          "__compat": {
+            "description": "<code>AggregateError</code> is serializable",
+            "mdn_url": "https://developer.mozilla.org/docs/Glossary/Serializable_object",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "103",
+                "notes": "Serialized properties: <code>name</code>, <code>message</code>, <code>cause</code>, <code>errors</code>."
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -468,6 +468,7 @@
         "serializable_object": {
           "__compat": {
             "description": "<code>Error</code> is serializable",
+            "mdn_url": "https://developer.mozilla.org/docs/Glossary/Serializable_object",
             "spec_url": "https://html.spec.whatwg.org/multipage/structured-data.html#serializable-objects",
             "support": {
               "chrome": {
@@ -479,8 +480,11 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1556604'>bug 1556604</a>."
+                "version_added": "103",
+                "notes": [
+                  "Version 103 serialized properties: <code>name</code>, <code>message</code>, <code>cause</code>, <code>fileName</code>, <code>lineNumber</code> and <code>columnNumber</code>.",
+                  "Version 104 additionally supports serialization of <code>stack</code> in <a href='https://developer.mozilla.org/docs/Web/API/Window/postMessage'><code>window.postMessage()</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/structuredClone'><code>structuredClone()</code></a>."
+                ]
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/builtins/EvalError.json
+++ b/javascript/builtins/EvalError.json
@@ -96,6 +96,7 @@
         "serializable_object": {
           "__compat": {
             "description": "<code>EvalError</code> is serializable",
+            "mdn_url": "https://developer.mozilla.org/docs/Glossary/Serializable_object",
             "spec_url": "https://html.spec.whatwg.org/multipage/structured-data.html#serializable-objects",
             "support": {
               "chrome": {
@@ -107,8 +108,11 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1556604'>bug 1556604</a>."
+                "version_added": "103",
+                "notes": [
+                  "Version 103 serializable properties: <code>name</code>, <code>message</code>, <code>cause</code>, <code>fileName</code>, <code>lineNumber</code> and <code>columnNumber</code>.",
+                  "Version 104 also serializes <code>stack</code> in <a href='https://developer.mozilla.org/docs/Web/API/Window/postMessage'><code>window.postMessage()</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/structuredClone'><code>structuredClone()</code></a>)."
+                ]
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/builtins/RangeError.json
+++ b/javascript/builtins/RangeError.json
@@ -96,6 +96,7 @@
         "serializable_object": {
           "__compat": {
             "description": "<code>RangeError</code> is serializable",
+            "mdn_url": "https://developer.mozilla.org/docs/Glossary/Serializable_object",
             "spec_url": "https://html.spec.whatwg.org/multipage/structured-data.html#serializable-objects",
             "support": {
               "chrome": {
@@ -107,8 +108,11 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1556604'>bug 1556604</a>."
+                "version_added": "103",
+                "notes": [
+                  "Version 103 serializable properties: <code>name</code>, <code>message</code>, <code>cause</code>, <code>fileName</code>, <code>lineNumber</code> and <code>columnNumber</code>.",
+                  "Version 104 also serializes <code>stack</code> in <a href='https://developer.mozilla.org/docs/Web/API/Window/postMessage'><code>window.postMessage()</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/structuredClone'><code>structuredClone()</code></a>)."
+                ]
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/builtins/ReferenceError.json
+++ b/javascript/builtins/ReferenceError.json
@@ -96,6 +96,7 @@
         "serializable_object": {
           "__compat": {
             "description": "<code>ReferenceError</code> is serializable",
+            "mdn_url": "https://developer.mozilla.org/docs/Glossary/Serializable_object",
             "spec_url": "https://html.spec.whatwg.org/multipage/structured-data.html#serializable-objects",
             "support": {
               "chrome": {
@@ -107,8 +108,11 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1556604'>bug 1556604</a>."
+                "version_added": "103",
+                "notes": [
+                  "Version 103 serializable properties: <code>name</code>, <code>message</code>, <code>cause</code>, <code>fileName</code>, <code>lineNumber</code> and <code>columnNumber</code>.",
+                  "Version 104 also serializes <code>stack</code> in <a href='https://developer.mozilla.org/docs/Web/API/Window/postMessage'><code>window.postMessage()</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/structuredClone'><code>structuredClone()</code></a>)."
+                ]
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/builtins/SyntaxError.json
+++ b/javascript/builtins/SyntaxError.json
@@ -96,6 +96,7 @@
         "serializable_object": {
           "__compat": {
             "description": "<code>SyntaxError</code> is serializable",
+            "mdn_url": "https://developer.mozilla.org/docs/Glossary/Serializable_object",
             "spec_url": "https://html.spec.whatwg.org/multipage/structured-data.html#serializable-objects",
             "support": {
               "chrome": {
@@ -107,8 +108,11 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1556604'>bug 1556604</a>."
+                "version_added": "103",
+                "notes": [
+                  "Version 103 serializable properties: <code>name</code>, <code>message</code>, <code>cause</code>, <code>fileName</code>, <code>lineNumber</code> and <code>columnNumber</code>.",
+                  "Version 104 also serializes <code>stack</code> in <a href='https://developer.mozilla.org/docs/Web/API/Window/postMessage'><code>window.postMessage()</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/structuredClone'><code>structuredClone()</code></a>)."
+                ]
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/builtins/TypeError.json
+++ b/javascript/builtins/TypeError.json
@@ -96,6 +96,7 @@
         "serializable_object": {
           "__compat": {
             "description": "<code>TypeError</code> is serializable",
+            "mdn_url": "https://developer.mozilla.org/docs/Glossary/Serializable_object",
             "spec_url": "https://html.spec.whatwg.org/multipage/structured-data.html#serializable-objects",
             "support": {
               "chrome": {
@@ -107,8 +108,11 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1556604'>bug 1556604</a>."
+                "version_added": "103",
+                "notes": [
+                  "Version 103 serializable properties: <code>name</code>, <code>message</code>, <code>cause</code>, <code>fileName</code>, <code>lineNumber</code> and <code>columnNumber</code>.",
+                  "Version 104 also serializes <code>stack</code> in <a href='https://developer.mozilla.org/docs/Web/API/Window/postMessage'><code>window.postMessage()</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/structuredClone'><code>structuredClone()</code></a>)."
+                ]
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/builtins/URIError.json
+++ b/javascript/builtins/URIError.json
@@ -96,6 +96,7 @@
         "serializable_object": {
           "__compat": {
             "description": "<code>URIError</code> is serializable",
+            "mdn_url": "https://developer.mozilla.org/docs/Glossary/Serializable_object",
             "spec_url": "https://html.spec.whatwg.org/multipage/structured-data.html#serializable-objects",
             "support": {
               "chrome": {
@@ -107,8 +108,11 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1556604'>bug 1556604</a>."
+                "version_added": "103",
+                "notes": [
+                  "Version 103 serializable properties: <code>name</code>, <code>message</code>, <code>cause</code>, <code>fileName</code>, <code>lineNumber</code> and <code>columnNumber</code>.",
+                  "Version 104 also serializes <code>stack</code> in <a href='https://developer.mozilla.org/docs/Web/API/Window/postMessage'><code>window.postMessage()</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/structuredClone'><code>structuredClone()</code></a>)."
+                ]
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
FF103 adds support for serializing native error classes in https://bugzilla.mozilla.org/show_bug.cgi?id=1556604#c33

Note that 
- this supports both standard and non-standard error properties (`name`, `message`, `cause`, `fileName`, `lineNumber` and `columnNumber`). The `stack` property is still only supported in nightly.
- it works for all the normal error types except for InternalError
- AggregateError support is in FF but this is not yet in spec so that is added but marked as "non-standard". This includes the `errors` field.
- I added info about the supported properties as a Note rather than as properties because the spec is fairly loose about what needs to be supported - essentially it is name + message + "any interesting properties.
 
Related docs work can be tracked in [#18208](https://github.com/mdn/content/issues/18208)