### PR TITLE
Link Android bug for navigator.mediaDevices.getDisplayMedia()

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -146,7 +146,8 @@
               "version_added": "72"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/487935'>bug 487935</a>."
             },
             "edge": [
               {
@@ -154,6 +155,7 @@
               },
               {
                 "version_added": "17",
+                "version_removed": "79",
                 "notes": "Available as a member of <code>Navigator</code> instead of <code>MediaDevices</code>."
               }
             ],
@@ -184,10 +186,7 @@
               "version_added": false
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false,
-              "notes": "API is available, but will always fail with <code>NotAllowedError</code>."
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
The WebView data is mirrored. It ended up like this seemingly due to an
incorrect interpretation of a "This also applies to webview_android"
review comment for Chrome Android, which was resolved by copying the
Firefox Android data:
https://github.com/mdn/browser-compat-data/pull/3290
