### PR TITLE
Move API features only available to web extensions

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -871,39 +871,6 @@
           }
         }
       },
-      "drawWindow": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawWindow",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "1.5"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "ellipse": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/ellipse",

--- a/api/Element.json
+++ b/api/Element.json
@@ -5722,40 +5722,6 @@
           }
         }
       },
-      "openOrClosedShadowRoot": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/openOrClosedShadowRoot",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "63",
-              "notes": "Available only to <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions'>WebExtensions</a>."
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": false
-          }
-        }
-      },
       "outerHTML": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/outerHTML",

--- a/webextensions/dom_extensions/CanvasRenderingContext2D.json
+++ b/webextensions/dom_extensions/CanvasRenderingContext2D.json
@@ -1,0 +1,36 @@
+{
+  "webextensions": {
+    "dom_extensions": {
+      "CanvasRenderingContext2D": {
+        "drawWindow": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/dom_extensions/CanvasRenderingContext2D/drawWindow",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1.5"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/webextensions/dom_extensions/CanvasRenderingContext2D.json
+++ b/webextensions/dom_extensions/CanvasRenderingContext2D.json
@@ -9,24 +9,16 @@
               "chrome": {
                 "version_added": false
               },
-              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": "1.5"
               },
               "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
               "safari": {
                 "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari_ios": "mirror"
             }
           }
         }

--- a/webextensions/dom_extensions/Element.json
+++ b/webextensions/dom_extensions/Element.json
@@ -1,0 +1,36 @@
+{
+  "webextensions": {
+    "dom_extensions": {
+      "Element": {
+        "openOrClosedShadowRoot": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/dom_extensions/Element/openOrClosedShadowRoot",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "63"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/webextensions/dom_extensions/Element.json
+++ b/webextensions/dom_extensions/Element.json
@@ -9,24 +9,16 @@
               "chrome": {
                 "version_added": false
               },
-              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": "63"
               },
               "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
               "safari": {
                 "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari_ios": "mirror"
             }
           }
         }


### PR DESCRIPTION
This PR moves API features that are only available to web extensions into `webextensions.dom_extensions` as suggested in https://github.com/mdn/browser-compat-data/pull/17354#issuecomment-1218285048.  CC @Elchi3
