### PR TITLE
Add Opera versions for TypedArray JavaScript builtin

### DIFF
--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -125,9 +125,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": false
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "15.4"
               },
@@ -409,12 +407,8 @@
                 "version_added": "0.12.0"
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": "36"
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "9.1"
               },
@@ -457,12 +451,8 @@
                 "version_added": "4.0.0"
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": "36"
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "9.1"
               },
@@ -505,12 +495,8 @@
                 "version_added": "4.0.0"
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": "36"
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "9.1"
               },
@@ -556,9 +542,7 @@
               "opera": {
                 "version_added": false
               },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "9.1"
               },
@@ -696,9 +680,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": false
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "15.4"
               },
@@ -750,9 +732,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": false
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "15.4"
               },
@@ -1483,9 +1463,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": false
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "10"
               },
@@ -1527,9 +1505,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": false
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "10"
               },
@@ -1571,9 +1547,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": false
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "10"
               },
@@ -1707,9 +1681,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": false
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "10"
               },


### PR DESCRIPTION
This PR adds real values for Opera and Opera Android for the `TypedArray` JavaScript builtin.  This sets Opera and Opera Android to mirror for all features, and thus fixes #17333.
