### PR TITLE
Update Chromium versions for api.MediaSession.setPositionState

### DIFF
--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -293,7 +293,7 @@
           "spec_url": "https://w3c.github.io/mediasession/#dom-mediasession-setpositionstate",
           "support": {
             "chrome": {
-              "version_added": "73"
+              "version_added": "81"
             },
             "chrome_android": {
               "version_added": "57"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `setPositionState` member of the `MediaSession` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaSession/setPositionState

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
