### PR TITLE
background-position-* 2-value syntax support in Safari 15.4

### DIFF
--- a/css/properties/background-position-x.json
+++ b/css/properties/background-position-x.json
@@ -63,7 +63,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/background-position-y.json
+++ b/css/properties/background-position-y.json
@@ -61,7 +61,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
Safari 15.4 now supports the 2-value syntax for background-position-x/background-position-y

See: https://bugs.webkit.org/show_bug.cgi?id=202148 for testcase and bug fix.