### PR TITLE
Remove service worker notes for FileReaderSync

### DIFF
--- a/api/FileReaderSync.json
+++ b/api/FileReaderSync.json
@@ -89,20 +89,17 @@
           "description": "Available in workers",
           "support": {
             "chrome": {
-              "version_added": "7",
-              "notes": "From Chrome 59, not supported in service workers."
+              "version_added": "7"
             },
             "chrome_android": "mirror",
             "deno": {
               "version_added": false
             },
             "edge": {
-              "version_added": "12",
-              "notes": "Not supported in service workers."
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": "8",
-              "notes": "From Firefox 61, not supported in service workers."
+              "version_added": "8"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -110,26 +107,17 @@
             },
             "oculus": "mirror",
             "opera": {
-              "version_added": "≤15",
-              "notes": "From Opera 46, not supported in service workers."
+              "version_added": "≤15"
             },
             "opera_android": {
-              "version_added": "≤14",
-              "notes": "From Opera 43, not supported in service workers."
+              "version_added": "≤14"
             },
             "safari": {
-              "version_added": "6",
-              "notes": "Not supported in service workers."
+              "version_added": "6"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "1.0",
-              "notes": "From version 7.0, not supported in service workers."
-            },
-            "webview_android": {
-              "version_added": "≤37",
-              "notes": "From version 59, not supported in service workers."
-            }
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This isn't supposed to be exposed in service workers per spec:
https://w3c.github.io/FileAPI/
