### PR TITLE
CSS: mark 'word-break: break-word' deprecated

### DIFF
--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -77,7 +77,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
### Supporting details
- https://github.com/validator/validator/issues/763#issuecomment-508637434
- https://developer.mozilla.org/en-US/docs/Web/CSS/word-break#sect2