### PR TITLE
Remove status blocks from webextensions

### DIFF
--- a/webextensions/api/extension.json
+++ b/webextensions/api/extension.json
@@ -96,11 +96,6 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
@@ -127,11 +122,6 @@
               "safari_ios": {
                 "version_added": "15"
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
@@ -300,11 +290,6 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
@@ -327,11 +312,6 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
@@ -354,11 +334,6 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
@@ -383,11 +358,6 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },

--- a/webextensions/api/notifications.json
+++ b/webextensions/api/notifications.json
@@ -44,11 +44,6 @@
                   "version_added": false
                 },
                 "safari_ios": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
               }
             }
           },
@@ -143,11 +138,6 @@
                   "version_added": false
                 },
                 "safari_ios": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
               }
             }
           },

--- a/webextensions/api/pkcs11.json
+++ b/webextensions/api/pkcs11.json
@@ -21,11 +21,6 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": false
             }
           }
         },
@@ -48,11 +43,6 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": false
             }
           }
         },
@@ -75,11 +65,6 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": false
             }
           }
         },
@@ -102,11 +87,6 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": false
             }
           }
         }

--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -148,11 +148,6 @@
                   "version_added": false
                 },
                 "safari_ios": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
               }
             }
           },
@@ -365,11 +360,6 @@
                     "version_added": false
                   },
                   "safari_ios": "mirror"
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
                 }
               }
             }

--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -411,11 +411,6 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": true
             }
           }
         },
@@ -460,11 +455,6 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": true
             }
           }
         }

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -639,11 +639,6 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1000,11 +1000,6 @@
                 "safari_ios": {
                   "version_added": "15"
                 }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
               }
             }
           },
@@ -1635,11 +1630,6 @@
                     "version_added": false
                   },
                   "safari_ios": "mirror"
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
                 }
               }
             },
@@ -2011,11 +2001,6 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
@@ -2068,11 +2053,6 @@
               "safari_ios": {
                 "version_added": "15"
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
@@ -2189,11 +2169,6 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": false
             }
           }
         },
@@ -2459,11 +2434,6 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
@@ -2566,11 +2536,6 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
@@ -2705,11 +2670,6 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
@@ -3707,11 +3667,6 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
@@ -3782,11 +3737,6 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": false,
-              "deprecated": false
             }
           }
         },
@@ -4025,11 +3975,6 @@
                 "safari_ios": {
                   "version_added": "15"
                 }
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
               }
             }
           },

--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -469,11 +469,6 @@
                   "version_added": false
                 },
                 "safari_ios": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
               }
             }
           },
@@ -1060,11 +1055,6 @@
                   "safari_ios": {
                     "version_added": "15"
                   }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
                 }
               }
             }
@@ -1215,11 +1205,6 @@
                   "safari_ios": {
                     "version_added": false
                   }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
                 }
               }
             }
@@ -1294,11 +1279,6 @@
                   "safari_ios": {
                     "version_added": false
                   }
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
                 }
               }
             }

--- a/webextensions/manifest/manifest_version.json
+++ b/webextensions/manifest/manifest_version.json
@@ -38,11 +38,6 @@
               "safari": {
                 "version_added": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
             }
           }
         },
@@ -64,11 +59,6 @@
               "safari": {
                 "version_added": "14"
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
             }
           }
         },
@@ -92,11 +82,6 @@
               "safari": {
                 "version_added": false
               }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
             }
           }
         }

--- a/webextensions/manifest/options_page.json
+++ b/webextensions/manifest/options_page.json
@@ -21,11 +21,6 @@
             "safari": {
               "version_added": "14"
             }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": true
           }
         }
       }

--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -75,11 +75,6 @@
                   "version_added": false
                 },
                 "safari_ios": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
               }
             }
           },
@@ -654,11 +649,6 @@
                   "version_added": false
                 },
                 "safari_ios": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
               }
             }
           },
@@ -1058,11 +1048,6 @@
                   "version_added": false
                 },
                 "safari_ios": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
               }
             }
           },

--- a/webextensions/manifest/theme_experiment.json
+++ b/webextensions/manifest/theme_experiment.json
@@ -19,11 +19,6 @@
             "safari": {
               "version_added": false
             }
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": false,
-            "deprecated": false
           }
         },
         "colors": {
@@ -44,11 +39,6 @@
               "safari": {
                 "version_added": false
               }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": false,
-              "deprecated": false
             }
           }
         },
@@ -70,11 +60,6 @@
               "safari": {
                 "version_added": false
               }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": false,
-              "deprecated": false
             }
           }
         },
@@ -96,11 +81,6 @@
               "safari": {
                 "version_added": false
               }
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": false,
-              "deprecated": false
             }
           }
         }


### PR DESCRIPTION
This PR removes the status blocks from the `webextensions/` folder, unblocking #17471.