### PR TITLE
Update deno.json with v1.24

### DIFF
--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -170,6 +170,13 @@
         "1.23": {
           "release_date": "2022-06-15",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.23.0",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "10.4"
+        },
+        "1.24": {
+          "release_date": "2022-07-20",
+          "release_notes": "https://github.com/denoland/deno/releases/tag/v1.24.0",
           "status": "current",
           "engine": "V8",
           "engine_version": "10.4"


### PR DESCRIPTION
#### Summary
Deno 1.24 was released today.

#### Test results and supporting details
Release notes: https://github.com/denoland/deno/releases/tag/v1.24.0
