### PR TITLE
Update Safari versions for Cache API

### DIFF
--- a/api/Cache.json
+++ b/api/Cache.json
@@ -24,7 +24,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "11.1"
+            "version_added": "12"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": {
@@ -61,7 +61,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -100,7 +100,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -140,7 +140,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -176,7 +176,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -212,7 +212,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -248,7 +248,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -287,7 +287,7 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -324,7 +324,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `Cache` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Cache

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
