### PR TITLE
Update Safari support for RegExp's dotAll property

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -177,7 +177,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "12"
+                "version_added": "11.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
Safari 11.1 support confirmed with this test on BrowserStack:
http://mdn-bcd-collector.appspot.com/tests/javascript/builtins/RegExp/dotAll

The implementation commit also maps to Safari 11.1:
https://github.com/WebKit/WebKit/commit/163dde9c65bff624b90515291d1ae168d3d44b69
https://github.com/WebKit/WebKit/blob/163dde9c65bff624b90515291d1ae168d3d44b69/Source/WebCore/Configurations/Version.xcconfig
