### PR TITLE
Add css.types.image.paint.additional_parameters subfeature

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1499,6 +1499,41 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "additional_paramters": {
+            "__compat": {
+              "description": "Supports additional parameters to pass to the <code>paintWorklet</code>",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
This PR adds an `additional_paramters` subfeature to `css.types.image.paint` to represent support (or lacking) for additional parameters passed to the `paint()` function.  Fixes #17138.
