### PR TITLE
Update Safari support for Number.isSafeInteger()

### DIFF
--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -604,7 +604,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "10"
+                "version_added": "9"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
Support in iOS 9 confirmed with this test:
http://mdn-bcd-collector.appspot.com/tests/javascript/builtins/Number/isSafeInteger

This was implemented in WebKit trunk version 601.1.2:
https://github.com/WebKit/WebKit/commit/456541e93f74bb98bc93804007d6e6e9593d3aa6
https://github.com/WebKit/WebKit/blob/456541e93f74bb98bc93804007d6e6e9593d3aa6/Source/WebCore/Configurations/Version.xcconfig

That maps to Safari 9, and the other Number constructor "extras" added
there are already marked as Safari 9 in BCD.

Part of https://github.com/mdn/browser-compat-data/pull/6526.
