### PR TITLE
Remove <audio> and <video> attributes that don't exist

### DIFF
--- a/html/elements/audio.json
+++ b/html/elements/audio.json
@@ -87,40 +87,6 @@
             }
           }
         },
-        "buffered": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤18"
-              },
-              "firefox": {
-                "version_added": "4"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": null
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "controls": {
           "__compat": {
             "support": {
@@ -205,38 +171,6 @@
             }
           }
         },
-        "mozcurrentsampleoffset": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "3.5"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": false
-            }
-          }
-        },
         "muted": {
           "__compat": {
             "support": {
@@ -261,46 +195,6 @@
                 "version_added": null
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "played": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "49"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "14"
-              },
-              "firefox": {
-                "version_added": "15"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "11"
-              },
-              "oculus": "mirror",
-              "opera": {
-                "version_added": "46"
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": "9.1"
-              },
-              "safari_ios": {
-                "version_added": true
-              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -412,44 +306,6 @@
               "webview_android": {
                 "version_added": "3"
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "volume": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤18"
-              },
-              "firefox": {
-                "version_added": null
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": null
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": {
-                "version_added": true
-              },
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -331,44 +331,6 @@
             }
           }
         },
-        "played": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": null
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤18"
-              },
-              "firefox": {
-                "version_added": "15"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": null
-              },
-              "oculus": "mirror",
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "poster": {
           "__compat": {
             "support": {


### PR DESCRIPTION
There are properties on the DOM APIs for most of these, but these aren't
attributes. While there's a muted attribute, there is no volume
attribute. The possible content attributes are listed here:
https://html.spec.whatwg.org/multipage/media.html#the-audio-element
https://html.spec.whatwg.org/multipage/media.html#the-video-element
