### PR TITLE
Mirror SpeechGrammar data for Chrome Android

### DIFF
--- a/api/SpeechGrammar.json
+++ b/api/SpeechGrammar.json
@@ -9,10 +9,7 @@
             "version_added": "25",
             "prefix": "webkit"
           },
-          "chrome_android": {
-            "version_added": "64",
-            "prefix": "webkit"
-          },
+          "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
             "version_added": "44",
@@ -60,10 +57,7 @@
               "version_added": "25",
               "prefix": "webkit"
             },
-            "chrome_android": {
-              "version_added": "64",
-              "prefix": "webkit"
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": "44",
@@ -111,9 +105,7 @@
             "chrome": {
               "version_added": "25"
             },
-            "chrome_android": {
-              "version_added": "64"
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": "44",
@@ -161,9 +153,7 @@
             "chrome": {
               "version_added": "25"
             },
-            "chrome_android": {
-              "version_added": "64"
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": "44",


### PR DESCRIPTION
This API is related to SpeechRecognition's grammars property, which is a
SpeechGrammarList. The data for that is all mirrored, so it's
implausible that SpeechGrammar alone was held back until Chrome 64.

There seems to have been no discussion about the difference in the PR
that added the data:
https://github.com/mdn/browser-compat-data/pull/976
