### PR TITLE
Make notes around event handler properties more consistent

### DIFF
--- a/api/DeviceOrientationEvent.json
+++ b/api/DeviceOrientationEvent.json
@@ -7,7 +7,7 @@
         "support": {
           "chrome": {
             "version_added": "7",
-            "notes": "Before version 50, Chrome provided absolute values instead of relative values for this event. Developers still needing absolute values may use the <code>ondeviceorientationabsolute</code> event."
+            "notes": "Before version 50, Chrome provided absolute values instead of relative values for this event. Developers still needing absolute values may use the <code>deviceorientationabsolute</code> event."
           },
           "chrome_android": "mirror",
           "edge": {
@@ -36,11 +36,11 @@
           },
           "samsunginternet_android": {
             "version_added": "1.0",
-            "notes": "Before Samsung Internet 5.0, Samsung Internet provided absolute values instead of relative values for this event. Developers still needing absolute values may use the <code>ondeviceorientationabsolute</code> event."
+            "notes": "Before Samsung Internet 5.0, Samsung Internet provided absolute values instead of relative values for this event. Developers still needing absolute values may use the <code>deviceorientationabsolute</code> event."
           },
           "webview_android": {
             "version_added": "3",
-            "notes": "Before version 50, Chrome provided absolute values instead of relative values for this event. Developers still needing absolute values may use the <code>ondeviceorientationabsolute</code> event."
+            "notes": "Before version 50, Chrome provided absolute values instead of relative values for this event. Developers still needing absolute values may use the <code>deviceorientationabsolute</code> event."
           }
         },
         "status": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -739,7 +739,7 @@
             "chrome": {
               "version_added": "83",
               "partial_implementation": true,
-              "notes": "The <code>onanimationcancel</code> property is not supported. To listen to this event, use <code>element.addEventListener('animationcancel', function() {});</code>. See <a href='https://crbug.com/868224'>bug 868224</a>."
+              "notes": "The <code>onanimationcancel</code> event handler property is not supported. To listen to this event, use <code>element.addEventListener('animationcancel', function() {});</code>. See <a href='https://crbug.com/868224'>bug 868224</a>."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -759,8 +759,9 @@
               },
               {
                 "version_added": "12",
+                "version_removed": "13.1",
                 "partial_implementation": true,
-                "notes": "The event handler is exposed but will never be called."
+                "notes": "Although the <code>onanimationcancel</code> event handler property is supported, the <code>animationcancel</code> event is never fired."
               }
             ],
             "safari_ios": "mirror",
@@ -785,13 +786,14 @@
                 "version_added": "79"
               },
               {
-                "version_added": "43",
-                "partial_implementation": true,
-                "notes": "The <code>onanimationend</code> property is not supported. To listen to this event, use <code>document.addEventListener('animationend', function() {});</code>. See <a href='https://crbug.com/868224'>bug 868224</a>."
-              },
-              {
                 "version_added": "81",
                 "prefix": "webkit"
+              },
+              {
+                "version_added": "43",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "The <code>onanimationend</code> event handler property is not supported. To listen to this event, use <code>document.addEventListener('animationend', function() {});</code>."
               }
             ],
             "chrome_android": "mirror",
@@ -800,13 +802,14 @@
                 "version_added": "18"
               },
               {
-                "version_added": "12",
-                "partial_implementation": true,
-                "notes": "The <code>onanimationend</code> property is not supported. To listen to this event, use <code>document.addEventListener('animationend', function() {});</code>. See <a href='https://crbug.com/868224'>bug 868224</a>."
-              },
-              {
                 "version_added": "81",
                 "prefix": "webkit"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "18",
+                "partial_implementation": true,
+                "notes": "The <code>onanimationend</code> event handler property is not supported. To listen to this event, use <code>document.addEventListener('animationend', function() {});</code>."
               }
             ],
             "firefox": [
@@ -815,15 +818,16 @@
               },
               {
                 "version_added": "5",
+                "version_removed": "51",
                 "partial_implementation": true,
-                "notes": "The <code>onanimationend</code> property is not supported. To listen to this event, use <code>document.addEventListener('animationend', function() {});</code>. See <a href='https://crbug.com/868224'>bug 868224</a>."
+                "notes": "The <code>onanimationend</code> event handler property is not supported. To listen to this event, use <code>document.addEventListener('animationend', function() {});</code>."
               }
             ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "10",
               "partial_implementation": true,
-              "notes": "The <code>onanimationend</code> property is not supported. To listen to this event, use <code>document.addEventListener('animationend', function() {});</code>. See <a href='https://crbug.com/868224'>bug 868224</a>."
+              "notes": "The <code>onanimationend</code> event handler property is not supported. To listen to this event, use <code>document.addEventListener('animationend', function() {});</code>."
             },
             "oculus": "mirror",
             "opera": "mirror",
@@ -853,13 +857,14 @@
                 "version_added": "79"
               },
               {
-                "version_added": "43",
-                "partial_implementation": true,
-                "notes": "The <code>onanimationiteration</code> property is not supported. To listen to this event, use <code>document.addEventListener('animationiteration', function() {});</code>. See <a href='https://crbug.com/868224'>bug 868224</a>."
-              },
-              {
                 "version_added": "81",
                 "prefix": "webkit"
+              },
+              {
+                "version_added": "43",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "The <code>onanimationiteration</code> event handler property is not supported. To listen to this event, use <code>document.addEventListener('animationiteration', function() {});</code>."
               }
             ],
             "chrome_android": "mirror",
@@ -868,13 +873,14 @@
                 "version_added": "18"
               },
               {
-                "version_added": "12",
-                "partial_implementation": true,
-                "notes": "The <code>onanimationiteration</code> property is not supported. To listen to this event, use <code>document.addEventListener('animationiteration', function() {});</code>. See <a href='https://crbug.com/868224'>bug 868224</a>."
-              },
-              {
                 "version_added": "81",
                 "prefix": "webkit"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "18",
+                "partial_implementation": true,
+                "notes": "The <code>onanimationiteration</code> event handler property is not supported. To listen to this event, use <code>document.addEventListener('animationiteration', function() {});</code>."
               }
             ],
             "firefox": [
@@ -883,15 +889,16 @@
               },
               {
                 "version_added": "5",
+                "version_removed": "51",
                 "partial_implementation": true,
-                "notes": "The <code>onanimationiteration</code> property is not supported. To listen to this event, use <code>document.addEventListener('animationiteration', function() {});</code>. See <a href='https://crbug.com/868224'>bug 868224</a>."
+                "notes": "The <code>onanimationiteration</code> event handler property is not supported. To listen to this event, use <code>document.addEventListener('animationiteration', function() {});</code>."
               }
             ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "10",
               "partial_implementation": true,
-              "notes": "The <code>onanimationiteration</code> property is not supported. To listen to this event, use <code>document.addEventListener('animationiteration', function() {});</code>. See <a href='https://crbug.com/868224'>bug 868224</a>."
+              "notes": "The <code>onanimationiteration</code> event handler property is not supported. To listen to this event, use <code>document.addEventListener('animationiteration', function() {});</code>."
             },
             "oculus": "mirror",
             "opera": "mirror",
@@ -921,13 +928,14 @@
                 "version_added": "79"
               },
               {
-                "version_added": "43",
-                "partial_implementation": true,
-                "notes": "The <code>onanimationstart</code> property is not supported. To listen to this event, use <code>document.addEventListener('animationstart', function() {});</code>. See <a href='https://crbug.com/868224'>bug 868224</a>."
-              },
-              {
                 "version_added": "81",
                 "prefix": "webkit"
+              },
+              {
+                "version_added": "43",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "The <code>onanimationstart</code> event handler property is not supported. To listen to this event, use <code>document.addEventListener('animationstart', function() {});</code>."
               }
             ],
             "chrome_android": "mirror",
@@ -936,13 +944,14 @@
                 "version_added": "18"
               },
               {
-                "version_added": "12",
-                "partial_implementation": true,
-                "notes": "The <code>onanimationstart</code> property is not supported. To listen to this event, use <code>document.addEventListener('animationstart', function() {});</code>. See <a href='https://crbug.com/868224'>bug 868224</a>."
-              },
-              {
                 "version_added": "81",
                 "prefix": "webkit"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "18",
+                "partial_implementation": true,
+                "notes": "The <code>onanimationstart</code> event handler property is not supported. To listen to this event, use <code>document.addEventListener('animationstart', function() {});</code>."
               }
             ],
             "firefox": [
@@ -951,15 +960,16 @@
               },
               {
                 "version_added": "5",
+                "version_removed": "51",
                 "partial_implementation": true,
-                "notes": "The <code>onanimationstart</code> property is not supported. To listen to this event, use <code>document.addEventListener('animationstart', function() {});</code>. See <a href='https://crbug.com/868224'>bug 868224</a>."
+                "notes": "The <code>onanimationstart</code> event handler property is not supported. To listen to this event, use <code>document.addEventListener('animationstart', function() {});</code>."
               }
             ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "10",
               "partial_implementation": true,
-              "notes": "The <code>onanimationstart</code> property is not supported. To listen to this event, use <code>document.addEventListener('animationstart', function() {});</code>. See <a href='https://crbug.com/868224'>bug 868224</a>."
+              "notes": "The <code>onanimationstart</code> event handler property is not supported. To listen to this event, use <code>document.addEventListener('animationstart', function() {});</code>."
             },
             "oculus": "mirror",
             "opera": "mirror",
@@ -7198,6 +7208,7 @@
               },
               {
                 "version_added": "74",
+                "version_removed": "87",
                 "partial_implementation": true,
                 "notes": "The <code>ontransitioncancel</code> event handler property is not supported. To listen to this event, use <code>element.addEventListener('transitioncancel', function() {});</code>."
               }
@@ -7220,8 +7231,9 @@
               },
               {
                 "version_added": "12",
+                "version_removed": "13.1",
                 "partial_implementation": true,
-                "notes": "Although the <code>ontransitioncancel</code> property is supported, the <code>transitioncancel</code> event is never fired."
+                "notes": "Although the <code>ontransitioncancel</code> event handler property is supported, the <code>transitioncancel</code> event is never fired."
               }
             ],
             "safari_ios": "mirror",
@@ -7256,13 +7268,14 @@
                 "version_added": "18"
               },
               {
-                "version_added": "12",
-                "partial_implementation": true,
-                "notes": "The <code>ontransitionend</code> event handler property is not supported. To listen to this event, use <code>element.addEventListener('transitionend', function() {});</code>."
-              },
-              {
                 "alternative_name": "webkittransitionend",
                 "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "18",
+                "partial_implementation": true,
+                "notes": "The <code>ontransitionend</code> event handler property is not supported. To listen to this event, use <code>element.addEventListener('transitionend', function() {});</code>."
               }
             ],
             "firefox": {
@@ -7581,7 +7594,7 @@
             "firefox_android": "mirror",
             "ie": {
               "version_added": "9",
-              "notes": "Internet Explorer only exposes the wheel event via <code>addEventListener</code>; there is no <code>onwheel</code> attribute on DOM objects. See <a href='https://connect.microsoft.com/IE/feedback/details/782835/missing-onwheel-attribute-for-the-wheel-event-although-its-supported-via-addeventlistener'>IE bug 782835</a>."
+              "notes": "The <code>onwheel</code> event handler property is not supported. To listen to this event, use <code>element.addEventListener('wheel', function() {});</code>. See <a href='https://connect.microsoft.com/IE/feedback/details/782835/missing-onwheel-attribute-for-the-wheel-event-although-its-supported-via-addeventlistener'>IE bug 782835</a>."
             },
             "oculus": "mirror",
             "opera": "mirror",

--- a/api/SVGAnimationElement.json
+++ b/api/SVGAnimationElement.json
@@ -125,29 +125,26 @@
           "support": {
             "chrome": [
               {
-                "version_added": "35",
-                "notes": "The event handler is <code>onbegin</code> for this event."
+                "version_added": "35"
               },
               {
                 "version_added": "31",
+                "version_removed": "35",
                 "partial_implementation": true,
-                "notes": "The event handler, <code>onbegin</code>, is not supported."
+                "notes": "The <code>onbegin</code> event handler property is not supported."
               }
             ],
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "79",
-              "notes": "The event handler is <code>onbegin</code> for this event."
-            },
+            "edge": "mirror",
             "firefox": [
               {
-                "version_added": "93",
-                "notes": "The event handler is <code>onbegin</code> for this event."
+                "version_added": "93"
               },
               {
                 "version_added": "6",
+                "version_removed": "93",
                 "partial_implementation": true,
-                "notes": "The event handler, <code>onbegin</code>, is not supported."
+                "notes": "The <code>onbegin</code> event handler property is not supported."
               }
             ],
             "firefox_android": "mirror",
@@ -160,7 +157,7 @@
             "safari": {
               "version_added": "10",
               "partial_implementation": true,
-              "notes": "The event handler, <code>onbegin</code>, is not supported."
+              "notes": "The <code>onbegin</code> event handler property is not supported."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -257,29 +254,26 @@
           "support": {
             "chrome": [
               {
-                "version_added": "35",
-                "notes": "The event handler is <code>onend</code> for this event."
+                "version_added": "35"
               },
               {
                 "version_added": "31",
+                "version_removed": "35",
                 "partial_implementation": true,
-                "notes": "The event handler, <code>onend</code>, is not supported."
+                "notes": "The <code>onend</code> event handler property is not supported."
               }
             ],
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "79",
-              "notes": "The event handler is <code>onend</code> for this event."
-            },
+            "edge": "mirror",
             "firefox": [
               {
-                "version_added": "93",
-                "notes": "The event handler is <code>onend</code> for this event."
+                "version_added": "93"
               },
               {
                 "version_added": "6",
+                "version_removed": "93",
                 "partial_implementation": true,
-                "notes": "The event handler, <code>onend</code>, is not supported."
+                "notes": "The <code>onend</code> event handler property is not supported."
               }
             ],
             "firefox_android": "mirror",
@@ -292,7 +286,7 @@
             "safari": {
               "version_added": "10",
               "partial_implementation": true,
-              "notes": "The event handler, <code>onend</code>, is not supported."
+              "notes": "The <code>onend</code> event handler property is not supported."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -427,29 +421,26 @@
           "support": {
             "chrome": [
               {
-                "version_added": "35",
-                "notes": "The event handler is <code>onrepeat</code> for this event."
+                "version_added": "35"
               },
               {
                 "version_added": "31",
+                "version_removed": "35",
                 "partial_implementation": true,
-                "notes": "The event handler, <code>onrepeat</code>, is not supported."
+                "notes": "The <code>onrepeat</code> event handler property is not supported."
               }
             ],
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "79",
-              "notes": "The event handler is <code>onrepeat</code> for this event."
-            },
+            "edge": "mirror",
             "firefox": [
               {
-                "version_added": "93",
-                "notes": "The event handler is <code>onrepeat</code> for this event."
+                "version_added": "93"
               },
               {
                 "version_added": "6",
+                "version_removed": "93",
                 "partial_implementation": true,
-                "notes": "The event handler, <code>onrepeat</code>, is not supported."
+                "notes": "The <code>onrepeat</code> event handler property is not supported."
               }
             ],
             "firefox_android": "mirror",
@@ -462,7 +453,7 @@
             "safari": {
               "version_added": "10",
               "partial_implementation": true,
-              "notes": "The event handler, <code>onrepeat</code>, is not supported."
+              "notes": "The <code>onrepeat</code> event handler property is not supported."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -310,7 +310,7 @@
             "safari": {
               "version_added": "11.1",
               "partial_implementation": true,
-              "notes": "Although the <code>onmessageerror</code> property is supported, the <code>messageerror</code> event is never fired. See <a href='https://webkit.org/b/171216'>bug 171216</a>."
+              "notes": "Although the <code>onmessageerror</code> event handler property is supported, the <code>messageerror</code> event is never fired. See <a href='https://webkit.org/b/171216'>bug 171216</a>."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/VisualViewport.json
+++ b/api/VisualViewport.json
@@ -300,7 +300,7 @@
               {
                 "version_added": "61",
                 "partial_implementation": true,
-                "notes": "The <code>onresize</code> property is not supported."
+                "notes": "The <code>onresize</code> event handler property is not supported."
               }
             ],
             "chrome_android": "mirror",
@@ -408,7 +408,7 @@
               {
                 "version_added": "61",
                 "partial_implementation": true,
-                "notes": "The <code>onscroll</code> property is not supported."
+                "notes": "The <code>onscroll</code> event handler property is not supported."
               }
             ],
             "chrome_android": "mirror",

--- a/api/Window.json
+++ b/api/Window.json
@@ -1716,17 +1716,17 @@
             "chrome": {
               "version_added": "35",
               "partial_implementation": true,
-              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
+              "notes": "The <code>ongamepadconnected</code> event handler property is not supported. See <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "chrome_android": {
               "version_added": "37",
               "partial_implementation": true,
-              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
+              "notes": "The <code>ongamepadconnected</code> event handler property is not supported. See <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "edge": {
               "version_added": "≤18",
               "partial_implementation": true,
-              "notes": "The event handler property (<code>ongamepadconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
+              "notes": "The <code>ongamepadconnected</code> event handler property is not supported. See <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "firefox": {
               "version_added": "29"
@@ -1765,17 +1765,17 @@
             "chrome": {
               "version_added": "35",
               "partial_implementation": true,
-              "notes": "The event handler property (<code>ongamepaddisconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
+              "notes": "The <code>ongamepaddisconnected</code> event handler property is not supported. See <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "chrome_android": {
               "version_added": "37",
               "partial_implementation": true,
-              "notes": "The event handler property (<code>ongamepaddisconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
+              "notes": "The <code>ongamepaddisconnected</code> event handler property is not supported. See <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "edge": {
               "version_added": "≤18",
               "partial_implementation": true,
-              "notes": "The event handler property (<code>ongamepaddisconnected</code>) is not supported; see <a href='https://crbug.com/1192878'>bug 1192878</a>."
+              "notes": "The <code>ongamepaddisconnected</code> event handler property is not supported. See <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "firefox": {
               "version_added": "29"


### PR DESCRIPTION
This uses the wording from the guideline:
https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#dom-events-eventname_event

Extra bits about `addEventListener()` are left alone.

Links to https://crbug.com/868224 are removed except for the remaining 
case of onanimationcancel. It was incorrectly linked for non-Chromium 
browsers in many places as well.

For SVGAnimationElement, the notes about the event handler property name
are removed, this is already shown by the MDN pages.