### PR TITLE
Mark 'scriptsizemultiplier' and 'scriptminsize' deprecated

### DIFF
--- a/mathml/elements/mstyle.json
+++ b/mathml/elements/mstyle.json
@@ -165,7 +165,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },
@@ -198,7 +198,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         }


### PR DESCRIPTION
They've been deprecated.

### Supporting details
- https://developer.mozilla.org/en-US/docs/Web/MathML/Element/mstyle#attributes
- https://github.com/w3c/mathml/issues/1#issuecomment-487751891