### PR TITLE
Update Firefox versions for api.CompositionEvent.CompositionEvent

### DIFF
--- a/api/CompositionEvent.json
+++ b/api/CompositionEvent.json
@@ -51,7 +51,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "52"
+              "version_added": "53"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `CompositionEvent` member of the `CompositionEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CompositionEvent/CompositionEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
