### PR TITLE
SVGStyleElement.type is deprecated

### DIFF
--- a/api/SVGStyleElement.json
+++ b/api/SVGStyleElement.json
@@ -175,6 +175,7 @@
       },
       "type": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStyleElement/type",
           "spec_url": "https://svgwg.org/svg2-draft/styling.html#__svg__SVGStyleElement__type",
           "support": {
             "chrome": {
@@ -212,7 +213,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
`SVGStyleElement.type` has the same behavior as [HTMLStyleElement.type](https://developer.mozilla.org/en-US/docs/Web/API/HTMLStyleElement/type) from HTML5. As that is deprecated, so is this.

I have matched the docs up for these in https://github.com/mdn/content/pull/19043