### PR TITLE
fix: chrome support for supportedValuesOf in V99

### DIFF
--- a/javascript/builtins/intl/Intl.json
+++ b/javascript/builtins/intl/Intl.json
@@ -98,7 +98,7 @@
             "spec_url": "https://tc39.es/proposal-intl-enumeration/#sec-intl.supportedvaluesof",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "99"
               },
               "chrome_android": "mirror",
               "deno": {


### PR DESCRIPTION
#### Summary
Chrome added support for supportedValues of in v99

#### Test results and supporting details
Tested in console in my browser.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
See: https://chromestatus.com/feature/5649454590853120