### PR TITLE
Add math-depth property

### DIFF
--- a/css/properties/math-depth.json
+++ b/css/properties/math-depth.json
@@ -1,0 +1,49 @@
+{
+  "css": {
+    "properties": {
+      "math-depth": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/math-depth",
+          "spec_url": "https://w3c.github.io/mathml-core/#the-math-script-level-property",
+          "support": {
+            "chrome": {
+              "version_added": "87",
+              "impl_url": "https://crrev.com/c/2423843",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features"
+                }
+              ]
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1667090'>bug 1667090</a>."
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/202303'>bug 202303</a>."
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### Summary

Add missing data for https://developer.mozilla.org/en-US/docs/Web/CSS/math-depth#specifications

#### Test results and supporting details

This is in Chrome 87: https://chromiumdash.appspot.com/commit/0feb1d195c8a413c53e808ed95df7e1b78089703

But not in Firefox/Webkit, see https://bugzil.la/1667090 and https://webkit.org/b/202303

#### Related issues

MDN article was initially introduced in https://github.com/mdn/content/pull/17812