### PR TITLE
Safari, Firefox, and IE do not support User-Agent client hints

### DIFF
--- a/http/headers/Accept-CH-Lifetime.json
+++ b/http/headers/Accept-CH-Lifetime.json
@@ -13,11 +13,11 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
@@ -25,7 +25,7 @@
               "version_added": null
             },
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/http/headers/Accept-CH.json
+++ b/http/headers/Accept-CH.json
@@ -15,17 +15,17 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -49,17 +49,17 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -84,11 +84,11 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -121,17 +121,17 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -387,17 +387,17 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -422,17 +422,17 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": null
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/http/headers/Content-DPR.json
+++ b/http/headers/Content-DPR.json
@@ -14,17 +14,17 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/http/headers/DPR.json
+++ b/http/headers/DPR.json
@@ -14,17 +14,17 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/http/headers/Device-Memory.json
+++ b/http/headers/Device-Memory.json
@@ -15,11 +15,11 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",

--- a/http/headers/Viewport-Width.json
+++ b/http/headers/Viewport-Width.json
@@ -14,17 +14,17 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/http/headers/Width.json
+++ b/http/headers/Width.json
@@ -14,17 +14,17 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": null
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
Safari, Firefox, and IE do not support User-Agent client hints.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
 - Firefox:
   - [Bugzilla bug 935216](https://bugzilla.mozilla.org/show_bug.cgi?id=935216) says HTTP response header `Accept-CH` (which requests hints) is not implemented
   - https://browserleaks.com/client-hints returns `undefined` for all hints
 - Safari:
   - [Tracking bug 241749](https://bugs.webkit.org/show_bug.cgi?id=241749)
 - IE:
   - [Microsoft documentation](https://docs.microsoft.com/en-us/microsoft-edge/web-platform/how-to-detect-win11#browsers-that-support-user-agent-client-hints)
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A
<!-- ✅ After submitting, review the results of the "Checks" tab! -->
