### PR TITLE
storage.managed_schema manifest key is not supported in Safari

### DIFF
--- a/webextensions/manifest/storage.json
+++ b/webextensions/manifest/storage.json
@@ -19,7 +19,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "14"
+              "version_added": false
             }
           }
         },
@@ -40,7 +40,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "14"
+                "version_added": false
               }
             }
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Safari does not support the [storage.managed API](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/managed). The [storage.managed_schema manifest key](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/storage) is part of that API, and therefore not supported either.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

I asked @xeenon, who works on extensions for Safari at Apple, and he confirms that these APIs are not supported.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
None
<!-- ✅ After submitting, review the results of the "Checks" tab! -->
