### PR TITLE
Update Firefox versions for api.WindowClient.navigate

### DIFF
--- a/api/WindowClient.json
+++ b/api/WindowClient.json
@@ -120,7 +120,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": "50"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `navigate` member of the `WindowClient` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WindowClient/navigate

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
