### PR TITLE
Update Firefox versions for ContactAddress API

### DIFF
--- a/api/ContactAddress.json
+++ b/api/ContactAddress.json
@@ -12,7 +12,8 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "13",
+            "version_removed": "23"
           },
           "firefox_android": "mirror",
           "ie": {


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `ContactAddress` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ContactAddress

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
