### PR TITLE
Remove api.PresentationRequest.startWithDevice from BCD

### DIFF
--- a/api/PresentationRequest.json
+++ b/api/PresentationRequest.json
@@ -302,46 +302,6 @@
             "deprecated": false
           }
         }
-      },
-      "startWithDevice": {
-        "__compat": {
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "51",
-              "version_removed": "88",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.presentation.controller.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
This PR removes the irrelevant `startWithDevice` member of the `PresentationRequest` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features). The lack of current support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0), even if the current BCD suggests support.
