### PR TITLE
Update Chrome implementation status for MathML token elements

### DIFF
--- a/mathml/elements/mi.json
+++ b/mathml/elements/mi.json
@@ -7,8 +7,15 @@
           "spec_url": "https://w3c.github.io/mathml-core/#identifier-mi",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "87",
+              "impl_url": "https://crrev.com/c/2391150",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/mathml/elements/mn.json
+++ b/mathml/elements/mn.json
@@ -7,8 +7,15 @@
           "spec_url": "https://w3c.github.io/mathml-core/#number-mn",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "87",
+              "impl_url": "https://crrev.com/c/2391150",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/mathml/elements/mo.json
+++ b/mathml/elements/mo.json
@@ -7,8 +7,15 @@
           "spec_url": "https://w3c.github.io/mathml-core/#operator-fence-separator-or-accent-mo",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "95",
+              "impl_url": "https://crrev.com/c/3121110",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/mathml/elements/ms.json
+++ b/mathml/elements/ms.json
@@ -7,8 +7,15 @@
           "spec_url": "https://w3c.github.io/mathml-core/#string-literal-ms",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "87",
+              "impl_url": "https://crrev.com/c/2391150",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/mathml/elements/mspace.json
+++ b/mathml/elements/mspace.json
@@ -7,8 +7,15 @@
           "spec_url": "https://w3c.github.io/mathml-core/#space-mspace",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "81",
+              "impl_url": "https://crrev.com/c/1936251",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/mathml/elements/mtext.json
+++ b/mathml/elements/mtext.json
@@ -7,8 +7,15 @@
           "spec_url": "https://w3c.github.io/mathml-core/#text-mtext",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "87",
+              "impl_url": "https://crrev.com/c/2391150",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
#### Summary
This updates Chrome implementation status for MathML elements
mi, mn, mo, ms, mspace, mtext. Note that operator are much
more complex, we only indicate the version after complete
implementation.

#### Test results and supporting details

mspace: https://chromiumdash.appspot.com/commit/9ead940b1b7ad68132fc7b49de4675e3a87826a8
text elements: https://chromiumdash.appspot.com/commit/626338059c6bd24c0ca5041b8f712966fb0a092b
operators (final patch): https://chromiumdash.appspot.com/commit/63360945c80fadd9d104790e566f3dc7e0ac90b4

#### Related issues
N/A