### PR TITLE
Mark 'moz-opaque' deprecated

### DIFF
--- a/html/elements/canvas.json
+++ b/html/elements/canvas.json
@@ -126,7 +126,7 @@
             "status": {
               "experimental": false,
               "standard_track": false,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
### Summary

In API it's been marked deprecated. We need to mark it deprecated in HTML as well.

### Supporting details
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/mozOpaque
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas#attr-moz-opaque
