### PR TITLE
Mar performance.setResourceTimingBufferSize() and event supported in iOS

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -797,9 +797,7 @@
             "safari": {
               "version_added": "11"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -848,9 +846,7 @@
             "safari": {
               "version_added": "11"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
Tested on iOS 11 with this collector test:
https://mdn-bcd-collector.appspot.com/tests/api/Performance

This comes from a PR that only updated the Safari data:
https://github.com/mdn/browser-compat-data/pull/3571

Part of https://github.com/mdn/browser-compat-data/pull/6526.
