### PR TITLE
Update Chromium versions for api.SVGStyleElement.sheet

### DIFF
--- a/api/SVGStyleElement.json
+++ b/api/SVGStyleElement.json
@@ -141,12 +141,24 @@
               "version_added": "9"
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "≤12.1"
-            },
-            "opera_android": {
-              "version_added": "≤12.1"
-            },
+            "opera": [
+              {
+                "version_added": "25"
+              },
+              {
+                "version_added": "≤12.1",
+                "version_removed": "15"
+              }
+            ],
+            "opera_android": [
+              {
+                "version_added": "25"
+              },
+              {
+                "version_added": "≤12.1",
+                "version_removed": "14"
+              }
+            ],
             "safari": {
               "version_added": "3"
             },
@@ -154,9 +166,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/api/SVGStyleElement.json
+++ b/api/SVGStyleElement.json
@@ -127,7 +127,7 @@
           "spec_url": "https://drafts.csswg.org/cssom/#dom-linkstyle-sheet",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "38"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `sheet` member of the `SVGStyleElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGStyleElement/sheet

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
