### PR TITLE
FF104 ships Array/TypedArray findLast() and findLastIndex() methods

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -545,16 +545,21 @@
                 "version_added": "1.16"
               },
               "edge": "mirror",
-              "firefox": {
-                "version_added": "103",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.array_find_last",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "104"
+                },
+                {
+                  "version_added": "103",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.experimental.array_find_last",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -594,16 +599,21 @@
                 "version_added": "1.16"
               },
               "edge": "mirror",
-              "firefox": {
-                "version_added": "103",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.array_find_last",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "104"
+                },
+                {
+                  "version_added": "103",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.experimental.array_find_last",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -676,16 +676,21 @@
                 "version_added": "1.16"
               },
               "edge": "mirror",
-              "firefox": {
-                "version_added": "103",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.array_find_last",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "104"
+                },
+                {
+                  "version_added": "103",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.experimental.array_find_last",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -725,16 +730,21 @@
                 "version_added": "1.16"
               },
               "edge": "mirror",
-              "firefox": {
-                "version_added": "103",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.array_find_last",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "104"
+                },
+                {
+                  "version_added": "103",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.experimental.array_find_last",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false


### PR DESCRIPTION
FF104 ships `Array.findLast` and `Array.findLastIndex` and the same methods in TypedArray in https://bugzilla.mozilla.org/show_bug.cgi?id=1775026. This follows on from the addition behind a preference in 103 that was added in #16854

Other docs work for this can be tracked in: https://github.com/mdn/content/issues/18774

FYI @queengooborg 

