### PR TITLE
Add missing CanvasFilter API

### DIFF
--- a/api/CanvasFilter.json
+++ b/api/CanvasFilter.json
@@ -15,6 +15,7 @@
           "ie": {
             "version_added": false
           },
+          "oculus": "mirror",
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
@@ -46,6 +47,7 @@
             "ie": {
               "version_added": false
             },
+            "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {

--- a/api/CanvasFilter.json
+++ b/api/CanvasFilter.json
@@ -1,0 +1,67 @@
+{
+  "api": {
+    "CanvasFilter": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "99"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "CanvasFilter": {
+        "__compat": {
+          "description": "<code>CanvasFilter()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/CanvasFilter.json
+++ b/api/CanvasFilter.json
@@ -27,7 +27,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }
@@ -60,7 +60,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/CanvasFilter.json
+++ b/api/CanvasFilter.json
@@ -2,6 +2,7 @@
   "api": {
     "CanvasFilter": {
       "__compat": {
+        "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#canvasfilter",
         "support": {
           "chrome": {
             "version_added": "99"
@@ -33,6 +34,7 @@
       },
       "CanvasFilter": {
         "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-canvasfilter",
           "description": "<code>CanvasFilter()</code> constructor",
           "support": {
             "chrome": {

--- a/api/CanvasFilter.json
+++ b/api/CanvasFilter.json
@@ -34,8 +34,8 @@
       },
       "CanvasFilter": {
         "__compat": {
-          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-canvasfilter",
           "description": "<code>CanvasFilter()</code> constructor",
+          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-canvasfilter",
           "support": {
             "chrome": {
               "version_added": "99"


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `CanvasFilter` API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CanvasFilter

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
