### PR TITLE
Remove MediaStream's stop() method

### DIFF
--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -610,46 +610,6 @@
             "deprecated": false
           }
         }
-      },
-      "stop": {
-        "__compat": {
-          "support": {
-            "chrome": {
-              "version_added": "29",
-              "version_removed": "47"
-            },
-            "chrome_android": "mirror",
-            "edge": {
-              "version_added": "13",
-              "version_removed": "79"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
This has been removed from all browsers for more than 2 years.
