### PR TITLE
Update Chromium versions for api.Location.toString

### DIFF
--- a/api/Location.json
+++ b/api/Location.json
@@ -649,7 +649,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/history.html#dom-location-href-dev",
           "support": {
             "chrome": {
-              "version_added": "52"
+              "version_added": "29"
             },
             "chrome_android": "mirror",
             "deno": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `toString` member of the `Location` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Location/toString

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
