### PR TITLE
Mark 'subscriptshift' and 'supscriptshift' deprecated

### DIFF
--- a/mathml/elements/msub.json
+++ b/mathml/elements/msub.json
@@ -72,7 +72,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         }

--- a/mathml/elements/msubsup.json
+++ b/mathml/elements/msubsup.json
@@ -72,7 +72,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },
@@ -104,7 +104,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         }

--- a/mathml/elements/msup.json
+++ b/mathml/elements/msup.json
@@ -72,7 +72,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         }


### PR DESCRIPTION
#### Summary
These features have been marked deprecated on MDN Web Docs already.

#### Supporting details
- https://developer.mozilla.org/en-US/docs/Web/MathML/Element/msubsup#attributes
- https://github.com/w3c/mathml/issues/27#issuecomment-679382734