### PR TITLE
Add Firefox notes for maction

### DIFF
--- a/mathml/elements/maction.json
+++ b/mathml/elements/maction.json
@@ -55,12 +55,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "1",
-                "notes": [
-                  "<code>statusline</code> and <code>toggle</code> are supported, <code>tooltip</code> is not implemented, see <a href='https://bugzil.la/544001'>bug 544001</a>.",
-                  "In Firefox 9, the non-standard <code>restyle</code> value has been removed.",
-                  "In Firefox 14, the syntax of <code>statusline</code> has been changed to match the MathML specification."
-                ]
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -70,8 +65,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "8",
-                "notes": "<code>toggle</code> is supported, <code>statusline</code> and <code>tooltip</code> are not implemented, see <a href='https://webkit.org/b/120059'>WebKit bug 120059</a>."
+                "version_added": "8"
               },
               "safari_ios": {
                 "version_added": false
@@ -83,6 +77,112 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "restyle": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "1",
+                  "version_removed": "9"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": false,
+                "deprecated": true
+              }
+            }
+          },
+          "statusline": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": [
+                  {
+                    "version_added": "9"
+                  },
+                  {
+                    "version_added": "1",
+                    "partial_implementation": true,
+                    "notes": "The first implementation used a syntax different from the one of the MathML 3 specification."
+                  }
+                ],
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": false,
+                "deprecated": true
+              }
+            }
+          },
+          "toggle": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "1"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "8"
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": false,
+                "deprecated": true
+              }
             }
           }
         },

--- a/mathml/elements/maction.json
+++ b/mathml/elements/maction.json
@@ -21,7 +21,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "Since Firefox 16, if an <code>actiontype</code> is not specified (is empty) or if the <code>selection</code> attribute is invalid, the markup will throw a MathML error (invalid-markup)."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -55,7 +56,11 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "1",
-                "notes": "<code>statusline</code> and <code>toggle</code> are supported, <code>tooltip</code> is not implemented, see <a href='https://bugzil.la/544001'>bug 544001</a>."
+                "notes": [
+                  "<code>statusline</code> and <code>toggle</code> are supported, <code>tooltip</code> is not implemented, see <a href='https://bugzil.la/544001'>bug 544001</a>.",
+                  "In Firefox 9, the non-standard <code>restyle</code> value has been removed.",
+                  "In Firefox 14, the syntax of <code>statusline</code> has been changed to match the MathML specification."
+                ]
               },
               "firefox_android": "mirror",
               "ie": {
@@ -67,6 +72,44 @@
               "safari": {
                 "version_added": "8",
                 "notes": "<code>toggle</code> is supported, <code>statusline</code> and <code>tooltip</code> are not implemented, see <a href='https://webkit.org/b/120059'>WebKit bug 120059</a>."
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "selection": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1",
+                "notes": [
+                  "In Firefox 15, the <code>selection</code> attribute is now ignored for actiontype other than <code>toggle</code>.",
+                  "In Firefox 16, the <code>selection</code> attribute is taken into account again when an unknown <code>actiontype</code> is specified."
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "8"
               },
               "safari_ios": {
                 "version_added": false


### PR DESCRIPTION
#### Summary

Add Firefox notes for maction, taken from MDN. For that purpose, also introduces data for the `selection` attribute.

#### Test results and supporting details

- Notes taken from https://developer.mozilla.org/en-US/docs/Web/MathML/Element/maction#gecko-specific_notes
- The `selection` attribute is generally used together with the `actiontype="toggle"`, so copy existing data to determine whether selection is supported.

#### Related issues

MDN notes are removed in https://github.com/mdn/content/pull/18594