### PR TITLE
fix: deno supports performance.timeorigin and performance.tojson

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -871,7 +871,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "1.22"
             },
             "edge": {
               "version_added": "16"
@@ -962,7 +962,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "1.22"
             },
             "edge": {
               "version_added": "12"


### PR DESCRIPTION
This PR adds a version number for Deno for `api.Performance.timeOrigin` and `api.Performance.toJSON.`

source: https://deno.com/blog/v1.22#performancetimeorigin-and-performancetojson