### PR TITLE
Support for `text-align-last` in Safari 16

### DIFF
--- a/css/properties/text-align-last.json
+++ b/css/properties/text-align-last.json
@@ -36,7 +36,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16.0"
+              "version_added": "16"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/text-align-last.json
+++ b/css/properties/text-align-last.json
@@ -36,8 +36,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
-              "notes": "See WebKit <a href='https://webkit.org/b/76173'>bug 76173</a>."
+              "version_added": "16.0"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
It's also currently in Safari Technology Preview. 
Tests run: https://github.com/Fyrd/caniuse/pull/6376

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
