### PR TITLE
Update Chromium versions for WritableStreamDefaultController API

### DIFF
--- a/api/WritableStreamDefaultController.json
+++ b/api/WritableStreamDefaultController.json
@@ -6,7 +6,7 @@
         "spec_url": "https://streams.spec.whatwg.org/#ws-default-controller-class",
         "support": {
           "chrome": {
-            "version_added": "58"
+            "version_added": "59"
           },
           "chrome_android": "mirror",
           "deno": {
@@ -104,9 +104,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "58"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `WritableStreamDefaultController` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WritableStreamDefaultController

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
