### PR TITLE
Mark 'initStorageEvent' deprecated

### DIFF
--- a/api/StorageEvent.json
+++ b/api/StorageEvent.json
@@ -128,7 +128,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
### Summary
All init*() methods are deprecated in favor of the constructor if there is one.

### Supporting details
- https://github.com/mdn/content/pull/19493#issuecomment-1213906012