### PR TITLE
Add NodeJS versions for Performance API

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -139,7 +139,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": false
+              "version_added": "16.7.0"
             },
             "oculus": "mirror",
             "opera": {
@@ -280,7 +280,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": false
+              "version_added": "16.7.0"
             },
             "oculus": "mirror",
             "opera": {
@@ -335,7 +335,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": false
+              "version_added": "16.7.0"
             },
             "oculus": "mirror",
             "opera": {
@@ -390,7 +390,7 @@
               "version_added": "10"
             },
             "nodejs": {
-              "version_added": false
+              "version_added": "16.7.0"
             },
             "oculus": "mirror",
             "opera": "mirror",


### PR DESCRIPTION
This PR adds real values for NodeJS for the `Performance` API.  This fixes #17294, which contains links to the documentation indicating the verison number.
