### PR TITLE
Mark 'rtcpTransport' deprecated

### DIFF
--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -420,7 +420,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -276,7 +276,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
### Summary
This property has been removed; the RTP and RTCP transports have been combined into a single `transport`.

### Supporting details
- https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender#obsolete_properties
- https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpReceiver#obsolete_properties

The latest spec doesn't have it
- https://w3c.github.io/webrtc-pc/#webidl-436594269
- https://w3c.github.io/webrtc-pc/#webidl-486223994