### PR TITLE
FF103 CSS :has() selector

### DIFF
--- a/css/selectors/has.json
+++ b/css/selectors/has.json
@@ -21,7 +21,7 @@
                   "value_to_set": "true"
                 }
               ],
-              "notes": "See <a href='https://bugzil.la/418039'>bug 418039</a>."
+              "impl_url": "https://bugzil.la/418039"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/has.json
+++ b/css/selectors/has.json
@@ -13,7 +13,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "103",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.has-selector.enabled",
+                  "value_to_set": "true"
+                }
+              ],
               "notes": "See <a href='https://bugzil.la/418039'>bug 418039</a>."
             },
             "firefox_android": "mirror",


### PR DESCRIPTION
FF103 adds support for [`:has()`](https://developer.mozilla.org/en-US/docs/Web/CSS/:has) behind a preference in https://bugzilla.mozilla.org/show_bug.cgi?id=1771896. This adds the BCD entry. 

Other docs work associated with this can be tracked in https://github.com/mdn/content/issues/19572

FYI @queengooborg 