### PR TITLE
Fix release script when getting contributors

### DIFF
--- a/scripts/release/stats.ts
+++ b/scripts/release/stats.ts
@@ -41,22 +41,7 @@ const stargazers = async (): Promise<number> => {
  *
  * @returns {number} The number of contributors that have contributed to the repository
  */
-const contributors = async (): Promise<number> => {
-  let count = 0;
-  let page = 1;
-
-  while (page > 0) {
-    // GitHub doesn't just expose the count on its own so we have to query further
-    const json = githubAPI(`/contributors?per_page=100&page=${page}`);
-    if (json.length === 0) {
-      break;
-    }
-    count += json.length;
-    page++;
-  }
-
-  return count;
-};
+const contributors = (): number => githubAPI(`/contributors --paginate`).length;
 
 /**
  * Get all of the stats for the release
@@ -162,7 +147,7 @@ export const getStats = async (
   end,
   ...stats(start),
   releaseContributors: getReleaseContributors(startDate).size,
-  totalContributors: await contributors(),
+  totalContributors: contributors(),
   stars: await stargazers(),
   features: countFeatures(),
 });


### PR DESCRIPTION
This PR fixes the release script when getting contributors.  It turns out that the GitHub CLI features the `--paginate` command, which automatically performs recursive page loading for us.
