### PR TITLE
Update Firefox versions for api.Clients.openWindow

### DIFF
--- a/api/Clients.json
+++ b/api/Clients.json
@@ -217,7 +217,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "45"
+              "version_added": "44"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `openWindow` member of the `Clients` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Clients/openWindow

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
