### PR TITLE
Update Chromium versions for EXT_color_buffer_float API

### DIFF
--- a/api/EXT_color_buffer_float.json
+++ b/api/EXT_color_buffer_float.json
@@ -6,7 +6,7 @@
         "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_float/",
         "support": {
           "chrome": {
-            "version_added": "63"
+            "version_added": "56"
           },
           "chrome_android": "mirror",
           "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `EXT_color_buffer_float` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/EXT_color_buffer_float

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
