### PR TITLE
Update Chrome implementation status for <semantics> and <maction>.

### DIFF
--- a/mathml/elements/maction.json
+++ b/mathml/elements/maction.json
@@ -16,7 +16,7 @@
                   "value_to_set": "Enabled"
                 }
               ],
-              "notes": "Only the basic implementation specified in MathML Core."
+              "notes": "By default, only the first child is rendered while the others have their <code>display</code> set to <code>none</code>. <code>actiontype</code> and <code>selection</code> attributes are ignored."
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/mathml/elements/maction.json
+++ b/mathml/elements/maction.json
@@ -7,8 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-maction",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "105",
+              "impl_url": "https://crrev.com/c/3720717",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ],
+              "notes": "Only the basic implementation specified in MathML Core."
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/mathml/elements/semantics.json
+++ b/mathml/elements/semantics.json
@@ -7,8 +7,16 @@
           "spec_url": "https://w3c.github.io/mathml-core/#semantics-and-presentation",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "88",
+              "impl_url": "https://crrev.com/c/2467903",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ],
+              "notes": "Only the basic implementation specified in MathML Core."
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/mathml/elements/semantics.json
+++ b/mathml/elements/semantics.json
@@ -16,7 +16,7 @@
                   "value_to_set": "Enabled"
                 }
               ],
-              "notes": "Only the basic implementation specified in MathML Core."
+              "notes": "By default, only the first child is rendered while the others have their <code>display</code> set to <code>none</code>."
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
#### Summary

Update Chrome implementation status for semantics and maction elements.

#### Test results and supporting details

Implemented here:
https://chromiumdash.appspot.com/commit/42f1b7704f3f39d72ace7dddd475dff36f22e364
https://chromiumdash.appspot.com/commit/a87f4c861b67fc4a8cf54d9da9b414c8e989e355

#### Related issues

MDN changes to align on MathML Core's implementations:
https://github.com/mdn/content/pull/18675
https://github.com/mdn/content/pull/18650
