### PR TITLE
Update Safari versions for Client API

### DIFF
--- a/api/Client.json
+++ b/api/Client.json
@@ -23,7 +23,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "11.1"
+            "version_added": "12"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -58,7 +58,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -94,7 +94,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -130,7 +130,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -166,7 +166,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -202,7 +202,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `Client` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Client

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
