### PR TITLE
Update Chromium versions for OES_fbo_render_mipmap API

### DIFF
--- a/api/OES_fbo_render_mipmap.json
+++ b/api/OES_fbo_render_mipmap.json
@@ -6,7 +6,7 @@
         "spec_url": "https://www.khronos.org/registry/webgl/extensions/OES_fbo_render_mipmap/",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "80"
           },
           "chrome_android": "mirror",
           "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `OES_fbo_render_mipmap` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/OES_fbo_render_mipmap

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
