### PR TITLE
Update Opera versions for api.SerialPort.forget

### DIFF
--- a/api/SerialPort.json
+++ b/api/SerialPort.json
@@ -171,9 +171,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `forget` member of the `SerialPort` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SerialPort/forget

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
