### PR TITLE
FF104 removes IDBFactory.open() options object

### DIFF
--- a/api/IDBFactory.json
+++ b/api/IDBFactory.json
@@ -246,6 +246,40 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "options_parameter": {
+          "__compat": {
+            "description": "<code>options</code> parameter for setting temporary/persistent storage.",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "26",
+                "version_removed": "104"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
         }
       }
     }

--- a/api/IDBFactory.json
+++ b/api/IDBFactory.json
@@ -275,7 +275,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
               "deprecated": true
             }


### PR DESCRIPTION
FF104 removes the proprietary `options` option to [IDBFactory.open()](https://developer.mozilla.org/en-US/docs/Web/API/IDBFactory/open) in https://bugzilla.mozilla.org/show_bug.cgi?id=1354500.

The options object wasn't in BCD, so I added it, pulling the info from the page above in the comment at https://developer.mozilla.org/en-US/docs/Web/API/IDBFactory/open#experimental_gecko_options_object
Next step will be to remove the docs.

Other docs work for this can be tracked in https://github.com/mdn/content/issues/19575

@queengooborg Note, w.r.t. "what do you document/subfeatures" my presumption is that for parameter options objects it is different than say functions - i.e. I am not expected to document the `name` and `version` parameters. . This is one reason to discuss which things need a BCD node and which do not.