### PR TITLE
Update Firefox support for showNotification() and getNotifications()

### DIFF
--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -156,7 +156,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "46"
+              "version_added": "44"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -460,7 +460,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "46"
+              "version_added": "44"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
Confirmed by running this test in Firefox 44:
https://mdn-bcd-collector.appspot.com/tests/api/ServiceWorkerRegistration

This data came from wiki migration:
https://github.com/mdn/browser-compat-data/pull/1015

Part of https://github.com/mdn/browser-compat-data/pull/6526
