### PR TITLE
Update Firefox versions for api.HTMLFieldSetElement.disabled

### DIFF
--- a/api/HTMLFieldSetElement.json
+++ b/api/HTMLFieldSetElement.json
@@ -97,7 +97,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "4"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `disabled` member of the `HTMLFieldSetElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLFieldSetElement/disabled

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
