### PR TITLE
Add __compat entries for all flex context CSS properties (+ fix discrepancies)

### DIFF
--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -2,43 +2,97 @@
   "css": {
     "properties": {
       "align-content": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-content",
+          "spec_url": [
+            "https://drafts.csswg.org/css-align/#align-justify-content",
+            "https://drafts.csswg.org/css-flexbox/#align-content-property"
+          ],
+          "support": {
+            "chrome": [
+              {
+                "version_added": "29"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "21"
+              }
+            ],
+            "chrome_android": "mirror",
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12"
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "28"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              }
+            ],
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": "11"
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": "12.1"
+            },
+            "opera_android": {
+              "version_added": "12.1"
+            },
+            "safari": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7"
+              }
+            ],
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": [
+              {
+                "version_added": "4.4"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "≤37"
+              }
+            ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "flex_context": {
           "__compat": {
             "description": "Supported in Flex Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-content",
             "spec_url": [
               "https://drafts.csswg.org/css-align/#align-justify-content",
               "https://drafts.csswg.org/css-flexbox/#align-content-property"
             ],
             "support": {
-              "chrome": [
-                {
-                  "version_added": "29"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "21"
-                }
-              ],
+              "chrome": {
+                "version_added": "21"
+              },
               "chrome_android": "mirror",
-              "edge": [
-                {
-                  "version_added": "12"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "12"
-                }
-              ],
-              "firefox": [
-                {
-                  "version_added": "28"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "49"
-                }
-              ],
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "28"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": "11"
@@ -50,26 +104,12 @@
               "opera_android": {
                 "version_added": "12.1"
               },
-              "safari": [
-                {
-                  "version_added": "9"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
+              "safari": {
+                "version_added": "9"
+              },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": [
-                {
-                  "version_added": "4.4"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "≤37"
-                }
-              ]
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -342,7 +382,6 @@
         "grid_context": {
           "__compat": {
             "description": "Supported in Grid Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-content",
             "spec_url": [
               "https://drafts.csswg.org/css-align/#align-justify-content",
               "https://drafts.csswg.org/css-flexbox/#align-content-property"

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -2,10 +2,74 @@
   "css": {
     "properties": {
       "align-items": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-items",
+          "spec_url": [
+            "https://drafts.csswg.org/css-align/#align-items-property",
+            "https://drafts.csswg.org/css-flexbox/#align-items-property"
+          ],
+          "support": {
+            "chrome": [
+              {
+                "version_added": "29"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "21"
+              }
+            ],
+            "chrome_android": "mirror",
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12"
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "20"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              }
+            ],
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": "11"
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": "12.1"
+            },
+            "opera_android": {
+              "version_added": "12.1"
+            },
+            "safari": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7"
+              }
+            ],
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "flex_context": {
           "__compat": {
             "description": "Supported in Flex Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-items",
             "spec_url": [
               "https://drafts.csswg.org/css-align/#align-items-property",
               "https://drafts.csswg.org/css-flexbox/#align-items-property"
@@ -16,35 +80,20 @@
                   "version_added": "52"
                 },
                 {
-                  "version_added": "29",
+                  "version_added": "21",
+                  "version_removed": "52",
                   "partial_implementation": true,
                   "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Chrome 52."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "21"
                 }
               ],
               "chrome_android": "mirror",
-              "edge": [
-                {
-                  "version_added": "12"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "12"
-                }
-              ],
-              "firefox": [
-                {
-                  "version_added": "20",
-                  "notes": "Multi-line flexbox has been supported since Firefox 28."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "49"
-                }
-              ],
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "20",
+                "notes": "Multi-line flexbox has been supported since Firefox 28."
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": "11",
@@ -57,44 +106,12 @@
               "opera_android": {
                 "version_added": "12.1"
               },
-              "safari": [
-                {
-                  "version_added": "9"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
+              "safari": {
+                "version_added": "7"
+              },
               "safari_ios": "mirror",
-              "samsunginternet_android": [
-                {
-                  "version_added": "6.0"
-                },
-                {
-                  "version_added": "2.0",
-                  "partial_implementation": true,
-                  "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Samsung Internet 6.0."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "1.5"
-                }
-              ],
-              "webview_android": [
-                {
-                  "version_added": "52"
-                },
-                {
-                  "version_added": "4.4",
-                  "partial_implementation": true,
-                  "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Chrome 52."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "≤37"
-                }
-              ]
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -308,7 +325,6 @@
         "grid_context": {
           "__compat": {
             "description": "Supported in Grid Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-items",
             "spec_url": [
               "https://drafts.csswg.org/css-align/#align-items-property",
               "https://drafts.csswg.org/css-flexbox/#align-items-property"

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -2,10 +2,74 @@
   "css": {
     "properties": {
       "align-self": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-self",
+          "spec_url": [
+            "https://drafts.csswg.org/css-align/#align-self-property",
+            "https://drafts.csswg.org/css-flexbox/#align-items-property"
+          ],
+          "support": {
+            "chrome": [
+              {
+                "version_added": "29"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "21"
+              }
+            ],
+            "chrome_android": "mirror",
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12"
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "20"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              }
+            ],
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": "10"
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": "12.1"
+            },
+            "opera_android": {
+              "version_added": "12.1"
+            },
+            "safari": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7"
+              }
+            ],
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "flex_context": {
           "__compat": {
             "description": "Supported in Flex Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-self",
             "spec_url": [
               "https://drafts.csswg.org/css-align/#align-self-property",
               "https://drafts.csswg.org/css-flexbox/#align-items-property"
@@ -16,35 +80,20 @@
                   "version_added": "36"
                 },
                 {
-                  "version_added": "29",
+                  "version_added": "21",
+                  "version_removed": "36",
                   "partial_implementation": true,
                   "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Chrome 52."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "21"
                 }
               ],
               "chrome_android": "mirror",
-              "edge": [
-                {
-                  "version_added": "12"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "12"
-                }
-              ],
-              "firefox": [
-                {
-                  "version_added": "20",
-                  "notes": "Before Firefox 27, only single-line flexbox is supported."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "49"
-                }
-              ],
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "20",
+                "notes": "Before Firefox 27, only single-line flexbox is supported."
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": "11"
@@ -56,44 +105,12 @@
               "opera_android": {
                 "version_added": "12.1"
               },
-              "safari": [
-                {
-                  "version_added": "9"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
+              "safari": {
+                "version_added": "7"
+              },
               "safari_ios": "mirror",
-              "samsunginternet_android": [
-                {
-                  "version_added": "3.0"
-                },
-                {
-                  "version_added": "2.0",
-                  "partial_implementation": true,
-                  "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Samsung Internet 6.0."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "1.5"
-                }
-              ],
-              "webview_android": [
-                {
-                  "version_added": "37"
-                },
-                {
-                  "version_added": "4.4",
-                  "partial_implementation": true,
-                  "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Chrome 52."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "≤37"
-                }
-              ]
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -340,7 +357,6 @@
         "grid_context": {
           "__compat": {
             "description": "Supported in Grid Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-self",
             "spec_url": [
               "https://drafts.csswg.org/css-align/#align-self-property",
               "https://drafts.csswg.org/css-flexbox/#align-items-property"

--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -2,10 +2,63 @@
   "css": {
     "properties": {
       "break-after": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-after",
+          "spec_url": [
+            "https://drafts.csswg.org/css-break/#break-between",
+            "https://drafts.csswg.org/css-regions/#region-flow-break",
+            "https://drafts.csswg.org/css-multicol/#break-before-break-after-break-inside"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "50"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "65"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": "10"
+            },
+            "oculus": "mirror",
+            "opera": [
+              {
+                "version_added": "37"
+              },
+              {
+                "version_added": "11.1",
+                "version_removed": "12.1"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "37"
+              },
+              {
+                "version_added": "11.1",
+                "version_removed": "12.1"
+              }
+            ],
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "multicol_context": {
           "__compat": {
             "description": "Supported in Multi-column Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-after",
             "spec_url": [
               "https://drafts.csswg.org/css-break/#break-between",
               "https://drafts.csswg.org/css-regions/#region-flow-break",
@@ -224,7 +277,6 @@
         "paged_context": {
           "__compat": {
             "description": "Supported in Paged Media",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-after",
             "spec_url": [
               "https://drafts.csswg.org/css-break/#break-between",
               "https://drafts.csswg.org/css-regions/#region-flow-break",

--- a/css/properties/break-before.json
+++ b/css/properties/break-before.json
@@ -2,10 +2,63 @@
   "css": {
     "properties": {
       "break-before": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-before",
+          "spec_url": [
+            "https://drafts.csswg.org/css-break/#break-between",
+            "https://drafts.csswg.org/css-regions/#region-flow-break",
+            "https://drafts.csswg.org/css-multicol/#break-before-break-after-break-inside"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "50"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "65"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": "10"
+            },
+            "oculus": "mirror",
+            "opera": [
+              {
+                "version_added": "37"
+              },
+              {
+                "version_added": "11.1",
+                "version_removed": "12.1"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "37"
+              },
+              {
+                "version_added": "11.1",
+                "version_removed": "12.1"
+              }
+            ],
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "multicol_context": {
           "__compat": {
             "description": "Supported in Multi-column Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-before",
             "spec_url": [
               "https://drafts.csswg.org/css-break/#break-between",
               "https://drafts.csswg.org/css-regions/#region-flow-break",
@@ -208,7 +261,6 @@
         "paged_context": {
           "__compat": {
             "description": "Supported in Paged Media",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-before",
             "spec_url": [
               "https://drafts.csswg.org/css-break/#break-between",
               "https://drafts.csswg.org/css-regions/#region-flow-break",

--- a/css/properties/break-inside.json
+++ b/css/properties/break-inside.json
@@ -2,10 +2,63 @@
   "css": {
     "properties": {
       "break-inside": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-inside",
+          "spec_url": [
+            "https://drafts.csswg.org/css-break/#break-within",
+            "https://drafts.csswg.org/css-regions/#region-flow-break",
+            "https://drafts.csswg.org/css-multicol/#break-before-break-after-break-inside"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "50"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "65"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": "10"
+            },
+            "oculus": "mirror",
+            "opera": [
+              {
+                "version_added": "37"
+              },
+              {
+                "version_added": "11.1",
+                "version_removed": "12.1"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "37"
+              },
+              {
+                "version_added": "11.1",
+                "version_removed": "12.1"
+              }
+            ],
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "multicol_context": {
           "__compat": {
             "description": "Supported in Multi-column Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-inside",
             "spec_url": [
               "https://drafts.csswg.org/css-break/#break-within",
               "https://drafts.csswg.org/css-regions/#region-flow-break",
@@ -97,7 +150,6 @@
         "paged_context": {
           "__compat": {
             "description": "Supported in Paged Media",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-inside",
             "spec_url": [
               "https://drafts.csswg.org/css-break/#break-within",
               "https://drafts.csswg.org/css-regions/#region-flow-break",

--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -2,10 +2,51 @@
   "css": {
     "properties": {
       "column-gap": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-gap",
+          "spec_url": [
+            "https://drafts.csswg.org/css-align/#column-row-gap",
+            "https://drafts.csswg.org/css-grid/#gutters",
+            "https://drafts.csswg.org/css-multicol/#column-gap"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1.5"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": "10"
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": "11.1"
+            },
+            "opera_android": {
+              "version_added": "11.1"
+            },
+            "safari": {
+              "version_added": "3"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "flex_context": {
           "__compat": {
             "description": "Supported in Flex Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-gap",
             "spec_url": [
               "https://drafts.csswg.org/css-align/#column-row-gap",
               "https://drafts.csswg.org/css-grid/#gutters",
@@ -26,9 +67,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": false
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "14.1"
               },
@@ -46,7 +85,6 @@
         "grid_context": {
           "__compat": {
             "description": "Supported in Grid Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-gap",
             "spec_url": [
               "https://drafts.csswg.org/css-align/#column-row-gap",
               "https://drafts.csswg.org/css-grid/#gutters",
@@ -119,7 +157,6 @@
         "multicol_context": {
           "__compat": {
             "description": "Supported in Multi-column Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-gap",
             "spec_url": [
               "https://drafts.csswg.org/css-align/#column-row-gap",
               "https://drafts.csswg.org/css-grid/#gutters",

--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -2,10 +2,43 @@
   "css": {
     "properties": {
       "gap": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gap",
+          "spec_url": "https://drafts.csswg.org/css-align/#gap-shorthand",
+          "support": {
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "flex_context": {
           "__compat": {
             "description": "Supported in Flex Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gap",
             "spec_url": "https://drafts.csswg.org/css-align/#gap-shorthand",
             "support": {
               "chrome": {
@@ -40,7 +73,6 @@
         "grid_context": {
           "__compat": {
             "description": "Supported in Grid Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gap",
             "spec_url": "https://drafts.csswg.org/css-align/#gap-shorthand",
             "support": {
               "chrome": [
@@ -171,7 +203,6 @@
         "multicol_context": {
           "__compat": {
             "description": "Supported in Multi-column Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gap",
             "spec_url": "https://drafts.csswg.org/css-align/#gap-shorthand",
             "support": {
               "chrome": {

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -2,10 +2,74 @@
   "css": {
     "properties": {
       "justify-content": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-content",
+          "spec_url": [
+            "https://drafts.csswg.org/css-align/#align-justify-content",
+            "https://drafts.csswg.org/css-flexbox/#justify-content-property"
+          ],
+          "support": {
+            "chrome": [
+              {
+                "version_added": "29"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "21"
+              }
+            ],
+            "chrome_android": "mirror",
+            "edge": [
+              {
+                "version_added": "12"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "12"
+              }
+            ],
+            "firefox": [
+              {
+                "version_added": "20"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              }
+            ],
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": "11"
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": "12.1"
+            },
+            "opera_android": {
+              "version_added": "12.1"
+            },
+            "safari": [
+              {
+                "version_added": "9"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "7"
+              }
+            ],
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "flex_context": {
           "__compat": {
             "description": "Supported in Flex Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-content",
             "spec_url": [
               "https://drafts.csswg.org/css-align/#align-justify-content",
               "https://drafts.csswg.org/css-flexbox/#justify-content-property"
@@ -16,35 +80,20 @@
                   "version_added": "52"
                 },
                 {
-                  "version_added": "29",
+                  "version_added": "21",
+                  "version_removed": "52",
                   "partial_implementation": true,
                   "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Chrome 52."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "21"
                 }
               ],
               "chrome_android": "mirror",
-              "edge": [
-                {
-                  "version_added": "12"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "12"
-                }
-              ],
-              "firefox": [
-                {
-                  "version_added": "20",
-                  "notes": "Before Firefox 27, Firefox supported only single-line flexbox."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "49"
-                }
-              ],
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "20",
+                "notes": "Before Firefox 27, Firefox supported only single-line flexbox."
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": "11"
@@ -56,44 +105,12 @@
               "opera_android": {
                 "version_added": "12.1"
               },
-              "safari": [
-                {
-                  "version_added": "9"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "7"
-                }
-              ],
+              "safari": {
+                "version_added": "7"
+              },
               "safari_ios": "mirror",
-              "samsunginternet_android": [
-                {
-                  "version_added": "6.0"
-                },
-                {
-                  "partial_implementation": true,
-                  "version_added": "2.0",
-                  "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Chrome 52."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "1.5"
-                }
-              ],
-              "webview_android": [
-                {
-                  "version_added": "52"
-                },
-                {
-                  "version_added": "4.4",
-                  "partial_implementation": true,
-                  "notes": "Older versions of the specification treat absolute positioned children as though they are a 0 by 0 flex item. Later specification versions take the children out of the flow and set their positions based on align and justify properties. Chrome implements the new behavior beginning with Chrome 52."
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "≤37"
-                }
-              ]
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -281,7 +298,6 @@
         "grid_context": {
           "__compat": {
             "description": "Supported in Grid Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-content",
             "spec_url": [
               "https://drafts.csswg.org/css-align/#align-justify-content",
               "https://drafts.csswg.org/css-flexbox/#justify-content-property"

--- a/css/properties/justify-items.json
+++ b/css/properties/justify-items.json
@@ -2,10 +2,47 @@
   "css": {
     "properties": {
       "justify-items": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-items",
+          "spec_url": "https://drafts.csswg.org/css-align/#justify-items-property",
+          "support": {
+            "chrome": {
+              "version_added": "52"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "20"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": "11"
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": "12.1"
+            },
+            "opera_android": {
+              "version_added": "12.1"
+            },
+            "safari": {
+              "version_added": "9"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "flex_context": {
           "__compat": {
             "description": "Supported in Flex Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-items",
             "spec_url": "https://drafts.csswg.org/css-align/#justify-items-property",
             "support": {
               "chrome": {
@@ -46,7 +83,6 @@
         "grid_context": {
           "__compat": {
             "description": "Supported in Grid Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-items",
             "spec_url": "https://drafts.csswg.org/css-align/#justify-items-property",
             "support": {
               "chrome": {

--- a/css/properties/justify-self.json
+++ b/css/properties/justify-self.json
@@ -2,10 +2,45 @@
   "css": {
     "properties": {
       "justify-self": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-self",
+          "spec_url": "https://drafts.csswg.org/css-align/#justify-self-property",
+          "support": {
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": "10"
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "flex_context": {
           "__compat": {
             "description": "Supported in Flex Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-self",
             "spec_url": "https://drafts.csswg.org/css-align/#justify-self-property",
             "support": {
               "chrome": {
@@ -44,7 +79,6 @@
         "grid_context": {
           "__compat": {
             "description": "Supported in Grid Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-self",
             "spec_url": "https://drafts.csswg.org/css-align/#justify-self-property",
             "support": {
               "chrome": {

--- a/css/properties/row-gap.json
+++ b/css/properties/row-gap.json
@@ -2,10 +2,43 @@
   "css": {
     "properties": {
       "row-gap": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/row-gap",
+          "spec_url": "https://drafts.csswg.org/css-align/#column-row-gap",
+          "support": {
+            "chrome": {
+              "version_added": "47"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "10.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
         "flex_context": {
           "__compat": {
             "description": "Supported in Flex Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/row-gap",
             "spec_url": "https://drafts.csswg.org/css-align/#column-row-gap",
             "support": {
               "chrome": {
@@ -40,7 +73,6 @@
         "grid_context": {
           "__compat": {
             "description": "Supported in Grid Layout",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/row-gap",
             "spec_url": "https://drafts.csswg.org/css-align/#column-row-gap",
             "support": {
               "chrome": [


### PR DESCRIPTION
This PR adds top-level `__compat` entries for all of the CSS properties that have flex and grid contexts, so that every feature in BCD has a compat statement.  This fixes #13804.

Additionally, this PR fixes a few small discrepancies between browsers where mirroring should be applied but isn't.
