### PR TITLE
Tighten up the types of walk utils to avoid redundant checks

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -38,10 +38,6 @@ const load = async (...dirs: string[]) => {
         // Add source_file props
         const walker = walk(undefined, contents);
         for (const { compat } of walker) {
-          if (!compat) {
-            continue;
-          }
-
           compat.source_file = normalizePath(path.relative(dirname, fp));
         }
 

--- a/scripts/migrations/007-experimental-false.ts
+++ b/scripts/migrations/007-experimental-false.ts
@@ -26,7 +26,7 @@ const dirname = fileURLToPath(new URL('.', import.meta.url));
  */
 export const fixExperimental = (bcd: CompatData | Identifier): void => {
   for (const { compat } of walk(undefined, bcd)) {
-    if (!compat?.status?.experimental) {
+    if (!compat.status?.experimental) {
       continue;
     }
 

--- a/scripts/migrations/009-mirror.ts
+++ b/scripts/migrations/009-mirror.ts
@@ -64,10 +64,8 @@ export const mirrorIfEquivalent = (
 ): void => {
   for (const { compat } of walk(undefined, bcd)) {
     for (const browser of browsers) {
-      if (compat) {
-        if (isMirrorEquivalent(compat.support, browser)) {
-          (compat.support[browser] as InternalSupportStatement) = 'mirror';
-        }
+      if (isMirrorEquivalent(compat.support, browser)) {
+        (compat.support[browser] as InternalSupportStatement) = 'mirror';
       }
     }
   }

--- a/scripts/release/build.ts
+++ b/scripts/release/build.ts
@@ -39,9 +39,6 @@ export const applyMirroring = (data: CompatData): CompatData => {
   const walker = walk(undefined, response);
 
   for (const feature of walker) {
-    if (!feature.compat) {
-      continue;
-    }
     for (const [browser, supportData] of Object.entries(
       feature.compat.support as InternalSupportStatement,
     )) {


### PR DESCRIPTION
`walk()` can never yield an object without a `compat` property, and yet
the common WalkOutput type made it look like it at all call sites. Fix
this by specializing the types and simplifying the call sites.
