### PR TITLE
Adds missing MDN page links to SVGStyleElement properties

### DIFF
--- a/api/SVGStyleElement.json
+++ b/api/SVGStyleElement.json
@@ -79,6 +79,7 @@
       },
       "media": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStyleElement/media",
           "spec_url": "https://svgwg.org/svg2-draft/styling.html#__svg__SVGStyleElement__media",
           "support": {
             "chrome": {
@@ -166,6 +167,7 @@
       },
       "title": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStyleElement/title",
           "spec_url": "https://svgwg.org/svg2-draft/styling.html#__svg__SVGStyleElement__title",
           "support": {
             "chrome": {


### PR DESCRIPTION
SVGStyleElement docs now updated. This adds links to the topics from BCD.

Part of https://github.com/mdn/content/issues/18775

FYI @queengooborg 