### PR TITLE
Remove MediaQueryList's "EventListener_objects" feature

### DIFF
--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -45,41 +45,6 @@
           "deprecated": false
         }
       },
-      "EventListener_objects": {
-        "__compat": {
-          "description": "<code>EventListener</code> objects as parameters",
-          "support": {
-            "chrome": {
-              "version_added": "39"
-            },
-            "chrome_android": "mirror",
-            "edge": {
-              "version_added": "≤79"
-            },
-            "firefox": {
-              "version_added": "55"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "14"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "EventTarget_inheritance": {
         "__compat": {
           "description": "<code>MediaQueryList</code> inherits <code>EventTarget</code>",


### PR DESCRIPTION
The meaning of this feature is very unclear and comes from wiki migration:
https://github.com/mdn/browser-compat-data/pull/1235

It is probably referring to whether addListener() and removeListener()
parameters are of type EventListener in IDL, but this really does not matter,
it's just a function that is passed.

Also, the change in browsers was done together with EventTarget inheritance,
already its own feature. The change in Chromium to illustrate:
https://source.chromium.org/chromium/chromium/src/+/5fc555b830a9b5b1536e242d8754d7e507bcc75a