### PR TITLE
Update Firefox versions for api.Path2D.ellipse

### DIFF
--- a/api/Path2D.json
+++ b/api/Path2D.json
@@ -259,7 +259,7 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": "31"
+              "version_added": "48"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `ellipse` member of the `Path2D` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Path2D/ellipse

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
