### PR TITLE
Add Firefox notes for semantics

### DIFF
--- a/mathml/elements/semantics.json
+++ b/mathml/elements/semantics.json
@@ -13,7 +13,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": [
+                "<code>annotation</code> and <code>annotation-xml</code> elements are ignored if the <code>src</code> attribute is set.",
+                "The algorithm for determining the visible child has been corrected in Firefox 23 to match the MathML specification. In prior versions only the first child element was rendered."
+              ]
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
#### Summary

Add Firefox notes for semantics, taken from MDN.

#### Test results and supporting details

https://developer.mozilla.org/en-US/docs/Web/MathML/Element/maction

#### Related issues

https://github.com/mdn/content/pull/18595