### PR TITLE
Deno 1.24 supports the unhandledrejection event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -6071,6 +6071,9 @@
               "version_added": "49"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.24"
+            },
             "edge": "mirror",
             "firefox": [
               {


### PR DESCRIPTION
#### Summary
The upcoming Deno 1.24 release adds support for the `unhandledrejection` event.

#### Test results and supporting details
PR that adds the feature to Deno, including tests: https://github.com/denoland/deno/pull/15211

cc: @lucacasonato 

Note: CI will fail until 1.24 is released today.