### PR TITLE
Add data for 2d canvas willReadFrequently parameter

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -751,6 +751,41 @@
                 "deprecated": false
               }
             }
+          },
+          "options_willReadFrequently_parameter": {
+            "__compat": {
+              "description": "<code>options.willReadFrequently</code> parameter",
+              "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-canvasrenderingcontext2dsettings-willreadfrequently",
+              "support": {
+                "chrome": {
+                  "version_added": "99"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "28"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false,
+                  "notes": "See <a href='https://webkit.org/b/244117'>bug 244117</a>."
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       },


### PR DESCRIPTION
Support in Firefox 28 and Chrome 99, and lack of support in Safari, was
confirmed with this test:
https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=10586

Additional evidence:
https://bugzilla.mozilla.org/show_bug.cgi?id=884226
https://chromestatus.com/feature/6051647656558592

A WebKit bug was filed and linked here.
