### PR TITLE
Add data for 2d canvas colorSpace parameter

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -704,6 +704,40 @@
               }
             }
           },
+          "options_colorSpace_parameter": {
+            "__compat": {
+              "description": "<code>options.colorSpace</code> parameter",
+              "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-canvasrenderingcontext2dsettings-colorspace",
+              "support": {
+                "chrome": {
+                  "version_added": "92"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "15.2"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "options_desynchronized_parameter": {
             "__compat": {
               "description": "<code>options.desynchronized</code> parameter",


### PR DESCRIPTION
Support in Chrome 92 and Safari 15.6 was confirmed with this test:
https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=10584

(Chrome doesn't support the color() function, and still paints black.)

Assume that Safari 15.2 is correct, matching ImageData's colorSpace
property.

Supporting evidence:
https://developer.apple.com/documentation/safari-release-notes/safari-15_2-release-notes
https://storage.googleapis.com/chromium-find-releases-static/f1e.html#f1e5b1b1561a449e1d6096bce01fcc6cd7e690ff
