### PR TITLE
feat(css): Add CSS Values Level 4 `cos()` compatibility data

### DIFF
--- a/css/types/cos.json
+++ b/css/types/cos.json
@@ -10,12 +10,8 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -24,20 +20,14 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "15.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,

--- a/css/types/cos.json
+++ b/css/types/cos.json
@@ -1,0 +1,51 @@
+{
+  "css": {
+    "types": {
+      "cos": {
+        "__compat": {
+          "description": "<code>cos()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/cos",
+          "spec_url": "https://drafts.csswg.org/css-values/#trig-funcs",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### Summary
Document the CSS `cos()` functional notation.

#### Test results and supporting details
[Safari/webkit already supports](https://webkit.org/blog/12445/new-webkit-features-in-safari-15-4/) this CSS function. [Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=1190444) will follow soon.
