### PR TITLE
Disallow {version_added: false} in arrays of support statements

### DIFF
--- a/test/linter/test-versions.ts
+++ b/test/linter/test-versions.ts
@@ -190,8 +190,6 @@ function checkVersions(
           continue;
         }
 
-        const statementKeys = Object.keys(statement);
-
         for (const property of ['version_added', 'version_removed']) {
           const version = statement[property];
           if (property == 'version_removed' && version === undefined) {
@@ -256,12 +254,10 @@ function checkVersions(
 
         if (
           Array.isArray(supportStatement) &&
-          statement.version_added === false &&
-          statementKeys.length == 1 &&
-          statementKeys[0] == 'version_added'
+          statement.version_added === false
         ) {
           logger.error(
-            chalk`{bold ${browser}} cannot have a {bold version_added: false} only in an array of statements.`,
+            chalk`{bold ${browser}} cannot have a {bold version_added: false} in an array of statements.`,
           );
         }
       }


### PR DESCRIPTION
This stricter lint already passes. Since "no support" is the default, it
doesn't make sense to enumerate multiple prefixes or alternative names
that aren't supported. Similarly, it doesn't make sense to have multiple
statments with notes split across them.

Enforcing this will make it easier to reason about mirroring.
