### PR TITLE
Update Firefox support for pc.iceConnectionState and event

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1788,7 +1788,7 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "52"
+              "version_added": "24"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1825,11 +1825,9 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "24"
             },
-            "firefox_android": {
-              "version_added": "44"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This was implemented in these commits/bug:
https://github.com/mozilla/gecko-dev/commit/98794b08f642c74005534b6aeea968a36dea467b
https://github.com/mozilla/gecko-dev/commit/1cfedb856586209e976a247387ab64d95880950a

https://bugzilla.mozilla.org/show_bug.cgi?id=823512 is marked mozilla24.

Firefox 24 was confirmed with the collector tests:
http://mdn-bcd-collector.appspot.com/tests/api/RTCPeerConnection
