### PR TITLE
Update Firefox versions for api.Document.scroll_event

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -6434,7 +6434,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "6"
+              "version_added": "9"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `scroll_event` member of the `Document` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Document/scroll_event

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
