### PR TITLE
Update Chromium versions for api.Text.Text

### DIFF
--- a/api/Text.json
+++ b/api/Text.json
@@ -48,7 +48,7 @@
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-text-text①",
           "support": {
             "chrome": {
-              "version_added": "28"
+              "version_added": "29"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Text` member of the `Text` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Text/Text

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
