### PR TITLE
Add spec URLs for javascript.operators.spread

### DIFF
--- a/javascript/operators/spread.json
+++ b/javascript/operators/spread.json
@@ -61,7 +61,7 @@
           "__compat": {
             "description": "Spread in array literals",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_array_literals",
-            "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-array-initializer",
+            "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-SpreadElement",
             "support": {
               "chrome": {
                 "version_added": "46"
@@ -119,6 +119,7 @@
           "__compat": {
             "description": "Spread in function calls",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_function_calls",
+            "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-ArgumentList",
             "support": {
               "chrome": {
                 "version_added": "46"
@@ -173,7 +174,7 @@
           "__compat": {
             "description": "Spread in object literals",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_object_literals",
-            "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-object-initializer",
+            "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-PropertyDefinition",
             "support": {
               "chrome": {
                 "version_added": "60"


### PR DESCRIPTION
@Josh-Cena This one could really use some review and guidance from you. Of the three ES spec URLs this change adds, I’m not 100% convinced that any of them are what we need here. The first one, `#prod-SpreadElement`, seems like the one most likely correct — but I’m less sure about the `#prod-ArgumentList` one, and even less sure about the `#prod-PropertyDefinition` one.

In general I have only a vague understanding of the formalism that the ES spec uses, and how it translates to the syntax in JavaScript code. But I found https://stackoverflow.com/a/37152508/441757 helpful in trying to connect the dots a bit more. However, that’s also made me realize I’m not sure exactly what “spread syntax” — or more like, which spread _syntaxes_ — our article at https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax is meant to be scoped to (and thus also what we should be scoping this BCD entry to).