### PR TITLE
Add a note regarding Firefox's lack of support for non-textual types for datalist

### DIFF
--- a/html/elements/datalist.json
+++ b/html/elements/datalist.json
@@ -18,7 +18,7 @@
             "firefox": {
               "version_added": "4",
               "partial_implementation": true,
-              "notes": "The <code>&lt;datalist&gt;</code> element will only create a dropdown for textual types, such <code>text</code>, <code>search</code>, <code>url</code>, <code>tel</code>, <code>email</code> and <code>number</code>. The <code>date</code>, <code>time</code>, <code>range</code> and <code>color</code> types are not supported."
+              "notes": "The <code>&lt;datalist&gt;</code> element will only create a dropdown for textual types, such as <code>text</code>, <code>search</code>, <code>url</code>, <code>tel</code>, <code>email</code> and <code>number</code>. The <code>date</code>, <code>time</code>, <code>range</code> and <code>color</code> types are not supported."
             },
             "firefox_android": [
               {

--- a/html/elements/datalist.json
+++ b/html/elements/datalist.json
@@ -18,7 +18,7 @@
             "firefox": {
               "version_added": "4",
               "partial_implementation": true,
-              "notes": "The <code>&lt;datalist&gt;</code> element will only create a dropdown for textual types, such <code>text</code>, <code>search</code>, <code>url</code>, <code>tel</code>, <code>email</code> and <code>number</code>."
+              "notes": "The <code>&lt;datalist&gt;</code> element will only create a dropdown for textual types, such <code>text</code>, <code>search</code>, <code>url</code>, <code>tel</code>, <code>email</code> and <code>number</code>. Date, time, range and color types are not supported."
             },
             "firefox_android": [
               {

--- a/html/elements/datalist.json
+++ b/html/elements/datalist.json
@@ -16,7 +16,9 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "4",
+              "partial_implementation": true,
+              "notes": "The <code>&lt;datalist&gt;</code> element will only create a dropdown for textual types, such <code>text</code>, <code>search</code>, <code>url</code>, <code>tel</code>, <code>email</code> and <code>number</code>."
             },
             "firefox_android": [
               {

--- a/html/elements/datalist.json
+++ b/html/elements/datalist.json
@@ -18,7 +18,7 @@
             "firefox": {
               "version_added": "4",
               "partial_implementation": true,
-              "notes": "The <code>&lt;datalist&gt;</code> element will only create a dropdown for textual types, such <code>text</code>, <code>search</code>, <code>url</code>, <code>tel</code>, <code>email</code> and <code>number</code>. Date, time, range and color types are not supported."
+              "notes": "The <code>&lt;datalist&gt;</code> element will only create a dropdown for textual types, such <code>text</code>, <code>search</code>, <code>url</code>, <code>tel</code>, <code>email</code> and <code>number</code>. The <code>date</code>, <code>time</code>, <code>range</code> and <code>color</code> types are not supported."
             },
             "firefox_android": [
               {


### PR DESCRIPTION
This PR adds a note to explain that the `<datalist>` element has no effect on non-textual inputs.  Fixes #17162.