### PR TITLE
Update Chromium versions for api.Element.role

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -7405,7 +7405,7 @@
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-role",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "103"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -7427,7 +7427,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `role` member of the `Element` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Element/role

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
