### PR TITLE
api.Document: deprecate domain, queryCommandIndeterm, queryCommandValue

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -2602,7 +2602,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -5636,7 +5636,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -5800,7 +5800,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
All these features have been marked deprecated on [Document page](https://developer.mozilla.org/en-US/docs/Web/API/Document) on MDN Web Docs already.

### Supporting details
**domain** - https://html.spec.whatwg.org/multipage/origin.html#relaxing-the-same-origin-restriction

**queryCommandIndeterm** and **queryCommandValue** - refer https://github.com/mdn/browser-compat-data/pull/5518