### PR TITLE
Update Chromium versions for api.HTMLAreaElement.toString

### DIFF
--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -808,7 +808,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/links.html#dom-hyperlink-href-dev",
           "support": {
             "chrome": {
-              "version_added": "52"
+              "version_added": "32"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `toString` member of the `HTMLAreaElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLAreaElement/toString

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
