### PR TITLE
Add a subfeature for api.FetchEvent.respondWith returning NetworkError

### DIFF
--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -301,23 +301,15 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#fetch-event-respondwith",
           "support": {
             "chrome": {
-              "version_added": "42",
-              "notes": "NetworkError thrown if request mode is same-origin and response type is cors (see <a href='https://bugzil.la/1222008'>bug 1222008</a>). This is being worked on - see <a href='https://www.chromestatus.com/feature/5694278818856960'>https://www.chromestatus.com/feature/5694278818856960</a>."
+              "version_added": "42"
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "17",
-              "notes": "NetworkError thrown if request mode is same-origin and response type is cors (see <a href='https://bugzil.la/1222008'>bug 1222008</a>). This is being worked on - see <a href='https://www.chromestatus.com/feature/5694278818856960'>https://www.chromestatus.com/feature/5694278818856960</a>."
+              "version_added": "17"
             },
-            "firefox": [
-              {
-                "version_added": "59",
-                "notes": "NetworkError thrown if request mode is same-origin and response type is cors (see <a href='https://bugzil.la/1222008'>bug 1222008</a>)."
-              },
-              {
-                "version_added": "44"
-              }
-            ],
+            "firefox": {
+              "version_added": "44"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -342,6 +334,39 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "networkerror_on_same-origin_cors": {
+          "__compat": {
+            "description": "<code>NetworkError</code> thrown if the request mode is <code>same-origin</code> and the response type is <code>cors</code>",
+            "support": {
+              "chrome": {
+                "version_added": "66"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "59"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         },
         "resource_url": {


### PR DESCRIPTION
This PR adds a subfeature to `api.FetchEvent.respondWith` for if a NetworkError is thrown if the request mode is `same-origin` and the response type is `cors`.  This moves the information from the original notes.  The version number for Chromium comes from the linked [ChromeStatus feature](https://www.chromestatus.com/feature/5694278818856960).
