### PR TITLE
Remove api.Element.MSManipulationStateChanged_event from BCD

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -373,43 +373,6 @@
           }
         }
       },
-      "MSManipulationStateChanged_event": {
-        "__compat": {
-          "description": "<code>MSManipulationStateChanged</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/MSManipulationStateChanged_event",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": {
-              "version_added": "12",
-              "version_removed": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": "11"
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": false
-          }
-        }
-      },
       "after": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/after",


### PR DESCRIPTION
This PR removes the irrelevant `MSManipulationStateChanged_event` member of the `Element` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features). The lack of current support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0), even if the current BCD suggests support.
