### PR TITLE
Update Firefox notes for api.CountQueuingStrategy.highWaterMark

### DIFF
--- a/api/CountQueuingStrategy.json
+++ b/api/CountQueuingStrategy.json
@@ -93,11 +93,17 @@
             "edge": {
               "version_added": "16"
             },
-            "firefox": {
-              "version_added": "65",
-              "partial_implementation": true,
-              "notes": "The property is defined on the instance instead of the prototype object. See <a href='https://bugzil.la/1684316'>bug 1684316</a>."
-            },
+            "firefox": [
+              {
+                "version_added": "89"
+              },
+              {
+                "version_added": "65",
+                "version_removed": "89",
+                "partial_implementation": true,
+                "notes": "The property is defined on the instance instead of the prototype object. See <a href='https://bugzil.la/1684316'>bug 1684316</a>."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/api/CountQueuingStrategy.json
+++ b/api/CountQueuingStrategy.json
@@ -93,17 +93,9 @@
             "edge": {
               "version_added": "16"
             },
-            "firefox": [
-              {
-                "version_added": "89"
-              },
-              {
-                "version_added": "65",
-                "version_removed": "89",
-                "partial_implementation": true,
-                "notes": "The property is defined on the instance instead of the prototype object. See <a href='https://bugzil.la/1684316'>bug 1684316</a>."
-              }
-            ],
+            "firefox": {
+              "version_added": "65"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `highWaterMark` member of the `CountQueuingStrategy` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CountQueuingStrategy/highWaterMark

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
