### PR TITLE
Mark 'degradationPreference' and 'priority' deprecated

### DIFF
--- a/api/RTCRtpSendParameters.json
+++ b/api/RTCRtpSendParameters.json
@@ -65,7 +65,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -135,7 +135,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
### Summary
They've been deprecated and are not in latest specs

### Supporting details
- https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSendParameters#obsolete_properties
- https://w3c.github.io/webrtc-pc/#webidl-1435279004