### PR TITLE
feat(css): Update Firefox support for CSS trig functions: `sin()`, `cos()`, `tan()`

### DIFF
--- a/css/types/cos.json
+++ b/css/types/cos.json
@@ -13,7 +13,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "103",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.trig.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/sin.json
+++ b/css/types/sin.json
@@ -13,7 +13,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "103",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.trig.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/tan.json
+++ b/css/types/tan.json
@@ -13,7 +13,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "103",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.trig.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Firefox 103 add support for CSS trig functions behind `layout.css.trig.enabled` flag.

#### Test results and supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Source: https://bugzilla.mozilla.org/show_bug.cgi?id=1774589#c1

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

To make sure, I tested `cos()` function in codepen using Firefox 103.0.2 (64-bit), with the flag enabled.