### PR TITLE
Mirror support for RTCRtpReceiver *_tracks_supported for Firefox Android

### DIFF
--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -152,9 +152,7 @@
               "firefox": {
                 "version_added": "59"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -189,9 +187,7 @@
               "firefox": {
                 "version_added": "68"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -330,9 +326,7 @@
               "firefox": {
                 "version_added": "59"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -365,9 +359,7 @@
               "firefox": {
                 "version_added": "68"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
After https://github.com/mdn/browser-compat-data/pull/17213 these are
the only remaining non-mirrored values in WebRTC APIs.

The data came from here:
https://github.com/mdn/browser-compat-data/pull/4340
https://bugzilla.mozilla.org/show_bug.cgi?id=1534466

Since there is no discussion about Android support at all, this seems
like a mistake.
