### PR TITLE
Copy notes for api.Window.requestAnimationFrame from MDN

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -4089,7 +4089,8 @@
             ],
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": "Before version 17, Edge does not reliably fire <code>requestAnimationFrame</code> before the paint cycle."
             },
             "firefox": [
               {
@@ -4120,7 +4121,8 @@
               }
             ],
             "ie": {
-              "version_added": "10"
+              "version_added": "10",
+              "notes": "Internet Explorer does not reliably fire <code>requestAnimationFrame</code> before the paint cycle."
             },
             "oculus": "mirror",
             "opera": "mirror",


### PR DESCRIPTION
This PR fixes #17295 by copying the notes from the MDN page.
