### PR TITLE
Update some CSS selectors spec URLs

### DIFF
--- a/css/selectors/modal.json
+++ b/css/selectors/modal.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>:modal</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:modal",
-          "spec_url": "https://www.w3.org/TR/selectors-4/#modal-state",
+          "spec_url": "https://drafts.csswg.org/selectors/#modal-state",
           "support": {
             "chrome": {
               "version_added": false

--- a/css/selectors/picture-in-picture.json
+++ b/css/selectors/picture-in-picture.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>:picture-in-picture</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:picture-in-picture",
-          "spec_url": "https://www.w3.org/TR/selectors-4/#pip-state",
+          "spec_url": "https://drafts.csswg.org/selectors/#pip-state",
           "support": {
             "chrome": {
               "version_added": "76"


### PR DESCRIPTION
These should use drafts.csswg.org URLs rather www.w3.org/TR URLs.