### PR TITLE
CSS update contain: style and add contain: inline-size

### DIFF
--- a/css/properties/contain.json
+++ b/css/properties/contain.json
@@ -11,24 +11,15 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "103"
-              },
-              {
-                "version_added": "69",
-                "partial_implementation": true,
-                "notes": "Firefox does not support the <code>style</code> value."
-              }
-            ],
+            "firefox": {
+                "version_added": "69"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "40"
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": "15.4"
@@ -41,6 +32,40 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "style_value": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain#style",
+            "spec_url": "https://drafts.csswg.org/css-contain/#valdef-contain-style",
+            "support": {
+              "chrome": {
+                "version_added": "52"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                  "version_added": "103"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/css/properties/contain.json
+++ b/css/properties/contain.json
@@ -12,7 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-                "version_added": "69"
+              "version_added": "69"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -34,8 +34,44 @@
             "deprecated": false
           }
         },
+        "inline-size_value": {
+          "__compat": {
+            "description": "<code>inline-size</code> value",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain#inline-size",
+            "spec_url": "https://www.w3.org/TR/css-contain-3/#valdef-contain-inline-size",
+            "support": {
+              "chrome": {
+                "version_added": "105"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "101"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "style_value": {
           "__compat": {
+            "description": "<code>style</code> value",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain#style",
             "spec_url": "https://drafts.csswg.org/css-contain/#valdef-contain-style",
             "support": {
@@ -45,7 +81,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                  "version_added": "103"
+                "version_added": "103"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/contain.json
+++ b/css/properties/contain.json
@@ -34,9 +34,8 @@
             "deprecated": false
           }
         },
-        "inline-size_value": {
+        "inline-size": {
           "__compat": {
-            "description": "<code>inline-size</code> value",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain#inline-size",
             "spec_url": "https://www.w3.org/TR/css-contain-3/#valdef-contain-inline-size",
             "support": {
@@ -69,9 +68,8 @@
             }
           }
         },
-        "style_value": {
+        "style": {
           "__compat": {
-            "description": "<code>style</code> value",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain#style",
             "spec_url": "https://drafts.csswg.org/css-contain/#valdef-contain-style",
             "support": {

--- a/css/properties/contain.json
+++ b/css/properties/contain.json
@@ -56,7 +56,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "15.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
Updates to the contain property

1. `contain: style`
   - FF103 support (already added as a note in #17326) now done properly as a subfeature). 
   - Also added in Safari 15.4 (tech preview https://developer.apple.com/safari/technology-preview/release-notes/)
   - Chrome - browser test of WPT shows works in original version.

3. Added `contain: inline-size`
   - FF101: https://bugzilla.mozilla.org/show_bug.cgi?id=1755565
   - Chrome 105: https://chromestatus.com/feature/6525308435955712
   - Safari tech preview: https://developer.apple.com/safari/technology-preview/release-notes/#:~:text=Enabled%20CSS%20Container%20Queries%20by%20default

Also verified that the other cases: strict, paint, content, size layout all appear in the first version of respective browser. This was done using spot checks of https://wpt.live/css/css-contain/ . Note that chrome had spotty support against the tests for `paint` up until Chrome 70, but can't find associated tests, and that's a while ago. So no need to add note I don't think.