### PR TITLE
Add Chromium versions for HTMLContentElement API

### DIFF
--- a/api/HTMLContentElement.json
+++ b/api/HTMLContentElement.json
@@ -22,20 +22,13 @@
             "version_added": false
           },
           "oculus": "mirror",
-          "opera": {
-            "version_added": "26",
-            "version_removed": "75"
-          },
-          "opera_android": {
-            "version_added": "26"
-          },
+          "opera": "mirror",
+          "opera_android": "mirror",
           "safari": {
             "version_added": false
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": {
-            "version_added": "3.0"
-          },
+          "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
         "status": {
@@ -66,20 +59,13 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "26",
-              "version_removed": "75"
-            },
-            "opera_android": {
-              "version_added": "26"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "3.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -111,20 +97,13 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "26",
-              "version_removed": "75"
-            },
-            "opera_android": {
-              "version_added": "26"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "3.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `HTMLContentElement` API.  The collector reports that this is unavailable in Opera Android and Samsung Internet, and the Opera data is just mirrored anyways, so this PR updates them all to `mirror`.
