### PR TITLE
Update Firefox versions for api.Event.composedPath

### DIFF
--- a/api/Event.json
+++ b/api/Event.json
@@ -322,7 +322,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "52"
+              "version_added": "59"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `composedPath` member of the `Event` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Event/composedPath

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
