### PR TITLE
Update Chromium versions for api.HTMLAreaElement.origin

### DIFF
--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -369,10 +369,10 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "5.1"
+              "version_added": "6"
             },
             "safari_ios": {
-              "version_added": "5"
+              "version_added": "6"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -369,10 +369,10 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "6"
+              "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "6"
+              "version_added": "10.3"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -351,7 +351,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/links.html#dom-hyperlink-origin-dev",
           "support": {
             "chrome": {
-              "version_added": "8"
+              "version_added": "32"
             },
             "chrome_android": "mirror",
             "edge": {

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -369,11 +369,9 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10"
             },
-            "safari_ios": {
-              "version_added": "10.3"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `origin` member of the `HTMLAreaElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLAreaElement/origin

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
