### PR TITLE
Update Chromium versions for api.MutationObserver.takeRecords

### DIFF
--- a/api/MutationObserver.json
+++ b/api/MutationObserver.json
@@ -209,7 +209,7 @@
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-mutationobserver-takerecords①",
           "support": {
             "chrome": {
-              "version_added": "18"
+              "version_added": "20"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `takeRecords` member of the `MutationObserver` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MutationObserver/takeRecords

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
