### PR TITLE
Update Chromium versions for OVR_multiview2 API

### DIFF
--- a/api/OVR_multiview2.json
+++ b/api/OVR_multiview2.json
@@ -5,17 +5,9 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/OVR_multiview2",
         "spec_url": "https://www.khronos.org/registry/webgl/extensions/OVR_multiview2/",
         "support": {
-          "chrome": [
-            {
-              "version_added": "75",
-              "alternative_name": "OVRMultiview2"
-            },
-            {
-              "version_added": "70",
-              "version_removed": "75",
-              "alternative_name": "WebGLMultiview"
-            }
-          ],
+          "chrome": {
+            "version_added": "93"
+          },
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
@@ -26,9 +18,7 @@
             "version_added": false
           },
           "oculus": "mirror",
-          "opera": {
-            "version_added": false
-          },
+          "opera": "mirror",
           "opera_android": {
             "version_added": false
           },
@@ -50,16 +40,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OVR_multiview2/framebufferTextureMultiviewOVR",
           "spec_url": "https://www.khronos.org/registry/webgl/extensions/OVR_multiview2/",
           "support": {
-            "chrome": [
-              {
-                "version_added": "75"
-              },
-              {
-                "version_added": "70",
-                "version_removed": "75",
-                "alternative_name": "framebufferTextureMultiviewWEBGL"
-              }
-            ],
+            "chrome": {
+              "version_added": "93"
+            },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -70,9 +53,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": {
               "version_added": false
             },

--- a/api/OVR_multiview2.json
+++ b/api/OVR_multiview2.json
@@ -6,9 +6,13 @@
         "spec_url": "https://www.khronos.org/registry/webgl/extensions/OVR_multiview2/",
         "support": {
           "chrome": {
+            "version_added": "93",
+            "partial_implementation": true,
+            "notes": "Not supported on macOS."
+          },
+          "chrome_android": {
             "version_added": "93"
           },
-          "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
             "version_added": "71"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `OVR_multiview2` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/OVR_multiview2

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._

Note: all of the original data is removed because this extension was not supported at all before Chrome 93, as tested in various versions on BrowserStack.  The alternative names only applied to the name of the interface, which are irrelevant in this case.
