### PR TITLE
Support fetch init.signal in Node.js

### DIFF
--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -197,6 +197,29 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": [
+              {
+                "version_added": "18.0.0"
+              },
+              {
+                "version_added": "17.5.0",
+                "flags": [
+                  {
+                    "name": "--experimental-fetch",
+                    "type": "runtime_flag"
+                  }
+                ]
+              },
+              {
+                "version_added": "16.15.0",
+                "flags": [
+                  {
+                    "name": "--experimental-fetch",
+                    "type": "runtime_flag"
+                  }
+                ]
+              }
+            ],
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -203,6 +203,7 @@
               },
               {
                 "version_added": "17.5.0",
+                "version_removed": "18.0.0",
                 "flags": [
                   {
                     "name": "--experimental-fetch",
@@ -212,6 +213,7 @@
               },
               {
                 "version_added": "16.15.0",
+                "version_removed": "17.0.0",
                 "flags": [
                   {
                     "name": "--experimental-fetch",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
The simplest `index.js` file to test this
```javascript
const controller = new AbortController();
const signal = controller.signal;

fetch('https://www.jetbrains.com/updates/updates.xml', {signal});
controller.abort();
```

In Node.js v18

```bash
nvm install 18.0.0
node index.js
```

> (node:28890) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
> (Use `node --trace-warnings ...` to show where the warning was created)
> 
> node:internal/per_context/domexception:53
>     ErrorCaptureStackTrace(this);
>     ^
> DOMException [AbortError]: The operation was aborted.
>     at new DOMException (node:internal/per_context/domexception:53:5)
>     at abortFetch (node:internal/deps/undici/undici:6328:21)
>     at requestObject.signal.addEventListener.once (node:internal/deps/undici/undici:6262:9)
>     at [nodejs.internal.kHybridDispatch] (node:internal/event_target:689:20)
>     at AbortSignal.dispatchEvent (node:internal/event_target:631:26)
>     at abortSignal (node:internal/abort_controller:292:10)
>     at AbortController.abort (node:internal/abort_controller:322:5)
>     at AbortSignal.abort (node:internal/deps/undici/undici:5591:36)
>     at [nodejs.internal.kHybridDispatch] (node:internal/event_target:689:20)
>     at AbortSignal.dispatchEvent (node:internal/event_target:631:26)

In Node.js v16.15

```bash
nvm install 16.15.0
node --experimental-fetch index.js
```

> (node:29943) ExperimentalWarning: Fetch is an experimental feature. This feature could change at any time
> (Use `node --trace-warnings ...` to show where the warning was created)
> node:internal/deps/undici/undici:7236
>       const error = new AbortError();
>                     ^
> 
> AbortError: The operation was aborted
>     at abortFetch (node:internal/deps/undici/undici:7236:21)
>     at AbortSignal.requestObject.signal.addEventListener.once (node:internal/deps/undici/undici:7173:9)
>     at AbortSignal.[nodejs.internal.kHybridDispatch] (node:internal/event_target:643:20)
>     at AbortSignal.dispatchEvent (node:internal/event_target:585:26)
>     at abortSignal (node:internal/abort_controller:284:10)
>     at AbortController.abort (node:internal/abort_controller:315:5)
>     at AbortSignal.abort (node:internal/deps/undici/undici:6602:36)
>     at AbortSignal.[nodejs.internal.kHybridDispatch] (node:internal/event_target:643:20)
>     at AbortSignal.dispatchEvent (node:internal/event_target:585:26)
>     at abortSignal (node:internal/abort_controller:284:10) {
>   code: 'ABORT_ERR'
> }

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://nodejs.org/en/blog/release/v16.15.0/

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
