### PR TITLE
Update Chromium versions for EXT_texture_compression_bptc API

### DIFF
--- a/api/EXT_texture_compression_bptc.json
+++ b/api/EXT_texture_compression_bptc.json
@@ -5,10 +5,20 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EXT_texture_compression_bptc",
         "spec_url": "https://www.khronos.org/registry/webgl/extensions/EXT_texture_compression_bptc/",
         "support": {
-          "chrome": {
+          "chrome": [
+            {
+              "version_added": "93"
+            },
+            {
+              "version_added": "92",
+              "version_removed": "93",
+              "partial_implementation": true,
+              "notes": "Only supported on macOS."
+            }
+          ],
+          "chrome_android": {
             "version_added": "92"
           },
-          "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
             "version_added": "68"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `EXT_texture_compression_bptc` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/EXT_texture_compression_bptc

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._

Note: while the OS differences were obtained from the collector results, and confirmed in BrowserStack, these statements were added manually.
