### PR TITLE
Fix Safari version for navigator.requestMediaKeySystemAccess()

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3710,7 +3710,7 @@
               ]
             },
             "safari": {
-              "version_added": "13.1"
+              "version_added": "12.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
Support in Safari 12.1 confirmed with this test:
https://mdn-bcd-collector.appspot.com/tests/api/Navigator/requestMediaKeySystemAccess

This also matches related APIs like MediaKeys.

The source of this data is also the collector tests:
https://github.com/mdn/browser-compat-data/pull/6829

It's not clear what went wrong then, some manual changes are possible.
