### PR TITLE
Mirror Android/Opera support for TypedArray copyWithin() and of()

### DIFF
--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -349,9 +349,7 @@
               "chrome": {
                 "version_added": "45"
               },
-              "chrome_android": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
               "deno": {
                 "version_added": "1.0"
               },
@@ -369,9 +367,7 @@
                 "version_added": "4.0.0"
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": "36"
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": "9.1"
@@ -1426,9 +1422,7 @@
               "chrome": {
                 "version_added": "45"
               },
-              "chrome_android": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
               "deno": {
                 "version_added": "1.0"
               },
@@ -1446,9 +1440,7 @@
                 "version_added": "4.0.0"
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": "9.1"


### PR DESCRIPTION
Chrome 45 was confirmed with these tests:
https://mdn-bcd-collector.appspot.com/tests/javascript/builtins/TypedArray/copyWithin
https://mdn-bcd-collector.appspot.com/tests/javascript/builtins/TypedArray/of

Then support in Opera 89 and Chrome Android 100 for the same were
confirmed in BrowserStack, and the data mirrored.
