### PR TITLE
Remove Chrome support for Sanitizer functions.

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -8509,14 +8509,7 @@
           "spec_url": "https://wicg.github.io/sanitizer-api/#dom-element-sethtml",
           "support": {
             "chrome": {
-              "version_added": "93",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "105"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -133,7 +133,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "105"
+                "version_added": false
               },
               {
                 "version_added": "93",
@@ -189,7 +189,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "105"
+                "version_added": false
               },
               {
                 "version_added": "93",
@@ -252,7 +252,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "105"
+                "version_added": false
               },
               {
                 "version_added": "93",

--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -254,15 +254,15 @@
           "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-sanitizefor",
           "support": {
             "chrome": {
-                "version_added": "93",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              },
+              "version_added": "93",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -131,22 +131,17 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Sanitizer/getConfiguration",
           "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-getconfiguration",
           "support": {
-            "chrome": [
-              {
-                "version_added": false
-              },
-              {
-                "version_added": "93",
-                "version_removed": "105",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome":
+            {
+              "version_added": "93",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -193,7 +188,6 @@
               },
               {
                 "version_added": "93",
-                "version_removed": "105",
                 "flags": [
                   {
                     "type": "preference",
@@ -250,13 +244,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Sanitizer/sanitizeFor",
           "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-sanitizefor",
           "support": {
-            "chrome": [
-              {
-                "version_added": false
-              },
+            "chrome":
               {
                 "version_added": "93",
-                "version_removed": "105",
                 "flags": [
                   {
                     "type": "preference",
@@ -264,8 +254,7 @@
                     "value_to_set": "enabled"
                   }
                 ]
-              }
-            ],
+              },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -138,6 +138,11 @@
                   "type": "preference",
                   "name": "enable-experimental-web-platform-features",
                   "value_to_set": "enabled"
+                },
+                {
+                  "type": "preference",
+                  "name": "sanitizer-api",
+                  "value_to_set": "enabled"
                 }
               ]
             },
@@ -157,6 +162,11 @@
                 {
                   "type": "preference",
                   "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                },
+                {
+                  "type": "preference",
+                  "name": "sanitizer-api",
                   "value_to_set": "enabled"
                 }
               ]
@@ -187,6 +197,11 @@
                 {
                   "type": "preference",
                   "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                },
+                {
+                  "type": "preference",
+                  "name": "sanitizer-api",
                   "value_to_set": "enabled"
                 }
               ]

--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -131,8 +131,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Sanitizer/getConfiguration",
           "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-getconfiguration",
           "support": {
-            "chrome":
-            {
+            "chrome": {
               "version_added": "93",
               "flags": [
                 {
@@ -182,21 +181,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Sanitizer/sanitize",
           "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-sanitize",
           "support": {
-            "chrome": [
-              {
-                "version_added": false
-              },
-              {
-                "version_added": "93",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "93",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
+            },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -244,8 +238,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Sanitizer/sanitizeFor",
           "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-sanitizefor",
           "support": {
-            "chrome":
-              {
+            "chrome": {
                 "version_added": "93",
                 "flags": [
                   {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Only part of the Sanitizer API is shipping in 105. The Chrome Status entry linked to below is less than clear. I've had several conversations with the feature developer. Also [a Chrome article](https://web.dev/sanitizer/) was recently updated to cover only the portions of the API that are actually shipping.

**This is why I always oppose putting anything on MDN before It reaches at least beta.**

#### Related issues
https://chromestatus.com/feature/5786893650231296

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
