### PR TITLE
Remove RTCDataChannel's stream property

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -882,39 +882,6 @@
           }
         }
       },
-      "stream": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCDataChannel/stream",
-          "support": {
-            "chrome": {
-              "version_added": "56"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "transferable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Glossary/Transferable_objects",


### PR DESCRIPTION
This is not in Chromium source:
https://chromium.googlesource.com/chromium/src/+/5882ee3573050ce1fbfbf45d1d8543ec0589cb89/third_party/blink/renderer/modules/peerconnection/rtc_data_channel.idl

More importantly, the string "stream" has never appeared in that file in
its entire history, so this was never supported.

It looks like actually this was once in Firefox, but long removed:
https://bugzilla.mozilla.org/show_bug.cgi?id=1281150

MDN change: https://github.com/mdn/content/pull/19029