### PR TITLE
Update support for <marquee>

### DIFF
--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -45,7 +45,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#dom-marquee-behavior",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "10"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -68,13 +68,9 @@
             "safari": {
               "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "5"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -88,7 +84,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#dom-marquee-bgcolor",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "10"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -109,15 +105,11 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3"
+              "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "1"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -167,7 +159,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#dom-marquee-direction",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "10"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -190,13 +182,9 @@
             "safari": {
               "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "5"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -246,7 +234,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#dom-marquee-height",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "10"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -269,13 +257,9 @@
             "safari": {
               "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "5"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -312,13 +296,9 @@
             "safari": {
               "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "5"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -355,13 +335,9 @@
             "safari": {
               "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "5"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -375,7 +351,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#dom-marquee-scrollamount",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "10"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -396,15 +372,11 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3"
+              "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "1"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -443,9 +415,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -573,7 +543,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#dom-marquee-truespeed",
           "support": {
             "chrome": {
-              "version_added": "9"
+              "version_added": "10"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -590,13 +560,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -633,13 +601,9 @@
             "safari": {
               "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "5"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -653,7 +617,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#dom-marquee-width",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "10"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -676,13 +640,9 @@
             "safari": {
               "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "5"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/html/elements/marquee.json
+++ b/html/elements/marquee.json
@@ -37,9 +37,7 @@
             "safari": {
               "version_added": "1.2"
             },
-            "safari_ios": {
-              "version_added": true
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -76,9 +74,7 @@
               "safari": {
                 "version_added": "1.2"
               },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -116,9 +112,7 @@
               "safari": {
                 "version_added": "1.2"
               },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -156,9 +150,7 @@
               "safari": {
                 "version_added": "1.2"
               },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -196,9 +188,7 @@
               "safari": {
                 "version_added": "1.2"
               },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -213,24 +203,24 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤18"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "3"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": null
+                "version_added": "5.5"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": "1.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -247,24 +237,24 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤18"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "3"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": null
+                "version_added": "5.5"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": "1.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -304,9 +294,7 @@
               "safari": {
                 "version_added": "1.2"
               },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -344,9 +332,7 @@
               "safari": {
                 "version_added": "1.2"
               },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -361,7 +347,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
@@ -378,7 +364,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "1.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -395,24 +381,24 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤18"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "3"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": null
+                "version_added": "5.5"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": "1.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -452,9 +438,7 @@
               "safari": {
                 "version_added": "1.2"
               },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },


### PR DESCRIPTION
`<marquee>` was implemented early in WebKit with support for all of the
attributes:
https://github.com/WebKit/WebKit/commit/f078926ed93315311433c0170ffc3cd03dec4663

The date (2003-10-29) maps to Safari 1.2, which matches existing data.

All of the reflected properties came later for Safari 5.1 / Chrome 10:
https://github.com/WebKit/WebKit/commit/0d3e783d28096e0f6a6e7d5b33c20eef71f26a49
https://github.com/WebKit/WebKit/blob/0d3e783d28096e0f6a6e7d5b33c20eef71f26a49/WebCore/Configurations/Version.xcconfig

For the loop/hspace/vspace attributes, just copy the IE/Edge data from
the reflected properties without verifying it.

Also fix some mirroring.

This is all really just to fix the support of trueSpeed in Safari, which
was false.

Part of https://github.com/mdn/browser-compat-data/pull/6526.