### PR TITLE
Add Edge versions for Function JavaScript builtin

### DIFF
--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -598,11 +598,17 @@
                 "deno": {
                   "version_added": "1.0"
                 },
-                "edge": {
-                  "version_added": "14",
-                  "partial_implementation": true,
-                  "notes": "Names for functions defined in a dictionary are properly assigned; however, anonymous functions defined on a var/let variable assignment have blank names."
-                },
+                "edge": [
+                  {
+                    "version_added": "79"
+                  },
+                  {
+                    "version_added": "14",
+                    "version_removed": "79",
+                    "partial_implementation": true,
+                    "notes": "Names for functions defined in a dictionary are properly assigned; however, anonymous functions defined on a var/let variable assignment have blank names."
+                  }
+                ],
                 "firefox": {
                   "version_added": "53"
                 },


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `Function` JavaScript builtin.  This fixes #16899.
