### PR TITLE
Safari 15.6 is released

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -209,14 +209,16 @@
         "15.5": {
           "release_date": "2022-05-16",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15_5-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "613.2.7"
         },
         "15.6": {
+          "release_date": "2022-07-20",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15_6-release-notes",
-          "status": "beta",
-          "engine": "WebKit"
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "613.3.9"
         },
         "16": {
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes",

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -181,14 +181,16 @@
         "15.5": {
           "release_date": "2022-05-16",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15_5-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "613.2.7"
         },
         "15.6": {
+          "release_date": "2022-07-20",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15_6-release-notes",
-          "status": "beta",
-          "engine": "WebKit"
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "613.3.9"
         },
         "16": {
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes",


### PR DESCRIPTION
This PR marks Safari 15.6 as the current version of Safari.  The release date comes from https://support.apple.com/en-us/HT213341, whereas the engine version comes from running Safari 15.6 itself on my Mac mini.
