### PR TITLE
Fix Edge support for webkitConvertPointFromNodeToPage etc.

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -6789,7 +6789,10 @@
               "version_removed": "39"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12",
+              "version_removed": "79"
+            },
             "firefox": {
               "version_added": false
             },
@@ -6828,7 +6831,10 @@
               "version_removed": "39"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "12",
+              "version_removed": "79"
+            },
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
Support in Edge 13 and 18 was confirmed with this test:
http://mdn-bcd-collector.appspot.com/tests/api/Window/webkitConvertPointFromNodeToPage

Then Edge 12 from Web Confluence was trusted to be correct:
https://github.com/mdn/browser-compat-data/pull/6526