### PR TITLE
Update Chrome/Safari versions for MessageEvent API

### DIFF
--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -54,7 +54,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/comms.html#the-messageevent-interface:dom-event-constructor",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "16"
             },
             "chrome_android": "mirror",
             "deno": {

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -81,7 +81,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "4"
+              "version_added": "6"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `MessageEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MessageEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
