### PR TITLE
Update WebKit support for innerHTML/outerHTML/innerText/outerText

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -4919,8 +4919,7 @@
           "spec_url": "https://w3c.github.io/DOM-Parsing/#dom-innerhtml-innerhtml",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "This API was previously available on the <code>Node</code> API."
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -4941,14 +4940,12 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "9",
-              "notes": "This API was previously available on the <code>Node</code> API."
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": "4.4",
-              "notes": "This API was previously available on the <code>Node</code> API."
+              "version_added": "1"
             }
           },
           "status": {
@@ -6024,8 +6021,7 @@
           "spec_url": "https://w3c.github.io/DOM-Parsing/#dom-element-outerhtml",
           "support": {
             "chrome": {
-              "version_added": "33",
-              "notes": "This API was previously available on the <code>Node</code> API."
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -6046,13 +6042,12 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "9"
+              "version_added": "1.3"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": "4.4",
-              "notes": "This API was previously available on the <code>Node</code> API."
+              "version_added": "1"
             }
           },
           "status": {

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -27,12 +27,12 @@
             "version_added": "10.1"
           },
           "safari": {
-            "version_added": "1.3"
+            "version_added": "1"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
-            "version_added": "≤37"
+            "version_added": "1"
           }
         },
         "status": {
@@ -1361,13 +1361,13 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3"
-            },
-            "safari_ios": {
               "version_added": "1"
             },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": "1"
+            }
           },
           "status": {
             "experimental": false,
@@ -1839,7 +1839,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": "1"
+            }
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
innerHTML and innerText was supported on HTMLElement from the beginning of WebKit:
https://github.com/WebKit/WebKit/blob/a063c2b75ddebd1edfe9c54c428d762bdb61f794/WebCore/khtml/ecma/kjs_html.cpp#L908-L911

outerHTML was implemented on 2004-05-05, after the Safari 1.2 release
but long before the Safari 1.3 release, so assume 1.3:
https://github.com/WebKit/WebKit/commit/09b1ec859efb384981e6f6f35e27363d83f78c38

outerText was implemented shortly after, also for 1.3:
https://github.com/WebKit/WebKit/commit/206f85c759065dc3df66c8818ef2eb3682ee7a22

Support for all 4 properties was manually confirmed in Safari 4 by
evaluating `document.body.innerHTML` and similar. This means any
remaining errors are before that time.

All of this was well before the initial releases of WebView Android and
Chrome, so set those versions to 1.

The notes about Node are wrong. innerHTML and outerHTML were originally
on HTMLElement, but that really doesn't matter, since even now when they
are on Element, they throw InvalidStateError for XML documents per spec:
https://w3c.github.io/DOM-Parsing/#ref-for-dom-innerhtml-innerhtml-2
https://w3c.github.io/DOM-Parsing/#ref-for-dom-element-outerhtml-2
