### PR TITLE
Update Chromium versions for api.Element.ariaInvalid

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1493,7 +1493,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Element.json
+++ b/api/Element.json
@@ -1471,7 +1471,7 @@
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariainvalid",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "102"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `ariaInvalid` member of the `Element` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Element/ariaInvalid

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
