### PR TITLE
Update Chromium versions for api.WritableStreamDefaultWriter.WritableStreamDefaultWriter

### DIFF
--- a/api/WritableStreamDefaultWriter.json
+++ b/api/WritableStreamDefaultWriter.json
@@ -65,7 +65,7 @@
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-default-writer-constructor①",
           "support": {
             "chrome": {
-              "version_added": "59"
+              "version_added": "78"
             },
             "chrome_android": "mirror",
             "deno": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `WritableStreamDefaultWriter` member of the `WritableStreamDefaultWriter` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WritableStreamDefaultWriter/WritableStreamDefaultWriter

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
