### PR TITLE
Update Firefox versions for api.EventSource.EventSource

### DIFF
--- a/api/EventSource.json
+++ b/api/EventSource.json
@@ -59,7 +59,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "6"
+              "version_added": "20"
             },
             "firefox_android": {
               "version_added": "45"

--- a/api/EventSource.json
+++ b/api/EventSource.json
@@ -102,7 +102,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "11"
+                "version_added": "20"
               },
               "firefox_android": {
                 "version_added": "45"


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `EventSource` member of the `EventSource` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/EventSource/EventSource

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
