### PR TITLE
Mirror many statements with bug links

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -491,39 +491,25 @@
               "notes": "See <a href='https://crbug.com/937101'>bug 937101</a>."
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1531223'>bug 1531223</a>."
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": false,
               "notes": "See <a href='https://webkit.org/b/195176'>bug 195176</a>."
             },
-            "safari_ios": {
-              "version_added": false
-            },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -609,26 +595,18 @@
               "version_added": false,
               "notes": "See <a href='https://crbug.com/937104'>bug 937104</a>."
             },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1310170'>bug 1310170</a>."
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": false
@@ -1027,26 +1005,18 @@
               "version_added": false,
               "notes": "See <a href='https://crbug.com/937104'>bug 937104</a>."
             },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1310170'>bug 1310170</a>."
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": false
@@ -1213,34 +1183,24 @@
               "version_added": false,
               "notes": "See <a href='https://crbug.com/778495'>bug 778495</a>."
             },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1287034'>bug 1287034</a>."
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": false,
               "notes": "See <a href='https://webkit.org/b/159801'>bug 159801</a>."
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1294,34 +1254,24 @@
               "version_added": false,
               "notes": "See <a href='https://crbug.com/778495'>bug 778495</a>."
             },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1287034'>bug 1287034</a>."
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": false,
               "notes": "See <a href='https://webkit.org/b/159801'>bug 159801</a>."
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1639,9 +1639,7 @@
               "notes": "A <code>selectionchange</code> event is fired on <code>Document</code>, see <a href='https://developer.mozilla.org/docs/Web/API/Document/selectionchange_event'><code>Document</code>'s <code>selectionchange</code> event</a>. See <a href='https://crbug.com/1327098'>bug 1327098</a> for firing the event on <code>&lt;input&gt;</code> elements."
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "92"
             },
@@ -1650,23 +1648,15 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": false,
               "notes": "See <a href='https://webkit.org/b/234348'>bug 234348</a>."
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -808,9 +808,7 @@
               "notes": "A <code>selectionchange</code> event is fired on <code>Document</code>, see <a href='https://developer.mozilla.org/docs/Web/API/Document/selectionchange_event'><code>Document</code>'s <code>selectionchange</code> event</a>. See <a href='https://crbug.com/1327098'>bug 1327098</a> for firing the event on <code>&lt;textarea&gt;</code> elements."
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "92"
             },
@@ -819,23 +817,15 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": false,
               "notes": "See <a href='https://webkit.org/b/234348'>bug 234348</a>."
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,

--- a/api/MIDIOutput.json
+++ b/api/MIDIOutput.json
@@ -58,12 +58,8 @@
               "version_added": false,
               "notes": "See <a href='https://crbug.com/471798'>bug 471798</a>."
             },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
             "firefox": [
               {
                 "version_added": "preview"
@@ -86,9 +82,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": false

--- a/api/MathMLElement.json
+++ b/api/MathMLElement.json
@@ -19,12 +19,8 @@
             "version_added": false
           },
           "oculus": "mirror",
-          "opera": {
-            "version_added": false
-          },
-          "opera_android": {
-            "version_added": false
-          },
+          "opera": "mirror",
+          "opera_android": "mirror",
           "safari": {
             "version_added": "13.1"
           },

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -925,9 +925,7 @@
               "notes": "See <a href='https://crbug.com/1244165'>bug 1244165</a>"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1209163'>bug 1209163</a>"
@@ -937,24 +935,16 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "15"
             },
             "safari_ios": {
               "version_added": false
             },
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -163,9 +163,7 @@
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/1247687'>bug 1247687</a>"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/api/_mixins/Body__Request.json
+++ b/api/_mixins/Body__Request.json
@@ -92,9 +92,7 @@
             "deno": {
               "version_added": "1.0"
             },
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1387483'>bug 1387483</a>."
@@ -104,22 +102,14 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "11.1"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -364,12 +364,8 @@
                   "version_added": false,
                   "notes": "See <a href='https://crbug.com/538475'>bug 538475</a>."
                 },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
@@ -378,9 +374,7 @@
                   "version_added": false
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": false
-                },
+                "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": false

--- a/css/properties/break-before.json
+++ b/css/properties/break-before.json
@@ -348,12 +348,8 @@
                   "version_added": false,
                   "notes": "See <a href='https://crbug.com/538475'>bug 538475</a>."
                 },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": {
-                  "version_added": false
-                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
@@ -362,9 +358,7 @@
                   "version_added": false
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": false
-                },
+                "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": false

--- a/css/properties/column-fill.json
+++ b/css/properties/column-fill.json
@@ -65,12 +65,8 @@
                 "version_added": false,
                 "notes": "See <a href='https://crbug.com/909596'>bug 909596</a>."
               },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -79,9 +75,7 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": false

--- a/css/properties/column-width.json
+++ b/css/properties/column-width.json
@@ -114,12 +114,8 @@
                 "version_added": false,
                 "notes": "See <a href='https://crbug.com/964183'>bug 964183</a>."
               },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -128,9 +124,7 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": false

--- a/css/properties/font-variant-alternates.json
+++ b/css/properties/font-variant-alternates.json
@@ -11,9 +11,7 @@
               "notes": "See <a href='https://crbug.com/716567'>bug 716567</a>."
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "34"
             },
@@ -22,22 +20,14 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "9.1"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/font-variant-position.json
+++ b/css/properties/font-variant-position.json
@@ -11,9 +11,7 @@
               "notes": "See <a href='https://crbug.com/1212668'>bug 1212668</a>."
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "34"
             },
@@ -22,22 +20,14 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "9.1"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/initial-letter-align.json
+++ b/css/properties/initial-letter-align.json
@@ -15,9 +15,7 @@
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1273021'>bug 1273021</a>."
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/css/properties/initial-letter.json
+++ b/css/properties/initial-letter.json
@@ -11,9 +11,7 @@
               "notes": "See <a href='https://crbug.com/1276900'>bug 1276900</a>."
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1223880'>bug 1223880</a>."
@@ -23,24 +21,16 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "prefix": "-webkit-",
               "version_added": "9",
               "notes": "See <a href='https://webkit.org/b/229090'>bug 229090</a> for the unprefixed property."
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,

--- a/css/properties/mask-border-outset.json
+++ b/css/properties/mask-border-outset.json
@@ -16,9 +16,7 @@
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/877294'>bug 877294</a>."
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/css/properties/mask-border-repeat.json
+++ b/css/properties/mask-border-repeat.json
@@ -16,9 +16,7 @@
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/877294'>bug 877294</a>."
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/css/properties/mask-border-slice.json
+++ b/css/properties/mask-border-slice.json
@@ -16,9 +16,7 @@
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/877294'>bug 877294</a>."
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/css/properties/mask-border-source.json
+++ b/css/properties/mask-border-source.json
@@ -16,9 +16,7 @@
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/877294'>bug 877294</a>."
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/css/properties/mask-border-width.json
+++ b/css/properties/mask-border-width.json
@@ -16,9 +16,7 @@
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/877294'>bug 877294</a>."
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/css/properties/mask-border.json
+++ b/css/properties/mask-border.json
@@ -16,9 +16,7 @@
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/877294'>bug 877294</a>."
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/css/properties/mask-origin.json
+++ b/css/properties/mask-origin.json
@@ -70,9 +70,7 @@
                 "version_added": false,
                 "notes": "See <a href='https://webkit.org/b/137293'>bug 137293</a>."
               },
-              "safari_ios": {
-                "version_added": false
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -144,9 +142,7 @@
                 "version_added": false,
                 "notes": "See <a href='https://webkit.org/b/137293'>bug 137293</a>."
               },
-              "safari_ios": {
-                "version_added": false
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -180,9 +176,7 @@
                 "version_added": false,
                 "notes": "See <a href='https://webkit.org/b/137293'>bug 137293</a>."
               },
-              "safari_ios": {
-                "version_added": false
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/offset-position.json
+++ b/css/properties/offset-position.json
@@ -10,26 +10,18 @@
               "version_added": false,
               "notes": "See <a href='https://crbug.com/638055'>bug 638055</a>."
             },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
             "firefox": {
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1559232'>bug 1559232</a>."
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": false

--- a/css/properties/overflow-clip-margin.json
+++ b/css/properties/overflow-clip-margin.json
@@ -15,9 +15,7 @@
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1661582'>bug 1661582</a>."
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/css/properties/ruby-position.json
+++ b/css/properties/ruby-position.json
@@ -67,12 +67,8 @@
                 "version_added": false,
                 "notes": "See <a href='https://crbug.com/1191394'>bug 1191394</a>."
               },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
               "firefox": {
                 "version_added": "88"
               },
@@ -81,9 +77,7 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": false
@@ -107,26 +101,18 @@
                 "version_added": false,
                 "notes": "See <a href='https://crbug.com/1258284'>bug 1258284</a>."
               },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
               "firefox": {
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/1055672'>bug 1055672</a>."
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": false

--- a/css/selectors/blank.json
+++ b/css/selectors/blank.json
@@ -16,9 +16,7 @@
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1197736'>bug 1197736</a>."
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/css/selectors/column.json
+++ b/css/selectors/column.json
@@ -16,9 +16,7 @@
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/1605558'>bug 1605558</a>."
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/css/selectors/empty.json
+++ b/css/selectors/empty.json
@@ -56,9 +56,7 @@
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/1106296'>bug 1106296</a>."
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/css/selectors/grammar-error.json
+++ b/css/selectors/grammar-error.json
@@ -26,9 +26,7 @@
               "version_added": false,
               "notes": "See <a href='https://webkit.org/b/175784'>bug 175784</a>."
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/selectors/has.json
+++ b/css/selectors/has.json
@@ -11,9 +11,7 @@
               "version_added": false,
               "notes": "See <a href='https://crbug.com/669058'>bug 669058</a>."
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false,
@@ -24,9 +22,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": "15.4"

--- a/css/selectors/nth-child.json
+++ b/css/selectors/nth-child.json
@@ -86,9 +86,7 @@
                 "version_added": false,
                 "notes": "See <a href='https://crbug.com/304163'>bug 304163</a>."
               },
-              "chrome_android": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
@@ -99,9 +97,7 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": "9"

--- a/css/selectors/nth-last-child.json
+++ b/css/selectors/nth-last-child.json
@@ -84,9 +84,7 @@
                 "version_added": false,
                 "notes": "See <a href='https://crbug.com/304163'>bug 304163</a>."
               },
-              "chrome_android": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
@@ -97,9 +95,7 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": "9"

--- a/css/selectors/spelling-error.json
+++ b/css/selectors/spelling-error.json
@@ -26,9 +26,7 @@
               "version_added": false,
               "notes": "See <a href='https://webkit.org/b/175784'>bug 175784</a>."
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/types/attr.json
+++ b/css/types/attr.json
@@ -56,9 +56,7 @@
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/1448248'>bug 1448248</a>."
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -69,9 +67,7 @@
                 "version_added": false,
                 "notes": "See <a href='https://webkit.org/b/204275'>bug 204275</a>."
               },
-              "safari_ios": {
-                "version_added": false
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -95,9 +91,7 @@
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/435426'>bug 435426</a>."
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -108,9 +102,7 @@
                 "version_added": false,
                 "notes": "See <a href='https://webkit.org/b/204275'>bug 204275</a>."
               },
-              "safari_ios": {
-                "version_added": false
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -133,9 +125,7 @@
                   "version_added": false,
                   "notes": "See <a href='https://bugzil.la/435426'>bug 435426</a>."
                 },
-                "firefox_android": {
-                  "version_added": false
-                },
+                "firefox_android": "mirror",
                 "ie": {
                   "version_added": false
                 },
@@ -146,9 +136,7 @@
                   "version_added": false,
                   "notes": "See <a href='https://webkit.org/b/204275'>bug 204275</a>."
                 },
-                "safari_ios": {
-                  "version_added": false
-                },
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror"
               },
@@ -172,9 +160,7 @@
                   "version_added": false,
                   "notes": "See <a href='https://bugzil.la/1448251'>bug 1448251</a>."
                 },
-                "firefox_android": {
-                  "version_added": false
-                },
+                "firefox_android": "mirror",
                 "ie": {
                   "version_added": false
                 },
@@ -185,9 +171,7 @@
                   "version_added": false,
                   "notes": "See <a href='https://webkit.org/b/204275'>bug 204275</a>."
                 },
-                "safari_ios": {
-                  "version_added": false
-                },
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror"
               },
@@ -211,9 +195,7 @@
                   "version_added": false,
                   "notes": "See <a href='https://bugzil.la/435426'>bug 435426</a>."
                 },
-                "firefox_android": {
-                  "version_added": false
-                },
+                "firefox_android": "mirror",
                 "ie": {
                   "version_added": false
                 },
@@ -224,9 +206,7 @@
                   "version_added": false,
                   "notes": "See <a href='https://webkit.org/b/204275'>bug 204275</a>."
                 },
-                "safari_ios": {
-                  "version_added": false
-                },
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror"
               },
@@ -250,9 +230,7 @@
                   "version_added": false,
                   "notes": "See <a href='https://bugzil.la/435426'>bug 435426</a>."
                 },
-                "firefox_android": {
-                  "version_added": false
-                },
+                "firefox_android": "mirror",
                 "ie": {
                   "version_added": false
                 },
@@ -263,9 +241,7 @@
                   "version_added": false,
                   "notes": "See <a href='https://webkit.org/b/204275'>bug 204275</a>."
                 },
-                "safari_ios": {
-                  "version_added": false
-                },
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror"
               },
@@ -289,9 +265,7 @@
                   "version_added": false,
                   "notes": "See <a href='https://bugzil.la/435426'>bug 435426</a>."
                 },
-                "firefox_android": {
-                  "version_added": false
-                },
+                "firefox_android": "mirror",
                 "ie": {
                   "version_added": false
                 },
@@ -302,9 +276,7 @@
                   "version_added": false,
                   "notes": "See <a href='https://webkit.org/b/204275'>bug 204275</a>."
                 },
-                "safari_ios": {
-                  "version_added": false
-                },
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror"
               },
@@ -328,9 +300,7 @@
                   "version_added": false,
                   "notes": "See <a href='https://bugzil.la/435426'>bug 435426</a>."
                 },
-                "firefox_android": {
-                  "version_added": false
-                },
+                "firefox_android": "mirror",
                 "ie": {
                   "version_added": false
                 },
@@ -341,9 +311,7 @@
                   "version_added": false,
                   "notes": "See <a href='https://webkit.org/b/204275'>bug 204275</a>."
                 },
-                "safari_ios": {
-                  "version_added": false
-                },
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror"
               },
@@ -367,9 +335,7 @@
                   "version_added": false,
                   "notes": "See <a href='https://bugzil.la/435426'>bug 435426</a>."
                 },
-                "firefox_android": {
-                  "version_added": false
-                },
+                "firefox_android": "mirror",
                 "ie": {
                   "version_added": false
                 },
@@ -380,9 +346,7 @@
                   "version_added": false,
                   "notes": "See <a href='https://webkit.org/b/204275'>bug 204275</a>."
                 },
-                "safari_ios": {
-                  "version_added": false
-                },
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror"
               },
@@ -406,9 +370,7 @@
                   "version_added": false,
                   "notes": "See <a href='https://bugzil.la/435426'>bug 435426</a>."
                 },
-                "firefox_android": {
-                  "version_added": false
-                },
+                "firefox_android": "mirror",
                 "ie": {
                   "version_added": false
                 },
@@ -419,9 +381,7 @@
                   "version_added": false,
                   "notes": "See <a href='https://webkit.org/b/204275'>bug 204275</a>."
                 },
-                "safari_ios": {
-                  "version_added": false
-                },
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror"
               },
@@ -445,9 +405,7 @@
                   "version_added": false,
                   "notes": "See <a href='https://bugzil.la/1448252'>bug 1448252</a>."
                 },
-                "firefox_android": {
-                  "version_added": false
-                },
+                "firefox_android": "mirror",
                 "ie": {
                   "version_added": false
                 },
@@ -458,9 +416,7 @@
                   "version_added": false,
                   "notes": "See <a href='https://webkit.org/b/204275'>bug 204275</a>."
                 },
-                "safari_ios": {
-                  "version_added": false
-                },
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror"
               },

--- a/css/types/frequency-percentage.json
+++ b/css/types/frequency-percentage.json
@@ -16,9 +16,7 @@
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/741643'>bug 741643</a>."
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/css/types/frequency.json
+++ b/css/types/frequency.json
@@ -16,9 +16,7 @@
               "version_added": false,
               "notes": "See <a href='https://bugzil.la/741643'>bug 741643</a>."
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -198,9 +198,7 @@
                 "notes": "See <a href='https://crbug.com/937101'>bug 937101</a>."
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": false
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "97"
               },
@@ -209,25 +207,15 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": false,
                 "notes": "See <a href='https://webkit.org/b/195176'>bug 195176</a>."
               },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": true,
@@ -244,26 +232,18 @@
                 "version_added": false,
                 "notes": "See <a href='https://crbug.com/937104'>bug 937104</a>."
               },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
               "firefox": {
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/1310170'>bug 1310170</a>."
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": false
@@ -364,26 +344,18 @@
                 "version_added": false,
                 "notes": "See <a href='https://crbug.com/937104'>bug 937104</a>."
               },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
               "firefox": {
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/1310170'>bug 1310170</a>."
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": false
@@ -412,9 +384,7 @@
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/1287034'>bug 1287034</a>."
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -425,9 +395,7 @@
                 "version_added": false,
                 "notes": "See <a href='https://webkit.org/b/159801'>bug 159801</a>."
               },
-              "safari_ios": {
-                "version_added": false
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -488,9 +456,7 @@
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/1287034'>bug 1287034</a>."
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -501,9 +467,7 @@
                 "version_added": false,
                 "notes": "See <a href='https://webkit.org/b/159801'>bug 159801</a>."
               },
-              "safari_ios": {
-                "version_added": false
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -198,9 +198,7 @@
                 "notes": "See <a href='https://crbug.com/937101'>bug 937101</a>."
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": false
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "97"
               },
@@ -209,22 +207,14 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "15.4"
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -241,26 +231,18 @@
                 "version_added": false,
                 "notes": "See <a href='https://crbug.com/937104'>bug 937104</a>."
               },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
               "firefox": {
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/1310170'>bug 1310170</a>."
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": false
@@ -327,26 +309,18 @@
                 "version_added": false,
                 "notes": "See <a href='https://crbug.com/937104'>bug 937104</a>."
               },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
               "firefox": {
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/1310170'>bug 1310170</a>."
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": false

--- a/http/headers/cache-control.json
+++ b/http/headers/cache-control.json
@@ -47,9 +47,7 @@
                 "version_added": false,
                 "notes": "See Chromium <a href='https://crbug.com/611416'>bug 611416</a>."
               },
-              "chrome_android": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "15",
                 "version_removed": "79"
@@ -64,9 +62,7 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": "11"
@@ -90,24 +86,18 @@
                 "version_added": false,
                 "notes": "See Chromium <a href='https://crbug.com/348877'>bug 348877</a>."
               },
-              "chrome_android": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
                 "notes": "See Bugzilla <a href='https://bugzil.la/995651'>bug 995651</a> comment 7."
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": false

--- a/http/headers/clear-site-data.json
+++ b/http/headers/clear-site-data.json
@@ -165,9 +165,7 @@
                 "version_added": false,
                 "notes": "See <a href='https://crbug.com/898503'>bug 898503</a>."
               },
-              "chrome_android": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": "63",
@@ -178,9 +176,7 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": false

--- a/http/headers/content-security-policy.json
+++ b/http/headers/content-security-policy.json
@@ -774,20 +774,14 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": false,
                 "notes": "See <a href='https://webkit.org/b/185070'>bug 185070</a>."
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": {
-                "version_added": false
-              },
+              "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
@@ -1429,9 +1423,7 @@
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/1343950'>bug 1343950</a>."
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/http/headers/feature-policy.json
+++ b/http/headers/feature-policy.json
@@ -166,22 +166,14 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": false
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": true,

--- a/mathml/elements/maction.json
+++ b/mathml/elements/maction.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "8"
             },

--- a/mathml/elements/menclose.json
+++ b/mathml/elements/menclose.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "7"
             },

--- a/mathml/elements/merror.json
+++ b/mathml/elements/merror.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "6"
             },

--- a/mathml/elements/mfrac.json
+++ b/mathml/elements/mfrac.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "5.1"
             },

--- a/mathml/elements/mi.json
+++ b/mathml/elements/mi.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "6"
             },

--- a/mathml/elements/mmultiscripts.json
+++ b/mathml/elements/mmultiscripts.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "6"
             },

--- a/mathml/elements/mn.json
+++ b/mathml/elements/mn.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "6"
             },

--- a/mathml/elements/mo.json
+++ b/mathml/elements/mo.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "6"
             },

--- a/mathml/elements/mover.json
+++ b/mathml/elements/mover.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "6"
             },

--- a/mathml/elements/mpadded.json
+++ b/mathml/elements/mpadded.json
@@ -23,12 +23,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "6"
             },

--- a/mathml/elements/mphantom.json
+++ b/mathml/elements/mphantom.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "6"
             },

--- a/mathml/elements/mroot.json
+++ b/mathml/elements/mroot.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "6"
             },

--- a/mathml/elements/mrow.json
+++ b/mathml/elements/mrow.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "6"
             },

--- a/mathml/elements/ms.json
+++ b/mathml/elements/ms.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },

--- a/mathml/elements/mspace.json
+++ b/mathml/elements/mspace.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },

--- a/mathml/elements/msqrt.json
+++ b/mathml/elements/msqrt.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "5.1"
             },

--- a/mathml/elements/mstyle.json
+++ b/mathml/elements/mstyle.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "5.1"
             },

--- a/mathml/elements/msub.json
+++ b/mathml/elements/msub.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "6"
             },

--- a/mathml/elements/msubsup.json
+++ b/mathml/elements/msubsup.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "6"
             },

--- a/mathml/elements/msup.json
+++ b/mathml/elements/msup.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "6"
             },

--- a/mathml/elements/mtable.json
+++ b/mathml/elements/mtable.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "5.1"
             },

--- a/mathml/elements/mtd.json
+++ b/mathml/elements/mtd.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "5.1"
             },

--- a/mathml/elements/mtext.json
+++ b/mathml/elements/mtext.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "6"
             },

--- a/mathml/elements/mtr.json
+++ b/mathml/elements/mtr.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "5.1"
             },

--- a/mathml/elements/munder.json
+++ b/mathml/elements/munder.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "5.1"
             },

--- a/mathml/elements/munderover.json
+++ b/mathml/elements/munderover.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "6"
             },

--- a/mathml/elements/semantics.json
+++ b/mathml/elements/semantics.json
@@ -20,12 +20,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },


### PR DESCRIPTION
This is based on manually reviewing cases where both the source and
mirrored version_added is false, and a note is added. The changes that
are adding notes about bugs were kept.
