### PR TITLE
Update Chromium versions for LayoutShiftAttribution API

### DIFF
--- a/api/LayoutShiftAttribution.json
+++ b/api/LayoutShiftAttribution.json
@@ -6,11 +6,11 @@
         "spec_url": "https://wicg.github.io/layout-instability/#sec-layout-shift-attribution",
         "support": {
           "chrome": {
-            "version_added": "77"
+            "version_added": "84"
           },
           "chrome_android": "mirror",
           "edge": {
-            "version_added": "80"
+            "version_added": "84"
           },
           "firefox": {
             "version_added": false
@@ -41,11 +41,11 @@
           "spec_url": "https://wicg.github.io/layout-instability/#dom-layoutshiftattribution-currentrect",
           "support": {
             "chrome": {
-              "version_added": "77"
+              "version_added": "84"
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "80"
+              "version_added": "84"
             },
             "firefox": {
               "version_added": false
@@ -77,11 +77,11 @@
           "spec_url": "https://wicg.github.io/layout-instability/#dom-layoutshiftattribution-node",
           "support": {
             "chrome": {
-              "version_added": "77"
+              "version_added": "84"
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "80"
+              "version_added": "84"
             },
             "firefox": {
               "version_added": false
@@ -113,11 +113,11 @@
           "spec_url": "https://wicg.github.io/layout-instability/#dom-layoutshiftattribution-previousrect",
           "support": {
             "chrome": {
-              "version_added": "77"
+              "version_added": "84"
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "80"
+              "version_added": "84"
             },
             "firefox": {
               "version_added": false
@@ -149,11 +149,11 @@
           "spec_url": "https://wicg.github.io/layout-instability/#sec-layout-shift-attribution",
           "support": {
             "chrome": {
-              "version_added": "77"
+              "version_added": "84"
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "80"
+              "version_added": "84"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `LayoutShiftAttribution` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/LayoutShiftAttribution

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
