### PR TITLE
Add Chromium versions for css.at-rules.media.-webkit-transform-3d

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1795,13 +1795,11 @@
             "spec_url": "https://compat.spec.whatwg.org/#css-media-queries-webkit-transform-3d",
             "support": {
               "chrome": {
-                "version_added": "2",
-                "version_removed": "36"
+                "version_added": "2"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12",
-                "version_removed": "79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "49"
@@ -1818,10 +1816,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "2",
-                "version_removed": "37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `-webkit-transform-3d` member of the `media` CSS @rule, based upon manual testing.

Test Code Used: https://codepen.io/estelle/pen/QWmzKPy

Fixes #17458.
