### PR TITLE
Update Chrome support for mst.getSettings()

### DIFF
--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -302,7 +302,7 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-getsettings",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": "59"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
The same changes is suggested by both confluence and collector:
https://github.com/mdn/browser-compat-data/pull/6526
https://github.com/mdn/browser-compat-data/pull/17224

Commit mapping also points to 59:
https://storage.googleapis.com/chromium-find-releases-static/b6a.html#b6a9c1ca0284fa7cd1995a2f266390e90bf06c65
