### PR TITLE
Update Chromium versions for api.ConvolverNode.normalize

### DIFF
--- a/api/ConvolverNode.json
+++ b/api/ConvolverNode.json
@@ -116,7 +116,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-convolvernode-normalize",
           "support": {
             "chrome": {
-              "version_added": "14"
+              "version_added": "18"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `normalize` member of the `ConvolverNode` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ConvolverNode/normalize

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
