### PR TITLE
mfrac@bevelled is removed from Firefox

### DIFF
--- a/mathml/elements/mfrac.json
+++ b/mathml/elements/mfrac.json
@@ -53,7 +53,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "71"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -72,7 +73,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },

--- a/mathml/elements/mfrac.json
+++ b/mathml/elements/mfrac.json
@@ -73,7 +73,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },


### PR DESCRIPTION
#### Summary

This commit marks mfrac@bevelled as deprecated since it is no longer
part of MathML Core. Also indicates that it was removed from
Firefox 71. It seems this was already done for MDN in the past.

#### Test results and supporting details

https://bugzilla.mozilla.org/show_bug.cgi?id=1587572
https://w3c.github.io/mathml-core/#fractions-mfrac

#### Related issues

Fixes https://github.com/mdn/content/issues/15359 again.
