### PR TITLE
Update Edge versions for EXT_sRGB API

### DIFF
--- a/api/EXT_sRGB.json
+++ b/api/EXT_sRGB.json
@@ -10,7 +10,7 @@
           },
           "chrome_android": "mirror",
           "edge": {
-            "version_added": false
+            "version_added": "80"
           },
           "firefox": [
             {


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `EXT_sRGB` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/EXT_sRGB

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
