### PR TITLE
Update Safari versions for Animation API

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -21,7 +21,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "13.1"
+            "version_added": "10.1"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -55,7 +55,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "13.1"
+              "version_added": "10.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -229,7 +229,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "13.1"
+              "version_added": "10.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -827,7 +827,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "13.1",
+              "version_added": "10.1",
               "notes": "Currently only the getter is supported"
             },
             "safari_ios": "mirror",


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `Animation` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.0.8).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Animation

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._

Note: due to issues with `update-bcd`, these changes were performed manually by comparing the results output for Safari 10.0 and 10.1.
