### PR TITLE
Update MediaSession setActionHandler for Safari/Firefox

### DIFF
--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -176,7 +176,8 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "82".
+                "version_added": "82",
+                "partial_implementation": true,
                 "notes": "Firefox exposes the API, but does not allow for the `togglemicrophone`, `togglecamera`, and `hangup` action types."
               },
               {

--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -201,7 +201,9 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15"
+              "version_added": "15",
+              "partial_implementation": true,
+              "notes": "Safari exposes the API, but does not allow for the `togglemicrophone`, `togglecamera`, and `hangup` action types."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -176,7 +176,8 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "82"
+                "version_added": "82".
+                "notes": "Firefox exposes the API, but does not allow for the `togglemicrophone`, `togglecamera`, and `hangup` action types."
               },
               {
                 "version_added": "71",

--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -205,7 +205,7 @@
             "safari": {
               "version_added": "15",
               "partial_implementation": true,
-              "notes": "Safari exposes the API, but does not allow for the `togglemicrophone`, `togglecamera`, and `hangup` action types."
+              "notes": "Safari exposes the API, but does not allow for the <code>togglemicrophone</code>, <code>togglecamera</code>, and <code>hangup</code> action types."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -178,7 +178,7 @@
               {
                 "version_added": "82",
                 "partial_implementation": true,
-                "notes": "Firefox exposes the API, but does not allow for the `togglemicrophone`, `togglecamera`, and `hangup` action types."
+                "notes": "Firefox exposes the API, but does not allow for the <code>togglemicrophone</code>, <code>togglecamera</code>, and <code>hangup</code> action types."
               },
               {
                 "version_added": "71",

--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -205,7 +205,7 @@
             "safari": {
               "version_added": "15",
               "partial_implementation": true,
-              "notes": "Safari exposes the API, but does not allow for the <code>togglemicrophone</code>, <code>togglecamera</code>, and <code>hangup</code> action types."
+              "notes": "Safari does not support for the <code>togglemicrophone</code>, <code>togglecamera</code>, and <code>hangup</code> action types."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -178,7 +178,7 @@
               {
                 "version_added": "82",
                 "partial_implementation": true,
-                "notes": "Firefox exposes the API, but does not allow for the <code>togglemicrophone</code>, <code>togglecamera</code>, and <code>hangup</code> action types."
+                "notes": "Firefox does not support the <code>togglemicrophone</code>, <code>togglecamera</code>, and <code>hangup</code> action types."
               },
               {
                 "version_added": "71",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

https://w3c.github.io/mediasession/#enumdef-mediasessionaction

`togglemicrophone`, `togglecamera`, and `hangup` are all listed as possible actions but using any of them in Safari 15 results in the following error:

> TypeError: Argument 1 ('action') to MediaSession.setActionHandler must be one of: "play", "pause", "seekbackward", "seekforward", "previoustrack", "nexttrack", "skipad", "stop", "seekto", "settrack"

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

https://github.com/mdn/content/pull/18528
