### PR TITLE
Updates edge browser to version 104

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -220,23 +220,29 @@
         },
         "103": {
           "release_date": "2022-06-23",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "103",
           "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1030126437-june-23"
         },
         "104": {
-          "release_date": "2022-08-04",
-          "status": "beta",
+          "release_date": "2022-08-05",
+          "status": "current",
           "engine": "Blink",
-          "engine_version": "104"
+          "engine_version": "104",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1040129347-august-5"
         },
         "105": {
           "release_date": "2022-09-01",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "105"
-        }
+        },
+        "106": {
+          "release_date": "2022-09-29",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "106"
       }
     }
   }

--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -243,6 +243,7 @@
           "status": "nightly",
           "engine": "Blink",
           "engine_version": "106"
+        }
       }
     }
   }


### PR DESCRIPTION
Hello everyone! 😉

I updated Edge browser to version 104, according to [this release note](https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1040129347-august-5).

And according to [this website](https://docs.microsoft.com/pt-br/deployedge/microsoft-edge-release-schedule), the release date of Edge 106 is 29/09/22.

:)