### PR TITLE
Update Chromium versions for api.AmbientLightSensor.illuminance

### DIFF
--- a/api/AmbientLightSensor.json
+++ b/api/AmbientLightSensor.json
@@ -91,8 +91,7 @@
               "notes": "In Chrome 79, this method stopped returning floats and returned integers to avoid fingerprinting."
             },
             "chrome_android": {
-              "version_added": "56",
-              "notes": "In Chrome for Android 79, this method stopped returning floats and returned integers to avoid fingerprinting."
+              "version_added": false
             },
             "edge": {
               "version_added": "79"

--- a/api/AmbientLightSensor.json
+++ b/api/AmbientLightSensor.json
@@ -105,19 +105,13 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `illuminance` member of the `AmbientLightSensor` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AmbientLightSensor/illuminance

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._

Note: the original version number came from the wiki migration, but Opera Android doesn't support this feature either.  The results came from a Samsung Galaxy S9, so I'm confident it's not a hardware incompatibility issue.