### PR TITLE
Update Chromium/Safari versions for api.EventSource.url

### DIFF
--- a/api/EventSource.json
+++ b/api/EventSource.json
@@ -445,11 +445,9 @@
               "version_added": "12"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "6"
             },
-            "safari_ios": {
-              "version_added": "5"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/EventSource.json
+++ b/api/EventSource.json
@@ -421,7 +421,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/server-sent-events.html#dom-eventsource-url-dev",
           "support": {
             "chrome": {
-              "version_added": "6"
+              "version_added": "18"
             },
             "chrome_android": "mirror",
             "deno": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `url` member of the `EventSource` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/EventSource/url

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
