### PR TITLE
Fix Safari support for PerformanceObserverEntryList

### DIFF
--- a/api/PerformanceObserverEntryList.json
+++ b/api/PerformanceObserverEntryList.json
@@ -60,7 +60,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -97,7 +97,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -134,7 +134,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "11"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
Confirmed with iOS 11 on BrowserStack with this test:
https://mdn-bcd-collector.appspot.com/tests/api/PerformanceObserverEntryList

This also matches the PerformanceObserver data.

Part of https://github.com/mdn/browser-compat-data/pull/6526.
