### PR TITLE
Update Opera versions for EXT_texture_norm16 API

### DIFF
--- a/api/EXT_texture_norm16.json
+++ b/api/EXT_texture_norm16.json
@@ -23,9 +23,7 @@
           "opera": {
             "version_added": false
           },
-          "opera_android": {
-            "version_added": false
-          },
+          "opera_android": "mirror",
           "safari": {
             "version_added": false
           },


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `EXT_texture_norm16` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/EXT_texture_norm16

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
