### PR TITLE
Update Chrome implementation status for MathML containers

### DIFF
--- a/mathml/elements/menclose.json
+++ b/mathml/elements/menclose.json
@@ -7,8 +7,7 @@
           "spec_url": "https://w3c.github.io/mathml/#presm_menclose",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/mathml/elements/merror.json
+++ b/mathml/elements/merror.json
@@ -7,8 +7,15 @@
           "spec_url": "https://w3c.github.io/mathml-core/#error-message-merror",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "81",
+              "impl_url": "https://crrev.com/c/1913250",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/mathml/elements/mpadded.json
+++ b/mathml/elements/mpadded.json
@@ -7,8 +7,15 @@
           "spec_url": "https://w3c.github.io/mathml-core/#adjust-space-around-content-mpadded",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "86",
+              "impl_url": "https://crrev.com/c/2288388",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/mathml/elements/mphantom.json
+++ b/mathml/elements/mphantom.json
@@ -7,8 +7,15 @@
           "spec_url": "https://w3c.github.io/mathml-core/#making-sub-expressions-invisible-mphantom",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "81",
+              "impl_url": "https://crrev.com/c/1913250",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/mathml/elements/mrow.json
+++ b/mathml/elements/mrow.json
@@ -7,8 +7,15 @@
           "spec_url": "https://w3c.github.io/mathml-core/#horizontally-group-sub-expressions-mrow",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+              "version_added": "81",
+              "impl_url": "https://crrev.com/c/1913250",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
#### Summary

- Remove link for menclose, there is no plan to implement it at the
  moment, it's not part of MathML Core.
- Update implementation status for merror, mpadded,
  mphantom, mrow.

#### Test results and supporting details

merror, mphantom, mrow: https://chromiumdash.appspot.com/commit/f815237956a0e1fbd6d956690dfd79f74736842f
mpadded: https://chromiumdash.appspot.com/commit/aefc5f1eb5484a6b6b262c906e38cc31c4b183a5

#### Related issues
N/A