### PR TITLE
Add Chromium versions for javascript.builtins.String.raw

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1508,20 +1508,14 @@
                 "version_added": "4.0.0"
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "9"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": false
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `raw` member of the `String` JavaScript builtin.  This fixes #17308 by mirroring the data.
