### PR TITLE
Update Safari versions for EXT_color_buffer_float API

### DIFF
--- a/api/EXT_color_buffer_float.json
+++ b/api/EXT_color_buffer_float.json
@@ -21,11 +21,9 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
-          },
-          "safari_ios": {
             "version_added": "15"
           },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `EXT_color_buffer_float` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/EXT_color_buffer_float

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
