### PR TITLE
Add bug link to api.SVGImageElement.crossOrigin

### DIFF
--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -49,7 +49,8 @@
           "spec_url": "https://svgwg.org/svg2-draft/embedded.html#__svg__SVGImageElement__crossOrigin",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/842321'>bug 842321</a>."
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR adds a bug link to api.SVGImageElement.crossOrigin for Chromium's planned implementation, as requested in https://github.com/mdn/browser-compat-data/pull/16962#issuecomment-1185277530.
