### PR TITLE
Update Chrome implementation status for MathML tables

### DIFF
--- a/mathml/elements/mtable.json
+++ b/mathml/elements/mtable.json
@@ -7,8 +7,15 @@
           "spec_url": "https://w3c.github.io/mathml-core/#table-or-matrix-mtable",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "104",
+              "impl_url": "https://crrev.com/c/3657309",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/mathml/elements/mtd.json
+++ b/mathml/elements/mtd.json
@@ -7,8 +7,15 @@
           "spec_url": "https://w3c.github.io/mathml-core/#entry-in-table-or-matrix-mtd",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "104",
+              "impl_url": "https://crrev.com/c/3657309",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/mathml/elements/mtr.json
+++ b/mathml/elements/mtr.json
@@ -7,8 +7,15 @@
           "spec_url": "https://w3c.github.io/mathml-core/#row-in-table-or-matrix-mtr",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "104",
+              "impl_url": "https://crrev.com/c/3657309",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
#### Summary

This updates Chrome implementation status for MathML
elements mtable, mtr, and mtd.

#### Test results and supporting details

The reference commit is:
https://chromiumdash.appspot.com/commit/b23dbd56353d612b1e4970c7a909a97e8674e04e

Note that basic support was implemented for a long time but it has
serious bugs that don't make it usable in practice:
https://chromiumdash.appspot.com/commit/c7262762d35528a427d4c2ce9106292026fdd5ce

#### Related issues

N/A