### PR TITLE
Update Chrome/Opera ProgressEvent data

### DIFF
--- a/api/ProgressEvent.json
+++ b/api/ProgressEvent.json
@@ -68,8 +68,12 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
             "safari": {
               "version_added": "6"
             },
@@ -138,7 +142,7 @@
           "spec_url": "https://xhr.spec.whatwg.org/#dom-progressevent-lengthcomputable",
           "support": {
             "chrome": {
-              "version_added": "50"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "deno": {
@@ -155,8 +159,12 @@
               "version_added": "10"
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
             "safari": {
               "version_added": "3.1"
             },


### PR DESCRIPTION
The lengthComputable property was in the initial implementation of
ProgressEvent in WebKit:
https://github.com/WebKit/WebKit/commit/13e3659e55eeec5a96acf0f2e85298ed89ad1316

That was before Chrome 1.

Support for the constructor and lengthComputable was manually confirmed
by testing in Opera 12.16 on macOS.
