### PR TITLE
feat(css): Add CSS Values Level 4 `exp()` compatibility data

### DIFF
--- a/css/types/exp.json
+++ b/css/types/exp.json
@@ -1,0 +1,41 @@
+{
+  "css": {
+    "types": {
+      "exp": {
+        "__compat": {
+          "description": "<code>exp()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/exp",
+          "spec_url": "https://drafts.csswg.org/css-values/#exponent-funcs",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### Summary
Document the CSS `exp()` functional notation.

#### Test results and supporting details
[Safari/webkit already supports](https://webkit.org/blog/12445/new-webkit-features-in-safari-15-4/) this CSS function.