### PR TITLE
Update Chromium versions for api.PushManager.permissionState

### DIFF
--- a/api/PushManager.json
+++ b/api/PushManager.json
@@ -172,7 +172,7 @@
           "spec_url": "https://w3c.github.io/push-api/#dom-pushmanager-permissionstate",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": "44"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `permissionState` member of the `PushManager` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PushManager/permissionState

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
