### PR TITLE
Update Samsung Internet versions for HTMLPortalElement API

### DIFF
--- a/api/HTMLPortalElement.json
+++ b/api/HTMLPortalElement.json
@@ -31,9 +31,7 @@
             "version_added": false
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": {
-            "version_added": "14.0"
-          },
+          "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
         "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Samsung Internet for the `HTMLPortalElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLPortalElement

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
