### PR TITLE
Don't retain notes etc. when mirroring results in version_added false

### DIFF
--- a/scripts/release/mirror.ts
+++ b/scripts/release/mirror.ts
@@ -338,8 +338,7 @@ export const bumpSupport = (
 
   if (newData.version_added === newData.version_removed) {
     // If version_added and version_removed are the same, feature is unsupported
-    newData.version_added = false;
-    delete newData.version_removed;
+    return { version_added: false };
   }
 
   return newData;


### PR DESCRIPTION
Note like "Removed due to the GLitch exploit" don't make sense when
there is no version_removed, and retaining prefix or alternative_name
also leads to data that doesn't make sense.