### PR TITLE
Update Chromium versions for api.RTCRtpEncodingParameters.maxFramerate

### DIFF
--- a/api/RTCRtpEncodingParameters.json
+++ b/api/RTCRtpEncodingParameters.json
@@ -210,7 +210,7 @@
           "spec_url": "https://w3c.github.io/webrtc-extensions/#dom-rtcrtpencodingparameters-maxframerate",
           "support": {
             "chrome": {
-              "version_added": "83"
+              "version_added": "81"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/RTCRtpEncodingParameters.json
+++ b/api/RTCRtpEncodingParameters.json
@@ -210,7 +210,7 @@
           "spec_url": "https://w3c.github.io/webrtc-extensions/#dom-rtcrtpencodingparameters-maxframerate",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "83"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

According to https://chromestatus.com/feature/6216116758118400 and
https://storage.googleapis.com/chromium-find-releases-static/9fe.html#9fe620ffcfaf81dc6ab3838a7d1ac5368fc1c53d,
this has been shipped since Chromium 81.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
