### PR TITLE
Update Safari versions for api.SVGStringList.length

### DIFF
--- a/api/SVGStringList.json
+++ b/api/SVGStringList.json
@@ -280,7 +280,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "13"
+              "version_added": "13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `length` member of the `SVGStringList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGStringList/length

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
