### PR TITLE
Correct many missing entries for iOS Safari Web Extensions

### DIFF
--- a/webextensions/api/action.json
+++ b/webextensions/api/action.json
@@ -16,7 +16,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": "mirror"
             }
@@ -36,7 +36,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": "mirror"
             }
@@ -56,7 +56,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": "mirror"
             }
@@ -76,7 +76,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": "mirror"
             }
@@ -96,7 +96,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": "mirror"
             }
@@ -116,7 +116,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": "mirror"
             }
@@ -156,7 +156,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": "mirror"
             }
@@ -176,7 +176,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": "mirror"
             }
@@ -216,7 +216,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": "mirror"
             }
@@ -243,7 +243,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16"
               },
               "safari_ios": "mirror"
             }
@@ -272,7 +272,7 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": "mirror"
             }
@@ -301,7 +301,7 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": "mirror"
             }
@@ -357,7 +357,7 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": "mirror"
             }
@@ -393,7 +393,7 @@
               ],
               "opera": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": "mirror"
             }
@@ -429,7 +429,7 @@
               ],
               "opera": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -463,7 +463,7 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16"
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/api/commands.json
+++ b/webextensions/api/commands.json
@@ -45,6 +45,9 @@
                 "opera": "mirror",
                 "safari": {
                   "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }
@@ -62,8 +65,9 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": null
-                }
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
               }
             }
           }
@@ -138,7 +142,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -159,7 +164,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           },
           "details": {
@@ -179,7 +185,8 @@
                   "opera": "mirror",
                   "safari": {
                     "version_added": false
-                  }
+                  },
+                  "safari_ios": "mirror"
                 }
               }
             },
@@ -199,7 +206,8 @@
                   "opera": "mirror",
                   "safari": {
                     "version_added": false
-                  }
+                  },
+                  "safari_ios": "mirror"
                 }
               }
             },
@@ -220,7 +228,8 @@
                   "opera": "mirror",
                   "safari": {
                     "version_added": false
-                  }
+                  },
+                  "safari_ios": "mirror"
                 }
               }
             }

--- a/webextensions/api/devtools.json
+++ b/webextensions/api/devtools.json
@@ -21,9 +21,11 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "16"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": false
+                }
               }
             },
             "inspect": {
@@ -43,9 +45,11 @@
                   },
                   "opera": "mirror",
                   "safari": {
-                    "version_added": false
+                    "version_added": "16"
                   },
-                  "safari_ios": "mirror"
+                  "safari_ios": {
+                    "version_added": false
+                  }
                 }
               }
             },
@@ -64,9 +68,11 @@
                   "firefox_android": "mirror",
                   "opera": "mirror",
                   "safari": {
-                    "version_added": false
+                    "version_added": "16"
                   },
-                  "safari_ios": "mirror"
+                  "safari_ios": {
+                    "version_added": false
+                  }
                 }
               }
             },
@@ -87,9 +93,11 @@
                   },
                   "opera": "mirror",
                   "safari": {
-                    "version_added": false
+                    "version_added": "16"
                   },
-                  "safari_ios": "mirror"
+                  "safari_ios": {
+                    "version_added": false
+                  }
                 }
               }
             }
@@ -112,9 +120,11 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "16"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": false
+                }
               }
             }
           },
@@ -136,9 +146,11 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "16"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": false
+                }
               }
             }
           }
@@ -187,9 +199,11 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "16"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": false
+                }
               }
             }
           },
@@ -294,9 +308,11 @@
                   },
                   "opera": "mirror",
                   "safari": {
-                    "version_added": false
+                    "version_added": "16"
                   },
-                  "safari_ios": "mirror"
+                  "safari_ios": {
+                    "version_added": false
+                  }
                 }
               }
             },
@@ -338,9 +354,11 @@
                   },
                   "opera": "mirror",
                   "safari": {
-                    "version_added": false
+                    "version_added": "16"
                   },
-                  "safari_ios": "mirror"
+                  "safari_ios": {
+                    "version_added": false
+                  }
                 }
               }
             }
@@ -473,9 +491,11 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "16"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": false
+                }
               }
             }
           },
@@ -497,9 +517,11 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "16"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": false
+                }
               }
             }
           },
@@ -519,9 +541,11 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "16"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": false
+                }
               }
             }
           },
@@ -543,9 +567,11 @@
                   "version_added": "41"
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "16"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": false
+                }
               }
             }
           }

--- a/webextensions/api/omnibox.json
+++ b/webextensions/api/omnibox.json
@@ -21,7 +21,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -45,7 +46,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -68,7 +70,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -91,7 +94,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -114,7 +118,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -137,7 +142,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -161,7 +167,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         }

--- a/webextensions/api/pageAction.json
+++ b/webextensions/api/pageAction.json
@@ -77,7 +77,7 @@
               },
               "safari_ios": {
                 "version_added": "15",
-                "notes": "The title is not displayed on iOS."
+                "notes": "The API exists, but the title not visible in the UI."
               }
             }
           }
@@ -217,7 +217,7 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16"
               },
               "safari_ios": "mirror"
             }
@@ -372,7 +372,7 @@
               },
               "safari_ios": {
                 "version_added": "15",
-                "notes": "The title is not displayed on iOS."
+                "notes": "The API exists, but the title not visible in the UI."
               }
             }
           },
@@ -395,8 +395,7 @@
                   "version_added": "14"
                 },
                 "safari_ios": {
-                  "version_added": "15",
-                  "notes": "The title is not displayed on iOS."
+                  "version_added": "15"
                 }
               }
             }

--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -32,7 +32,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -868,11 +868,11 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "notes": "Only fired in response to a message from an extension's containing app.",
+                "notes": "In Safari 14, this event is fired in response to a message from an extension's containing app. In Safari 15.4 and later, this event is also fired in response to a message from webpages.",
                 "version_added": "14"
               },
               "safari_ios": {
-                "notes": "Only fired in response to a message from an extension's containing app.",
+                "notes": "In Safari 15, this event is fired in response to a message from an extension's containing app. In Safari 15.4 and later, this event is also fired in response to a message from webpages.",
                 "version_added": "15"
               }
             }

--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -130,9 +130,11 @@
                   "version_added": true
                 },
                 "safari": {
-                  "version_added": true
+                  "version_added": "14"
                 },
-                "safari_ios": "mirror"
+                "safari_ios": {
+                  "version_added": "15"
+                }
               }
             }
           },
@@ -318,7 +320,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/api/theme.json
+++ b/webextensions/api/theme.json
@@ -19,7 +19,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -40,7 +41,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -61,7 +63,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -82,7 +85,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           },
           "windowId": {
@@ -101,7 +105,8 @@
                 "opera": "mirror",
                 "safari": {
                   "version_added": false
-                }
+                },
+                "safari_ios": "mirror"
               }
             }
           }
@@ -123,7 +128,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           },
           "windowId": {
@@ -142,7 +148,8 @@
                 "opera": "mirror",
                 "safari": {
                   "version_added": false
-                }
+                },
+                "safari_ios": "mirror"
               }
             }
           }

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -919,7 +919,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "notes": "extraInfoSpec options are not supported.",
+                "notes": "<code>extraInfoSpec</code> options are not supported.",
                 "version_added": "14"
               },
               "safari_ios": {
@@ -1456,7 +1456,7 @@
               },
               "opera": "mirror",
               "safari": {
-                "notes": "extraInfoSpec options are not supported.",
+                "notes": "<code>extraInfoSpec</code> options are not supported.",
                 "version_added": "14"
               },
               "safari_ios": {
@@ -1980,7 +1980,7 @@
               },
               "opera": "mirror",
               "safari": {
-                "notes": "extraInfoSpec options are not supported.",
+                "notes": "<code>extraInfoSpec</code> options are not supported.",
                 "version_added": "14"
               },
               "safari_ios": {
@@ -2396,7 +2396,7 @@
               },
               "opera": "mirror",
               "safari": {
-                "notes": "extraInfoSpec options are not supported.",
+                "notes": "<code>extraInfoSpec</code> options are not supported.",
                 "version_added": "14"
               },
               "safari_ios": {
@@ -2789,7 +2789,7 @@
               },
               "opera": "mirror",
               "safari": {
-                "notes": "extraInfoSpec options are not supported.",
+                "notes": "<code>extraInfoSpec</code> options are not supported.",
                 "version_added": "14"
               },
               "safari_ios": {
@@ -3284,7 +3284,7 @@
               },
               "opera": "mirror",
               "safari": {
-                "notes": "extraInfoSpec options are not supported.",
+                "notes": "<code>extraInfoSpec</code> options are not supported.",
                 "version_added": "14"
               },
               "safari_ios": {
@@ -3739,7 +3739,7 @@
               },
               "opera": "mirror",
               "safari": {
-                "notes": "extraInfoSpec options are not supported.",
+                "notes": "<code>extraInfoSpec</code> options are not supported.",
                 "version_added": "14"
               },
               "safari_ios": {
@@ -4247,7 +4247,7 @@
               },
               "opera": "mirror",
               "safari": {
-                "notes": "extraInfoSpec options are not supported.",
+                "notes": "<code>extraInfoSpec</code> options are not supported.",
                 "version_added": "14"
               },
               "safari_ios": {
@@ -4742,7 +4742,7 @@
               },
               "opera": "mirror",
               "safari": {
-                "notes": "extraInfoSpec options are not supported.",
+                "notes": "<code>extraInfoSpec</code> options are not supported.",
                 "version_added": "14"
               },
               "safari_ios": {

--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -125,11 +125,11 @@
                 "opera": "mirror",
                 "safari": {
                   "version_added": "14",
-                  "notes": "Always returns false."
+                  "notes": "Always returns <code>false</code>."
                 },
                 "safari_ios": {
                   "version_added": "15",
-                  "notes": "Always returns false."
+                  "notes": "Always returns <code>false</code>."
                 }
               }
             }

--- a/webextensions/manifest/action.json
+++ b/webextensions/manifest/action.json
@@ -26,12 +26,10 @@
             "firefox_android": "mirror",
             "opera": "mirror",
             "safari": {
-              "version_added": null,
-              "notes": [
-                "Available for use in Manifest V3 or later.",
-                "If an extension defines a browser action, it is not allowed to define a page action as well."
-              ]
-            }
+              "version_added": "15.4",
+              "notes": "Available for use in Manifest V3 or later."
+            },
+            "safari_ios": "mirror"
           }
         },
         "browser_style": {
@@ -49,8 +47,9 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": null
-              }
+                "version_added": false
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -69,8 +68,9 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": null
-              }
+                "version_added": false
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -97,9 +97,10 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": null,
+                "version_added": "15.4",
                 "notes": "SVG icons are not supported. Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -116,8 +117,9 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": null
-              }
+                "version_added": "15.4"
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -137,8 +139,9 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": null
-              }
+                "version_added": "15.4"
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -157,8 +160,9 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": null
-              }
+                "version_added": false
+              },
+              "safari_ios": "mirror"
             }
           }
         }

--- a/webextensions/manifest/author.json
+++ b/webextensions/manifest/author.json
@@ -18,8 +18,12 @@
             "firefox_android": "mirror",
             "opera": "mirror",
             "safari": {
-              "notes": "Not displayed in Safari Extensions preferences.",
+              "notes": "Not displayed in Safari Extensions settings.",
               "version_added": "14"
+            },
+            "safari_ios": {
+              "notes": "Not displayed in Safari Extensions settings.",
+              "version_added": "15"
             }
           }
         }

--- a/webextensions/manifest/background.json
+++ b/webextensions/manifest/background.json
@@ -18,6 +18,9 @@
             "opera": "mirror",
             "safari": {
               "version_added": "14"
+            },
+            "safari_ios": {
+              "version_added": "15"
             }
           }
         },
@@ -37,6 +40,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -63,6 +69,10 @@
               "safari": {
                 "notes": "Before 14.1, only persistent pages are supported.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "notes": "Only non-persistent pages are supported. Requires <code>persistent: false</code>.",
+                "version_added": "15"
               }
             }
           }
@@ -84,6 +94,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }

--- a/webextensions/manifest/browser_action.json
+++ b/webextensions/manifest/browser_action.json
@@ -31,6 +31,13 @@
                 "Available for use in Manifest V2 only.",
                 "If an extension defines a browser action, it is not allowed to define a page action as well."
               ]
+            },
+            "safari_ios": {
+              "version_added": "15",
+              "notes": [
+                "Available for use in Manifest V2 only.",
+                "If an extension defines a browser action, it is not allowed to define a page action as well."
+              ]
             }
           }
         },
@@ -50,7 +57,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -70,7 +78,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -99,6 +108,10 @@
               "safari": {
                 "version_added": "14",
                 "notes": "SVG icons are not supported. Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
+              },
+              "safari_ios": {
+                "version_added": "15",
+                "notes": "SVG icons are not supported. Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
               }
             }
           }
@@ -121,6 +134,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -144,6 +160,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -164,7 +183,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         }

--- a/webextensions/manifest/chrome_settings_overrides.json
+++ b/webextensions/manifest/chrome_settings_overrides.json
@@ -22,7 +22,8 @@
             },
             "safari": {
               "version_added": false
-            }
+            },
+            "safari_ios": "mirror"
           }
         },
         "homepage": {
@@ -45,7 +46,8 @@
               },
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -69,7 +71,8 @@
               },
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           },
           "alternate_urls": {
@@ -90,7 +93,8 @@
                 },
                 "safari": {
                   "version_added": false
-                }
+                },
+                "safari_ios": "mirror"
               }
             }
           },
@@ -114,7 +118,8 @@
                 },
                 "safari": {
                   "version_added": false
-                }
+                },
+                "safari_ios": "mirror"
               }
             }
           },
@@ -138,7 +143,8 @@
                 },
                 "safari": {
                   "version_added": false
-                }
+                },
+                "safari_ios": "mirror"
               }
             }
           },
@@ -160,7 +166,8 @@
                 },
                 "safari": {
                   "version_added": false
-                }
+                },
+                "safari_ios": "mirror"
               }
             }
           },
@@ -182,7 +189,8 @@
                 },
                 "safari": {
                   "version_added": false
-                }
+                },
+                "safari_ios": "mirror"
               }
             }
           },
@@ -204,7 +212,8 @@
                 },
                 "safari": {
                   "version_added": false
-                }
+                },
+                "safari_ios": "mirror"
               }
             }
           },
@@ -226,7 +235,8 @@
                 },
                 "safari": {
                   "version_added": false
-                }
+                },
+                "safari_ios": "mirror"
               }
             }
           },
@@ -251,7 +261,8 @@
                 },
                 "safari": {
                   "version_added": false
-                }
+                },
+                "safari_ios": "mirror"
               }
             }
           },
@@ -275,7 +286,8 @@
                 },
                 "safari": {
                   "version_added": false
-                }
+                },
+                "safari_ios": "mirror"
               }
             }
           },
@@ -299,7 +311,8 @@
                 },
                 "safari": {
                   "version_added": false
-                }
+                },
+                "safari_ios": "mirror"
               }
             }
           },
@@ -321,7 +334,8 @@
                 },
                 "safari": {
                   "version_added": false
-                }
+                },
+                "safari_ios": "mirror"
               }
             }
           },
@@ -345,7 +359,8 @@
                 },
                 "safari": {
                   "version_added": false
-                }
+                },
+                "safari_ios": "mirror"
               }
             }
           },
@@ -369,7 +384,8 @@
                 },
                 "safari": {
                   "version_added": false
-                }
+                },
+                "safari_ios": "mirror"
               }
             }
           },
@@ -393,7 +409,8 @@
                 },
                 "safari": {
                   "version_added": false
-                }
+                },
+                "safari_ios": "mirror"
               }
             }
           },
@@ -417,7 +434,8 @@
                 },
                 "safari": {
                   "version_added": false
-                }
+                },
+                "safari_ios": "mirror"
               }
             }
           }
@@ -440,7 +458,8 @@
               },
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         }

--- a/webextensions/manifest/chrome_url_overrides.json
+++ b/webextensions/manifest/chrome_url_overrides.json
@@ -22,6 +22,9 @@
             },
             "safari": {
               "version_added": "14.1"
+            },
+            "safari_ios": {
+              "version_added": "15"
             }
           }
         },
@@ -43,7 +46,8 @@
               },
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -65,7 +69,8 @@
               },
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -92,7 +97,11 @@
               },
               "safari": {
                 "version_added": "14.1",
-                "notes": "An extension can define a custom new tab or window page, but it does not take effect until the user chooses the extension to override the page in Safari's <em>General</em> preferences."
+                "notes": "An extension can define a custom new tab or window page, but it does not take effect until the user chooses the extension to override the page in Safari's <em>General</em> settings."
+              },
+              "safari_ios": {
+                "version_added": "15",
+                "notes": "An extension can define a custom new tab or window page, but it does not take effect until the user chooses the extension to override the page in Safari's <em>Extensions</em> settings."
               }
             }
           }

--- a/webextensions/manifest/commands.json
+++ b/webextensions/manifest/commands.json
@@ -20,7 +20,11 @@
             "opera": "mirror",
             "safari": {
               "version_added": "14",
-              "notes": "Ability to change the keyboard shortcut for a command not supported."
+              "notes": "Changing the keyboard shortcut for a command is not supported."
+            },
+            "safari_ios": {
+              "version_added": "15",
+              "notes": "Changing the keyboard shortcut for a command is not supported."
             }
           }
         },
@@ -42,6 +46,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -68,7 +75,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -94,7 +102,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -120,7 +129,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -146,7 +156,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -167,6 +178,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -187,7 +201,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -207,7 +222,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         }

--- a/webextensions/manifest/content_scripts.json
+++ b/webextensions/manifest/content_scripts.json
@@ -20,6 +20,10 @@
             "safari": {
               "version_added": "14",
               "notes": "Content scripts are not applied to tabs until the user grants permission via the extension's access popover in the toolbar."
+            },
+            "safari_ios": {
+              "version_added": "15",
+              "notes": "Content scripts are not applied to tabs until the user grants permission via the extension's access alert."
             }
           }
         },
@@ -39,6 +43,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -59,6 +66,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -79,7 +89,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -99,6 +110,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -119,7 +133,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -139,6 +154,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -160,7 +178,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -180,6 +199,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -201,6 +223,10 @@
               "safari": {
                 "version_added": "14",
                 "notes": "Content scripts are not applied to tabs until the user grants permission via the extension's access popover in the toolbar. Additional loads after permission is granted will respect <code>run_at</code>."
+              },
+              "safari_ios": {
+                "version_added": "15",
+                "notes": "Content scripts are not applied to tabs until the user grants permission via the extension's access alert. Additional loads after permission is granted will respect <code>run_at</code>."
               }
             }
           }

--- a/webextensions/manifest/content_security_policy.json
+++ b/webextensions/manifest/content_security_policy.json
@@ -22,6 +22,9 @@
             "opera": "mirror",
             "safari": {
               "version_added": "14"
+            },
+            "safari_ios": {
+              "version_added": "15"
             }
           }
         },
@@ -53,9 +56,10 @@
                 "notes": "Available to Manifest V3 only."
               },
               "safari": {
-                "version_added": null,
+                "version_added": "15.4",
                 "notes": "Available to Manifest V3 only."
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -73,8 +77,9 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": null
-              }
+                "version_added": false
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -92,8 +97,9 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": null
-              }
+                "version_added": false
+              },
+              "safari_ios": "mirror"
             }
           }
         }

--- a/webextensions/manifest/default_locale.json
+++ b/webextensions/manifest/default_locale.json
@@ -18,6 +18,9 @@
             "opera": "mirror",
             "safari": {
               "version_added": "14"
+            },
+            "safari_ios": {
+              "version_added": "15"
             }
           }
         }

--- a/webextensions/manifest/description.json
+++ b/webextensions/manifest/description.json
@@ -18,6 +18,9 @@
             "opera": "mirror",
             "safari": {
               "version_added": "14"
+            },
+            "safari_ios": {
+              "version_added": "15"
             }
           }
         }

--- a/webextensions/manifest/developer.json
+++ b/webextensions/manifest/developer.json
@@ -18,7 +18,8 @@
             },
             "safari": {
               "version_added": false
-            }
+            },
+            "safari_ios": "mirror"
           }
         }
       }

--- a/webextensions/manifest/devtools_page.json
+++ b/webextensions/manifest/devtools_page.json
@@ -19,6 +19,9 @@
             },
             "opera": "mirror",
             "safari": {
+              "version_added": "16"
+            },
+            "safari_ios": {
               "version_added": false
             }
           }

--- a/webextensions/manifest/externally_connectable.json
+++ b/webextensions/manifest/externally_connectable.json
@@ -21,7 +21,7 @@
             "opera": "mirror",
             "safari": {
               "version_added": "15.4",
-              "notes": "Safari only supports the 'matches' attribute."
+              "notes": "Safari only supports the <code>matches</code> attribute."
             },
             "safari_ios": "mirror"
           }

--- a/webextensions/manifest/homepage_url.json
+++ b/webextensions/manifest/homepage_url.json
@@ -17,8 +17,12 @@
             "firefox_android": "mirror",
             "opera": "mirror",
             "safari": {
-              "notes": "Not displayed in Safari Extensions preferences.",
+              "notes": "Not displayed in Safari Extensions settings.",
               "version_added": "14"
+            },
+            "safari_ios": {
+              "notes": "Not displayed in Safari Extensions settings.",
+              "version_added": "15"
             }
           }
         }

--- a/webextensions/manifest/icons.json
+++ b/webextensions/manifest/icons.json
@@ -22,6 +22,10 @@
             "safari": {
               "version_added": "14",
               "notes": "SVG icons are not supported."
+            },
+            "safari_ios": {
+              "version_added": "15",
+              "notes": "SVG icons are not supported."
             }
           }
         }

--- a/webextensions/manifest/incognito.json
+++ b/webextensions/manifest/incognito.json
@@ -18,7 +18,8 @@
             "opera": "mirror",
             "safari": {
               "version_added": false
-            }
+            },
+            "safari_ios": "mirror"
           }
         },
         "not_allowed": {
@@ -37,7 +38,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -57,7 +59,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -78,7 +81,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         }

--- a/webextensions/manifest/manifest_version.json
+++ b/webextensions/manifest/manifest_version.json
@@ -18,6 +18,9 @@
             "opera": "mirror",
             "safari": {
               "version_added": "14"
+            },
+            "safari_ios": {
+              "version_added": "15"
             }
           }
         },
@@ -37,7 +40,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             },
             "status": {
               "experimental": false,
@@ -63,6 +67,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             },
             "status": {
@@ -90,11 +97,12 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
-              }
+                "version_added": "15.4"
+              },
+              "safari_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/webextensions/manifest/name.json
+++ b/webextensions/manifest/name.json
@@ -18,6 +18,9 @@
             "opera": "mirror",
             "safari": {
               "version_added": "14"
+            },
+            "safari_ios": {
+              "version_added": "15"
             }
           }
         }

--- a/webextensions/manifest/offline_enabled.json
+++ b/webextensions/manifest/offline_enabled.json
@@ -18,7 +18,8 @@
             "opera": "mirror",
             "safari": {
               "version_added": false
-            }
+            },
+            "safari_ios": "mirror"
           }
         }
       }

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -18,6 +18,9 @@
             "opera": "mirror",
             "safari": {
               "version_added": "14"
+            },
+            "safari_ios": {
+              "version_added": "15"
             }
           }
         },
@@ -36,6 +39,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -57,7 +63,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -80,7 +87,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -99,7 +107,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -120,7 +129,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -141,7 +151,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -162,6 +173,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -183,7 +197,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -204,6 +219,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -225,6 +243,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -246,7 +267,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -265,7 +287,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -284,7 +307,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -305,7 +329,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -324,7 +349,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -347,7 +373,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -368,7 +395,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -391,7 +419,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -411,7 +440,10 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -433,7 +465,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -454,7 +487,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -475,7 +509,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -498,7 +533,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -519,7 +555,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -540,7 +577,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -561,7 +599,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -582,6 +621,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -603,7 +645,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -624,6 +667,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -645,6 +691,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -666,7 +715,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         }

--- a/webextensions/manifest/options_page.json
+++ b/webextensions/manifest/options_page.json
@@ -20,6 +20,9 @@
             },
             "safari": {
               "version_added": "14"
+            },
+            "safari_ios": {
+              "version_added": "15"
             }
           },
           "status": {

--- a/webextensions/manifest/options_ui.json
+++ b/webextensions/manifest/options_ui.json
@@ -18,6 +18,9 @@
             "opera": "mirror",
             "safari": {
               "version_added": "14"
+            },
+            "safari_ios": {
+              "version_added": "15"
             }
           }
         },
@@ -38,7 +41,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -62,7 +66,8 @@
               "safari": {
                 "version_added": false,
                 "notes": "Options pages are always opened in a separate browser tab."
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -82,6 +87,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }

--- a/webextensions/manifest/page_action.json
+++ b/webextensions/manifest/page_action.json
@@ -28,6 +28,10 @@
             "safari": {
               "version_added": "14",
               "notes": "If an extension defines a page action, it is not allowed to define a browser action as well."
+            },
+            "safari_ios": {
+              "version_added": "15",
+              "notes": "If an extension defines a page action, it is not allowed to define a browser action as well."
             }
           }
         },
@@ -47,7 +51,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -76,6 +81,10 @@
               "safari": {
                 "version_added": "14",
                 "notes": "SVG icons are not supported. Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
+              },
+              "safari_ios": {
+                "version_added": "15",
+                "notes": "SVG icons are not supported. Grayscale images will be treated as template icons and processed with the system accent color and system appearance."
               }
             }
           }
@@ -98,6 +107,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -120,6 +132,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -138,7 +153,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -158,7 +174,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -178,7 +195,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         }

--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -18,6 +18,9 @@
             "opera": "mirror",
             "safari": {
               "version_added": "14"
+            },
+            "safari_ios": {
+              "version_added": "15"
             }
           }
         },
@@ -38,6 +41,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -59,6 +65,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -80,7 +89,8 @@
               },
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -103,7 +113,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -122,7 +133,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -151,7 +163,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -172,7 +185,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -193,7 +207,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -214,6 +229,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -235,7 +253,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -260,6 +279,9 @@
               "safari": {
                 "notes": "Available as an alias to the <code>menus</code> permission.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -279,7 +301,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -300,6 +323,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -321,7 +347,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -340,7 +367,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -361,7 +389,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -382,7 +411,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -403,7 +433,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -424,7 +455,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -447,7 +479,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -470,7 +503,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -491,7 +525,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -512,7 +547,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -533,6 +569,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -556,6 +595,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -577,7 +619,8 @@
               },
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -598,7 +641,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -619,7 +663,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -640,7 +685,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -661,7 +707,8 @@
               },
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -682,7 +729,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -705,7 +753,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -726,6 +775,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -747,7 +799,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -770,6 +823,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -791,7 +847,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -812,7 +869,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -836,6 +894,10 @@
               "safari": {
                 "notes": "Before Safari 16, this permission granted a 10 MB storage quota. Since Safari 16, the storage quota is unlimited.",
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "notes": "Does not grant an unlimited storage quota. Grants a 10 MB storage quota, instead of the standard 5 MB.",
+                "version_added": "15"
               }
             }
           }
@@ -859,6 +921,9 @@
               },
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -880,6 +945,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
               }
             }
           }
@@ -901,7 +969,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         }

--- a/webextensions/manifest/protocol_handlers.json
+++ b/webextensions/manifest/protocol_handlers.json
@@ -16,7 +16,8 @@
             "opera": "mirror",
             "safari": {
               "version_added": false
-            }
+            },
+            "safari_ios": "mirror"
           }
         },
         "dat": {
@@ -33,7 +34,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -51,7 +53,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -69,7 +72,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -87,7 +91,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -105,7 +110,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -123,7 +129,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -141,7 +148,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -159,7 +167,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         }

--- a/webextensions/manifest/short_name.json
+++ b/webextensions/manifest/short_name.json
@@ -18,6 +18,9 @@
             "opera": "mirror",
             "safari": {
               "version_added": "14"
+            },
+            "safari_ios": {
+              "version_added": "15"
             }
           }
         }

--- a/webextensions/manifest/sidebar_action.json
+++ b/webextensions/manifest/sidebar_action.json
@@ -20,7 +20,8 @@
             },
             "safari": {
               "version_added": false
-            }
+            },
+            "safari_ios": "mirror"
           }
         },
         "browser_style": {
@@ -39,7 +40,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -62,7 +64,8 @@
               },
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -84,7 +87,8 @@
               },
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -106,7 +110,8 @@
               },
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -126,7 +131,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         }

--- a/webextensions/manifest/storage.json
+++ b/webextensions/manifest/storage.json
@@ -19,7 +19,10 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14"
+            },
+            "safari_ios": {
+              "version_added": "15"
             }
           }
         },
@@ -41,7 +44,8 @@
               },
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         }

--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -105,12 +105,9 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": false,
-                  "notes": "The CSS color form is not supported for this property."
-                },
-                "safari_ios": {
                   "version_added": false
-                }
+                },
+                "safari_ios": "mirror"
               }
             }
           },

--- a/webextensions/manifest/theme_experiment.json
+++ b/webextensions/manifest/theme_experiment.json
@@ -18,7 +18,8 @@
             "opera": "mirror",
             "safari": {
               "version_added": false
-            }
+            },
+            "safari_ios": "mirror"
           },
           "status": {
             "experimental": true,
@@ -43,7 +44,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             },
             "status": {
               "experimental": true,
@@ -69,7 +71,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             },
             "status": {
               "experimental": true,
@@ -95,7 +98,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             },
             "status": {
               "experimental": true,

--- a/webextensions/manifest/theme_experiment.json
+++ b/webextensions/manifest/theme_experiment.json
@@ -38,6 +38,7 @@
               },
               "opera": "mirror",
               "safari": {
+                "version_added": false
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/manifest/user_scripts.json
+++ b/webextensions/manifest/user_scripts.json
@@ -20,7 +20,8 @@
             },
             "safari": {
               "version_added": false
-            }
+            },
+            "safari_ios": "mirror"
           }
         },
         "api_script": {
@@ -41,7 +42,8 @@
               },
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         }

--- a/webextensions/manifest/version.json
+++ b/webextensions/manifest/version.json
@@ -21,6 +21,9 @@
             },
             "safari": {
               "version_added": "14"
+            },
+            "safari_ios": {
+              "version_added": "15"
             }
           }
         }

--- a/webextensions/manifest/version_name.json
+++ b/webextensions/manifest/version_name.json
@@ -18,6 +18,9 @@
             "opera": "mirror",
             "safari": {
               "version_added": "14"
+            },
+            "safari_ios": {
+              "version_added": "15"
             }
           }
         }

--- a/webextensions/manifest/web_accessible_resources.json
+++ b/webextensions/manifest/web_accessible_resources.json
@@ -18,6 +18,9 @@
             "opera": "mirror",
             "safari": {
               "version_added": "14"
+            },
+            "safari_ios": {
+              "version_added": "15"
             }
           }
         },
@@ -35,8 +38,9 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": null
-              }
+                "version_added": false
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -56,8 +60,9 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": null
-              }
+                "version_added": "15.4"
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -77,8 +82,9 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": null
-              }
+                "version_added": "15.4"
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -96,8 +102,10 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": null
-              }
+                "version_added": false,
+                "notes": "The extension's base URL is always dynamic in Safari."
+              },
+              "safari_ios": "mirror"
             }
           }
         }

--- a/webextensions/match_patterns.json
+++ b/webextensions/match_patterns.json
@@ -17,6 +17,9 @@
           "opera": "mirror",
           "safari": {
             "version_added": "14"
+          },
+          "safari_ios": {
+            "version_added": "15"
           }
         }
       },
@@ -38,6 +41,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -57,7 +63,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -77,6 +84,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -97,6 +107,9 @@
               "opera": "mirror",
               "safari": {
                 "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
               }
             }
           }
@@ -115,7 +128,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -133,7 +147,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -153,7 +168,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -173,7 +189,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -193,7 +210,8 @@
               "opera": "mirror",
               "safari": {
                 "version_added": false
-              }
+              },
+              "safari_ios": "mirror"
             }
           }
         }


### PR DESCRIPTION
This gets the iOS Safari Web Extension data up-to-date with current shipping versions. Also fix some notes and changed `null` to `false` for macOS Safari versions (no other browsers used `null`).