### PR TITLE
Update versions for iframe's reflected allow property

### DIFF
--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -92,9 +92,7 @@
             "chrome": {
               "version_added": "60"
             },
-            "chrome_android": {
-              "version_added": "66"
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": "74"
@@ -104,9 +102,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "53"
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": "11.1"


### PR DESCRIPTION
That Chrome 60 is correct is confirmed with this test:
http://mdn-bcd-collector.appspot.com/tests/api/HTMLIFrameElement/allow

Web Confluence also supports the same for Chrome Android:
https://github.com/mdn/browser-compat-data/pull/6526

Finally, this matches the html.elements.iframe.allow data.
