### PR TITLE
Mark gl.lineWidth() as actually supported

### DIFF
--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -4376,27 +4376,34 @@
           "spec_url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "9"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": "25"
+            },
             "edge": {
-              "version_added": "12",
-              "version_removed": "79"
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "4"
             },
             "firefox_android": "mirror",
             "ie": {
               "version_added": "11"
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
+            "opera": {
+              "version_added": "12"
             },
-            "safari_ios": "mirror",
+            "opera_android": {
+              "version_added": "12"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": {
+              "version_added": "8"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "4.4.3"


### PR DESCRIPTION
The method exists, confirmed with this test in recent Chrome, Firefox
and Safari:
http://mdn-bcd-collector.appspot.com/tests/api/WebGLRenderingContext/lineWidth

https://jsfiddle.net/jkmLae4x/ is a demo and actually the method doesn't
seem to do anything, still drawing a 1px line. There's a warning about
this on MDN already:
https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/lineWidth

Some notes could make sense, but would require deep research to figure
out if the minimum and maximum line width are always 1, or
gl.lineWidth(5) would work in some case.

This effectively reverts this old commit:
https://github.com/mdn/browser-compat-data/commit/3e009d0996879f088fb3cffc77f2cd9f7225ff59

The data before that is trusted, and matches most other features of
WebGLRenderingContext.
