### PR TITLE
Update Opera versions for api.Window.appinstalled_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -194,8 +194,14 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": false,
+              "notes": "Opera exposes the <code>onappinstalled</code> event handler, but the event is never fired."
+            },
+            "opera_android": {
+              "version_added": false,
+              "notes": "Opera exposes the <code>onappinstalled</code> event handler, but the event is never fired."
+            },
             "safari": {
               "version_added": false
             },

--- a/api/Window.json
+++ b/api/Window.json
@@ -194,12 +194,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `appinstalled_event` member of the `Window` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Window/appinstalled_event

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
