### PR TITLE
CSS: mark 'overflow: overlay' deprecated

### DIFF
--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -154,7 +154,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         }


### PR DESCRIPTION
### Summary
An alternate has been defined for it: [scrollbar-gutter](https://drafts.csswg.org/css-overflow/#scrollbar-gutter-property)

### Supporting details
- https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#overlay
- https://github.com/w3c/csswg-drafts/issues/6090#issuecomment-800455577
- https://bugs.webkit.org/show_bug.cgi?id=32388#c10