### PR TITLE
Support for persistAcrossSessions

### DIFF
--- a/webextensions/api/scripting.json
+++ b/webextensions/api/scripting.json
@@ -40,6 +40,26 @@
               },
               "safari_ios": "mirror"
             }
+          },
+          "persistAcrossSessions": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "88"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "101",
+                  "note": "Prior to Firefox 105.0 `true`, to indicate a script is persistent, wa s not supported."
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
           }
         },
         "executeScript": {

--- a/webextensions/api/scripting.json
+++ b/webextensions/api/scripting.json
@@ -50,7 +50,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "101",
-                  "notes": "Prior to Firefox 105.0 `true`, to indicate a script is persistent, was not supported."
+                  "notes": "Prior to Firefox 105, <code>true</code>, to indicate a script is persistent, was not supported."
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",

--- a/webextensions/api/scripting.json
+++ b/webextensions/api/scripting.json
@@ -50,7 +50,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "101",
-                  "note": "Prior to Firefox 105.0 `true`, to indicate a script is persistent, was not supported."
+                  "notes": "Prior to Firefox 105.0 `true`, to indicate a script is persistent, was not supported."
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",

--- a/webextensions/api/scripting.json
+++ b/webextensions/api/scripting.json
@@ -50,7 +50,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "101",
-                  "note": "Prior to Firefox 105.0 `true`, to indicate a script is persistent, wa s not supported."
+                  "note": "Prior to Firefox 105.0 `true`, to indicate a script is persistent, was not supported."
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",


### PR DESCRIPTION
#### Summary
Support for  identifying a content script as persistent in the `scripting` API is added in Firefox 105. This change adds a note that `persistAcrossSessions` did not support the "true" setting Price released 105.

#### Related issues
Addresses the documentation needs of [Bug 1751436](https://bugzilla.mozilla.org/show_bug.cgi?id=1751436) Add support for `persistAcrossSessions` in `scripting.RegisteredContentScript`

#### Test results and supporting details
None, tests fail locally; awaiting online tests