### PR TITLE
New files - one for the new :modal and one for the missing :picture-in-picture

### DIFF
--- a/css/selectors/modal.json
+++ b/css/selectors/modal.json
@@ -1,0 +1,41 @@
+{
+  "css": {
+    "selectors": {
+      "modal": {
+        "__compat": {
+          "description": "<code>:modal</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:modal",
+          "spec_url": "https://www.w3.org/TR/selectors-4/#modal-state",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "103"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.6"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/picture-in-picture.json
+++ b/css/selectors/picture-in-picture.json
@@ -1,0 +1,41 @@
+{
+  "css": {
+    "selectors": {
+      "picture-in-picture": {
+        "__compat": {
+          "description": "<code>:picture-in-picture</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:picture-in-picture",
+          "spec_url": "https://www.w3.org/TR/selectors-4/#pip-state",
+          "support": {
+            "chrome": {
+              "version_added": "76"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
- `:modal` is a new pseudo class in FF103
  - Also `:modal` in safari: https://developer.apple.com/documentation/safari-release-notes/safari-15_6-release-notes

- `:picture-in-picture` is an already existing pseudo class but its bcd and spec url are missing here https://developer.mozilla.org/en-US/docs/Web/CSS/:picture-in-picture#specifications
  - picture-in-picture in chrome: https://googlechrome.github.io/samples/picture-in-picture/css-pseudo-class.
  - I could not find its support in other browsers but I've left `"experimental": false`.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
Doc issue tracker for `:modal`: https://github.com/mdn/content/issues/17470
Spec: https://www.w3.org/TR/selectors-4/#modal-state