### PR TITLE
Update MathML implementation status for Blink-based browsers

### DIFF
--- a/mathml/elements/math.json
+++ b/mathml/elements/math.json
@@ -10,15 +10,13 @@
               {
                 "version_added": "80",
                 "impl_url": "https://crbug.com/6606",
-                "partial_implementation": true,
                 "flags": [
                   {
                     "type": "preference",
                     "name": "#enable-experimental-web-platform-features",
                     "value_to_set": "Enabled"
                   }
-                ],
-                "notes": "This is a new Blink-based implementation started in 2019."
+                ]
               },
               {
                 "version_added": "24",
@@ -32,15 +30,13 @@
             "edge": {
               "version_added": "80",
               "impl_url": "https://crbug.com/6606",
-              "partial_implementation": true,
               "flags": [
                 {
                   "type": "preference",
                   "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "Enabled"
                 }
-              ],
-              "notes": "This is a new Blink-based implementation started in 2019."
+              ]
             },
             "firefox": [
               {
@@ -63,15 +59,13 @@
               {
                 "version_added": "67",
                 "impl_url": "https://crbug.com/6606",
-                "partial_implementation": true,
                 "flags": [
                   {
                     "type": "preference",
                     "name": "#enable-experimental-web-platform-features",
                     "value_to_set": "Enabled"
                   }
-                ],
-                "notes": "This is a new Blink-based implementation started in 2019."
+                ]
               },
               {
                 "version_added": "9.5",

--- a/mathml/elements/math.json
+++ b/mathml/elements/math.json
@@ -6,15 +6,41 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/math",
           "spec_url": "https://w3c.github.io/mathml-core/#the-top-level-math-element",
           "support": {
-            "chrome": {
-              "version_added": "24",
-              "version_removed": "25",
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
-            },
+            "chrome": [
+              {
+                "version_added": "80",
+                "impl_url": "https://crbug.com/6606",
+                "partial_implementation": true,
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "This is a new Blink-based implementation started in 2019."
+              },
+              {
+                "version_added": "24",
+                "version_removed": "25",
+                "partial_implementation": true,
+                "impl_url": "https://crbug.com/152430",
+                "notes": "Removed in Chrome 25 because <a href='https://crbug.com/152430#c32'>code was not yet production ready</a>."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "80",
+              "impl_url": "https://crbug.com/6606",
+              "partial_implementation": true,
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ],
+              "notes": "This is a new Blink-based implementation started in 2019."
             },
             "firefox": [
               {
@@ -33,12 +59,27 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "9.5",
-              "version_removed": "15",
-              "partial_implementation": true,
-              "notes": "Only supported in XHTML documents."
-            },
+            "opera": [
+              {
+                "version_added": "67",
+                "impl_url": "https://crbug.com/6606",
+                "partial_implementation": true,
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "This is a new Blink-based implementation started in 2019."
+              },
+              {
+                "version_added": "9.5",
+                "version_removed": "15",
+                "partial_implementation": true,
+                "notes": "Only supported in XHTML documents."
+              }
+            ],
             "opera_android": {
               "version_added": "10.1",
               "version_removed": "14",


### PR DESCRIPTION
#### Summary

A new MathML implementation started in Blink in 2019 and very basic
support was implemented under the "experimental web platform features"
flag. This corresponds to Blink 80 [1]. As a consequence, update the
Blink-based browsers accordingly:

- Chrome switched to Blink in version 28 [2], before that there was a
  WebKit implementation that was implemented enabled only in Chrome 24.
  We keep that information and add link to why it was removed in
  Chrome 25. Also add the new implementation in version 80.

- Edge switched to Blink in version 79 [3], add the new
  implementation in version 80.

- Opera switched to Blink in version 15 [4], before that there was a
  Presto implementation. We keep that information and add the new
  implementation in version 67 (corresponding to Blink version 80).

- Opera Android does not support flags [5], so MathML cannot be
  enabled for now. Don't change anything for this entry.

#### Test results and supporting details

[1] https://chromiumdash.appspot.com/commit/ee4ac810348a8dd42fb0f5bc7353c507e4ab17c6
    https://chromiumdash.appspot.com/commit/6a1f248788b300a9d2b96c977976e747c5ec4aaa
    https://chromiumdash.appspot.com/commit/e4f3a0881c7a63f5ed0ff9dd68ef04d84a535969
    https://chromiumdash.appspot.com/commit/63dd456d6e73f1d41aadf211aefa3456f5825f47
    https://chromiumdash.appspot.com/commit/9bbdc694b075ea78b913f89954571f55ad14f0d8
    https://chromiumdash.appspot.com/commit/8b8b60fb32ffcc41c3ae41224389822969e172f3
[2] Cf chrome.json
[3] Cf edge.json
[4] Cf opera.json
[5] npm test is reporting that.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/16890