### PR TITLE
Update Chromium versions for api.MediaCapabilities.encodingInfo

### DIFF
--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -85,16 +85,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities/encodingInfo",
           "spec_url": "https://w3c.github.io/media-capabilities/#ref-for-dom-mediacapabilities-encodinginfo",
           "support": {
-            "chrome": {
-              "version_added": "67",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "chrome://flags/#enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "101"
+              },
+              {
+                "version_added": "67",
+                "version_removed": "101",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "chrome://flags/#enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `encodingInfo` member of the `MediaCapabilities` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaCapabilities/encodingInfo

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
