### PR TITLE
Remove notes about old Firefox ESR releases

### DIFF
--- a/api/Cache.json
+++ b/api/Cache.json
@@ -14,12 +14,9 @@
             "version_added": "16"
           },
           "firefox": {
-            "version_added": "41",
-            "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-          },
-          "firefox_android": {
             "version_added": "41"
           },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -54,12 +51,9 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -96,12 +90,9 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "41",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "41"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -139,12 +130,9 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "41",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "41"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -178,12 +166,9 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "41",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "41"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -217,12 +202,9 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "41",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "41"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -256,12 +238,9 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "41",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "41"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -295,12 +274,9 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "41",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "41"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -338,12 +314,9 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "41",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "41"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -21,12 +21,9 @@
             "version_added": "16"
           },
           "firefox": {
-            "version_added": "41",
-            "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-          },
-          "firefox_android": {
             "version_added": "41"
           },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -99,12 +96,9 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -138,12 +132,9 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "41",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "41"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -177,12 +168,9 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "41",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "41"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -216,12 +204,9 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "41",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "41"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -262,12 +247,9 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "41",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "41"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -301,12 +283,9 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "41",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "41"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/Client.json
+++ b/api/Client.json
@@ -13,12 +13,9 @@
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "44",
-            "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-          },
-          "firefox_android": {
             "version_added": "44"
           },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -51,12 +48,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -90,12 +84,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -129,12 +120,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -204,12 +192,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/Clients.json
+++ b/api/Clients.json
@@ -13,12 +13,9 @@
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "44",
-            "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-          },
-          "firefox_android": {
             "version_added": "44"
           },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -51,12 +48,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -90,12 +84,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "45",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "45"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -136,19 +127,10 @@
                 "notes": "<code>Client</code> objects returned in most recent focus order."
               },
               {
-                "version_added": "44",
-                "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "54",
-                "notes": "<code>Client</code> objects returned in most recent focus order."
-              },
-              {
                 "version_added": "44"
               }
             ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -233,12 +215,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "45",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "45"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/ExtendableEvent.json
+++ b/api/ExtendableEvent.json
@@ -13,12 +13,9 @@
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "44",
-            "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-          },
-          "firefox_android": {
             "version_added": "44"
           },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -56,12 +53,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/ExtendableMessageEvent.json
+++ b/api/ExtendableMessageEvent.json
@@ -13,12 +13,9 @@
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "44",
-            "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-          },
-          "firefox_android": {
             "version_added": "44"
           },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -52,12 +49,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -91,12 +85,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -130,12 +121,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -205,12 +193,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -244,12 +229,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -13,12 +13,9 @@
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "44",
-            "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-          },
-          "firefox_android": {
             "version_added": "44"
           },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -52,12 +49,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -91,12 +85,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "45",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "45"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -324,19 +315,10 @@
                 "notes": "NetworkError thrown if request mode is same-origin and response type is cors (see <a href='https://bugzil.la/1222008'>bug 1222008</a>)."
               },
               {
-                "version_added": "44",
-                "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-              }
-            ],
-            "firefox_android": [
-              {
-                "version_added": "59",
-                "notes": "NetworkError thrown if request mode is same-origin and response type is cors (see <a href='https://bugzil.la/1222008'>bug 1222008</a>)."
-              },
-              {
                 "version_added": "44"
               }
             ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/InstallEvent.json
+++ b/api/InstallEvent.json
@@ -12,12 +12,9 @@
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "44",
-            "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-          },
-          "firefox_android": {
             "version_added": "44"
           },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -48,12 +45,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -86,12 +80,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3954,12 +3954,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/NotificationEvent.json
+++ b/api/NotificationEvent.json
@@ -13,12 +13,9 @@
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "44",
-            "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-          },
-          "firefox_android": {
             "version_added": "44"
           },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -63,12 +60,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -112,12 +106,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -157,12 +148,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/PushEvent.json
+++ b/api/PushEvent.json
@@ -13,8 +13,7 @@
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "44",
-            "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+            "version_added": "44"
           },
           "firefox_android": {
             "version_added": "48"
@@ -63,8 +62,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "48"
@@ -112,8 +110,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "48"

--- a/api/PushManager.json
+++ b/api/PushManager.json
@@ -13,8 +13,7 @@
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "44",
-            "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+            "version_added": "44"
           },
           "firefox_android": {
             "version_added": "48"
@@ -57,8 +56,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers."
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "48"
@@ -98,8 +96,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "48"
@@ -142,8 +139,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "48"
@@ -183,8 +179,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "48"
@@ -227,8 +222,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "48"
@@ -267,8 +261,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "48"
@@ -312,10 +305,7 @@
             },
             "firefox": {
               "version_added": "44",
-              "notes": [
-                "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API.",
-                "From Firefox 72 onwards, can only be called in response to a user gesture such as a <code>click</code> event."
-              ]
+              "notes": "From Firefox 72 onwards, can only be called in response to a user gesture such as a <code>click</code> event."
             },
             "firefox_android": {
               "version_added": "48",
@@ -362,8 +352,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "48"
@@ -408,8 +397,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "48"

--- a/api/PushMessageData.json
+++ b/api/PushMessageData.json
@@ -13,8 +13,7 @@
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "44",
-            "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+            "version_added": "44"
           },
           "firefox_android": {
             "version_added": "48"
@@ -58,8 +57,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "48"
@@ -103,8 +101,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "48"
@@ -148,8 +145,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "48"
@@ -193,8 +189,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "48"

--- a/api/PushSubscription.json
+++ b/api/PushSubscription.json
@@ -13,8 +13,7 @@
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "44",
-            "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+            "version_added": "44"
           },
           "firefox_android": {
             "version_added": "48"
@@ -58,8 +57,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "48"
@@ -146,8 +144,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "48"
@@ -191,8 +188,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "48"
@@ -323,8 +319,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "48"

--- a/api/ServiceWorker.json
+++ b/api/ServiceWorker.json
@@ -13,12 +13,9 @@
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "44",
-            "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-          },
-          "firefox_android": {
             "version_added": "44"
           },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -126,12 +123,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -165,12 +159,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -205,12 +196,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -13,12 +13,9 @@
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "44",
-            "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-          },
-          "firefox_android": {
             "version_added": "44"
           },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -51,12 +48,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -91,12 +85,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -165,12 +156,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -204,12 +192,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -252,12 +237,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -336,12 +318,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -375,12 +354,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -13,12 +13,9 @@
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "44",
-            "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-          },
-          "firefox_android": {
             "version_added": "44"
           },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -94,12 +91,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -312,12 +306,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -459,12 +450,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -503,12 +491,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -550,12 +535,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -637,12 +619,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -683,12 +662,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -809,8 +785,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "48"
@@ -861,8 +836,7 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "48"
@@ -904,12 +878,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -980,12 +951,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -1022,12 +990,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -16,12 +16,9 @@
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "44",
-            "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-          },
-          "firefox_android": {
             "version_added": "44"
           },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -54,12 +51,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -162,12 +156,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "46",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "46"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -244,12 +235,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -391,8 +379,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "48"
@@ -437,12 +424,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -476,12 +460,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "46",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "46"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -819,12 +800,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -862,12 +840,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -908,12 +883,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -983,12 +955,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/WindowClient.json
+++ b/api/WindowClient.json
@@ -13,12 +13,9 @@
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "44",
-            "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-          },
-          "firefox_android": {
             "version_added": "44"
           },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -51,12 +48,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -90,12 +84,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -129,12 +120,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -174,12 +162,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44",
-              "notes": "<a href='https://www.mozilla.org/en-US/firefox/organizations/'>Extended Support Releases (ESR)</a> before Firefox 78 ESR do not support service workers and the Push API."
-            },
-            "firefox_android": {
               "version_added": "44"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/javascript/builtins/webassembly/CompileError.json
+++ b/javascript/builtins/webassembly/CompileError.json
@@ -21,8 +21,7 @@
                 "version_added": "16"
               },
               "firefox": {
-                "version_added": "52",
-                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                "version_added": "52"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -67,8 +66,7 @@
                   "version_added": "16"
                 },
                 "firefox": {
-                  "version_added": "52",
-                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                  "version_added": "52"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/webassembly/Instance.json
+++ b/javascript/builtins/webassembly/Instance.json
@@ -18,8 +18,7 @@
                 "version_added": "16"
               },
               "firefox": {
-                "version_added": "52",
-                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                "version_added": "52"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -61,8 +60,7 @@
                   "version_added": "16"
                 },
                 "firefox": {
-                  "version_added": "52",
-                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                  "version_added": "52"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -104,8 +102,7 @@
                   "version_added": "16"
                 },
                 "firefox": {
-                  "version_added": "52",
-                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                  "version_added": "52"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/webassembly/LinkError.json
+++ b/javascript/builtins/webassembly/LinkError.json
@@ -21,8 +21,7 @@
                 "version_added": "16"
               },
               "firefox": {
-                "version_added": "52",
-                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                "version_added": "52"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -67,8 +66,7 @@
                   "version_added": "16"
                 },
                 "firefox": {
-                  "version_added": "52",
-                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                  "version_added": "52"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/webassembly/Memory.json
+++ b/javascript/builtins/webassembly/Memory.json
@@ -18,8 +18,7 @@
                 "version_added": "16"
               },
               "firefox": {
-                "version_added": "52",
-                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                "version_added": "52"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -61,8 +60,7 @@
                   "version_added": "16"
                 },
                 "firefox": {
-                  "version_added": "52",
-                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                  "version_added": "52"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -153,8 +151,7 @@
                   "version_added": "16"
                 },
                 "firefox": {
-                  "version_added": "52",
-                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                  "version_added": "52"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -196,8 +193,7 @@
                   "version_added": "16"
                 },
                 "firefox": {
-                  "version_added": "52",
-                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                  "version_added": "52"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/webassembly/Module.json
+++ b/javascript/builtins/webassembly/Module.json
@@ -18,8 +18,7 @@
                 "version_added": "16"
               },
               "firefox": {
-                "version_added": "52",
-                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                "version_added": "52"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -61,8 +60,7 @@
                   "version_added": "16"
                 },
                 "firefox": {
-                  "version_added": "52",
-                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                  "version_added": "52"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -104,8 +102,7 @@
                   "version_added": "16"
                 },
                 "firefox": {
-                  "version_added": "52",
-                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                  "version_added": "52"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -147,8 +144,7 @@
                   "version_added": "16"
                 },
                 "firefox": {
-                  "version_added": "52",
-                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                  "version_added": "52"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -190,8 +186,7 @@
                   "version_added": "16"
                 },
                 "firefox": {
-                  "version_added": "52",
-                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                  "version_added": "52"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/webassembly/RunTimeError.json
+++ b/javascript/builtins/webassembly/RunTimeError.json
@@ -21,8 +21,7 @@
                 "version_added": "16"
               },
               "firefox": {
-                "version_added": "52",
-                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                "version_added": "52"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -67,8 +66,7 @@
                   "version_added": "16"
                 },
                 "firefox": {
-                  "version_added": "52",
-                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                  "version_added": "52"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/webassembly/Table.json
+++ b/javascript/builtins/webassembly/Table.json
@@ -18,8 +18,7 @@
                 "version_added": "16"
               },
               "firefox": {
-                "version_added": "52",
-                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                "version_added": "52"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -61,8 +60,7 @@
                   "version_added": "16"
                 },
                 "firefox": {
-                  "version_added": "52",
-                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                  "version_added": "52"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -104,8 +102,7 @@
                   "version_added": "16"
                 },
                 "firefox": {
-                  "version_added": "52",
-                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                  "version_added": "52"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -147,8 +144,7 @@
                   "version_added": "16"
                 },
                 "firefox": {
-                  "version_added": "52",
-                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                  "version_added": "52"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -190,8 +186,7 @@
                   "version_added": "16"
                 },
                 "firefox": {
-                  "version_added": "52",
-                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                  "version_added": "52"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -233,8 +228,7 @@
                   "version_added": "16"
                 },
                 "firefox": {
-                  "version_added": "52",
-                  "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                  "version_added": "52"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/javascript/builtins/webassembly/WebAssembly.json
+++ b/javascript/builtins/webassembly/WebAssembly.json
@@ -17,8 +17,7 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "52",
-              "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+              "version_added": "52"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -59,8 +58,7 @@
                 "version_added": "16"
               },
               "firefox": {
-                "version_added": "52",
-                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                "version_added": "52"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -146,8 +144,7 @@
                 "version_added": "16"
               },
               "firefox": {
-                "version_added": "52",
-                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                "version_added": "52"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -233,8 +230,7 @@
                 "version_added": "16"
               },
               "firefox": {
-                "version_added": "52",
-                "notes": "Disabled in the Firefox 52 Extended Support Release (ESR)."
+                "version_added": "52"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
Firefox ESR 52 and 78 are far in the past now, and in particular the ESR
78 notes make the compat data for everything around Service Workers and
the Push API messier and harder to interpret.

This change allows mirroring more of the data for Firefox Android.
