### PR TITLE
Document `source_file` property

### DIFF
--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -162,6 +162,8 @@ The `__compat` object consists of the following:
   It is intended to be used as a caption or title and should be kept short.
   The `<code>`, `<kbd>`, `<em>`, and `<strong>` HTML elements may be used.
 
+- An automated `source_file` property containing the path to the source file containing the feature. This is used to create links to the repository source (in the form of `https://github.com/mdn/browser-compat-data/blob/main/<source_file>`). For example, `api.History.forward` will contain a `source_file` property of `api/History.json` since the feature is defined in that file.
+
 - An optional `mdn_url` property which **points to an MDN reference page documenting the feature**.
   It needs to be a valid URL, and should be the language-neutral URL (e.g. use `https://developer.mozilla.org/docs/Web/CSS/text-align` instead of `https://developer.mozilla.org/en-US/docs/Web/CSS/text-align`).
 


### PR DESCRIPTION
This PR adds the `source_file` property to the schema documentation, addressing the feedback in https://github.com/mdn/browser-compat-data/pull/16675#issuecomment-1217730387.
