### PR TITLE
Mark dtx, ptime, and codecPayloadType deprecated

### DIFF
--- a/api/RTCRtpEncodingParameters.json
+++ b/api/RTCRtpEncodingParameters.json
@@ -99,7 +99,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -132,7 +132,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -307,7 +307,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
#### Summary
These features were at risk and finally got removed from the specs.

#### Supporting details
- https://github.com/w3c/webrtc-pc/pull/2351