### PR TITLE
Update Chromium versions for URL API

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -7,7 +7,7 @@
         "support": {
           "chrome": [
             {
-              "version_added": "32"
+              "version_added": "23"
             },
             {
               "version_added": "19",


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `URL` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/URL

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
