### PR TITLE
Update Safari versions for api.SVGPointList.length

### DIFF
--- a/api/SVGPointList.json
+++ b/api/SVGPointList.json
@@ -288,7 +288,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "13"
+              "version_added": "13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `length` member of the `SVGPointList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGPointList/length

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
