### PR TITLE
Update Safari versions for api.SVGTransformList.length

### DIFF
--- a/api/SVGTransformList.json
+++ b/api/SVGTransformList.json
@@ -367,7 +367,7 @@
               "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": "13"
+              "version_added": "13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `length` member of the `SVGTransformList` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SVGTransformList/length

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
