### PR TITLE
feat(css): Update CSS Values Level 4 `sin()` compatibility data

### DIFF
--- a/css/types/sin.json
+++ b/css/types/sin.json
@@ -10,12 +10,8 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -24,20 +20,14 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "15.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,


### PR DESCRIPTION
#### Summary

Update the `sin()` function to pre-set Chromium derivatives as "mirror" as well while we're here for easier maintenance down the line.

Suggested by @queengooborg .