### PR TITLE
Update Safari support for Intl.getCanonicalLocales()

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -77,7 +77,7 @@
               },
               "opera_android": "mirror",
               "safari": {
-                "version_added": "11"
+                "version_added": "10.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
Implemented in WebKit trunk version 603.1.9:
https://github.com/WebKit/WebKit/commit/67075eeb6d10b167702a82bf82a62d582067fabf
https://github.com/WebKit/WebKit/blob/67075eeb6d10b167702a82bf82a62d582067fabf/Source/WebCore/Configurations/Version.xcconfig

That maps to 10.1, which is the same change suggested by Web Confluence.

Part of https://github.com/mdn/browser-compat-data/pull/6526.