### PR TITLE
Remove incorrect notes on `MediaQueryList.addEventListener`

### DIFF
--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -27,12 +27,10 @@
             "version_added": "12.1"
           },
           "safari": {
-            "version_added": "5.1",
-            "notes": "Before Safari 14, <code>MediaQueryList</code> is based on <code>EventTarget</code>, so you must use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
+            "version_added": "5.1"
           },
           "safari_ios": {
-            "version_added": "5",
-            "notes": "Before Safari 14, <code>MediaQueryList</code> is based on <code>EventTarget</code>, so you must use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
+            "version_added": "5"
           },
           "samsunginternet_android": "mirror",
           "webview_android": {
@@ -108,12 +106,10 @@
               "version_added": "12.1"
             },
             "safari": {
-              "version_added": "5.1",
-              "notes": "Before Safari 14, <code>MediaQueryList</code> is based on <code>EventTarget</code>, so you must use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
+              "version_added": "5.1"
             },
             "safari_ios": {
-              "version_added": "5",
-              "notes": "Before Safari 14, <code>MediaQueryList</code> is based on <code>EventTarget</code>, so you must use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
+              "version_added": "5"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {


### PR DESCRIPTION
#### Summary

`MediaQueryList.addEventListener` was **not** based on EventTarget before Safari 14, otherwise it would implement the `addEventListener` and `removeEventListener` methods and so you would not need to use `addListener`.

It looks like [this might have been accidentally flipped in code review](https://github.com/mdn/browser-compat-data/pull/6403#discussion_r463062928) ('is not' => 'was not' => 'is').

#### Test results and supporting details

N/A

#### Related issues

N/A