### PR TITLE
Update Chrome implementation status for fractions/radicals/scripts

### DIFF
--- a/mathml/elements/mfrac.json
+++ b/mathml/elements/mfrac.json
@@ -7,8 +7,15 @@
           "spec_url": "https://w3c.github.io/mathml-core/#fractions-mfrac",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "83",
+              "impl_url": "https://crrev.com/c/2041665",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/mathml/elements/mmultiscripts.json
+++ b/mathml/elements/mmultiscripts.json
@@ -7,8 +7,15 @@
           "spec_url": "https://w3c.github.io/mathml-core/#prescripts-and-tensor-indices-mmultiscripts",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "86",
+              "impl_url": "https://crrev.com/c/2264334",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/mathml/elements/mover.json
+++ b/mathml/elements/mover.json
@@ -7,8 +7,15 @@
           "spec_url": "https://w3c.github.io/mathml-core/#underscripts-and-overscripts-munder-mover-munderover",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "84",
+              "impl_url": "https://crrev.com/c/2119538",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/mathml/elements/mroot.json
+++ b/mathml/elements/mroot.json
@@ -7,8 +7,15 @@
           "spec_url": "https://w3c.github.io/mathml-core/#radicals-msqrt-mroot",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "86",
+              "impl_url": "https://crrev.com/c/2190671",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/mathml/elements/msqrt.json
+++ b/mathml/elements/msqrt.json
@@ -7,8 +7,15 @@
           "spec_url": "https://w3c.github.io/mathml-core/#radicals-msqrt-mroot",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "86",
+              "impl_url": "https://crrev.com/c/2190671",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/mathml/elements/msub.json
+++ b/mathml/elements/msub.json
@@ -7,8 +7,15 @@
           "spec_url": "https://w3c.github.io/mathml-core/#subscripts-and-superscripts-msub-msup-msubsup",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "84",
+              "impl_url": "https://crrev.com/c/2128081",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/mathml/elements/msubsup.json
+++ b/mathml/elements/msubsup.json
@@ -7,8 +7,15 @@
           "spec_url": "https://w3c.github.io/mathml-core/#subscripts-and-superscripts-msub-msup-msubsup",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "84",
+              "impl_url": "https://crrev.com/c/2128081",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/mathml/elements/msup.json
+++ b/mathml/elements/msup.json
@@ -7,8 +7,15 @@
           "spec_url": "https://w3c.github.io/mathml-core/#subscripts-and-superscripts-msub-msup-msubsup",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "84",
+              "impl_url": "https://crrev.com/c/2128081",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/mathml/elements/munder.json
+++ b/mathml/elements/munder.json
@@ -7,8 +7,15 @@
           "spec_url": "https://w3c.github.io/mathml-core/#underscripts-and-overscripts-munder-mover-munderover",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "84",
+              "impl_url": "https://crrev.com/c/2119538",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/mathml/elements/munderover.json
+++ b/mathml/elements/munderover.json
@@ -7,8 +7,15 @@
           "spec_url": "https://w3c.github.io/mathml-core/#underscripts-and-overscripts-munder-mover-munderover",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "84",
+              "impl_url": "https://crrev.com/c/2119538",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
#### Summary

Update Chrome implementation status for the MathML elements mfrac,
msqrt, mroot, munder, mover, munderover, msub, msup, subsup and
mmultiscripts.

#### Test results and supporting details

See the following commits:

https://chromiumdash.appspot.com/commit/be67bb3749103109f3f62384f091e511b254a139 (NB: Chrome 82 was skipped)
https://chromiumdash.appspot.com/commit/f92feecbca3807c0b6a0d568b0efb5e64816e044
https://chromiumdash.appspot.com/commit/ac2ef89a732a203c9ef8b4ca1e042d5c01167e90
https://chromiumdash.appspot.com/commit/df7b1383ecd861b0aea5da898b9ccd0b7eaf9c52
https://chromiumdash.appspot.com/commit/3d681bf1ff155cba072d431b547d958dad386803

#### Related issues

N/A
