### PR TITLE
Fix `:autofill` status for Chrome and Chromium-based browsers

### DIFF
--- a/css/selectors/autofill.json
+++ b/css/selectors/autofill.json
@@ -7,15 +7,10 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:autofill",
           "spec_url": "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-autofill",
           "support": {
-            "chrome": [
-              {
-                "version_added": "96"
-              },
-              {
-                "version_added": "1",
-                "prefix": "-webkit-"
-              }
-            ],
+            "chrome": {
+              "version_added": "1",
+              "prefix": "-webkit-"
+            },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": [


### PR DESCRIPTION
#### Summary
Some time ago `:autofill` pseudo-class was considered working in Chrome without prefix and updated in https://github.com/mdn/browser-compat-data/pull/12835. Despite the feature status page information, the pseudo-class is still behind feature-flag, so only prefixed version works.

#### Test results and supporting details
- https://chromestatus.com/feature/5592445322526720 (`:autofill` status page)
- https://bugs.chromium.org/p/chromium/issues/detail?id=1164311#c8 (feature-flag discussion)
- https://ngc27m.csb.app (`:autofill` support demo)

#### Related issues
Fixes https://github.com/mdn/browser-compat-data/issues/13716
