### PR TITLE
Add Firefox versions for overflow-clip-margin CSS property

### DIFF
--- a/css/properties/overflow-clip-margin.json
+++ b/css/properties/overflow-clip-margin.json
@@ -12,8 +12,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1661582'>bug 1661582</a>."
+              "version_added": "102",
+              "impl_url": "https://bugzil.la/1769512"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -30,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `overflow-clip-margin` CSS property, based upon information in a tracking bug.  The data was then confirmed using the mdn-bcd-collector project (v6.1.1).

Tracking Bug: https://bugzil.la/1769512

This fixes #17306.
