### PR TITLE
Update Edge 12 support for many TypedArray members

### DIFF
--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -155,7 +155,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "4"
@@ -205,7 +205,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "4"
@@ -255,7 +255,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "4"
@@ -356,7 +356,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "34"
@@ -400,7 +400,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "37"
@@ -448,7 +448,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "37"
@@ -496,7 +496,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "37"
@@ -544,7 +544,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "38"
@@ -592,7 +592,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "37"
@@ -634,7 +634,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "37"
@@ -784,7 +784,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "38"
@@ -826,7 +826,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "38"
@@ -982,7 +982,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "37",
@@ -1068,7 +1068,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "37"
@@ -1110,7 +1110,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "37"
@@ -1152,7 +1152,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "37",
@@ -1195,7 +1195,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "4"
@@ -1245,7 +1245,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "38"
@@ -1433,7 +1433,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "38"
@@ -1477,7 +1477,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "37"
@@ -1521,7 +1521,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "37"
@@ -1565,7 +1565,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "37"
@@ -1609,7 +1609,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "4"
@@ -1659,7 +1659,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "38"
@@ -1701,7 +1701,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "37"
@@ -1745,7 +1745,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "46"
@@ -1787,7 +1787,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "4"
@@ -1937,7 +1937,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "37"


### PR DESCRIPTION
These changes are suggested by Web Confluence:
https://github.com/mdn/browser-compat-data/pull/6526.

Exactly the same features are changed to ≤13 by the collector,
where Edge 12 results aren't available:
https://github.com/mdn/browser-compat-data/pull/17224

For a bunch of these, there was also support in IE 10, and in those
cases Edge 14 is very implausible.
