### PR TITLE
Add Samsung Internet 18.0

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -219,9 +219,15 @@
         },
         "17.0": {
           "release_date": "2022-05-04",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "96"
+        },
+        "18.0": {
+          "release_date": "2022-08-08",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "99"
         }
       }
     }


### PR DESCRIPTION
This PR adds Samsung Internet 18.0 to BCD.
