### PR TITLE
Deno 1.24 supports the PromiseRejectionEvent

### DIFF
--- a/api/PromiseRejectionEvent.json
+++ b/api/PromiseRejectionEvent.json
@@ -10,7 +10,7 @@
           },
           "chrome_android": "mirror",
           "deno": {
-            "version_added": false
+            "version_added": "1.24"
           },
           "edge": "mirror",
           "firefox": {
@@ -49,7 +49,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "1.24"
             },
             "edge": "mirror",
             "firefox": {
@@ -88,7 +88,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "1.24"
             },
             "edge": "mirror",
             "firefox": {
@@ -127,7 +127,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "1.24"
             },
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
#### Summary
The upcoming Deno 1.24 release adds support for `PromiseRejectionEvent`.

#### Test results and supporting details
PR that adds the feature to Deno, including tests: https://github.com/denoland/deno/pull/15211

cc: @lucacasonato 

Note: CI will fail until 1.24 is released today.