### PR TITLE
Add Opera versions for css.types.color.hwb

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -499,9 +499,7 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": "15"


### PR DESCRIPTION
This PR adds real values for Opera and Opera Android for the `hwb` member of the `color` CSS type.  This fixes #17298.
