### PR TITLE
Mark navigator 'platform' and 'vendor' deprecated

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2174,7 +2174,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -4462,7 +4462,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
### Summary
They are non-normative.They've been marked deprecated on MDN Web Docs in ~2016. Also, they are non-normative.
Browser implementers have been advised not to provide much info out of them:
>  Any information in this API that varies from user to user can be used to profile the user. In fact, if enough such information is available, a user can actually be uniquely identified. For this reason, user agent implementers are _**strongly urged to include as little information in this API as possible**_.

### Supporting details
#### Vendor
- https://developer.mozilla.org/en-US/docs/Web/API/Navigator#navigator.vendor
- https://github.com/mdn/content/pull/12526
- https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-vendor-dev

#### Platform
- https://developer.mozilla.org/en-US/docs/Web/API/Navigator#navigator.platform
- https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-platform-dev
