### PR TITLE
clip-path: clarifying for Edge, marking as partial for IE

### DIFF
--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -25,7 +25,7 @@
               },
               {
                 "version_added": "12",
-                "partial-implementation": true,
+                "partial_implementation": true,
                 "notes": "Only supports clip paths defined by <code>url()</code>."
               }
             ],
@@ -35,7 +35,7 @@
             "firefox_android": "mirror",
             "ie": {
               "version_added": "10",
-              "partial-implementation": true,
+              "partial_implementation": true,
               "notes": "Only supports clip paths defined by <code>url()</code>."
             },
             "oculus": "mirror",

--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -19,16 +19,24 @@
               }
             ],
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "partial-implementation": true,
+                "notes": "Only supports clip paths defined by <code>url()</code>."
+              }
+            ],
             "firefox": {
               "version_added": "3.5"
             },
             "firefox_android": "mirror",
             "ie": {
               "version_added": "10",
-              "notes": "Internet Explorer only supports clip paths defined by <code>url()</code>."
+              "partial-implementation": true,
+              "notes": "Only supports clip paths defined by <code>url()</code>."
             },
             "oculus": "mirror",
             "opera": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

Edge only recognized `url()` values before version 79. For both IE and Edge (pre-79), it's now marked as a partial implementation.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Caniuse: https://caniuse.com/css-clip-path, https://caniuse.com/mdn-css_properties_clip-path_basic_shape

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #17015 by clarifying.
<!-- ✅ After submitting, review the results of the "Checks" tab! -->
