### PR TITLE
Updates firefox browser to version 103

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -739,23 +739,30 @@
         "102": {
           "release_date": "2022-06-28",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/102",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "102"
         },
         "103": {
           "release_date": "2022-07-26",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/103",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "103"
         },
         "104": {
           "release_date": "2022-08-23",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/104",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "104"
+        },
+        "105": {
+          "release_date": "2022-09-20",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/105",
+          "status": "nightly",
+          "engine": "Gecko",
+          "engine_version": "105"
         }
       }
     }

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -606,23 +606,30 @@
         "102": {
           "release_date": "2022-06-28",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/102",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "102"
         },
         "103": {
           "release_date": "2022-07-26",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/103",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "103"
         },
         "104": {
           "release_date": "2022-08-23",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/104",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "104"
+        },
+        "105": {
+          "release_date": "2022-09-20",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/105",
+          "status": "nightly",
+          "engine": "Gecko",
+          "engine_version": "105"
         }
       }
     }


### PR DESCRIPTION
Hello everyone!

I updated Firefox browser to version 103 according to [this release note](https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/103).

And according to [this release note](https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/105), the release date of firefox 105 is 20/09/22.

 🙂