### PR TITLE
Unprefixed user-select not in Safari 16

### DIFF
--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -53,9 +53,6 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "16"
-              },
-              {
                 "version_added": "3",
                 "prefix": "-webkit-"
               },
@@ -66,9 +63,6 @@
               }
             ],
             "safari_ios": [
-              {
-                "version_added": "16"
-              },
               {
                 "prefix": "-webkit-",
                 "version_added": "3"

--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -62,12 +62,10 @@
                 "prefix": "-khtml-"
               }
             ],
-            "safari_ios": [
-              {
-                "prefix": "-webkit-",
-                "version_added": "3"
-              }
-            ],
+            "safari_ios": {
+              "prefix": "-webkit-",
+              "version_added": "3"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": [
               {


### PR DESCRIPTION
This has been reverted in https://github.com/WebKit/WebKit/commit/e4b63beaeb743e2d311d689590ec49bb0728b3ff