### PR TITLE
Add Firefox implementation notes for menclose@notation

### DIFF
--- a/mathml/elements/menclose.json
+++ b/mathml/elements/menclose.json
@@ -42,27 +42,9 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "32",
-                  "notes": "Notation <code>phasorangle</code> was implemented."
-                },
-                {
-                  "version_added": "24",
-                  "partial_implementation": true,
-                  "notes": "Notation <code>updiagonalarrow</code> was implemented."
-                },
-                {
-                  "version_added": "2",
-                  "partial_implementation": true,
-                  "notes": "Notation <code>madruwb</code> was implemented."
-                },
-                {
-                  "version_added": "1",
-                  "partial_implementation": true,
-                  "notes": "Only notations from MathML2 were implemented."
-                }
-              ],
+              "firefox": {
+                "version_added": "1"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -84,6 +66,108 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "madruwb": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "2"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "7"
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "phasorangle": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "32"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "updiagonalarrow": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "24"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         }

--- a/mathml/elements/menclose.json
+++ b/mathml/elements/menclose.json
@@ -44,23 +44,12 @@
               "edge": "mirror",
               "firefox": [
                 {
-                  "version_added": "32",
-                  "notes": "Notation <code>phasorangle</code> was implemented."
-                },
-                {
-                  "version_added": "24",
-                  "partial_implementation": true,
-                  "notes": "Notation <code>updiagonalarrow</code> was implemented."
-                },
-                {
-                  "version_added": "2",
-                  "partial_implementation": true,
-                  "notes": "Notation <code>madruwb</code> was implemented."
+                  "version_added": "32"
                 },
                 {
                   "version_added": "1",
                   "partial_implementation": true,
-                  "notes": "Only notations from MathML2 were implemented."
+                  "notes": "<code>madruwb</code>, <code>updiagonalarrow</code> and <code>phasorangle</code> are not supported."
                 }
               ],
               "firefox_android": "mirror",

--- a/mathml/elements/menclose.json
+++ b/mathml/elements/menclose.json
@@ -42,9 +42,27 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "1"
-              },
+              "firefox": [
+                {
+                  "version_added": "32",
+                  "notes": "Notation <code>phasorangle</code> was implemented."
+                },
+                {
+                  "version_added": "24",
+                  "partial_implementation": true,
+                  "notes": "Notation <code>updiagonalarrow</code> was implemented."
+                },
+                {
+                  "version_added": "2",
+                  "partial_implementation": true,
+                  "notes": "Notation <code>madruwb</code> was implemented."
+                },
+                {
+                  "version_added": "1",
+                  "partial_implementation": true,
+                  "notes": "Only notations from MathML2 were implemented."
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/mathml/elements/menclose.json
+++ b/mathml/elements/menclose.json
@@ -44,12 +44,23 @@
               "edge": "mirror",
               "firefox": [
                 {
-                  "version_added": "32"
+                  "version_added": "32",
+                  "notes": "Notation <code>phasorangle</code> was implemented."
+                },
+                {
+                  "version_added": "24",
+                  "partial_implementation": true,
+                  "notes": "Notation <code>updiagonalarrow</code> was implemented."
+                },
+                {
+                  "version_added": "2",
+                  "partial_implementation": true,
+                  "notes": "Notation <code>madruwb</code> was implemented."
                 },
                 {
                   "version_added": "1",
                   "partial_implementation": true,
-                  "notes": "<code>madruwb</code>, <code>updiagonalarrow</code> and <code>phasorangle</code> are not supported."
+                  "notes": "Only notations from MathML2 were implemented."
                 }
               ],
               "firefox_android": "mirror",


### PR DESCRIPTION
#### Summary

Import Firefox implementation notes for menclose@notation from https://developer.mozilla.org/en-US/docs/Web/MathML/Element/menclose#gecko-specific_notes

#### Test results and supporting details

This was taken from MDN's Gecko-specific notes, I haven't checked again whether that's accurate.

#### Related issues

https://github.com/mdn/content/pull/18589