### PR TITLE
Update Chromium versions for api.ServiceWorkerContainer.controller

### DIFF
--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -48,7 +48,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "74"
+              "version_added": "44"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -41,14 +41,14 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#navigator-service-worker-controller",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": "54"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": "74"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `controller` member of the `ServiceWorkerContainer` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ServiceWorkerContainer/controller

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
