### PR TITLE
Don't set experimental to false for preview browser releases

### DIFF
--- a/scripts/fix/status.ts
+++ b/scripts/fix/status.ts
@@ -5,6 +5,7 @@ import { BrowserName, Identifier } from '../../types/types.js';
 
 import fs from 'node:fs';
 
+import { checkExperimental } from '../../test/linter/test-status.js';
 import { IS_WINDOWS } from '../../test/utils.js';
 
 import bcd from '../../index.js';
@@ -21,45 +22,8 @@ const fixStatus = (key: string, value: Identifier): Identifier => {
       compat.status.standard_track = true;
     }
 
-    if (compat.status.experimental) {
-      const browserSupport: Set<BrowserName> = new Set();
-
-      for (const [browser, support] of Object.entries(compat.support)) {
-        // Consider only the first part of an array statement.
-        const statement = Array.isArray(support) ? support[0] : support;
-        // Ignore anything behind flag, prefix or alternative name
-        if (statement.flags || statement.prefix || statement.alternative_name) {
-          continue;
-        }
-        if (statement.version_added && !statement.version_removed) {
-          browserSupport.add(browser as BrowserName);
-        }
-      }
-
-      // Now check which of Blink, Gecko and WebKit support it.
-
-      const engineSupport = new Set();
-
-      for (const browser of browserSupport) {
-        const currentRelease = Object.values(browsers[browser].releases).find(
-          (r) => r.status === 'current',
-        );
-        const engine = currentRelease?.engine;
-        if (engine) {
-          engineSupport.add(engine);
-        }
-      }
-
-      let engineCount = 0;
-      for (const engine of ['Blink', 'Gecko', 'WebKit']) {
-        if (engineSupport.has(engine)) {
-          engineCount++;
-        }
-      }
-
-      if (engineCount > 1) {
-        compat.status.experimental = false;
-      }
+    if (!checkExperimental(compat)) {
+      compat.status.experimental = false;
     }
   }
 


### PR DESCRIPTION
This PR updates the linter to not require `experimental` if a browser's `version_added` is set to `preview`.  Additionally, this PR de-duplicates some of the code used between the linter and the fix script.
