### PR TITLE
Update Safari versions for api.GestureEvent.GestureEvent

### DIFF
--- a/api/GestureEvent.json
+++ b/api/GestureEvent.json
@@ -58,7 +58,7 @@
               "version_added": "9"
             },
             "safari_ios": {
-              "version_added": "2"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari macOS/iOS/iPadOS for the `GestureEvent` member of the `GestureEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/GestureEvent/GestureEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
