### PR TITLE
Fix enumerate-features script when dataFrom argument is used

### DIFF
--- a/scripts/diff-features.ts
+++ b/scripts/diff-features.ts
@@ -55,8 +55,10 @@ function enumerate(ref: string, skipGitHub: boolean): Set<string> {
   if (!skipGitHub) {
     try {
       return new Set(getEnumerationFromGithub(ref));
-    } catch {
-      console.error('Fetching artifact from GitHub failed. Using fallback.');
+    } catch (e) {
+      console.error(
+        `Fetching artifact from GitHub failed: ${e.message} Using fallback.`,
+      );
     }
   }
 

--- a/scripts/enumerate-features.ts
+++ b/scripts/enumerate-features.ts
@@ -20,7 +20,7 @@ async function enumerateFeatures(dataFrom: string) {
 
   const walker = lowLevelWalk(
     dataFrom
-      ? await import(path.join(process.cwd(), dataFrom, 'index.js'))
+      ? (await import(path.join(process.cwd(), dataFrom, 'index.js'))).default
       : undefined,
   );
 


### PR DESCRIPTION
This PR fixes the `enumerate-features` script when using the `dataFrom` argument.  An issue arose during release notes creation when the fallback from GitHub was needed, due to `import()` returning a `default` object.
