### PR TITLE
Update Chromium versions for javascript.builtins.Intl.supportedValuesOf

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -96,7 +96,7 @@
             "spec_url": "https://tc39.es/proposal-intl-enumeration/#sec-intl.supportedvaluesof",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "99"
               },
               "chrome_android": "mirror",
               "deno": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `supportedValuesOf` member of the `Intl` JavaScript builtin, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/javascript/builtins/Intl/supportedValuesOf

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
