### PR TITLE
Updates opera browser to version 90

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -683,19 +683,26 @@
         "89": {
           "release_date": "2022-07-07",
           "release_notes": "https://blogs.opera.com/desktop/2022/07/opera-89-stable/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "103"
         },
         "90": {
-          "status": "beta",
+          "release_date": "2022-08-18",
+          "release_notes": "https://blogs.opera.com/desktop/2022/08/opera-90-stable/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "104"
         },
         "91": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "105"
+        },
+        "92": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "106"
         }
       }
     }


### PR DESCRIPTION
Hello everyone!

According to this [release note](https://blogs.opera.com/desktop/2022/08/opera-90-stable/) opera browser has updated to version 90. 

😉