### PR TITLE
Add NodeJS v16.14.0

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -349,6 +349,13 @@
           "engine": "V8",
           "engine_version": "9.4"
         },
+        "16.14.0": {
+          "release_date": "2022-02-08",
+          "release_notes": "https://nodejs.org/en/blog/release/v16.14.0/",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "9.4"
+        },
         "16.15.0": {
           "release_date": "2022-04-27",
           "release_notes": "https://nodejs.org/en/blog/release/v16.15.0/",


### PR DESCRIPTION
This PR adds NodeJS v16.14.0 to the browser data.
