### PR TITLE
Replace backslashes with forward slashes for filepaths on Windows

### DIFF
--- a/test/lint.ts
+++ b/test/lint.ts
@@ -54,9 +54,9 @@ const loadAndCheckFiles = async (...files: string[]): Promise<DataType> => {
         full: path.relative(process.cwd(), file),
         category: '',
       };
-      if (path.sep !== '/') {
+      if (path.sep === '\\') {
         // Normalize file paths for Windows users
-        filePath.full = filePath.full.replace(path.sep, '/');
+        filePath.full = filePath.full.replace(/\\/g, '/');
       }
       if (filePath.full.includes('/')) {
         filePath.category = filePath.full.split('/')[0];

--- a/test/lint.ts
+++ b/test/lint.ts
@@ -54,8 +54,12 @@ const loadAndCheckFiles = async (...files: string[]): Promise<DataType> => {
         full: path.relative(process.cwd(), file),
         category: '',
       };
-      if (filePath.full.includes(path.sep)) {
-        filePath.category = filePath.full.split(path.sep)[0];
+      if (path.sep !== '/') {
+        // Normalize file paths for Windows users
+        filePath.full = filePath.full.replace(path.sep, '/');
+      }
+      if (filePath.full.includes('/')) {
+        filePath.category = filePath.full.split('/')[0];
       }
 
       try {

--- a/test/linter/test-filename.ts
+++ b/test/linter/test-filename.ts
@@ -55,7 +55,7 @@ const processData = (
     .replace('html/elements/input/', 'html/elements/input/type_')
     .replace('javascript/builtins/globals', 'javascript/builtins');
 
-  const failed = testFeaturePresence(data, p.split(path.sep), '');
+  const failed = testFeaturePresence(data, p.split('/'), '');
   if (failed) {
     logger.error(failed);
   }


### PR DESCRIPTION
This should fix the issue reported by @hamishwillee in https://github.com/mdn/browser-compat-data/pull/17278#issuecomment-1208799737.
