### PR TITLE
Updates chrome browser to version 104

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -718,27 +718,34 @@
         "103": {
           "release_date": "2022-06-21",
           "release_notes": "https://chromereleases.googleblog.com/2022/06/stable-channel-update-for-desktop_21.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "103"
         },
         "104": {
           "release_date": "2022-08-02",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2022/08/stable-channel-update-for-desktop.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "104"
         },
         "105": {
           "release_date": "2022-08-30",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "105"
         },
         "106": {
           "release_date": "2022-09-27",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Blink",
           "engine_version": "106"
+        },
+        "107": {
+          "release_date": "2022-10-25",
+          "status": "planned",
+          "engine": "Blink",
+          "engine_version": "107"
         }
       }
     }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -555,27 +555,34 @@
         "103": {
           "release_date": "2022-06-21",
           "release_notes": "https://chromereleases.googleblog.com/2022/06/chrome-for-android-update_01675415440.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "103"
         },
         "104": {
           "release_date": "2022-08-02",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2022/08/chrome-for-android-update.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "104"
         },
         "105": {
           "release_date": "2022-08-30",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "105"
         },
         "106": {
           "release_date": "2022-09-27",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Blink",
           "engine_version": "106"
+        },
+        "107": {
+          "release_date": "2022-10-25",
+          "status": "planned",
+          "engine": "Blink",
+          "engine_version": "107"
         }
       }
     }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -519,27 +519,34 @@
         "103": {
           "release_date": "2022-06-21",
           "release_notes": "https://chromereleases.googleblog.com/2022/05/chrome-for-android-update_01678544884.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "103"
         },
         "104": {
           "release_date": "2022-08-02",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2022/08/chrome-for-android-update.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "104"
         },
         "105": {
           "release_date": "2022-08-30",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "105"
         },
         "106": {
           "release_date": "2022-09-27",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Blink",
           "engine_version": "106"
+        },
+        "107": {
+          "release_date": "2022-10-25",
+          "status": "planned",
+          "engine": "Blink",
+          "engine_version": "107"
         }
       }
     }


### PR DESCRIPTION
Hello! 

This PR updates Chrome to version 104.

And according to https://chromiumdash.appspot.com/schedule, the release date of Chrome 107 is 25/10/2022.