### PR TITLE
Update all browsers versions for SVGAltGlyphElement API

### DIFF
--- a/api/SVGAltGlyphElement.json
+++ b/api/SVGAltGlyphElement.json
@@ -6,12 +6,14 @@
         "spec_url": "https://www.w3.org/TR/SVG11/text.html#InterfaceSVGAltGlyphElement",
         "support": {
           "chrome": {
-            "version_added": "1"
+            "version_added": "1",
+            "version_removed": "40"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
             "version_added": "4",
+            "version_removed": "49",
             "notes": "partial support, see <a href='https://bugzil.la/456286'>bug 456286</a> and <a href='https://bugzil.la/571808'>bug 571808</a>."
           },
           "firefox_android": "mirror",
@@ -19,12 +21,8 @@
             "version_added": false
           },
           "oculus": "mirror",
-          "opera": {
-            "version_added": "10.6"
-          },
-          "opera_android": {
-            "version_added": "11"
-          },
+          "opera": "mirror",
+          "opera_android": "mirror",
           "safari": {
             "version_added": "4"
           },
@@ -32,9 +30,7 @@
             "version_added": "3"
           },
           "samsunginternet_android": "mirror",
-          "webview_android": {
-            "version_added": "37"
-          }
+          "webview_android": "mirror"
         },
         "status": {
           "experimental": false,
@@ -48,24 +44,22 @@
           "spec_url": "https://www.w3.org/TR/SVG11/text.html#__svg__SVGAltGlyphElement__format",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "40"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "4"
+              "version_added": "20",
+              "version_removed": "49"
             },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "10.6"
-            },
-            "opera_android": {
-              "version_added": "11"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "4"
             },
@@ -74,7 +68,7 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": "37"
+              "version_added": false
             }
           },
           "status": {
@@ -90,24 +84,22 @@
           "spec_url": "https://www.w3.org/TR/SVG11/text.html#__svg__SVGGlyphRefElement__glyphRef",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "40"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "4"
+              "version_added": "20",
+              "version_removed": "49"
             },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "10.6"
-            },
-            "opera_android": {
-              "version_added": "11"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "4"
             },
@@ -115,9 +107,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/svg/elements/altGlyph.json
+++ b/svg/elements/altGlyph.json
@@ -22,12 +22,8 @@
               "version_added": null
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "10.6"
-            },
-            "opera_android": {
-              "version_added": "11"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "4"
             },

--- a/svg/elements/altGlyph.json
+++ b/svg/elements/altGlyph.json
@@ -46,7 +46,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -78,7 +78,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -115,7 +115,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -152,7 +152,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -184,7 +184,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -216,7 +216,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -249,7 +249,7 @@
             "description": "<code>xlink:href</code>",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -281,7 +281,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/svg/elements/altGlyph.json
+++ b/svg/elements/altGlyph.json
@@ -7,7 +7,8 @@
           "spec_url": "https://www.w3.org/TR/SVG11/text.html#AltGlyphElement",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "40"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects the real values for all browsers for the `SVGAltGlyphElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGAltGlyphElement

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
