### PR TITLE
Update Chromium versions for api.HTMLScriptElement.crossOrigin

### DIFF
--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -128,7 +128,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#dom-script-crossorigin",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "19"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `crossOrigin` member of the `HTMLScriptElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLScriptElement/crossOrigin

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
