### PR TITLE
API: Mark `Attr.specified` deprecated

### DIFF
--- a/api/Attr.json
+++ b/api/Attr.json
@@ -275,7 +275,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
### Summary
The `Attr.specified` has been marked deprecated on MDN Web Docs. And W3 specs calls it "useless".

### Supporting details
- https://developer.mozilla.org/en-US/docs/Web/API/Attr/specified
- https://dom.spec.whatwg.org/#interface-attr
