### PR TITLE
Update Chromium versions for api.Window.appinstalled_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -180,7 +180,7 @@
           "spec_url": "https://wicg.github.io/manifest-incubations/#dom-window-onappinstalled",
           "support": {
             "chrome": {
-              "version_added": "64"
+              "version_added": "61"
             },
             "chrome_android": {
               "version_added": "57"


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `appinstalled_event` member of the `Window` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Window/appinstalled_event

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
