### PR TITLE
Update Chromium versions for api.HTMLSourceElement.sizes

### DIFF
--- a/api/HTMLSourceElement.json
+++ b/api/HTMLSourceElement.json
@@ -122,7 +122,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content.html#dom-source-sizes",
           "support": {
             "chrome": {
-              "version_added": "36"
+              "version_added": "38"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `sizes` member of the `HTMLSourceElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/HTMLSourceElement/sizes

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
