### PR TITLE
Update Chrome/Opera support for MediaStreamTrack's stop() method

### DIFF
--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -629,7 +629,7 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-stop",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "32"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -643,12 +643,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "45"
-            },
-            "opera_android": {
-              "version_added": "43"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "11"
             },


### PR DESCRIPTION
The original data is from wiki migration:
https://github.com/mdn/browser-compat-data/pull/1248

The commit implementing the stop() method is here:
https://chromium.googlesource.com/chromium/src/+/ffbe9abb72c71abaf8623c56c9ad7f6ee04f48b4

That suggests Chrome 31 by naive date mapping.

But Chrome 32 was confirmed by evaluating
`MediaStreamTrack.prototype.stop` on Chrome 31 and 32 on BrowserStack.

Part of https://github.com/mdn/browser-compat-data/pull/6526.
