### PR TITLE
Add Safari 15.6 to BCD

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -213,6 +213,11 @@
           "engine": "WebKit",
           "engine_version": "613.2.7"
         },
+        "15.6": {
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15_6-release-notes",
+          "status": "beta",
+          "engine": "WebKit"
+        },
         "16": {
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes",
           "status": "beta",


### PR DESCRIPTION
This PR adds the Safari 15.6 beta to BCD.
