### PR TITLE
Mirror Chrome Android data for Intl.getCanonicalLocales()

### DIFF
--- a/javascript/builtins/intl/Intl.json
+++ b/javascript/builtins/intl/Intl.json
@@ -52,9 +52,7 @@
               "chrome": {
                 "version_added": "54"
               },
-              "chrome_android": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
               "deno": {
                 "version_added": "1.8"
               },


### PR DESCRIPTION
Support was confirmed by running `Intl.getCanonicalLocales('EN-US')` in
Chrome 96 on Android.

Web Confluence supports Chrome 54 being the correct version:
https://github.com/mdn/browser-compat-data/pull/6526
