### PR TITLE
Mark Firefox Android as partial implementation

### DIFF
--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -20,6 +20,7 @@
               },
               "firefox_android": {
                 "version_added": "27",
+                "partial_implementation": true,
                 "notes": "Firefox for Android doesn't allow the user to choose a custom color, only one of the predefined ones."
               },
               "ie": {


### PR DESCRIPTION
This PR sets `html.elements.input.type_color` to `partial_implementation` for Firefox Android, since the lack of user-selectable colors is a big enough issue to cause compatibility conflicts.  Fixes #17125.
