### PR TITLE
Update Firefox versions for api.HTMLElement.input_event

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1434,7 +1434,7 @@
               }
             ],
             "firefox": {
-              "version_added": "6"
+              "version_added": "9"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `input_event` member of the `HTMLElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLElement/input_event

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
