### PR TITLE
Add Firefox notes for mspace@width

### DIFF
--- a/mathml/elements/mspace.json
+++ b/mathml/elements/mspace.json
@@ -140,7 +140,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "notes": "Support for negative values has been implemented in Firefox 23."
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
#### Summary

Add Firefox notes for mspace@width, taken from MDN.

#### Test results and supporting details

https://developer.mozilla.org/en-US/docs/Web/MathML/Element/mspace#gecko-specific_notes

#### Related issues

https://github.com/mdn/content/pull/18598