### PR TITLE
Remove api.GestureEvent.GestureEvent from BCD

### DIFF
--- a/api/GestureEvent.json
+++ b/api/GestureEvent.json
@@ -34,42 +34,6 @@
           "deprecated": false
         }
       },
-      "GestureEvent": {
-        "__compat": {
-          "description": "<code>GestureEvent()</code> constructor",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/GestureEvent/GestureEvent",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "9"
-            },
-            "safari_ios": {
-              "version_added": "2"
-            },
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": false
-          }
-        }
-      },
       "initGestureEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GestureEvent/initGestureEvent",


### PR DESCRIPTION
This PR removes the irrelevant `GestureEvent` member of the `GestureEvent` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features). The lack of current support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0), even if the current BCD suggests support.
