### PR TITLE
Update Opera versions for OES_texture_float API

### DIFF
--- a/api/OES_texture_float.json
+++ b/api/OES_texture_float.json
@@ -21,9 +21,7 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": {
-            "version_added": false
-          },
+          "opera_android": "mirror",
           "safari": {
             "version_added": "8"
           },


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `OES_texture_float` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/OES_texture_float

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
