### PR TITLE
Add Safari 15.6 to BCD

### DIFF
--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -185,6 +185,11 @@
           "engine": "WebKit",
           "engine_version": "613.2.7"
         },
+        "15.6": {
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15_6-release-notes",
+          "status": "beta",
+          "engine": "WebKit"
+        },
         "16": {
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes",
           "status": "beta",


### PR DESCRIPTION
This PR adds the missing Safari iOS 15.6 release from BCD, which was forgotten in #17152.
