### PR TITLE
Update Opera versions for OES_standard_derivatives API

### DIFF
--- a/api/OES_standard_derivatives.json
+++ b/api/OES_standard_derivatives.json
@@ -21,9 +21,7 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": {
-            "version_added": false
-          },
+          "opera_android": "mirror",
           "safari": {
             "version_added": "8"
           },


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `OES_standard_derivatives` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/OES_standard_derivatives

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
