### PR TITLE
Simplify multiple support statements with just notes for font-size-adjust

### DIFF
--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -20,20 +20,17 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "40"
-              },
-              {
                 "version_added": "3",
                 "notes": "Before Firefox 40, <code>font-size-adjust: 0</code> was incorrectly interpreted as <code>font-size-adjust: none</code> (<a href='https://bugzil.la/1144885'>bug 1144885</a>)."
               },
               {
                 "version_added": "1",
-                "notes": "Before Firefox 3, <code>font-size-adjust</code> was supported on Windows only."
+                "version_removed": "3",
+                "partial_implementation": true,
+                "notes": "<code>font-size-adjust</code> was only supported on Windows."
               }
             ],
-            "firefox_android": {
-              "version_added": "4"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -27,7 +27,7 @@
                 "version_added": "1",
                 "version_removed": "3",
                 "partial_implementation": true,
-                "notes": "<code>font-size-adjust</code> was only supported on Windows."
+                "notes": "Only supported on Windows."
               }
             ],
             "firefox_android": "mirror",


### PR DESCRIPTION
This PR is a cherry-pick of #17006 for the `font-size-adjust` CSS property (the only remaining CSS feature).
