### PR TITLE
Update Chrome/Safari versions for api.EventSource.withCredentials

### DIFF
--- a/api/EventSource.json
+++ b/api/EventSource.json
@@ -490,11 +490,9 @@
               "version_added": "12"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": "5"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/EventSource.json
+++ b/api/EventSource.json
@@ -474,7 +474,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "11"
+              "version_added": "6"
             },
             "firefox_android": {
               "version_added": "45"

--- a/api/EventSource.json
+++ b/api/EventSource.json
@@ -466,7 +466,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/server-sent-events.html#dom-eventsource-withcredentials-dev",
           "support": {
             "chrome": {
-              "version_added": "6"
+              "version_added": "26"
             },
             "chrome_android": "mirror",
             "deno": {
@@ -474,7 +474,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "6"
+              "version_added": "11"
             },
             "firefox_android": {
               "version_added": "45"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `withCredentials` member of the `EventSource` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/EventSource/withCredentials

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
