### PR TITLE
feat(css): Add CSS Values Level 4 `atan()` compatibility data

### DIFF
--- a/css/types/atan.json
+++ b/css/types/atan.json
@@ -1,0 +1,51 @@
+{
+  "css": {
+    "types": {
+      "atan": {
+        "__compat": {
+          "description": "<code>atan()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/atan",
+          "spec_url": "https://drafts.csswg.org/css-values/#trig-funcs",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### Summary
Document the CSS `atan()` functional notation.

#### Test results and supporting details
[Safari/webkit already supports](https://webkit.org/blog/12445/new-webkit-features-in-safari-15-4/) this CSS function. [Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=1190444) will follow soon.
