### PR TITLE
Fix wrong version_added for parentElement on IE

### DIFF
--- a/api/Node.json
+++ b/api/Node.json
@@ -1095,7 +1095,7 @@
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "9",
+              "version_added": "8",
               "notes": "Only supported on <code>Element</code>."
             },
             "oculus": "mirror",


### PR DESCRIPTION
parentElement is available in IE8 but the document stated that it was made available with IE9 - fixed!

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Changed version_added for parentElement on IE from 9 to 8 as requested (https://github.com/mdn/browser-compat-data/issues/16189#issuecomment-1126126172)

#### Test results and supporting details
Simply check that `document.body.firstChild.parentElement` returns `<body>` on a website running in IE8.

#### Related issues
Fixes #16189
