### PR TITLE
Update Firefox Android versions for api.HTMLElement.dragexit_event

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -868,9 +868,7 @@
             "firefox": {
               "version_added": "3.5"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "10"
             },


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox Android for the `dragexit_event` member of the `HTMLElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLElement/dragexit_event

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
