### PR TITLE
Update Safari version for element.getElementsByClassName()

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -4221,7 +4221,7 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "6"
+              "version_added": "3.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This change was made by the collector in https://github.com/mdn/browser-compat-data/pull/14236
and is also supported by source archeology:

https://github.com/WebKit/WebKit/commit/74c8babf4d4580c0a65ec8cda910c28d8bb9e35e
https://github.com/WebKit/WebKit/blob/74c8babf4d4580c0a65ec8cda910c28d8bb9e35e/WebCore/Configurations/Version.xcconfig

That's WebKit trunk version 525.1, mapping to Safari 3.1.
