### PR TITLE
Add browser notes regarding displaystyle/scriptlevel/mathvariant

### DIFF
--- a/mathml/global_attributes.json
+++ b/mathml/global_attributes.json
@@ -69,7 +69,7 @@
             "firefox": {
               "version_added": "83",
               "impl_url": "https://hg.mozilla.org/mozilla-central/rev/60a72a6c7c1d",
-              "notes": "Prior to Firefox 83, the attribute was only accepted on a few elements, as specified in MathML 3."
+              "notes": "Prior to Firefox 83, the attribute was only accepted on a few elements, as specified in MathML 3 and not implemented via <code>math-style</code>."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -82,7 +82,8 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "14",
-              "impl_url": "https://trac.webkit.org/changeset/267578"
+              "impl_url": "https://trac.webkit.org/changeset/267578",
+              "notes": "Since Safari 14.1, attribute is implemented via <code>math-style</code>."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -306,7 +307,10 @@
             "firefox": {
               "version_added": "70",
               "impl_url": "https://hg.mozilla.org/mozilla-central/rev/3b30c8db537c",
-              "notes": "Prior to Firefox 70, the attribute was only accepted on a few elements, as specified in MathML 3."
+              "notes": [
+                "Prior to Firefox 70, the attribute was only accepted on a few elements, as specified in MathML 3.",
+                "Implementation does not rely on the CSS approach described in MathML Core (via <code>text-transform</code>."
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -321,7 +325,10 @@
               "version_added": "10",
               "impl_url": "https://trac.webkit.org/changeset/203679",
               "partial_implementation": true,
-              "notes": "Safari only accepts the attribute on a few elements, as specified in MathML 3."
+              "notes": [
+                "Safari only accepts the attribute on a few elements, as specified in MathML 3.",
+                "Implementation does not rely on the CSS approach described in MathML Core (via <code>text-transform</code>."
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -355,7 +362,10 @@
             "firefox": {
               "version_added": "70",
               "impl_url": "https://hg.mozilla.org/mozilla-central/rev/3b30c8db537c",
-              "notes": "Prior to Firefox 70, the attribute was only accepted on a few elements, as specified in MathML 3."
+              "notes": [
+                "Prior to Firefox 70, the attribute was only accepted on a few elements, as specified in MathML 3.",
+                "Implementation does not rely on the CSS approach described in MathML Core (via <code>math-depth</code> and <code>font-size: math</code>)."
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/mathml/global_attributes.json
+++ b/mathml/global_attributes.json
@@ -69,7 +69,7 @@
             "firefox": {
               "version_added": "83",
               "impl_url": "https://hg.mozilla.org/mozilla-central/rev/60a72a6c7c1d",
-              "notes": "Prior to Firefox 83, the attribute was only accepted on a few elements, as specified in MathML 3 and not implemented via <code>math-style</code>."
+              "notes": "Prior to Firefox 83, the attribute was only accepted on a few elements, as specified in MathML 3, and was not implemented via <code>math-style</code>."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/mathml/global_attributes.json
+++ b/mathml/global_attributes.json
@@ -83,7 +83,7 @@
             "safari": {
               "version_added": "14",
               "impl_url": "https://trac.webkit.org/changeset/267578",
-              "notes": "Since Safari 14.1, attribute is implemented via <code>math-style</code>."
+              "notes": "Since Safari 14.1, this attribute is implemented via <code>math-style</code>."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Contrary to Chrome and MathML Core, some legacy implementations of
displaystyle/scriptlevel/mathvariant in WebKit/Firefox do not rely on
CSS. This commit imports some notes related to that from MDN:

https://developer.mozilla.org/en-US/docs/Web/MathML/Global_attributes/mathvariant#notes_on_mathml_versions
https://developer.mozilla.org/en-US/docs/Web/MathML/Global_attributes/displaystyle#notes_on_mathml_versions
https://developer.mozilla.org/en-US/docs/Web/MathML/Global_attributes/scriptlevel#notes_on_mathml_versions

#### Test results and supporting details

These are just taken from MDN, but `displaystyle/math-style` was checked here too:

https://bugzilla.mozilla.org/show_bug.cgi?id=1666075
https://bugs.webkit.org/show_bug.cgi?id=216702

#### Related issues

N/A