### PR TITLE
backdrop-filter: Update FF compatibility to 103

### DIFF
--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -24,25 +24,29 @@
             "edge": {
               "version_added": "17"
             },
-            "firefox": {
-              "version_added": "70",
-              "notes": "See <a href='https://bugzil.la/1578503'>bug 1578503</a>.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.backdrop-filter.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "type": "preference",
-                  "name": "gfx.webrender.all",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "103"
+              },
+              {
+                "version_added": "70",
+                "notes": "See <a href='https://bugzil.la/1578503'>bug 1578503</a>.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.backdrop-filter.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "gfx.webrender.all",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+            ],
             "firefox_android": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1578503'>bug 1578503</a>."
+              "version_added": "103"
             },
             "ie": {
               "version_added": false

--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -43,7 +43,7 @@
                     "value_to_set": "true"
                   }
                 ]
-              },
+              }
             ],
             "firefox_android": {
               "version_added": "103"


### PR DESCRIPTION
As [Bug 1578503](https://bugzilla.mozilla.org/show_bug.cgi?id=1578503) has been closed as fixed in Firefox 103, which will be released on July 26, 2022, The compatibility table for this feature needs to be updated.