### PR TITLE
Update Chromium support for mst.applyConstraints() and getCapabilities()

### DIFF
--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -41,7 +41,7 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-applyconstraints",
           "support": {
             "chrome": {
-              "version_added": "63"
+              "version_added": "59"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -55,19 +55,13 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "46"
-            },
-            "opera_android": {
-              "version_added": "43"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "11"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "7.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -226,7 +220,7 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-getcapabilities",
           "support": {
             "chrome": {
-              "version_added": "66"
+              "version_added": "59"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
These methods were both first exposed when ImageCapture shipped:
https://storage.googleapis.com/chromium-find-releases-static/44e.html#44e0ad0c40c920ab5259514c5ea262c8bd7cd5a5

So it was not full support from the start, but this would be better
captured as subfeatures for parameter support, if anyone would still be
interested in these details so long after.

Both confluence and collector suggest these exact changes:
https://github.com/mdn/browser-compat-data/pull/6526
https://github.com/mdn/browser-compat-data/pull/17224
