### PR TITLE
FF104 HTMLElement.focus() param focusVisible

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1197,6 +1197,39 @@
             "deprecated": false
           }
         },
+        "options_focusVisible_parameter": {
+          "__compat": {
+            "description": "<code>options.focusVisible</code> parameter",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "104"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "options_preventScroll_parameter": {
           "__compat": {
             "description": "<code>options.preventScroll</code> parameter",


### PR DESCRIPTION
FF104 adds support for [`HTMLElement.focus()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#parameters) param `focusVisible` in https://bugzilla.mozilla.org/show_bug.cgi?id=1765083. 

This is not supported in chromium or webkit yet, though there are bugs https://bugs.chromium.org/p/chromium/issues/detail?id=1317039 and https://bugs.webkit.org/show_bug.cgi?id=242456

Related docs work can be tracked in https://github.com/mdn/content/issues/19302
