### PR TITLE
Remove initProgressEvent()

### DIFF
--- a/api/ProgressEvent.json
+++ b/api/ProgressEvent.json
@@ -84,54 +84,6 @@
           }
         }
       },
-      "initProgressEvent": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ProgressEvent/initProgressEvent",
-          "support": {
-            "chrome": {
-              "version_added": "1",
-              "version_removed": "17"
-            },
-            "chrome_android": "mirror",
-            "deno": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": "12",
-              "version_removed": "79"
-            },
-            "firefox": {
-              "version_added": "3.5",
-              "version_removed": "22"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": "10"
-            },
-            "oculus": "mirror",
-            "opera": {
-              "version_added": "≤12.1",
-              "version_removed": "15"
-            },
-            "opera_android": {
-              "version_added": "≤12.1",
-              "version_removed": "14"
-            },
-            "safari": {
-              "version_added": "3.1",
-              "version_removed": "6"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "lengthComputable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ProgressEvent/lengthComputable",


### PR DESCRIPTION
This has been removed from all browsers for more than 2 years.

MDN change: https://github.com/mdn/content/pull/19021