### PR TITLE
Update Firefox/Opera support for mst.applyConstraints()

### DIFF
--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -48,19 +48,15 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "50"
+              "version_added": "43"
             },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "46"
-            },
-            "opera_android": {
-              "version_added": "43"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "11"
             },


### PR DESCRIPTION
This was implemented in Firefox 43:
https://bugzilla.mozilla.org/show_bug.cgi?id=912342

The same change is also made by mdn-bcd-collector:
https://github.com/mdn/browser-compat-data/pull/17224

This reverts what appears to be a mistaken edit while updating Chrome
which was probably intended to update the Opera data:
https://github.com/mdn/browser-compat-data/pull/1746

And now actually mirror the Opera data.

Part of https://github.com/mdn/browser-compat-data/pull/6526.
