### PR TITLE
Add Firefox note for lspace/rspace

### DIFF
--- a/mathml/elements/mo.json
+++ b/mathml/elements/mo.json
@@ -176,7 +176,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "notes": "In Firefox 16, default value for entries that are not in the operator dictionary has been changed to <code>0.2777777777777778em</code>."
               },
               "firefox_android": "mirror",
               "ie": {
@@ -372,7 +373,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "notes": "In Firefox 16, default value for entries that are not in the operator dictionary has been changed to <code>0.2777777777777778em</code>."
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
#### Summary

Take notes from

https://developer.mozilla.org/en-US/docs/Web/MathML/Element/mo#gecko-specific_notes

But:

- Clarify this is the default for entries that are not in the operator dictionary.
  Otherwise, https://w3c.github.io/mathml-core/#operator-dictionary-human will be used.

- Express the default value using CSS <length-percentage> as legacy values are deprecated:
  https://developer.mozilla.org/en-US/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths

#### Test results and supporting details

This info is copied from MDN.

#### Related issues

This will be removed from MDN at https://github.com/mdn/content/pull/18592