### PR TITLE
Update Firefox versions for SVGAnimatedPreserveAspectRatio API

### DIFF
--- a/api/SVGAnimatedPreserveAspectRatio.json
+++ b/api/SVGAnimatedPreserveAspectRatio.json
@@ -13,7 +13,7 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "1.5"
+            "version_added": "22"
           },
           "firefox_android": "mirror",
           "ie": {


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `SVGAnimatedPreserveAspectRatio` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGAnimatedPreserveAspectRatio

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
