### PR TITLE
Update Chromium versions for api.SubtleCrypto.deriveBits

### DIFF
--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -255,7 +255,9 @@
               "version_added": "7"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": "6.0"
+            },
             "webview_android": "mirror"
           },
           "status": {

--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -206,7 +206,7 @@
           "spec_url": "https://w3c.github.io/webcrypto/#SubtleCrypto-method-deriveBits",
           "support": {
             "chrome": {
-              "version_added": "37"
+              "version_added": "41"
             },
             "chrome_android": "mirror",
             "deno": [

--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -255,9 +255,7 @@
               "version_added": "7"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `deriveBits` member of the `SubtleCrypto` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/SubtleCrypto/deriveBits

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
