### PR TITLE
Update Edge versions for api.WritableStreamDefaultWriter.WritableStreamDefaultWriter

### DIFF
--- a/api/WritableStreamDefaultWriter.json
+++ b/api/WritableStreamDefaultWriter.json
@@ -72,7 +72,7 @@
               "version_added": "1.0"
             },
             "edge": {
-              "version_added": "16"
+              "version_added": "79"
             },
             "firefox": [
               {


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `WritableStreamDefaultWriter` member of the `WritableStreamDefaultWriter` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WritableStreamDefaultWriter/WritableStreamDefaultWriter

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
