### PR TITLE
FF103 supports the CSS contain:style option

### DIFF
--- a/css/properties/contain.json
+++ b/css/properties/contain.json
@@ -11,10 +11,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "69",
-              "notes": "Firefox does not support the <code>style</code> value."
-            },
+            "firefox": [
+              {
+                "version_added": "103"
+              },
+              {
+                "version_added": "69",
+                "partial_implementation": true,
+                "notes": "Firefox does not support the <code>style</code> value."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
FF103 adds support for the contain: style property in https://bugzilla.mozilla.org/show_bug.cgi?id=1463600.

Other docs work for this can be tracked in https://github.com/mdn/content/issues/19452

@queengooborg I updated this to make the previous support marked as "partial implementation" and add full support in 103. Seems to make more sense than having a subfeature just for the style option.