### PR TITLE
Update Safari support for String.codePointAt/fromCodePoint/raw

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -454,7 +454,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "10"
+                "version_added": "9"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -792,7 +792,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "10"
+                "version_added": "9"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -1515,7 +1515,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "10"
+                "version_added": "9"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
Safari 9.1 and iOS 9 are suggested by Web Confluence.

These are the commits implemented these methods:

https://github.com/WebKit/WebKit/commit/96329e0299ec3ac9f992020e162b24e4eb5f0517
https://github.com/WebKit/WebKit/blob/96329e0299ec3ac9f992020e162b24e4eb5f0517/Source/WebCore/Configurations/Version.xcconfig

https://github.com/WebKit/WebKit/commit/0535e1e759c599a8245e6d74c7194ab651a49239
https://github.com/WebKit/WebKit/blob/0535e1e759c599a8245e6d74c7194ab651a49239/Source/WebCore/Configurations/Version.xcconfig

https://github.com/WebKit/WebKit/commit/54d3ba427dbf70078a3648c048e944b6a3580c20
https://github.com/WebKit/WebKit/blob/54d3ba427dbf70078a3648c048e944b6a3580c20/Source/WebCore/Configurations/Version.xcconfig

That's WebKit trunk version 601.1.29-31, all mapping to Safari 9.

Part of https://github.com/mdn/browser-compat-data/pull/6526.
