### PR TITLE
Update bgcolor HTML attribute

### DIFF
--- a/html/elements/body.json
+++ b/html/elements/body.json
@@ -140,20 +140,14 @@
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "1.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": true
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/html/elements/body.json
+++ b/html/elements/body.json
@@ -141,10 +141,10 @@
               },
               "oculus": "mirror",
               "opera": {
-                "version_added": "≤12.1"
+                "version_added": "≤15"
               },
               "opera_android": {
-                "version_added": "≤12.1"
+                "version_added": "≤14"
               },
               "safari": {
                 "version_added": "1"

--- a/html/elements/body.json
+++ b/html/elements/body.json
@@ -140,8 +140,12 @@
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
+              "opera": {
+                "version_added": "≤12.1"
+              },
+              "opera_android": {
+                "version_added": "≤12.1"
+              },
               "safari": {
                 "version_added": "1"
               },

--- a/html/elements/body.json
+++ b/html/elements/body.json
@@ -143,7 +143,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "1.2"
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/col.json
+++ b/html/elements/col.json
@@ -79,12 +79,14 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": false
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -94,7 +96,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": "1.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/col.json
+++ b/html/elements/col.json
@@ -94,10 +94,10 @@
               },
               "oculus": "mirror",
               "opera": {
-                "version_added": "≤12.1"
+                "version_added": "≤15"
               },
               "opera_android": {
-                "version_added": "≤12.1"
+                "version_added": "≤14"
               },
               "safari": {
                 "version_added": "1"

--- a/html/elements/col.json
+++ b/html/elements/col.json
@@ -93,8 +93,12 @@
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
+              "opera": {
+                "version_added": "≤12.1"
+              },
+              "opera_android": {
+                "version_added": "≤12.1"
+              },
               "safari": {
                 "version_added": "1"
               },

--- a/html/elements/col.json
+++ b/html/elements/col.json
@@ -96,7 +96,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "1.2"
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/colgroup.json
+++ b/html/elements/colgroup.json
@@ -79,12 +79,14 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": false
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -94,7 +96,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": "1.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/colgroup.json
+++ b/html/elements/colgroup.json
@@ -94,10 +94,10 @@
               },
               "oculus": "mirror",
               "opera": {
-                "version_added": "≤12.1"
+                "version_added": "≤15"
               },
               "opera_android": {
-                "version_added": "≤12.1"
+                "version_added": "≤14"
               },
               "safari": {
                 "version_added": "1"

--- a/html/elements/colgroup.json
+++ b/html/elements/colgroup.json
@@ -93,8 +93,12 @@
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
+              "opera": {
+                "version_added": "≤12.1"
+              },
+              "opera_android": {
+                "version_added": "≤12.1"
+              },
               "safari": {
                 "version_added": "1"
               },

--- a/html/elements/colgroup.json
+++ b/html/elements/colgroup.json
@@ -96,7 +96,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "1.2"
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/table.json
+++ b/html/elements/table.json
@@ -96,14 +96,10 @@
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "1.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/table.json
+++ b/html/elements/table.json
@@ -99,7 +99,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "1.2"
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/table.json
+++ b/html/elements/table.json
@@ -97,10 +97,10 @@
               },
               "oculus": "mirror",
               "opera": {
-                "version_added": "≤12.1"
+                "version_added": "≤15"
               },
               "opera_android": {
-                "version_added": "≤12.1"
+                "version_added": "≤14"
               },
               "safari": {
                 "version_added": "1"

--- a/html/elements/table.json
+++ b/html/elements/table.json
@@ -96,8 +96,12 @@
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
+              "opera": {
+                "version_added": "≤12.1"
+              },
+              "opera_android": {
+                "version_added": "≤12.1"
+              },
               "safari": {
                 "version_added": "1"
               },

--- a/html/elements/tbody.json
+++ b/html/elements/tbody.json
@@ -79,12 +79,14 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": false
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -94,7 +96,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": "1.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/tbody.json
+++ b/html/elements/tbody.json
@@ -94,10 +94,10 @@
               },
               "oculus": "mirror",
               "opera": {
-                "version_added": "≤12.1"
+                "version_added": "≤15"
               },
               "opera_android": {
-                "version_added": "≤12.1"
+                "version_added": "≤14"
               },
               "safari": {
                 "version_added": "1"

--- a/html/elements/tbody.json
+++ b/html/elements/tbody.json
@@ -93,8 +93,12 @@
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
+              "opera": {
+                "version_added": "≤12.1"
+              },
+              "opera_android": {
+                "version_added": "≤12.1"
+              },
               "safari": {
                 "version_added": "1"
               },

--- a/html/elements/tbody.json
+++ b/html/elements/tbody.json
@@ -96,7 +96,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "1.2"
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/td.json
+++ b/html/elements/td.json
@@ -172,7 +172,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "1.2"
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/td.json
+++ b/html/elements/td.json
@@ -169,8 +169,12 @@
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
+              "opera": {
+                "version_added": "≤12.1"
+              },
+              "opera_android": {
+                "version_added": "≤12.1"
+              },
               "safari": {
                 "version_added": "1"
               },

--- a/html/elements/td.json
+++ b/html/elements/td.json
@@ -155,12 +155,14 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": false
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -170,7 +172,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": "1.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/td.json
+++ b/html/elements/td.json
@@ -170,10 +170,10 @@
               },
               "oculus": "mirror",
               "opera": {
-                "version_added": "≤12.1"
+                "version_added": "≤15"
               },
               "opera_android": {
-                "version_added": "≤12.1"
+                "version_added": "≤14"
               },
               "safari": {
                 "version_added": "1"

--- a/html/elements/tfoot.json
+++ b/html/elements/tfoot.json
@@ -79,12 +79,14 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": false
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -94,7 +96,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": "1.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/tfoot.json
+++ b/html/elements/tfoot.json
@@ -94,10 +94,10 @@
               },
               "oculus": "mirror",
               "opera": {
-                "version_added": "≤12.1"
+                "version_added": "≤15"
               },
               "opera_android": {
-                "version_added": "≤12.1"
+                "version_added": "≤14"
               },
               "safari": {
                 "version_added": "1"

--- a/html/elements/tfoot.json
+++ b/html/elements/tfoot.json
@@ -93,8 +93,12 @@
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
+              "opera": {
+                "version_added": "≤12.1"
+              },
+              "opera_android": {
+                "version_added": "≤12.1"
+              },
               "safari": {
                 "version_added": "1"
               },

--- a/html/elements/tfoot.json
+++ b/html/elements/tfoot.json
@@ -96,7 +96,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "1.2"
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/th.json
+++ b/html/elements/th.json
@@ -172,7 +172,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "1.2"
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/th.json
+++ b/html/elements/th.json
@@ -169,8 +169,12 @@
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
+              "opera": {
+                "version_added": "≤12.1"
+              },
+              "opera_android": {
+                "version_added": "≤12.1"
+              },
               "safari": {
                 "version_added": "1"
               },

--- a/html/elements/th.json
+++ b/html/elements/th.json
@@ -155,12 +155,14 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": false
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -170,7 +172,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": "1.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/th.json
+++ b/html/elements/th.json
@@ -170,10 +170,10 @@
               },
               "oculus": "mirror",
               "opera": {
-                "version_added": "≤12.1"
+                "version_added": "≤15"
               },
               "opera_android": {
-                "version_added": "≤12.1"
+                "version_added": "≤14"
               },
               "safari": {
                 "version_added": "1"

--- a/html/elements/thead.json
+++ b/html/elements/thead.json
@@ -79,12 +79,14 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": false
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -94,7 +96,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": "1.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/thead.json
+++ b/html/elements/thead.json
@@ -94,10 +94,10 @@
               },
               "oculus": "mirror",
               "opera": {
-                "version_added": "≤12.1"
+                "version_added": "≤15"
               },
               "opera_android": {
-                "version_added": "≤12.1"
+                "version_added": "≤14"
               },
               "safari": {
                 "version_added": "1"

--- a/html/elements/thead.json
+++ b/html/elements/thead.json
@@ -93,8 +93,12 @@
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
+              "opera": {
+                "version_added": "≤12.1"
+              },
+              "opera_android": {
+                "version_added": "≤12.1"
+              },
               "safari": {
                 "version_added": "1"
               },

--- a/html/elements/thead.json
+++ b/html/elements/thead.json
@@ -96,7 +96,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "1.2"
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/tr.json
+++ b/html/elements/tr.json
@@ -79,12 +79,14 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": false
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -94,7 +96,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": "1.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/tr.json
+++ b/html/elements/tr.json
@@ -94,10 +94,10 @@
               },
               "oculus": "mirror",
               "opera": {
-                "version_added": "≤12.1"
+                "version_added": "≤15"
               },
               "opera_android": {
-                "version_added": "≤12.1"
+                "version_added": "≤14"
               },
               "safari": {
                 "version_added": "1"

--- a/html/elements/tr.json
+++ b/html/elements/tr.json
@@ -93,8 +93,12 @@
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
+              "opera": {
+                "version_added": "≤12.1"
+              },
+              "opera_android": {
+                "version_added": "≤12.1"
+              },
               "safari": {
                 "version_added": "1"
               },

--- a/html/elements/tr.json
+++ b/html/elements/tr.json
@@ -96,7 +96,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "1.2"
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates the data for the `bgcolor` HTML attribute, which fixes #17310.  The version numbers come from other instances of the property, and confirmed by testing the oldest possible browsers in BrowserStack.
