### PR TITLE
Split page and avoid-page; correct Firefox data

### DIFF
--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -402,9 +402,45 @@
               }
             }
           },
+          "avoid-page": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "50"
+                },
+                "chrome_android": "mirror",
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": "10"
+                },
+                "oculus": "mirror",
+                "opera": {
+                  "version_added": "11.1",
+                  "version_removed": "12.1"
+                },
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "10"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "page": {
             "__compat": {
-              "description": "<code>page</code> and <code>avoid-page</code>",
               "support": {
                 "chrome": {
                   "version_added": "50"


### PR DESCRIPTION
This PR separates the subfeatures for `page` and `avoid-page`, and then corrects the Firefox data.  Fixes #17031.
