### PR TITLE
Mark features supported behind incompatible prefix 'experimental'

### DIFF
--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -71,7 +71,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -152,7 +152,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": false,
               "deprecated": false
             }


### PR DESCRIPTION
### Summary
As per the [guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#choosing-an-experimental-status) these features are experimental.
> If a feature is supported behind incompatible prefixes only (such as -webkit- in one engine and -moz- in another), no matter how many engines support the feature overall, then set experimental to true. If two or more engines support a feature behind a common prefix (such as -webkit- only), then set experimental to false.
