### PR TITLE
FF104 Supports SVGStyleElement.disabled

### DIFF
--- a/api/SVGStyleElement.json
+++ b/api/SVGStyleElement.json
@@ -43,6 +43,40 @@
           "deprecated": false
         }
       },
+      "disabled": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStyleElement/disabled",
+          "spec_url": "https://svgwg.org/svg2-draft/styling.html#__svg__SVGStyleElement__disabled",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "104"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "media": {
         "__compat": {
           "spec_url": "https://svgwg.org/svg2-draft/styling.html#__svg__SVGStyleElement__media",

--- a/api/SVGStyleElement.json
+++ b/api/SVGStyleElement.json
@@ -49,7 +49,7 @@
           "spec_url": "https://svgwg.org/svg2-draft/styling.html#__svg__SVGStyleElement__disabled",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "102"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/SVGStyleElement.json
+++ b/api/SVGStyleElement.json
@@ -71,7 +71,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/SVGStyleElement.json
+++ b/api/SVGStyleElement.json
@@ -71,7 +71,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
FF104 Supports `SVGStyleElement.disabled` in https://bugzilla.mozilla.org/show_bug.cgi?id=1712623

This is very new to the spec. That hasn't even been regenerated yet, but you can see the addition in https://github.com/w3c/svgwg/pull/879/files - note, this is where I got the spec URL for the feature.

Other docs work related to this can be tracked in https://github.com/mdn/content/issues/18775