### PR TITLE
Add Picture-in-Picture support for Chrome on Android

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -2952,7 +2952,7 @@
               "version_added": "69"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "105"
             },
             "edge": "mirror",
             "firefox": {
@@ -4750,7 +4750,7 @@
               "version_added": "69"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "105"
             },
             "edge": "mirror",
             "firefox": {

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -119,7 +119,7 @@
               "version_added": "69"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "105"
             },
             "edge": "mirror",
             "firefox": {
@@ -159,7 +159,7 @@
               "version_added": "69"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "105"
             },
             "edge": "mirror",
             "firefox": {
@@ -280,7 +280,7 @@
               "version_added": "69"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "105"
             },
             "edge": "mirror",
             "firefox": {
@@ -627,7 +627,7 @@
               "version_added": "69"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "105"
             },
             "edge": "mirror",
             "firefox": {

--- a/api/PictureInPictureEvent.json
+++ b/api/PictureInPictureEvent.json
@@ -16,7 +16,7 @@
             }
           ],
           "chrome_android": {
-            "version_added": false
+            "version_added": "105"
           },
           "edge": "mirror",
           "firefox": {
@@ -65,7 +65,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": false
+              "version_added": "105"
             },
             "edge": "mirror",
             "firefox": {
@@ -107,7 +107,7 @@
               "version_added": "69"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "105"
             },
             "edge": "mirror",
             "firefox": {

--- a/api/PictureInPictureWindow.json
+++ b/api/PictureInPictureWindow.json
@@ -9,7 +9,7 @@
             "version_added": "69"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "105"
           },
           "edge": "mirror",
           "firefox": {
@@ -44,7 +44,7 @@
               "version_added": "69"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "105"
             },
             "edge": "mirror",
             "firefox": {
@@ -84,7 +84,7 @@
               "version_added": "69"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "105"
             },
             "edge": "mirror",
             "firefox": {
@@ -120,7 +120,7 @@
               "version_added": "69"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "105"
             },
             "edge": "mirror",
             "firefox": {

--- a/api/_mixins/DocumentOrShadowRoot__Document.json
+++ b/api/_mixins/DocumentOrShadowRoot__Document.json
@@ -342,7 +342,7 @@
               "version_added": "69"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "105"
             },
             "edge": "mirror",
             "firefox": {

--- a/api/_mixins/DocumentOrShadowRoot__ShadowRoot.json
+++ b/api/_mixins/DocumentOrShadowRoot__ShadowRoot.json
@@ -260,7 +260,7 @@
               "version_added": "69"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "105"
             },
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
Following https://groups.google.com/a/chromium.org/g/blink-dev/c/jXkQiIVpxr8, Picture-in-Picture support is about to be enabled on Chrome on Android.

FYI @liberato-at-chromium