### PR TITLE
Mark `api.Event.cancelBubble` deprecated

### DIFF
--- a/api/Event.json
+++ b/api/Event.json
@@ -256,7 +256,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
#### Summary
It's a no-op setting now and has been marked deprecated already on Web Docs.

#### Supporting details
- https://developer.mozilla.org/en-US/docs/Web/API/Event/cancelBubble  (refer https://github.com/mdn/content/pull/9917)
- https://chromestatus.com/feature/6091485216768000
- https://bugzilla.mozilla.org/show_bug.cgi?id=1324380