### PR TITLE
Update Safari versions for CacheStorage API

### DIFF
--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -31,7 +31,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "11.1"
+            "version_added": "12"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -63,7 +63,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -106,7 +106,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -142,7 +142,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -178,7 +178,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -214,7 +214,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -257,7 +257,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -293,7 +293,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `CacheStorage` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CacheStorage

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
