### PR TITLE
Mirror WebView data for RTCPeerConnection

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -184,9 +184,7 @@
               "samsunginternet_android": {
                 "version_added": "7.0"
               },
-              "webview_android": {
-                "version_added": "49"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -225,9 +223,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "57"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -267,9 +263,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "57"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -309,9 +303,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "57"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -350,9 +342,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "57"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -185,7 +185,7 @@
                 "version_added": "7.0"
               },
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "49"
               }
             },
             "status": {
@@ -226,7 +226,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "57"
               }
             },
             "status": {
@@ -268,7 +268,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "57"
               }
             },
             "status": {
@@ -310,7 +310,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "57"
               }
             },
             "status": {
@@ -351,7 +351,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": "57"
               }
             },
             "status": {


### PR DESCRIPTION
The correct Chromium versions were determined here:
https://github.com/mdn/browser-compat-data/pull/12830

But WebView statements weren't updated then.