### PR TITLE
Mark file system sync APIs 'deprecated'

### DIFF
--- a/api/DirectoryEntrySync.json
+++ b/api/DirectoryEntrySync.json
@@ -37,7 +37,7 @@
         "status": {
           "experimental": false,
           "standard_track": false,
-          "deprecated": false
+          "deprecated": true
         }
       }
     }

--- a/api/DirectoryReaderSync.json
+++ b/api/DirectoryReaderSync.json
@@ -37,7 +37,7 @@
         "status": {
           "experimental": false,
           "standard_track": false,
-          "deprecated": false
+          "deprecated": true
         }
       }
     }

--- a/api/EntrySync.json
+++ b/api/EntrySync.json
@@ -37,7 +37,7 @@
         "status": {
           "experimental": false,
           "standard_track": false,
-          "deprecated": false
+          "deprecated": true
         }
       }
     }

--- a/api/FileEntrySync.json
+++ b/api/FileEntrySync.json
@@ -37,7 +37,7 @@
         "status": {
           "experimental": false,
           "standard_track": false,
-          "deprecated": false
+          "deprecated": true
         }
       }
     }

--- a/api/FileSystemSync.json
+++ b/api/FileSystemSync.json
@@ -31,7 +31,7 @@
         "status": {
           "experimental": false,
           "standard_track": false,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "name": {
@@ -64,7 +64,7 @@
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -98,7 +98,7 @@
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
### Summary
All these features have following warning on mdn/content pages:
> Warning: This interface is deprecated and is no more on the standard track. Do not use it anymore. Use the [File and Directory Entries API](https://developer.mozilla.org/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.

For example https://developer.mozilla.org/en-US/docs/Web/API/DirectoryEntrySync#sect2

### Supporting details
- https://bugs.chromium.org/p/chromium/issues/detail?id=695508#c22
- https://github.com/mdn/content/pull/15815