### PR TITLE
Update Opera versions for CloseEvent API

### DIFF
--- a/api/CloseEvent.json
+++ b/api/CloseEvent.json
@@ -116,10 +116,10 @@
             },
             "oculus": "mirror",
             "opera": {
-              "version_added": "≤15"
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": "≤14"
+              "version_added": "12.1"
             },
             "safari": {
               "version_added": "6"
@@ -159,10 +159,10 @@
             },
             "oculus": "mirror",
             "opera": {
-              "version_added": "≤15"
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": "≤14"
+              "version_added": "12.1"
             },
             "safari": {
               "version_added": "6"
@@ -202,10 +202,10 @@
             },
             "oculus": "mirror",
             "opera": {
-              "version_added": "≤15"
+              "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": "≤14"
+              "version_added": "12.1"
             },
             "safari": {
               "version_added": "6"


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `CloseEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CloseEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
