### PR TITLE
Update Chromium versions for api.IntersectionObserver.thresholds

### DIFF
--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -299,7 +299,7 @@
           "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-thresholds",
           "support": {
             "chrome": {
-              "version_added": "51"
+              "version_added": "52"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `thresholds` member of the `IntersectionObserver` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/IntersectionObserver/thresholds

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
