### PR TITLE
Update Safari versions for Clients API

### DIFF
--- a/api/Clients.json
+++ b/api/Clients.json
@@ -23,7 +23,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "11.1"
+            "version_added": "12"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -58,7 +58,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -94,7 +94,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -144,7 +144,7 @@
               "version_added": "29"
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -186,7 +186,7 @@
                 "version_added": "41"
               },
               "safari": {
-                "version_added": "11.1"
+                "version_added": "12"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -231,7 +231,7 @@
               "version_added": "41"
             },
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `Clients` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Clients

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
