### PR TITLE
Update some WebRTC APIs first (partially) implemented in Firefox 24

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1353,11 +1353,9 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "24"
             },
-            "firefox_android": {
-              "version_added": "44"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -1436,11 +1434,9 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "24"
             },
-            "firefox_android": {
-              "version_added": "44"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -2001,12 +1997,18 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": {
-              "version_added": "22"
-            },
-            "firefox_android": {
-              "version_added": "44"
-            },
+            "firefox": [
+              {
+                "version_added": "38"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "38",
+                "partial_implementation": true,
+                "notes": "Although the <code>onnegotiationneeded</code> property is supported, the <code>negotiationneeded</code> event is never fired."
+              }
+            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -2690,11 +2692,9 @@
               "version_added": "15"
             },
             "firefox": {
-              "version_added": "22"
+              "version_added": "24"
             },
-            "firefox_android": {
-              "version_added": "44"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -2728,12 +2728,18 @@
             "edge": {
               "version_added": "15"
             },
-            "firefox": {
-              "version_added": "22"
-            },
-            "firefox_android": {
-              "version_added": "44"
-            },
+            "firefox": [
+              {
+                "version_added": "36"
+              },
+              {
+                "version_added": "24",
+                "version_removed": "36",
+                "partial_implementation": true,
+                "notes": "Although the <code>onsignalingstatechange</code> property is supported, the <code>signalingstatechange</code> event is not fired as an <code>Event</code> object. See <a href='https://bugzil.la/1075133'>bug 1075133</a>."
+              }
+            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
getLocalStreams() and getRemoteStreams() were first implemented here:
https://github.com/mozilla/gecko-dev/commit/98794b08f642c74005534b6aeea968a36dea467b
https://bugzilla.mozilla.org/show_bug.cgi?id=823512

signalingState and the onsignalingstatechange event handler property
were first implemented as part of the same bug:
https://github.com/mozilla/gecko-dev/commit/98794b08f642c74005534b6aeea968a36dea467b
https://github.com/mozilla/gecko-dev/commit/f26f472d40e8417d76fe502b811afb38403ee5d9

But it wasn't until Firefox 36 that the signalingstatechange event was
fired correctly as an Event:
https://github.com/mozilla/gecko-dev/commit/e794725154660a9301388164261a65b45cce21d0
https://bugzilla.mozilla.org/show_bug.cgi?id=1075133

Similarly, the negotiationneeded event wasn't fired (at all) until
Firefox 38:
https://github.com/mozilla/gecko-dev/commit/1f815978b4f878bb5cd5b1f3f54d86d7dfede32a
https://bugzilla.mozilla.org/show_bug.cgi?id=1017888
