### PR TITLE
Update Opera versions for api.USBDevice.forget

### DIFF
--- a/api/USBDevice.json
+++ b/api/USBDevice.json
@@ -522,9 +522,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `forget` member of the `USBDevice` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/USBDevice/forget

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
