### PR TITLE
Add Safari versions for css.properties.font-family.system-ui

### DIFF
--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -80,19 +80,10 @@
                 },
                 {
                   "alternative_name": "-apple-system",
-                  "version_added": "9",
-                  "notes": "Supported since macOS 10.11."
-                }
-              ],
-              "safari_ios": [
-                {
-                  "version_added": "11"
-                },
-                {
-                  "alternative_name": "-apple-system",
                   "version_added": "9"
                 }
               ],
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -46,7 +46,7 @@
             "deprecated": false
           }
         },
-        "system_ui": {
+        "system-ui": {
           "__compat": {
             "description": "<code>system-ui</code>",
             "support": {
@@ -74,15 +74,25 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": {
-                "alternative_name": "-apple-system",
-                "version_added": "9",
-                "notes": "Supported since macOS 10.11."
-              },
-              "safari_ios": {
-                "alternative_name": "-apple-system",
-                "version_added": "9"
-              },
+              "safari": [
+                {
+                  "version_added": "11"
+                },
+                {
+                  "alternative_name": "-apple-system",
+                  "version_added": "9",
+                  "notes": "Supported since macOS 10.11."
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "11"
+                },
+                {
+                  "alternative_name": "-apple-system",
+                  "version_added": "9"
+                }
+              ],
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `system-ui` member of the `font-family` CSS property.  This updates the data to match CanIUse: https://caniuse.com/?search=system-ui (Fixes #17337)  Also, this changes the key from `system_ui` to `system-ui` to adhere to our data structure.
