### PR TITLE
Update Opera versions for api.HTMLElement.inert

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1322,16 +1322,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "47",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": "15.5"


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `inert` member of the `HTMLElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLElement/inert

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
