### PR TITLE
Add WebGL 1 features to WebGL2RenderingContext

### DIFF
--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -35,6 +35,78 @@
           "deprecated": false
         }
       },
+      "activeTexture": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/activeTexture",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "attachShader": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/attachShader",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "beginQuery": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/beginQuery",
@@ -75,6 +147,81 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/beginTransformFeedback",
           "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "bindAttribLocation": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/bindAttribLocation",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "bindBuffer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/bindBuffer",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.1"
+          ],
           "support": {
             "chrome": {
               "version_added": "56"
@@ -179,10 +326,124 @@
           }
         }
       },
+      "bindFramebuffer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/bindFramebuffer",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.1"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "bindRenderbuffer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/bindRenderbuffer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "bindSampler": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/bindSampler",
           "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "bindTexture": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/bindTexture",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.1"
+          ],
           "support": {
             "chrome": {
               "version_added": "56"
@@ -287,10 +548,10 @@
           }
         }
       },
-      "blitFramebuffer": {
+      "blendColor": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/blitFramebuffer",
-          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/blendColor",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -323,9 +584,118 @@
           }
         }
       },
-      "bufferSubData": {
+      "blendEquation": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/bufferSubData",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/blendEquation",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "blendEquationSeparate": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/blendEquationSeparate",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "blendFunc": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/blendFunc",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "blendFuncSeparate": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/blendFuncSeparate",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -365,7 +735,9 @@
                 "version_added": "60"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "79"
+              },
               "firefox": {
                 "version_added": "79"
               },
@@ -388,6 +760,264 @@
               "standard_track": true,
               "deprecated": false
             }
+          }
+        }
+      },
+      "blitFramebuffer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/blitFramebuffer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "bufferData": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/bufferData",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "bufferSubData": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/bufferSubData",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "canvas": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/canvas",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#DOM-WebGLRenderingContext-canvas",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "OffscreenCanvas": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "44",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "gfx.offscreencanvas.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
+      "checkFramebufferStatus": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/checkFramebufferStatus",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "clear": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/clear",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -634,6 +1264,114 @@
           }
         }
       },
+      "clearColor": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/clearColor",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "clearDepth": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/clearDepth",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "clearStencil": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/clearStencil",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "clientWaitSync": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/clientWaitSync",
@@ -670,10 +1408,263 @@
           }
         }
       },
+      "colorMask": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/colorMask",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "commit": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/commit",
+          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#offscreencontext-commit",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "44",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "gfx.offscreencanvas.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "compileShader": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/compileShader",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "compressedTexImage2D": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/compressedTexImage2D",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#COMPRESSEDTEXIMAGE2D",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "SharedArrayBuffer_as_param": {
+          "__compat": {
+            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "support": {
+              "chrome": {
+                "version_added": "60"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "79"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
       "compressedTexImage3D": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/compressedTexImage3D",
           "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "SharedArrayBuffer_as_param": {
+          "__compat": {
+            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "support": {
+              "chrome": {
+                "version_added": "60"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "79"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
+      "compressedTexSubImage2D": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/compressedTexSubImage2D",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#COMPRESSEDTEXSUBIMAGE2D",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -811,10 +1802,190 @@
           }
         }
       },
+      "copyTexImage2D": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/copyTexImage2D",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "copyTexSubImage2D": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/copyTexSubImage2D",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "copyTexSubImage3D": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/copyTexSubImage3D",
           "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createBuffer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/createBuffer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createFramebuffer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/createFramebuffer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createProgram": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/createProgram",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -883,10 +2054,118 @@
           }
         }
       },
+      "createRenderbuffer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/createRenderbuffer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "createSampler": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/createSampler",
           "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createShader": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/createShader",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createTexture": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/createTexture",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -991,10 +2270,190 @@
           }
         }
       },
+      "cullFace": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/cullFace",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "deleteBuffer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/deleteBuffer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "deleteFramebuffer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/deleteFramebuffer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "deleteProgram": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/deleteProgram",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "deleteQuery": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/deleteQuery",
           "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "deleteRenderbuffer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/deleteRenderbuffer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -1063,10 +2522,82 @@
           }
         }
       },
+      "deleteShader": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/deleteShader",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "deleteSync": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/deleteSync",
           "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "deleteTexture": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/deleteTexture",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -1171,6 +2702,258 @@
           }
         }
       },
+      "depthFunc": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/depthFunc",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "depthMask": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/depthMask",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "depthRange": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/depthRange",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "detachShader": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/detachShader",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "disable": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/disable",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "disableVertexAttribArray": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/disableVertexAttribArray",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "drawArrays": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/drawArrays",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "drawArraysInstanced": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/drawArraysInstanced",
@@ -1243,6 +3026,42 @@
           }
         }
       },
+      "drawElements": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/drawElements",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "drawElementsInstanced": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/drawElementsInstanced",
@@ -1279,10 +3098,154 @@
           }
         }
       },
+      "drawingBufferHeight": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/drawingBufferHeight",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#DOM-WebGLRenderingContext-drawingBufferHeight",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "drawingBufferWidth": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/drawingBufferWidth",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#DOM-WebGLRenderingContext-drawingBufferWidth",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "drawRangeElements": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/drawRangeElements",
           "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.9",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "enable": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/enable",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "enableVertexAttribArray": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/enableVertexAttribArray",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -1423,10 +3386,298 @@
           }
         }
       },
+      "finish": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/finish",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "flush": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/flush",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "framebufferRenderbuffer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/framebufferRenderbuffer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "framebufferTexture2D": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/framebufferTexture2D",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "framebufferTextureLayer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/framebufferTextureLayer",
           "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "frontFace": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/frontFace",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "generateMipmap": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/generateMipmap",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getActiveAttrib": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getActiveAttrib",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getActiveUniform": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getActiveUniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -1567,6 +3818,117 @@
           }
         }
       },
+      "getAttachedShaders": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getAttachedShaders",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getAttribLocation": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getAttribLocation",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getBufferParameter": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getBufferParameter",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.3"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getBufferSubData": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/getBufferSubData",
@@ -1636,10 +3998,157 @@
           }
         }
       },
+      "getContextAttributes": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getContextAttributes",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.2",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getError": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getError",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getExtension": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getExtension",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.14",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getFragDataLocation": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/getFragDataLocation",
           "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.7",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getFramebufferAttachmentParameter": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getFramebufferAttachmentParameter",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4"
+          ],
           "support": {
             "chrome": {
               "version_added": "56"
@@ -1744,6 +4253,120 @@
           }
         }
       },
+      "getParameter": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getParameter",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.2"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getProgramInfoLog": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getProgramInfoLog",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getProgramParameter": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getProgramParameter",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.7"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getQuery": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/getQuery",
@@ -1816,10 +4439,229 @@
           }
         }
       },
+      "getRenderbufferParameter": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getRenderbufferParameter",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.5"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getSamplerParameter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/getSamplerParameter",
           "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getShaderInfoLog": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getShaderInfoLog",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getShaderParameter": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getShaderParameter",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getShaderPrecisionFormat": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getShaderPrecisionFormat",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getShaderSource": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getShaderSource",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getSupportedExtensions": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getSupportedExtensions",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.14",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -1888,10 +4730,88 @@
           }
         }
       },
+      "getTexParameter": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getTexParameter",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getTransformFeedbackVarying": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/getTransformFeedbackVarying",
           "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.15",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getUniform": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getUniform",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8"
+          ],
           "support": {
             "chrome": {
               "version_added": "56"
@@ -1996,6 +4916,153 @@
           }
         }
       },
+      "getUniformLocation": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getUniformLocation",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getVertexAttrib": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getVertexAttrib",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getVertexAttribOffset": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getVertexAttribOffset",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "hint": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/hint",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "invalidateFramebuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/invalidateFramebuffer",
@@ -2068,10 +5135,229 @@
           }
         }
       },
+      "isBuffer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/isBuffer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isContextLost": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/isContextLost",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.13",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isEnabled": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/isEnabled",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.2"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isFramebuffer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/isFramebuffer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isProgram": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/isProgram",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "isQuery": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/isQuery",
           "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isRenderbuffer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/isRenderbuffer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -2140,10 +5426,82 @@
           }
         }
       },
+      "isShader": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/isShader",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "isSync": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/isSync",
           "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isTexture": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/isTexture",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -2248,6 +5606,80 @@
           }
         }
       },
+      "linkProgram": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/linkProgram",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "makeXRCompatible": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/makeXRCompatible",
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-webglrenderingcontextbase-makexrcompatible",
+          "support": {
+            "chrome": {
+              "version_added": "79"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": {
+              "version_added": "11.2"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "pauseTransformFeedback": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/pauseTransformFeedback",
@@ -2284,10 +5716,194 @@
           }
         }
       },
+      "pixelStorei": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/pixelStorei",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#PIXEL_STORAGE_PARAMETERS",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.2"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "polygonOffset": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/polygonOffset",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "readBuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/readBuffer",
           "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "readPixels": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/readPixels",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.12",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "SharedArrayBuffer_as_param": {
+          "__compat": {
+            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "support": {
+              "chrome": {
+                "version_added": "60"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "79"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
+      "renderbufferStorage": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/renderbufferStorage",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.5"
+          ],
           "support": {
             "chrome": {
               "version_added": "56"
@@ -2392,6 +6008,42 @@
           }
         }
       },
+      "sampleCoverage": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/sampleCoverage",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "samplerParameterf": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/samplerParameter",
@@ -2432,6 +6084,333 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/samplerParameter",
           "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.13",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "scissor": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/scissor",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.4",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "shaderSource": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/shaderSource",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "stencilFunc": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/stencilFunc",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "stencilFuncSeparate": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/stencilFuncSeparate",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "stencilMask": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/stencilMask",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "stencilMaskSeparate": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/stencilMaskSeparate",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "stencilOp": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/stencilOp",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "stencilOpSeparate": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/stencilOpSeparate",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "texImage2D": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/texImage2D",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6"
+          ],
           "support": {
             "chrome": {
               "version_added": "56"
@@ -2533,6 +6512,84 @@
           }
         }
       },
+      "texParameterf": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/texParameter",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "texParameteri": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/texParameter",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "texStorage2D": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/texStorage2D",
@@ -2573,6 +6630,45 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/texStorage3D",
           "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "texSubImage2D": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/texSubImage2D",
+          "spec_url": [
+            "https://www.khronos.org/registry/webgl/specs/latest/1.0/#TEXSUBIMAGE2D",
+            "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6"
+          ],
           "support": {
             "chrome": {
               "version_added": "56"
@@ -2712,8 +6808,44 @@
       },
       "uniform1f": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniform",
-          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform1fv": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -2748,8 +6880,44 @@
       },
       "uniform1i": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniform",
-          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform1iv": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -2856,8 +7024,44 @@
       },
       "uniform2f": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniform",
-          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform2fv": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -2892,8 +7096,44 @@
       },
       "uniform2i": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniform",
-          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform2iv": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -3000,8 +7240,44 @@
       },
       "uniform3f": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniform",
-          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform3fv": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -3036,8 +7312,44 @@
       },
       "uniform3i": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniform",
-          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform3iv": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -3144,8 +7456,44 @@
       },
       "uniform4f": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniform",
-          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform4fv": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -3180,8 +7528,44 @@
       },
       "uniform4i": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniform",
-          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "uniform4iv": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniform",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -3324,8 +7708,8 @@
       },
       "uniformMatrix2fv": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniformMatrix",
-          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniformMatrix",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -3531,8 +7915,8 @@
       },
       "uniformMatrix3fv": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniformMatrix",
-          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniformMatrix",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -3738,8 +8122,8 @@
       },
       "uniformMatrix4fv": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniformMatrix",
-          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/uniformMatrix",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -3878,6 +8262,504 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniformMatrix",
           "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "SharedArrayBuffer_as_param": {
+          "__compat": {
+            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "support": {
+              "chrome": {
+                "version_added": "60"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "79"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
+      "useProgram": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/useProgram",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "validateProgram": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/validateProgram",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vertexAttrib1f": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/vertexAttrib",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vertexAttrib1fv": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/vertexAttrib",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "SharedArrayBuffer_as_param": {
+          "__compat": {
+            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "support": {
+              "chrome": {
+                "version_added": "60"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "79"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
+      "vertexAttrib2f": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/vertexAttrib",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vertexAttrib2fv": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/vertexAttrib",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "SharedArrayBuffer_as_param": {
+          "__compat": {
+            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "support": {
+              "chrome": {
+                "version_added": "60"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "79"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
+      "vertexAttrib3f": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/vertexAttrib",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vertexAttrib3fv": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/vertexAttrib",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "SharedArrayBuffer_as_param": {
+          "__compat": {
+            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "support": {
+              "chrome": {
+                "version_added": "60"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "79"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
+      "vertexAttrib4f": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/vertexAttrib",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vertexAttrib4fv": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/vertexAttrib",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
           "support": {
             "chrome": {
               "version_added": "56"
@@ -4193,6 +9075,78 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/vertexAttribIPointer",
           "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vertexAttribPointer": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/vertexAttribPointer",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "viewport": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/viewport",
+          "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.4",
           "support": {
             "chrome": {
               "version_added": "56"

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -272,40 +272,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "bindFramebuffer": {
@@ -354,40 +320,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -484,40 +416,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "blendColor": {
@@ -610,40 +508,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "blendEquationSeparate": {
@@ -689,40 +553,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -897,40 +727,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "bufferSubData": {
@@ -976,40 +772,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -1144,40 +906,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -1577,40 +1305,6 @@
               "deprecated": false
             }
           }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "compressedTexSubImage2D": {
@@ -1656,73 +1350,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          },
-          "SharedArrayBuffer_as_param": {
-            "__compat": {
-              "description": "<code>SharedArrayBuffer</code> as a parameter",
-              "support": {
-                "chrome": {
-                  "version_added": "60"
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "79"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
           }
         }
       },
@@ -3104,40 +2731,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "framebufferTexture2D": {
@@ -3183,40 +2776,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -3309,40 +2868,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -3577,40 +3102,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "getContextAttributes": {
@@ -3798,40 +3289,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "getParameter": {
@@ -3976,40 +3433,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "getRenderbufferParameter": {
@@ -4058,40 +3481,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -4372,40 +3761,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "getUniform": {
@@ -4454,40 +3809,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -4583,40 +3904,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -4850,40 +4137,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -5292,40 +4545,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "polygonOffset": {
@@ -5418,73 +4637,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          },
-          "SharedArrayBuffer_as_param": {
-            "__compat": {
-              "description": "<code>SharedArrayBuffer</code> as a parameter",
-              "support": {
-                "chrome": {
-                  "version_added": "60"
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "79"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
         }
       },
       "renderbufferStorage": {
@@ -5533,40 +4685,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -6031,73 +5149,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          },
-          "SharedArrayBuffer_as_param": {
-            "__compat": {
-              "description": "<code>SharedArrayBuffer</code> as a parameter",
-              "support": {
-                "chrome": {
-                  "version_added": "60"
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "79"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
         }
       },
       "texParameterf": {
@@ -6146,40 +5197,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -6230,40 +5247,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "texSubImage2D": {
@@ -6312,73 +5295,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          },
-          "SharedArrayBuffer_as_param": {
-            "__compat": {
-              "description": "<code>SharedArrayBuffer</code> as a parameter",
-              "support": {
-                "chrome": {
-                  "version_added": "60"
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "79"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
           }
         }
       },
@@ -7162,73 +6078,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          },
-          "SharedArrayBuffer_as_param": {
-            "__compat": {
-              "description": "<code>SharedArrayBuffer</code> as a parameter",
-              "support": {
-                "chrome": {
-                  "version_added": "60"
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "79"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
         }
       },
       "uniformMatrix3fv": {
@@ -7275,73 +6124,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          },
-          "SharedArrayBuffer_as_param": {
-            "__compat": {
-              "description": "<code>SharedArrayBuffer</code> as a parameter",
-              "support": {
-                "chrome": {
-                  "version_added": "60"
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "79"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
         }
       },
       "uniformMatrix4fv": {
@@ -7387,73 +6169,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "WebGL2": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "56"
-              },
-              "chrome_android": {
-                "version_added": "58"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "51"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          },
-          "SharedArrayBuffer_as_param": {
-            "__compat": {
-              "description": "<code>SharedArrayBuffer</code> as a parameter",
-              "support": {
-                "chrome": {
-                  "version_added": "60"
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "79"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
           }
         }
       },
@@ -7639,41 +6354,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "SharedArrayBuffer_as_param": {
-          "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
-            "support": {
-              "chrome": {
-                "version_added": "60"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": {
-                "version_added": "79"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "vertexAttrib2f": {
@@ -7765,41 +6445,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "SharedArrayBuffer_as_param": {
-          "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
-            "support": {
-              "chrome": {
-                "version_added": "60"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": {
-                "version_added": "79"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -7893,41 +6538,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "SharedArrayBuffer_as_param": {
-          "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
-            "support": {
-              "chrome": {
-                "version_added": "60"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": {
-                "version_added": "79"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "vertexAttrib4f": {
@@ -8019,41 +6629,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "SharedArrayBuffer_as_param": {
-          "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
-            "support": {
-              "chrome": {
-                "version_added": "60"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": {
-                "version_added": "79"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },


### PR DESCRIPTION
This PR adds all of the WebGLRenderingContext features to WebGL2RenderingContext, then confirms the data using the collector project.

Note: the "removals" in WebGL2RenderingContext are simply due to Git assuming that some existing lines are getting replaced.  No features are actually removed in this PR.